### PR TITLE
tlcs900h: Fix immediate mask in BIT #,r

### DIFF
--- a/ares/component/processor/tlcs900h/instruction.cpp
+++ b/ares/component/processor/tlcs900h/instruction.cpp
@@ -829,9 +829,9 @@ auto TLCS900H::instructionRegister(R register) -> void {
   }
   case 0x33: {  //BIT #,r
     if constexpr(Long) return undefined();
-    auto immediate = fetchImmediate<n8>();
+    data = fetch();
     prefetch(6);
-    return instructionBit(register, immediate);
+    return instructionBit(register, toImmediate<n4>(data));
   }
   case 0x34: {  //TSET #,r
     if constexpr(Long) return undefined();

--- a/ares/component/processor/tlcs900h/instructions.cpp
+++ b/ares/component/processor/tlcs900h/instructions.cpp
@@ -26,7 +26,7 @@ auto TLCS900H::instructionBit(Source source, Offset offset) -> void {
   NF = 0;
   VF = Undefined;
   HF = 1;
-  ZF = !load(source).bit(load(offset) & Source::bits - 1);
+  ZF = !load(source).bit(load(offset));
   SF = Undefined;
 }
 


### PR DESCRIPTION
The BIT (imm, reg) instruction uses the low 4 bits of its immediate operand even
when the register operand is only 8 bits wide. When the register is 8 bits and
the immediate value is between 8 and 15, ZF will be always be set. ares was
erroneously using only the bottom 3 immediate bits in this case (so 15 would
behave the same as 7).

With this fix, sprites now render correctly in the Neo Geo Pocket game Pocket
Tennis.

This bug was discovered by comparing against an instruction trace from MAME.
This change is the functional equivalent of commit
57e42cda31430c75566403c5f27ec290dc123da3 in the MAME git repo.

Before:
![before](https://user-images.githubusercontent.com/8510192/124574165-1134bd00-ddff-11eb-9a06-526a9c441a2c.png)
After:
![after](https://user-images.githubusercontent.com/8510192/124574176-12fe8080-ddff-11eb-8a17-e2d5d17c38ef.png)