### PR TITLE
Fix building mia on Linux.

### DIFF
--- a/mia/GNUmakefile
+++ b/mia/GNUmakefile
@@ -1,5 +1,6 @@
 name := mia
 build := optimized
+threaded := true
 local := true
 flags += -I. -I.. -I../ares
 


### PR DESCRIPTION
Although mia doesn't use threads itself, it includes `ares/ares.hpp` and ares *does* use threads, so we need to build with `-pthread` in order to link successfully.