### PR TITLE
Initialize Neo Geo Pocket port 1 to zero

### DIFF
--- a/ares/ngp/cpu/cpu.cpp
+++ b/ares/ngp/cpu/cpu.cpp
@@ -155,14 +155,14 @@ auto CPU::power() -> void {
   dma2 = {};
   dma3 = {};
 
-  p10.latch = 1; p10.flow = 1;
-  p11.latch = 1; p11.flow = 1;
-  p12.latch = 1; p12.flow = 1;
-  p13.latch = 1; p13.flow = 1;
-  p14.latch = 1; p14.flow = 1;
-  p15.latch = 1; p15.flow = 1;
-  p16.latch = 1; p16.flow = 1;
-  p17.latch = 1; p17.flow = 1;
+  p10.latch = 0; p10.flow = 1;
+  p11.latch = 0; p11.flow = 1;
+  p12.latch = 0; p12.flow = 1;
+  p13.latch = 0; p13.flow = 1;
+  p14.latch = 0; p14.flow = 1;
+  p15.latch = 0; p15.flow = 1;
+  p16.latch = 0; p16.flow = 1;
+  p17.latch = 0; p17.flow = 1;
 
   p20.latch = 1; p20.mode = 1;
   p21.latch = 1; p21.mode = 1;


### PR DESCRIPTION
In the game Dynamite Slugger, when your batter strikes out it loads a
16-bit word from 0x0000 and resets the game if anything but zero comes
back. The second byte, at address 0x0001, is mapped to internal port 1,
and currently almost all port values are initialized to 1 at power on.

In a 2019 nesdev post [1], Near stated that port emulation was incomplete
and likely incorrect. Without hardware tests, I'd rather not touch this
code more than necessary, but at the very least it seems more correct to
initialize the latched value in port 1 to zero.

There is a chance that the null dereference in Dynamite Slugger is
itself the result of an emulation bug, but all I have to compare against
is MAME, and the game behaves the same there. I believe this is decent
evidence that we are seeing a real game bug and that reading back zero
is what would have occurred on actual hardware.

[1] http://forums.nesdev.com/viewtopic.php?f=23&t=18579#p236069
"I added ports 1, 2, A, and B. Although ports 1 (d8-d15) and 2 (a16-a23)
are ... strange. They're likely emulated very wrong. I don't even
understand how one can change the direction of the data bus. I'm ...
suspecting that ports have their own latch values, but the manual isn't
very clear on this."