### PR TITLE
Add workaround for Wayland compatibility

### DIFF
--- a/hiro/gtk/application.cpp
+++ b/hiro/gtk/application.cpp
@@ -95,6 +95,8 @@ auto pApplication::state() -> State& {
 
 auto pApplication::initialize() -> void {
   #if defined(DISPLAY_XORG)
+  // If running on Wayland, force usage of XWayland
+  setenv("GDK_BACKEND", "x11", 1);
   XInitThreads();
   state().display = XOpenDisplay(nullptr);
   state().screenSaverXDG = (bool)execute("xdg-screensaver", "--version").output.find("xdg-screensaver");


### PR DESCRIPTION
When running on Wayland, Gtk3 will use the Wayland backend instead of X11 by default, but there are assumptions everywhere in hiro that the Gtk3 window will be an X11 window. This causes ares to crash when running on Wayland.
The ideal solution would be to add proper support for Wayland in hiro, but this would be a lot of work.
This PR instead adds a workaround, which sets an environment variable to override the defaults in Gtk3 and make it create an X11 window, even when running on Wayland. This adds the requirement of XWayland being installed, which should not be an issue, as a lot of widespread Linux desktop software is not yet Wayland compatible and therefore also requires its presence.

Tested on Arch Linux with KDE on Wayland.