### PR TITLE
ngp: re-enable saving ram to disk on unload

### DIFF
--- a/mia/system/neo-geo-pocket-color.cpp
+++ b/mia/system/neo-geo-pocket-color.cpp
@@ -21,8 +21,8 @@ auto NeoGeoPocketColor::load(string location) -> bool {
 }
 
 auto NeoGeoPocketColor::save(string location) -> bool {
-//Pak::save("cpu.ram", ".cram");
-//Pak::save("apu.ram", ".aram");
+  Pak::save("cpu.ram", ".cram");
+  Pak::save("apu.ram", ".aram");
 
   return true;
 }

--- a/mia/system/neo-geo-pocket.cpp
+++ b/mia/system/neo-geo-pocket.cpp
@@ -21,8 +21,8 @@ auto NeoGeoPocket::load(string location) -> bool {
 }
 
 auto NeoGeoPocket::save(string location) -> bool {
-//Pak::save("cpu.ram", ".cram");
-//Pak::save("apu.ram", ".aram");
+  Pak::save("cpu.ram", ".cram");
+  Pak::save("apu.ram", ".aram");
 
   return true;
 }


### PR DESCRIPTION
This code was commented out in commit
4e8232118288a0db8cb266bb07f278ee4184adbd which otherwise only affected
TLCS900/H timing. I believe this was left in by mistake. Uncommenting
this code restores the ability to persist BIOS settings across play
sessions.