### PR TITLE
ngp: allow BIOS to handle the boot process

### DIFF
--- a/ares/ngp/cpu/cpu.hpp
+++ b/ares/ngp/cpu/cpu.hpp
@@ -52,7 +52,6 @@ struct CPU : TLCS900H, Thread {
   auto step(u32 clocks) -> void override;
   auto pollPowerButton() -> void;
   auto power() -> void;
-  auto fastBoot() -> void;
 
   //memory.cpp
   auto width(n24 address) -> u32 override;
@@ -741,6 +740,9 @@ struct CPU : TLCS900H, Thread {
     n8 b6;
     n8 b7;
   } unknown;
+
+//unserialized:
+  n32 pollPowerButtonSkipCounter;
 };
 
 extern CPU cpu;

--- a/ares/ngp/system/system.cpp
+++ b/ares/ngp/system/system.cpp
@@ -97,14 +97,16 @@ auto System::unload() -> void {
 auto System::power(bool reset) -> void {
   for(auto& setting : node->find<Node::Setting::Setting>()) setting->setLatch();
 
+  //enable or disable boot animation.
+  n16 bootAnim = NeoGeoPocket::Model::NeoGeoPocketColor() ? 0x530c : 0x4618;
+  bios.program(bootAnim, fastBoot->latch() ? 0x0e : 0xf1); //0x0e = ret, 0xf1 = ld
+
   cartridge.power();
   cpu.power();
   apu.power();
   kge.power();
   psg.power();
   scheduler.power(cpu);
-
-  if(fastBoot->latch() && cartridge.flash[0]) cpu.fastBoot();
 }
 
 }


### PR DESCRIPTION
Neo Geo Pocket is an "always on" system. On first boot, it quickly
enters a low power state via a halt instruction. From there, the user
must press the power button to wake the sytem. At this point, the BIOS
setup is shown, requiring the user to pick a preferred language among
other choices. When power is pressed again, the system returns to a low
power state. This state is maintained by an internal battery should the
external batteries discharge or be removed. The hardware reset entry
point will not execute again until the internal battery fails.

The current design of ares appears to be motivated by a few goals:
- Avoid requiring the user to press the emulated power button
- Avoid showing the BIOS setup more times than necessary
- Enable "fast boot" mode to skip the boot animation

The required power button press is avoided by skipping the first boot
code entirely in CPU::power(). Emulation never begins at the hardware
reset vector, but rather at 0xFF1800, following MAME's lead. This entry
point appears to have been for development purposes only and is not
referenced by the BIOS itself. Crucially, it does not run some
bookkeeping logic that only occurs when entering a low power state
either after a cold boot, in response to a power button press, or after
a software requested shutdown. Skipping this logic can cause the BIOS
setup to be shown on next boot.

The BIOS setup is avoided by simulating the bookkeping done by the BIOS
in the emulator itself. This logic is located in CPU::load(), meaning
that it does not run between system resets. Therefore, resetting a game
can still cause the BIOS setup to be shown. The BIOS setup is also
skipped by fast boot mode.

Fast boot mode bypasses the BIOS entirely on boot, jumping straight to
the cartridge entry point. This means all of the many important side
effects of the boot process must be replicated by CPU::fastBoot().
Currently, it also gives the user no way to select Japanese as a
preferred language.

The existing solutions to these problems fall short of providing a
consistent user experience, tightly couple ares to the internals of the
BIOS rom, and (particularly with fast boot) have been a source of many
bugs. This change removes the existing solutions in favor of ones that
let the BIOS handle the entirety of the boot process.

The new code in this change does the following:
- Begin execution at the hardware reset vector on first boot
- Begin execution at the VECT_SHUTDOWN syscall on subsequent boots
- Simulate a power button press when entering a low power state
- Patch the BIOS to skip the boot animation in fast boot mode

Starting at the hardware reset vector ensures the BIOS setup will be
shown on first boot, affording the user the opportunity to pick a
preferred language. Subsequent boots will begin at the VECT_SHUTDOWN
system call. It may seem counterintuitive, but this allows the BIOS to
perform cleanup that would normally only occur when the user shuts off
the device before switching cartridges. In both of these cases, we can
avoid requiring the user to press the emulated power button by
simulating a button press on their behalf. It's a low tech solution to
be sure, but a reliable one.

Finally, the implementation of fast boot mode is replaced with a single
byte patch to the BIOS to immediately return from the routine that plays
the boot animation.