### PR TITLE
ngp: fix address used to test ram initialization

### DIFF
--- a/ares/ngp/cpu/cpu.cpp
+++ b/ares/ngp/cpu/cpu.cpp
@@ -86,7 +86,7 @@ auto CPU::power() -> void {
   //detect whether the loaded ram data has already been through the boot process.
   //this byte is written when entering or leaving a halt state and is never zero,
   //making it convenient to test.
-  if(ram[0x6c7a] != 0) {
+  if(ram[0x2c7a] != 0) {
     //read VECT_SHUTDOWN; it may seem counterintuitive to jump here on power-on,
     //but it allows the BIOS to perform cleanup that would normally only occur
     //when the user shuts off the device before switching cartridges.


### PR DESCRIPTION
My last change indexed into the ram array by an absolute memory address,
but the array only covers a portion of the address space beginning at
0x4000. This was in fact indexing past the end of the array, but it
appeared to work as long as 1) something was mapped there and 2) that
something was nonzero. It's possible that booting from the shutdown
vector every time doesn't have any negative side effects, but booting
from the hardware reset vector the first time is still the more correct
thing to do from an accuracy perspective.