### PR TITLE
lucia: support digital presses from analog inputs

### DIFF
--- a/lucia/emulator/emulator.cpp
+++ b/lucia/emulator/emulator.cpp
@@ -190,8 +190,8 @@ auto Emulator::input(ares::Node::Input::Input input) -> void {
       for(auto& inputNode : inputDevice.inputs) {
         if(inputNode.name != input->name()) continue;
         if(auto button = input->cast<ares::Node::Input::Button>()) {
-          auto value = inputNode.mapping->value();
-          return button->setValue(value);
+          auto pressed = inputNode.mapping->pressed();
+          return button->setValue(pressed);
         }
         if(auto axis = input->cast<ares::Node::Input::Axis>()) {
           auto value = inputNode.mapping->value();

--- a/lucia/input/input.cpp
+++ b/lucia/input/input.cpp
@@ -163,6 +163,10 @@ auto InputDigital::value() -> s16 {
   return result;
 }
 
+auto InputDigital::pressed() -> bool {
+  return value() != 0;
+}
+
 //
 
 auto InputAnalog::bind(u32 binding, shared_pointer<HID::Device> device, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> bool {
@@ -226,6 +230,10 @@ auto InputAnalog::value() -> s16 {
   }
 
   return sclamp<16>(result);
+}
+
+auto InputAnalog::pressed() -> bool {
+  return value() > 16384;
 }
 
 //

--- a/lucia/input/input.hpp
+++ b/lucia/input/input.hpp
@@ -10,6 +10,7 @@ struct InputMapping {
 
   virtual auto bind(u32 binding, shared_pointer<HID::Device>, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> bool = 0;
   virtual auto value() -> s16 = 0;
+  virtual auto pressed() -> bool { return false; }
 
   string assignments[BindingLimit];
 
@@ -31,6 +32,7 @@ struct InputDigital : InputMapping {
   using InputMapping::bind;
   auto bind(u32 binding, shared_pointer<HID::Device>, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> bool override;
   auto value() -> s16 override;
+  auto pressed() -> bool override;
 };
 
 //0 ... +32767
@@ -38,6 +40,7 @@ struct InputAnalog : InputMapping {
   using InputMapping::bind;
   auto bind(u32 binding, shared_pointer<HID::Device>, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> bool override;
   auto value() -> s16 override;
+  auto pressed() -> bool override;
 };
 
 //-32768 ... +32767


### PR DESCRIPTION
lucia maps the N64 C-buttons to the right thumbstick of the virtual pad.
These are analog inputs on the virtual pad, so sampled analog values are
not converted to digital. This means any nonzero value is treated as
button press, which is not ideal when mapped to an analog input device.

This change introduces a helper to convert raw input values to a binary
"pressed" state at time of use, currently only defined for digital and
analog input mappings - for relative and absolute inputs this concept
would not make much sense.

This fixes #16.