### PR TITLE
Optimize SH7604 Recompiler Min Cycles for 32X

### DIFF
--- a/ares/md/m32x/sh7604.cpp
+++ b/ares/md/m32x/sh7604.cpp
@@ -52,7 +52,7 @@ auto M32X::SH7604::step(u32 clocks) -> void {
 
 auto M32X::SH7604::power(bool reset) -> void {
   Thread::create(23'000'000, {&M32X::SH7604::main, this});
-  recompiler.min_cycles = 23;
+  recompiler.min_cycles = 22;
   SH2::power(reset);
   irq = {};
   irq.vres.enable = 1;


### PR DESCRIPTION
	modified:   ares/md/m32x/sh7604.cpp

Change the cached interpreter's recompiler min_cycles value from 23 to 22.
It's just ever so slightly too agressive.

This addresses problems with the bonus levels in Knuckles Chaotix,
as well as the hang in Virtua Fighter after selecting your character.

This appears to be the optimal value through lots of additional testing.
There were no other problems observed in the 32X library by lowering this
value to 22. Additionally, there were no further gains to be made by going
any lower (all the way to zero) such as correcting the hang at the end of
the match in Brutal: Above the Claw or NBA Jam failing to go in-game. Both
of these currently require using the full interpreter, and not the cached
interpreter enabled by default to correct timing issues.

This fixes 5% of games in the 32X library. :-)