### PR TITLE
z80: correct the effect of IE on next instruction

### DIFF
--- a/ares/component/processor/z80/instruction.cpp
+++ b/ares/component/processor/z80/instruction.cpp
@@ -1,11 +1,6 @@
 auto Z80::instruction() -> void {
+  EI = 0;
   P = 0;
-
-  if(EI) {
-    EI = 0;
-    IFF1 = 1;
-    IFF2 = 1;
-  }
 
   if(HALT) {
     return wait(1);

--- a/ares/component/processor/z80/instructions.cpp
+++ b/ares/component/processor/z80/instructions.cpp
@@ -217,7 +217,9 @@ auto Z80::instructionDJNZ_e() -> void { Q = 0;
 }
 
 auto Z80::instructionEI() -> void { Q = 0;
-  EI = 1;  //raise IFF1, IFF2 after the next instruction
+  IFF1 = 1;
+  IFF2 = 1;
+  EI = 1;  //ignore maskable interrupts until after the next instruction
 }
 
 auto Z80::instructionEX_irr_rr(n16& x, n16& y) -> void { Q = 0;

--- a/ares/component/processor/z80/z80.cpp
+++ b/ares/component/processor/z80/z80.cpp
@@ -35,8 +35,8 @@ auto Z80::power(MOSFET mosfet) -> void {
 }
 
 auto Z80::irq(bool maskable, n16 pc, n8 extbus) -> bool {
-  if(EI) return false;  //do not execute interrupts immediately after EI instruction
-  if(maskable && !IFF1) return false;
+  //do not execute maskable interrupts if disabled or immediately after EI instruction
+  if(maskable && (!IFF1 || EI)) return false;
   R.bit(0,6)++;
 
   push(PC);


### PR DESCRIPTION
The implementation of IE in the Z80 processor was incorrectly causing
nonmaskable interrupts raised before the next instruction to be dropped.
A correct implementation should do two things:
- set IFF1 and IFF2 to 1
- disable maskable interrupts until after the following instruction

This fixes the issue of audio dropping out of Neo Geo Pocket games
seemingly at random.

References:
Z80 CPU User Manual (http://www.zilog.com/docs/z80/UM0080.pdf)
Page 6: "NMI is always recognized at the end of the current instruction,
independent of the status of the interrupt enable flip-flop..."
Page 183: "During the execution of this instruction [EI] and the
following instruction, maskable interrupts are disabled."