### PR TITLE
TMS9918, V9938, SMS VDP: fix sprite size emulation

### DIFF
--- a/ares/component/video/tms9918/sprite.cpp
+++ b/ares/component/video/tms9918/sprite.cpp
@@ -34,8 +34,7 @@ auto TMS9918::Sprite::run(n8 hoffset, n8 voffset) -> void {
   output = {};
 
   n4 color;
-  n4 hlimit = (8 << io.zoom) - 1;
-  n5 vlimit = (8 << io.zoom << io.size) - 1;
+  n5 hlimit = (8 << io.zoom << io.size) - 1, vlimit = hlimit;
 
   for(auto& o : objects) {
     if(o.y == 0xd0) continue;

--- a/ares/component/video/v9938/sprite.cpp
+++ b/ares/component/video/v9938/sprite.cpp
@@ -101,8 +101,7 @@ auto V9938::Sprite::run(n8 x, n8 y) -> void {
 
 auto V9938::Sprite::sprite1(n8 hoffset, n8 voffset) -> void {
   n4 color;
-  n4 hlimit = (8 << io.zoom) - 1;
-  n5 vlimit = (8 << io.zoom << io.size) - 1;
+  n5 hlimit = (8 << io.zoom << io.size) - 1, vlimit = hlimit;
 
   for(auto& o : objects) {
     if(o.y == 0xd0) break;
@@ -126,8 +125,7 @@ auto V9938::Sprite::sprite1(n8 hoffset, n8 voffset) -> void {
 
 auto V9938::Sprite::sprite2(n8 hoffset, n8 voffset) -> void {
   n4 color;
-  n4 hlimit = (8 << io.zoom) - 1;
-  n5 vlimit = (8 << io.zoom << io.size) - 1;
+  n5 hlimit = (8 << io.zoom << io.size) - 1, vlimit = hlimit;
 
   for(auto& o : objects) {
     if(o.y == 0xd8) break;

--- a/ares/ms/vdp/sprite.cpp
+++ b/ares/ms/vdp/sprite.cpp
@@ -88,8 +88,7 @@ auto VDP::Sprite::graphics1(n8 hoffset, n9 voffset) -> void {
 }
 
 auto VDP::Sprite::graphics2(n8 hoffset, n9 voffset) -> void {
-  n4 hlimit = (8 << io.zoom) - 1;
-  n5 vlimit = (8 << io.zoom << io.size) - 1;
+  n5 hlimit = (8 << io.zoom << io.size) - 1, vlimit = hlimit;
   for(auto& o : objects) {
     if(o.y == 0xd0) continue;
     if(hoffset < o.x) continue;


### PR DESCRIPTION
Commit 532aafe074388b1a368334f7c25b085f73c34936 made some improvements
to sprite zoom (magnification) emulation. It also corrected sprite size
emulation in the SMS VDP in what is referred to as Mode 4 by most
sources ("graphics3" in ares). Unfortunately, it erroneously applied the
same changes to the TMS9918 and V9938 as well as the SMS VDP in TMS9918
compatible modes. This caused widespread regressions in ColecoVision,
SG-1000, MSX, and MSX2 emulation.

This commit reverts the changes made outside of SMS VDP Mode 4,
restoring the dimensions of double sized sprites from 8x16 to 16x16.