### PR TITLE
cv: clear top bit of controller port reads

### DIFF
--- a/ares/cv/controller/gamepad/gamepad.cpp
+++ b/ares/cv/controller/gamepad/gamepad.cpp
@@ -53,7 +53,7 @@ auto Gamepad::read() -> n8 {
     xHold = 1, swap(leftLatch, rightLatch);
   }
 
-  n8 data = 0xff;
+  n8 data = 0x7f;
   if(select == 0) {
          if(one->value  ()) data.bit(0,3) = 0b1101;
     else if(two->value  ()) data.bit(0,3) = 0b0111;


### PR DESCRIPTION
I couldn't find any references describing the expected value of the top
bit of controller port reads, but some games require it to be cleared.
Here is an example from Defender when it is waiting a 1/2 button press:

```
in   a,($FC)    ; read controller 1
cp   $7D        ; compare 1 button
jr   z,$876D
cp   $77        ; compare 2 button
jr   z,$8773
```

Clearing it fixes input in games that depend on all the undefined bits.