### PR TITLE
tms9918: fix interrupt behavior

### DIFF
--- a/ares/component/video/tms9918/io.cpp
+++ b/ares/component/video/tms9918/io.cpp
@@ -11,7 +11,7 @@ auto TMS9918::status() -> n8 {
   sprite.io.collision = 0;
   sprite.io.overflow = 0;
   irqFrame.pending = 0;
-  irq(0);
+  poll();
 
   return data;
 }
@@ -56,7 +56,7 @@ auto TMS9918::register(n3 register, n8 data) -> void {
     irqFrame.enable      = data.bit(5);
     dac.io.displayEnable = data.bit(6);
     io.vramMode          = data.bit(7);
-    if(!irqFrame.enable) irqFrame.pending = 0;
+    poll();
     break;
 
   case 2:

--- a/ares/component/video/tms9918/tms9918.cpp
+++ b/ares/component/video/tms9918/tms9918.cpp
@@ -36,14 +36,18 @@ auto TMS9918::main() -> void {
 
   io.vcounter++;
   if(io.vcounter == 262) io.vcounter = 0;
-  if(io.vcounter ==   0) irqFrame.pending = 0;
-  if(io.vcounter == 192) irqFrame.pending = 1, irq(irqFrame.enable), frame();
+  if(io.vcounter == 192) irqFrame.pending = 1, poll(), frame();
+}
+
+auto TMS9918::poll() -> void {
+  irq(irqFrame.pending && irqFrame.enable);
 }
 
 auto TMS9918::power() -> void {
   background.power();
   sprite.power();
   dac.power();
+  irqFrame = {};
   io = {};
 }
 

--- a/ares/component/video/tms9918/tms9918.hpp
+++ b/ares/component/video/tms9918/tms9918.hpp
@@ -21,6 +21,7 @@ struct TMS9918 {
   auto unload() -> void;
 
   auto main() -> void;
+  auto poll() -> void;
   auto power() -> void;
 
   //io.cpp

--- a/ares/cv/cpu/cpu.cpp
+++ b/ares/cv/cpu/cpu.cpp
@@ -24,8 +24,8 @@ auto CPU::unload() -> void {
 }
 
 auto CPU::main() -> void {
-  if(state.nmiLine) {
-    state.nmiLine = 0;  //edge-sensitive
+  if(state.nmiPending) {
+    state.nmiPending = 0;  //edge-sensitive
     debugger.interrupt("NMI");
     irq(0, 0x0066, 0xff);
   }
@@ -46,6 +46,7 @@ auto CPU::step(uint clocks) -> void {
 }
 
 auto CPU::setNMI(bool value) -> void {
+  if(!state.nmiLine && value) state.nmiPending = 1;
   state.nmiLine = value;
 }
 

--- a/ares/cv/cpu/cpu.hpp
+++ b/ares/cv/cpu/cpu.hpp
@@ -46,6 +46,7 @@ struct CPU : Z80, Z80::Bus, Thread {
 
 private:
   struct State {
+    bool nmiPending = 0;
     bool nmiLine = 0;
     bool irqLine = 0;
   } state;

--- a/ares/cv/cpu/serialization.cpp
+++ b/ares/cv/cpu/serialization.cpp
@@ -3,6 +3,7 @@ auto CPU::serialize(serializer& s) -> void {
   Thread::serialize(s);
   s(ram);
   s(expansion);
+  s(state.nmiPending);
   s(state.nmiLine);
   s(state.irqLine);
   s(io.replaceBIOS);


### PR DESCRIPTION
The existing implementation was very incorrect. Fortunately, this chip
is well documented and the correct behavior is quite easy to implement.
This fixes most of the remaining ColecoVision bugs that aren't related
to missing peripheral support.

The TMS9918 is also used by the SG-1000 and MSX cores. I don't have a
list of bugs for those platforms, so I couldn't do any targeted testing,
but I booted up a few games and did not see any new issues.