### PR TITLE
nall: Add macOS deployment target flags

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -135,6 +135,10 @@ endif
 ifeq ($(platform),macos)
   flags   += -stdlib=libc++
   options += -lc++ -lobjc
+  ifneq ($(local),true)
+    flags   += -mmacosx-version-min=10.14 -arch x86_64
+    options += -mmacosx-version-min=10.14 -arch x86_64
+  endif
 endif
 
 # linux settings


### PR DESCRIPTION
I do not have a macOS 10.14 system to test if it actually runs on this version, however it does compile with the appropriately versioned headers and run on more recent macos versions.

Related to #28.