### PR TITLE
cv: disable cart rom mirroring

### DIFF
--- a/ares/cv/cartridge/cartridge.cpp
+++ b/ares/cv/cartridge/cartridge.cpp
@@ -38,4 +38,9 @@ auto Cartridge::save() -> void {
 auto Cartridge::power() -> void {
 }
 
+auto Cartridge::read(n16 address) -> n8 {
+  if(address >= rom.size()) return 0xff;
+  return rom.read(address);
+}
+
 }

--- a/ares/cv/cartridge/cartridge.hpp
+++ b/ares/cv/cartridge/cartridge.hpp
@@ -13,10 +13,12 @@ struct Cartridge {
   auto save() -> void;
   auto power() -> void;
 
+  auto read(n16 address) -> n8;
+
   //serialization.cpp
   auto serialize(serializer&) -> void;
 
-//private:
+private:
   struct Information {
     string title;
     string region;

--- a/ares/cv/cpu/memory.cpp
+++ b/ares/cv/cpu/memory.cpp
@@ -4,7 +4,7 @@ auto CPU::read(n16 address) -> n8 {
   if(address >= 0x2000 && address <= 0x7fff && io.replaceRAM ) return expansion.read(address);
   if(address >= 0x0000 && address <= 0x1fff) return system.bios[address & 0x1fff];
   if(address >= 0x6000 && address <= 0x7fff) return ram.read(address - 0x6000);
-  if(address >= 0x8000 && address <= 0xffff) return cartridge.rom.read(address - 0x8000);
+  if(address >= 0x8000 && address <= 0xffff) return cartridge.read(address - 0x8000);
   return data;
 }
 


### PR DESCRIPTION
ColecoVision carts contain up to 4 separate 8 KiB banks, and there is no
mirroring when some banks are absent. The existing mirroring behavior
was causing Sammy Lightfoot to freeze on load.