### PR TITLE
tms9918: allow sprites to bleed off top/left screen edge

### DIFF
--- a/ares/component/video/tms9918/sprite.cpp
+++ b/ares/component/video/tms9918/sprite.cpp
@@ -6,10 +6,11 @@ auto TMS9918::Sprite::setup(n8 voffset) -> void {
   n14 attributeAddress;
   attributeAddress.bit(7,13) = io.attributeTableAddress;
   for(u32 index : range(32)) {
-    n8 y = self.vram.read(attributeAddress++);
+    i9 y = self.vram.read(attributeAddress++);
     if(y == 0xd0) break;
+    if(y >= 0xe0) y -= 0x100;
 
-    n8 x = self.vram.read(attributeAddress++);
+    i9 x = self.vram.read(attributeAddress++);
     n8 pattern = self.vram.read(attributeAddress++);
     n8 extra = self.vram.read(attributeAddress++);
 

--- a/ares/component/video/tms9918/tms9918.hpp
+++ b/ares/component/video/tms9918/tms9918.hpp
@@ -74,8 +74,8 @@ protected:
     auto serialize(serializer&) -> void;
 
     struct Object {
-      n8 x;
-      n8 y = 0xd0;
+      i9 x;
+      i9 y = 0xd0;
       n8 pattern;
       n4 color;
     } objects[4];


### PR DESCRIPTION
The TMS9918 allows for sprites to, in the words of TI's VDP Programmer's
Guide, "bleed" off the top or left edge of the screen. Depending on the
edge, this is accomplished by different means.

Proper implementation of this behavior is known to affect the following
ColecoVision games:
- Frogger: some sprites should be hidden off the left edge of the screen
- The Heist: the player sprite crosses the left edge of the screen
- Bump 'N' Jump: car sprites cross the top edge of the screen

It looks as though the V9938 and SMS VDP will require similar fixes.