### PR TITLE
cv, msx, sg: init VRAM to zero on load

### DIFF
--- a/ares/cv/vdp/vdp.cpp
+++ b/ares/cv/vdp/vdp.cpp
@@ -7,6 +7,8 @@ VDP vdp;
 #include "serialization.cpp"
 
 auto VDP::load(Node::Object parent) -> void {
+  vram.allocate(16_KiB, 0x00);
+
   node = parent->append<Node::Object>("VDP");
 
   screen = node->append<Node::Video::Screen>("Screen", 256, 192);
@@ -45,7 +47,6 @@ auto VDP::power() -> void {
   TMS9918::power();
   Thread::create(system.colorburst() * 2, [&] { main(); });
   screen->power();
-  vram.allocate(0x4000);
 }
 
 }

--- a/ares/msx/vdp/vdp.cpp
+++ b/ares/msx/vdp/vdp.cpp
@@ -15,6 +15,7 @@ auto VDP::load(Node::Object parent) -> void {
     screen->setSize(256, 192);
     screen->setScale(1.0, 1.0);
     screen->setAspect(1.0, 1.0);
+    TMS9918::vram.allocate(16_KiB, 0x00);
     TMS9918::load(screen);
   }
 
@@ -24,6 +25,9 @@ auto VDP::load(Node::Object parent) -> void {
     screen->setSize(512, 424);
     screen->setScale(0.5, 0.5);
     screen->setAspect(1.0, 1.0);
+    V9938::vram.allocate(128_KiB, 0x00);
+    V9938::xram.allocate(64_KiB, 0x00);
+    V9938::pram.allocate(16);
     V9938::load(screen);
   }
 }
@@ -58,15 +62,11 @@ auto VDP::frame() -> void {
 
 auto VDP::power() -> void {
   if(Model::MSX()) {
-    TMS9918::vram.allocate(16_KiB);
     TMS9918::power();
     Thread::create(system.colorburst() * 2, [&] { TMS9918::main(); });
   }
 
   if(Model::MSX2()) {
-    V9938::vram.allocate(128_KiB);
-    V9938::xram.allocate(64_KiB);
-    V9938::pram.allocate(16);
     V9938::power();
     Thread::create(system.colorburst() * 2, [&] { V9938::main(); });
   }

--- a/ares/sg/vdp/vdp.cpp
+++ b/ares/sg/vdp/vdp.cpp
@@ -7,6 +7,8 @@ VDP vdp;
 #include "serialization.cpp"
 
 auto VDP::load(Node::Object parent) -> void {
+  vram.allocate(16_KiB, 0x00);
+
   node = parent->append<Node::Object>("VDP");
 
   screen = node->append<Node::Video::Screen>("Screen", 256, 192);
@@ -45,7 +47,6 @@ auto VDP::power() -> void {
   TMS9918::power();
   Thread::create(system.colorburst() * 2, [&] { main(); });
   screen->power();
-  vram.allocate(0x4000);
 }
 
 }


### PR DESCRIPTION
Initialize VRAM to zero on load for systems that use the TMS9918/V9938.
On real hardware this memory will be in a partially indeterminate state,
but as far as approximations go, 0x00 is much less problematic than
0xff. A sprite attribute table filled with 0xff is interpreted to have
valid entries for sprites in the top right corner of the screen. If the
pattern data is also filled with 0xff, a white square will be drawn in
the corner. On the other hand, a sprite entry of all 0x00 bytes will be
fully transparent (due to the color byte being zero) and therefore
invisible.

This is most noticeable in games that never get around to fully
initializing VRAM, such as the ColecoVision game Boulder Dash, which has
a permanent square in the corner.

SG-1000 games only seem to exhibit this problem briefly after booting,
and only for certain games, as they eventually get around to
initializing VRAM. Some homebrew is more seriously affected.

MSX compatibility is in too poor a state to test comprehensively, but a
survey of other emulators shows initializing VRAM to zero is the norm.

This change also allows VRAM to carry over across soft resets. This
should be closer to hardware behavior, though in reality it is possible
for some bits to be perturbed.