### PR TITLE
ms, v9938: allow sprites to bleed off top/left screen edge

### DIFF
--- a/ares/component/video/v9938/sprite.cpp
+++ b/ares/component/video/v9938/sprite.cpp
@@ -11,10 +11,11 @@ auto V9938::Sprite::setup(n8 voffset) -> void {
 
     n14 address = io.nameTableAddress & 0x03f80;
     for(u32 index : range(32)) {
-      n8 y = self.vram.read(address++);
+      i9 y = self.vram.read(address++);
       if(y == 0xd0) break;
+      if(y >= 0xe0) y -= 0x100;
 
-      n8 x = self.vram.read(address++);
+      i9 x = self.vram.read(address++);
       n8 pattern = self.vram.read(address++);
       n8 attributes = self.vram.read(address++);
 
@@ -48,10 +49,11 @@ auto V9938::Sprite::setup(n8 voffset) -> void {
 
     n17 address = io.nameTableAddress & 0x1fe00;
     for(u32 index : range(32)) {
-      n8 y = self.vram.read(address++);
+      i9 y = self.vram.read(address++);
       if(y == 0xd8) break;
+      if(y >= 0xe0) y -= 0x100;
 
-      n8 x = self.vram.read(address++);
+      i9 x = self.vram.read(address++);
       n8 pattern = self.vram.read(address++);
       n8 reserved = self.vram.read(address++);
 

--- a/ares/component/video/v9938/v9938.hpp
+++ b/ares/component/video/v9938/v9938.hpp
@@ -125,8 +125,8 @@ protected:
     auto serialize(serializer&) -> void;
 
     struct Object {
-      n8 x;
-      n8 y = 0xd0;
+      i9 x;
+      i9 y = 0xd0;
       n8 pattern;
       n4 color;
       n1 collision;

--- a/ares/ms/vdp/sprite.cpp
+++ b/ares/ms/vdp/sprite.cpp
@@ -8,10 +8,11 @@ auto VDP::Sprite::setup(n9 voffset) -> void {
     n14 attributeAddress;
     attributeAddress.bit(7,13) = io.attributeTableAddress;
     for(u32 index : range(32)) {
-      n8 y = self.vram[attributeAddress++];
+      i9 y = self.vram[attributeAddress++];
       if(y == 0xd0) break;
+      if(y >= 0xe0) y -= 0x100;
 
-      n8 x = self.vram[attributeAddress++];
+      i9 x = self.vram[attributeAddress++];
       n8 pattern = self.vram[attributeAddress++];
       n8 extra = self.vram[attributeAddress++];
 
@@ -35,10 +36,11 @@ auto VDP::Sprite::setup(n9 voffset) -> void {
     attributeAddress.bit(8,13) = io.attributeTableAddress.bit(1,6);
 
     for(u32 index : range(64)) {
-      n8 y = self.vram[attributeAddress + index];
+      i9 y = self.vram[attributeAddress + index];
       if(self.vlines() == 192 && y == 0xd0) break;
+      if(y >= 0xf0) y -= 0x100;
 
-      n8 x = self.vram[attributeAddress + 0x80 + (index << 1)];
+      i9 x = self.vram[attributeAddress + 0x80 + (index << 1)];
       n8 pattern = self.vram[attributeAddress + 0x81 + (index << 1)];
 
       if(io.shift) x -= 8;

--- a/ares/ms/vdp/vdp.hpp
+++ b/ares/ms/vdp/vdp.hpp
@@ -106,8 +106,8 @@ struct VDP : Thread {
     auto serialize(serializer&) -> void;
 
     struct Object {
-      n8 x;
-      n8 y = 0xd0;
+      i9 x;
+      i9 y = 0xd0;
       n8 pattern;
       n4 color;
     } objects[8];


### PR DESCRIPTION
Apply fixes to the Master System VDP and the V9938 (used by MSX 2) that
are analogous to the recent TMS9918 fix.