### PR TITLE
gb: only raise stat interrupts if display enabled

### DIFF
--- a/ares/gb/ppu/ppu.cpp
+++ b/ares/gb/ppu/ppu.cpp
@@ -156,6 +156,8 @@ auto PPU::mode(n2 mode) -> void {
 }
 
 auto PPU::stat() -> void {
+  if(!status.displayEnable) return;
+
   bool irq = status.irq;
 
   status.irq  = status.interruptHblank && status.mode == 0;


### PR DESCRIPTION
This emulation bug, combined with the intentional emulation of the
hardware bug that causes spurious stat interrupts, was causing stat
interrupts to be raised when the display was disabled.

This stops the GB game Cool Hand from freezing after selecting cribbage.