### PR TITLE
gb: reconcile LY with STAT interrupts

### DIFF
--- a/ares/gb/ppu/io.cpp
+++ b/ares/gb/ppu/io.cpp
@@ -48,7 +48,7 @@ auto PPU::readIO(u32 cycle, n16 address, n8 data) -> n8 {
   }
 
   if(address == 0xff44 && cycle == 2) {  //LY
-    return status.ly;
+    return getLY();
   }
 
   if(address == 0xff45 && cycle == 2) {  //LYC
@@ -187,11 +187,6 @@ auto PPU::writeIO(u32 cycle, n16 address, n8 data) -> void {
 
   if(address == 0xff43 && cycle == 2) {  //SCX
     status.scx = data;
-    return;
-  }
-
-  if(address == 0xff44 && cycle == 2) {  //LY
-    status.ly = 0;
     return;
   }
 

--- a/ares/gb/ppu/ppu.cpp
+++ b/ares/gb/ppu/ppu.cpp
@@ -163,15 +163,9 @@ auto PPU::stat() -> void {
   status.irq  = status.interruptHblank && status.mode == 0;
   status.irq |= status.interruptVblank && status.mode == 1;
   status.irq |= status.interruptOAM    && status.mode == 2;
-  status.irq |= status.interruptLYC    && coincidence();
+  status.irq |= status.interruptLYC    && compareLYC();
 
   if(!irq && status.irq) cpu.raise(CPU::Interrupt::Stat);
-}
-
-auto PPU::coincidence() -> bool {
-  u32 ly = status.ly;
-  if(ly == 153 && status.lx >= 92) ly = 0;  //LYC=0 triggers early during LY=153
-  return ly == status.lyc;
 }
 
 auto PPU::step(u32 clocks) -> void {

--- a/ares/gb/ppu/ppu.hpp
+++ b/ares/gb/ppu/ppu.hpp
@@ -32,7 +32,6 @@ struct PPU : Thread {
   auto main() -> void;
   auto mode(n2 mode) -> void;
   auto stat() -> void;
-  auto coincidence() -> bool;
   auto step(u32 clocks) -> void;
 
   auto hflip(n16 tiledata) const -> n16;
@@ -43,6 +42,7 @@ struct PPU : Thread {
   auto canAccessVRAM() const -> bool;
   auto canAccessOAM() const -> bool;
   auto compareLYC() const -> bool;
+  auto getLY() const -> n8;
 
   //io.cpp
   auto vramAddress(n13 address) const -> n16;

--- a/ares/gb/ppu/timing.cpp
+++ b/ares/gb/ppu/timing.cpp
@@ -38,3 +38,34 @@ auto PPU::compareLYC() const -> bool {
 
   return lyc == ly;
 }
+
+auto PPU::getLY() const -> n8 {
+  auto ly  = status.ly;
+
+  if(Model::GameBoy() || Model::SuperGameBoy()) {
+    auto lx = status.lx >> 2;
+    if(ly == 153 && lx >= 1) return 0;
+  }
+
+  if(Model::GameBoyColor() && cpu.lowSpeed()) {
+    auto lx = status.lx >> 2;
+    if(ly != 153 && lx >= 113) {
+      static const n3 pattern[8] = {0, 0, 2, 0, 4, 4, 6, 0};
+      if(ly.bit(0,3) != 0xf) {
+        ly.bit(0,2) = pattern[ly.bit(0,2)];
+      } else {
+        ly.bit(0,3) = 0;
+        ly.bit(4,6) = pattern[ly.bit(4,6)];
+      }
+      return ly;
+    }
+    if(ly == 153 && lx >= 1) return 0;
+  }
+
+  if(Model::GameBoyColor() && cpu.highSpeed()) {
+    auto lx = status.lx >> 1;
+    if(ly == 153 && lx >= 6) return 0;
+  }
+
+  return ly;
+}


### PR DESCRIPTION
Previously, ares was emulating the coincidence flag in the the STAT
register with M-cycle accuracy but was much less accurate with the
timing of coincidence triggered STAT interrupts or with resetting the LY
register to 0 during vblank. This was breaking a pattern common to a
number of games that goes like this:

1) Write 0 to LYC and set the coincidence interrupt enable bit in STAT
2) In the STAT interrupt handler, read LY and increment by one
3) Loop until LY equals the incremented value

ares would trigger a STAT interrupt during line 153 but LY would
continue to read back as 153 instead of 0. A game incrementing this
value and waiting for it to appear in LY would become stuck in an
infinite loop, as there is no line 154.

This change brings M-cycle accuracy to the LY register and STAT
interrupts using "The Cycle-Accurate Game Boy Docs" by AntonioND as a
reference. It also stops resetting LY on write, as this erroneously
described behavior is not hardware accurate.

The following games should now be playable:
- Elite Soccer
- Mouse Trap Hotel
- Shantae