### PR TITLE
gb: only trigger STAT at start of OAM search

### DIFF
--- a/ares/gb/ppu/ppu.cpp
+++ b/ares/gb/ppu/ppu.cpp
@@ -162,7 +162,7 @@ auto PPU::stat() -> void {
 
   status.irq  = status.interruptHblank && status.mode == 0;
   status.irq |= status.interruptVblank && status.mode == 1;
-  status.irq |= status.interruptOAM    && status.mode == 2;
+  status.irq |= status.interruptOAM    && triggerOAM();
   status.irq |= status.interruptLYC    && compareLYC();
 
   if(!irq && status.irq) cpu.raise(CPU::Interrupt::Stat);

--- a/ares/gb/ppu/ppu.hpp
+++ b/ares/gb/ppu/ppu.hpp
@@ -43,6 +43,7 @@ struct PPU : Thread {
   auto canAccessOAM() const -> bool;
   auto compareLYC() const -> bool;
   auto getLY() const -> n8;
+  auto triggerOAM() const -> bool;
 
   //io.cpp
   auto vramAddress(n13 address) const -> n16;

--- a/ares/gb/ppu/timing.cpp
+++ b/ares/gb/ppu/timing.cpp
@@ -69,3 +69,9 @@ auto PPU::getLY() const -> n8 {
 
   return ly;
 }
+
+auto PPU::triggerOAM() const -> bool {
+  if(status.mode != 2) return 0;
+  auto lx = status.lx >> (cpu.status.speedDouble ? 1 : 2);
+  return lx == (status.ly == 0 ? 1 : 0);
+}


### PR DESCRIPTION
STAT interrupts triggered by mode 2 (OAM search) should only occur at the
start of the line. Crucially, writes to STAT in the midst of mode 2 that
enable OAM interrupts should not trigger a STAT interrupt. This is
especially important on DMG because of the hardware bug that causes STAT
writes to briefly enable all STAT interrupts. Spurious STAT interrupts
that would not have occurred on real hardware can violate the
assumptions of games that aren't expecting them. Mortal Kombat 3 is one
such game, and it is now playable.