### PR TITLE
gbc: invert HDMA5 bit 7 on read

### DIFF
--- a/ares/gb/cpu/io.cpp
+++ b/ares/gb/cpu/io.cpp
@@ -97,8 +97,8 @@ auto CPU::readIO(u32 cycle, n16 address, n8 data) -> n8 {
 
   if(Model::GameBoyColor())
   if(address == 0xff55 && cycle == 2) {  //HDMA5
-    data.bit(0,6) = status.dmaLength;
-    data.bit(7)   = status.hdmaActive;
+    data.bit(0,6) =  status.dmaLength;
+    data.bit(7)   = !status.hdmaActive;
     return data;
   }
 


### PR DESCRIPTION
A refactor in v116r07 replaced the variable dmaCompleted with dmaActive
but failed to update its usage on HDMA5 register reads. Bit 7 should
read 0 if HDMA is active and 1 if completed.

This change will affect many (most?) GBC games.