### PR TITLE
gb: bring fast boot closer to normal boot

### DIFF
--- a/ares/gb/system/system.cpp
+++ b/ares/gb/system/system.cpp
@@ -135,8 +135,12 @@ auto System::power(bool reset) -> void {
 
     if(fastBoot->latch()) {
       if(name == "boot.dmg-1.rom") {
-        bootROM.program(0x64, 0x18);
-        bootROM.program(0x65, 0x7a);
+        //skip the first 0x60 loop iterations (~4 seconds) and disable scrolling
+        bootROM.program(0x55, 0x26); //ld   h,$60 ; loop upcount   = 0x60
+        bootROM.program(0x56, 0x60);
+        bootROM.program(0x57, 0x16); //ld   d,$04 ; loop downcount = 0x04
+        bootROM.program(0x58, 0x04);
+        bootROM.program(0x88, 0x00); //nop        ; disable scroll
       }
       //todo: add fast boot patches for other boot ROMs
     }


### PR DESCRIPTION
The previous fast boot patch skipped the entire Nintendo logo animation
and sound. Unfortunately, this left a number of registers with different
values than they would otherwise have. The European release of the game
Dr. Franken does not initialize SCY, and fast boot was leaving it set to
100 instead of zero, causing the first logo to be shifted offscreen.

It would be easy enough to amend the patch to initialize SCY to 0, but
for most games this will cause the Nintendo logo to appear for a single
frame, which doesn't look so great.

This new patch skips the first ~4 seconds of the boot animation and
disables scrolling but otherwise leaves things alone. The result is a
a stationary Nintendo logo that appears centered on the screen,
accompanied by the usual sound, for ~1.5 seconds.