### PR TITLE
gb: use stable sort for sprites

### DIFF
--- a/ares/gb/ppu/dmg.cpp
+++ b/ares/gb/ppu/dmg.cpp
@@ -51,11 +51,7 @@ auto PPU::scanlineDMG() -> void {
   }
 
   //sort by X-coordinate
-  for(u32 lo = 0; lo < sprites; lo++) {
-    for(u32 hi = lo + 1; hi < sprites; hi++) {
-      if(sprite[hi].x < sprite[lo].x) swap(sprite[lo], sprite[hi]);
-    }
-  }
+  sort(sprite, sprites, [](auto l, auto r) { return l.x < r.x; });
 }
 
 auto PPU::runDMG() -> void {


### PR DESCRIPTION
On DMG, sprites are sorted by x value then by OAM address. As the sprite
array begins in OAM order, a stable sort on x can achieve the desired
result. Conveniently, nall already contains a stable sort implementation
that is optimized for small arrays.

This fixes ordering issues with speech bubbles in Crayon Shin-chan 3.