### PR TITLE
md: vdp dma & h-int fixes

### DIFF
--- a/ares/md/vdp/irq.cpp
+++ b/ares/md/vdp/irq.cpp
@@ -11,7 +11,7 @@ auto VDP::IRQ::poll() -> void {
     vdp.debugger.interrupt(CPU::Interrupt::HorizontalBlank);
     cpu.raise(CPU::Interrupt::HorizontalBlank);
   } else {
-    hblank.pending = 0;
+    // note: pending H-INT is not cleared when disabled
     cpu.lower(CPU::Interrupt::HorizontalBlank);
   }
 

--- a/ares/md/vdp/main.cpp
+++ b/ares/md/vdp/main.cpp
@@ -81,8 +81,7 @@ auto VDP::slot() -> void {
     state.refreshing = 0;
     return;
   }
-  if(fifo.run()) return;
-  if(prefetch.run()) return;
+  if(!fifo.run()) prefetch.run();
   dma.run();
 }
 


### PR DESCRIPTION
1) Allow VDP DMA to run at full speed
2) Avoid erroneous cancellation of H-INT

Fixes graphical issues in:
- Another World (E) #74
- 3 Ninjas Kick Back (U) #76
- Virtua Racing (U)
- Burning Force (U)
- TiTAN Overdrive 2 (E)