### PR TITLE
gb: remove limit on window width

### DIFF
--- a/ares/gb/ppu/cgb.cpp
+++ b/ares/gb/ppu/cgb.cpp
@@ -116,7 +116,6 @@ auto PPU::runWindowCGB() -> void {
   n8 scrollX = px + 7 - latch.wx;
   n3 tileX = scrollX & 7;
 
-  if(scrollX >= 160u) return;  //also matches underflow (scrollX < 0)
   if(tileX == 0 || px == 0) readTileCGB(status.windowTilemapSelect, scrollX, scrollY, window.tiledata, window.attributes);
 
   n2 index;

--- a/ares/gb/ppu/dmg.cpp
+++ b/ares/gb/ppu/dmg.cpp
@@ -106,7 +106,6 @@ auto PPU::runWindowDMG() -> void {
   n8 scrollX = px + 7 - latch.wx;
   n3 tileX = scrollX & 7;
 
-  if(scrollX >= 160u) return;  //also matches underflow (scrollX < 0)
   if(tileX == 0 || px == 0) readTileDMG(status.windowTilemapSelect, scrollX, scrollY, window.tiledata);
 
   n2 index;


### PR DESCRIPTION
I couldn't find any research to support this limit, nor does it match
the behavior of other emulators. Everything I could find indicates that
the window should be drawn to the end of the line.

This fixes the right edge of the pause screen in Heiankyo Alien.