### PR TITLE
gb: emulate serial transfers with no link

### DIFF
--- a/ares/gb/cpu/io.cpp
+++ b/ares/gb/cpu/io.cpp
@@ -49,8 +49,7 @@ auto CPU::readIO(u32 cycle, n16 address, n8 data) -> n8 {
   }
 
   if(address == 0xff01 && cycle == 2) {  //SB
-    //unemulated
-    return 0x00;
+    return status.serialData;
   }
 
   if(address == 0xff02 && cycle == 2) {  //SC

--- a/ares/gb/cpu/timing.cpp
+++ b/ares/gb/cpu/timing.cpp
@@ -54,6 +54,8 @@ auto CPU::timer16384hz() -> void {
 
 auto CPU::timer8192hz() -> void {
   if(status.serialTransfer && status.serialClock) {
+    status.serialData <<= 1;
+    status.serialData |= 1;
     if(--status.serialBits == 0) {
       status.serialTransfer = 0;
       raise(Interrupt::Serial);


### PR DESCRIPTION
When a serial transfer is started using the internal clock and no second
device is connected via link cable, 1 bits are shifted into the SB
register. This behavior must be emulated for the game Alleyway;
otherwise, it does not accept player input.