### PR TITLE
Creating support for Jaleco JF11/JF14 (Mapper 140)

### DIFF
--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -2,6 +2,7 @@ namespace Board {
 
 #include "bandai-fcg.cpp"
 #include "jaleco-jf.cpp"
+#include "jaleco-jf11-jf14.cpp"
 #include "konami-vrc1.cpp"
 #include "konami-vrc2.cpp"
 #include "konami-vrc3.cpp"
@@ -49,6 +50,7 @@ auto Interface::create(string board) -> Interface* {
   if(!p) p = HVC_UxROM::create(board);
   if(!p) p = IremTAMS1::create(board);
   if(!p) p = JalecoJF::create(board);
+  if(!p) p = Jaleco_JF11_JF14::create(board);
   if(!p) p = KonamiVRC1::create(board);
   if(!p) p = KonamiVRC2::create(board);
   if(!p) p = KonamiVRC3::create(board);

--- a/ares/fc/cartridge/board/jaleco-jf11-jf14.cpp
+++ b/ares/fc/cartridge/board/jaleco-jf11-jf14.cpp
@@ -1,0 +1,68 @@
+struct Jaleco_JF11_JF14 : Interface {
+  static auto create(string id) -> Interface* {
+    if(id == "JALECO-JF11-JF14") return new Jaleco_JF11_JF14;
+    return nullptr;
+  }
+
+  Memory::Readable<n8> programROM;
+  Memory::Writable<n8> programRAM;
+  Memory::Readable<n8> characterROM;
+  Memory::Writable<n8> characterRAM;
+
+  auto load() -> void override {
+    Interface::load(programROM, "program.rom");
+    Interface::load(characterROM, "character.rom");
+    Interface::load(characterRAM, "character.ram");
+    Interface::load(programRAM, "save.ram");
+    mirror = pak->attribute("mirror") == "vertical";
+  }
+
+  auto save() -> void override {
+    Interface::save(characterRAM, "character.ram");
+  }
+
+  auto readPRG(n32 address, n8 data) -> n8 override {
+    if(address < 0x8000) return data;
+    return programROM.read(programBank << 15 | (n15)address);
+  }
+
+  auto writePRG(n32 address, n8 data) -> void override {
+    if(address < 0x6000 || address > 0x7fff) return;
+    characterBank = data.bit(0,1);
+    programBank = data.bit(4,5);
+  }
+
+  auto readCHR(n32 address, n8 data) -> n8 override {
+    if(address & 0x2000) {
+      address = address >> !mirror & 0x0400 | (n10)address;
+      return ppu.readCIRAM(address);
+    }
+    address = characterBank << 13 | (n13)address;
+    if(characterROM) return characterROM.read(address);
+    if(characterRAM) return characterRAM.read(address);
+    return data;
+  }
+
+  auto writeCHR(n32 address, n8 data) -> void override {
+    if(address & 0x2000) {
+      address = address >> !mirror & 0x0400 | (n10)address;
+      return ppu.writeCIRAM(address, data);
+    }
+    address = characterBank << 13 | (n13)address;
+    if(characterRAM) return characterRAM.write(address, data);
+  }
+
+  auto power() -> void override {
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(characterRAM);
+    s(mirror);
+    s(programBank);
+    s(characterBank);
+  }
+
+  n1 mirror;  //0 = horizontal, 1 = vertical
+  n2 programBank;
+  n2 characterBank;
+};

--- a/ares/fc/cartridge/board/jaleco-jf11-jf14.cpp
+++ b/ares/fc/cartridge/board/jaleco-jf11-jf14.cpp
@@ -39,7 +39,6 @@ struct Jaleco_JF11_JF14 : Interface {
       address = address >> !mirror & 0x0400 | (n10)address;
       return ppu.writeCIRAM(address, data);
     }
-    address = characterBank << 13 | (n13)address;
   }
 
   auto power() -> void override {

--- a/ares/fc/cartridge/board/jaleco-jf11-jf14.cpp
+++ b/ares/fc/cartridge/board/jaleco-jf11-jf14.cpp
@@ -7,18 +7,12 @@ struct Jaleco_JF11_JF14 : Interface {
   Memory::Readable<n8> programROM;
   Memory::Writable<n8> programRAM;
   Memory::Readable<n8> characterROM;
-  Memory::Writable<n8> characterRAM;
 
   auto load() -> void override {
     Interface::load(programROM, "program.rom");
-    Interface::load(characterROM, "character.rom");
-    Interface::load(characterRAM, "character.ram");
     Interface::load(programRAM, "save.ram");
+    Interface::load(characterROM, "character.rom");
     mirror = pak->attribute("mirror") == "vertical";
-  }
-
-  auto save() -> void override {
-    Interface::save(characterRAM, "character.ram");
   }
 
   auto readPRG(n32 address, n8 data) -> n8 override {
@@ -39,7 +33,6 @@ struct Jaleco_JF11_JF14 : Interface {
     }
     address = characterBank << 13 | (n13)address;
     if(characterROM) return characterROM.read(address);
-    if(characterRAM) return characterRAM.read(address);
     return data;
   }
 
@@ -49,14 +42,12 @@ struct Jaleco_JF11_JF14 : Interface {
       return ppu.writeCIRAM(address, data);
     }
     address = characterBank << 13 | (n13)address;
-    if(characterRAM) return characterRAM.write(address, data);
   }
 
   auto power() -> void override {
   }
 
   auto serialize(serializer& s) -> void override {
-    s(characterRAM);
     s(mirror);
     s(programBank);
     s(characterBank);

--- a/ares/fc/cartridge/board/jaleco-jf11-jf14.cpp
+++ b/ares/fc/cartridge/board/jaleco-jf11-jf14.cpp
@@ -5,12 +5,10 @@ struct Jaleco_JF11_JF14 : Interface {
   }
 
   Memory::Readable<n8> programROM;
-  Memory::Writable<n8> programRAM;
   Memory::Readable<n8> characterROM;
 
   auto load() -> void override {
     Interface::load(programROM, "program.rom");
-    Interface::load(programRAM, "save.ram");
     Interface::load(characterROM, "character.rom");
     mirror = pak->attribute("mirror") == "vertical";
   }

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -297,7 +297,7 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
     prgram = 8192;
     break;
-
+    
   case  75:
     s += "  board:  KONAMI-VRC-1\n";
     s += "    chip type=VRC1\n";
@@ -320,6 +320,11 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
 
   case  97:
     s += "  board:  IREM-TAM-S1\n";
+    break;
+
+  case  140:
+    s += "  board:  JALECO-JF11-JF14\n";
+    s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
     break;
 
   case 159:


### PR DESCRIPTION
Now the following games are supported in ares:

* Youkai Club: https://youtu.be/ol3mdaTrao8
* Mississippi Satsujin Jiken: https://youtu.be/9zmvD8aFvhE
* Bio Senshi Dan - Increaser Tono Tatakai: https://youtu.be/eiSniHKkfLI

There's a few graphical errors in _Bio Senshi Dan - Increaser Tono Tatakai_ (eg.: the title screen), but I'm unsure it's mapper related.