### PR TITLE
md: fix sprites and dma fills

### DIFF
--- a/ares/ares/ares.hpp
+++ b/ares/ares/ares.hpp
@@ -46,7 +46,7 @@ namespace ares {
 
   //incremented only when serialization format changes
   static const u32    SerializerSignature = 0x31545342;  //"BST1" (little-endian)
-  static const string SerializerVersion   = "121";
+  static const string SerializerVersion   = "123";
 
   namespace VFS {
     using Pak = shared_pointer<vfs::directory>;

--- a/ares/md/vdp/dma.cpp
+++ b/ares/md/vdp/dma.cpp
@@ -33,7 +33,7 @@ auto VDP::DMA::load() -> void {
 }
 
 auto VDP::DMA::fill() -> void {
-  auto data = vdp.fifo.slots[3].data;
+  auto data = vdp.fifo.slots[0].data;
   switch(vdp.command.target) {
   case 1: vdp.vram.writeByte(vdp.command.address, data >> 8); break;
   case 3: vdp.cram.write(vdp.command.address, data); break;

--- a/ares/md/vdp/io.cpp
+++ b/ares/md/vdp/io.cpp
@@ -140,7 +140,6 @@ auto VDP::writeDataPort(n16 data) -> void {
   command.latch = 0;
   command.ready = 1;
 
-  if(dma.mode == 2) dma.wait = 0;
   fifo.write(command.target, command.address, data);
   command.address += command.increment;
 }

--- a/ares/md/vdp/serialization.cpp
+++ b/ares/md/vdp/serialization.cpp
@@ -161,11 +161,11 @@ auto VDP::Sprite::serialize(serializer& s) -> void {
   s(cache);
   s(mappings);
   s(mappingCount);
-  s(patternX);
+  s(maskCheck);
+  s(maskActive);
   s(patternIndex);
   s(patternSlice);
   s(patternCount);
-  s(patternStop);
   s(visible);
   s(visibleLink);
   s(visibleCount);

--- a/ares/md/vdp/vdp.hpp
+++ b/ares/md/vdp/vdp.hpp
@@ -301,8 +301,8 @@ struct VDP : Thread {
     VDP& vdp;
 
     //the per-scanline sprite limits are different between H40 and H32 modes
-    auto objectLimit() const -> u32 { return vdp.latch.displayWidth ? 20 : 16; }
-    auto tileLimit()   const -> u32 { return vdp.latch.displayWidth ? 40 : 32; }
+    auto lineObjectLimit()  const -> u32 { return vdp.latch.displayWidth ? 20 : 16; }
+    auto frameObjectLimit() const -> u32 { return vdp.latch.displayWidth ? 80 : 64; }
 
     //sprite.cpp
     auto write(n16 address, n16 data) -> void;
@@ -346,15 +346,15 @@ struct VDP : Thread {
       n1  priority;
       n9  x;
     };
-    Mapping mappings[20];
+    Mapping mappings[21];
 
     n8  mappingCount;
 
-    n9  patternX;
+    n1  maskCheck;
+    n1  maskActive;
     n8  patternIndex;
     n8  patternSlice;
     n8  patternCount;
-    n1  patternStop;
 
     n7  visible[20];
     n8  visibleLink;


### PR DESCRIPTION
1) Corrects sprite processing per the test cases of the Sprite Masking and Overflow Test ROM by Nemesis.
This fixes sprite rendering in Mickey Mania's Moose Chase level.

2) Adjusts the DMA fill / FIFO interaction (regression from #97).
This fixes graphical errors seen in #104 (multiple games).