### PR TITLE
ruby: fix conflated keys on Windows

### DIFF
--- a/ruby/input/keyboard/rawinput.cpp
+++ b/ruby/input/keyboard/rawinput.cpp
@@ -21,8 +21,8 @@ struct InputKeyboardRawInput {
     u32 flag = input->data.keyboard.Flags;
 
     for(auto& key : keys) {
-      if(key.code != code) continue;
-      key.value = (key.flag == flag);
+      if(key.code != code || key.flag != (flag & ~1)) continue;
+      key.value = ~flag & 1;
     }
   }
 


### PR DESCRIPTION
The flags returned by the Raw Input API have distinct meanings. The
lowest bit reflects the state of the key and the next two bits indicate
scan code prefixes. An oversimplified interpretation of these flags was
causing ruby to conflate events for keys that differ only by prefix.

Reference:
https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-rawkeyboard

The full set of conflated key pairs:
Return Enter
Keypad0 Insert
Keypad1 End
Keypad2 Down
Keypad3 PageDown
Keypad4 Left
Keypad6 Right
Keypad7 Home
Keypad8 Up
Keypad9 PageUp
LeftAlt RightAlt
LeftControl RightControl
Multiply PrintScreen
Point Delete
Slash Divide