### PR TITLE
Workaround for Github issue: https://github.com/higan-emu/ares/issues/61

### DIFF
--- a/ares/n64/pi/pi.cpp
+++ b/ares/n64/pi/pi.cpp
@@ -41,15 +41,22 @@ auto PI::power(bool reset) -> void {
   //d18    = osVersion
   //d19    = osRomType (0 = Gamepak; 1 = 64DD)
   string cic = cartridge.cic();
-  if(reset == 0) {
+
+  //FIXME: https://github.com/higan-emu/ares/issues/61
+  //This is currently a workaround to get both Battletanx (U) games to boot. PIF RAM offset 0x24 is where IPL2 reads a bunch of status information from the PIF. 
+  //"adding" 0x20000 is the same as setting bit 17. This bit is a flag that states whether the console is starting from cold boot, or NMI (a "soft" reset). 0=cold reset. 1=NMI.
+  //Additionally, similar to other bits of data from this word, this particular bit is shifted into the bit 0 position, and stored in CPU register s5 for possible use in IPL3 
+  //or further game code. Unfortunately the boot process is currently not well understood. This is likely masking an initialization error when powering on from a cold boot 
+  //within the emulator. If this issue is identified and addressed, then we should check and make use of the reset flag properly here (remove the comment from the next line). 
+  if(/*reset == */0) {
     if(cic == "CIC-NUS-6101" || cic == "CIC-NUS-7102") ram.write<Word>(0x24, 0x00043f3f);
     if(cic == "CIC-NUS-6102" || cic == "CIC-NUS-7101") ram.write<Word>(0x24, 0x00003f3f);
     if(cic == "CIC-NUS-6103" || cic == "CIC-NUS-7103") ram.write<Word>(0x24, 0x0000783f);
     if(cic == "CIC-NUS-6105" || cic == "CIC-NUS-7105") ram.write<Word>(0x24, 0x0000913f);
     if(cic == "CIC-NUS-6106" || cic == "CIC-NUS-7106") ram.write<Word>(0x24, 0x0000853f);
   }
-
-  if(reset == 1) {
+  else
+  {
     if(cic == "CIC-NUS-6101" || cic == "CIC-NUS-7102") ram.write<Word>(0x24, 0x00063f3f);
     if(cic == "CIC-NUS-6102" || cic == "CIC-NUS-7101") ram.write<Word>(0x24, 0x00023f3f);
     if(cic == "CIC-NUS-6103" || cic == "CIC-NUS-7103") ram.write<Word>(0x24, 0x0002783f);


### PR DESCRIPTION
This is a workaround to address issues with playing Battletanx (U) & Battletanx - Global Assault (U) in this emulator. This will allow everyone to play these two games until the boot process is better understood and we better understand what is missing that prevents these games from booting. Extensive testing has been performed against the entire N64 USA rom set to make sure this doesn't negatively impact any other games.

Again, this is just a workaround which has been discussed on discord, with comments to indicate this should be updated once we have a better understanding of the overall boot process and identify what is missing here. For now, end users will just be able to enjoy these games.