### PR TITLE
n64: consume cycles to compensate for skipped RDRAM initialization

### DIFF
--- a/ares/n64/ri/io.cpp
+++ b/ares/n64/ri/io.cpp
@@ -20,6 +20,18 @@ auto RI::readWord(u32 address) -> u32 {
   if(address == 3) {
     //RI_SELECT
     data = io.select;
+    if constexpr(!Accuracy::RDRAM::Broadcasting) {
+      //this register is read by IPL3 to check if RDRAM initialization should be
+      //skipped. if we are forcing it to be skipped, we should also consume
+      //enough cycles to not inadvertently speed up the boot process.
+      //Wave Race 64 Shindou Pak Taiou Version will freeze on the N64 logo if
+      //the SCC count register, which increments at half the CPU clock rate, has
+      //too small a value.
+      //after a cold boot on real hardware with no expansion pak and using the
+      //CIC-NUS-6102 IPL3, upon reaching the test ROM's entry point the count
+      //register was measured to be ~0x1184000.
+      cpu.step(17'641'000);
+    }
   }
 
   if(address == 4) {


### PR DESCRIPTION
The RI_SELECT register is read by IPL3 to check if RDRAM initialization
should be skipped. If we are forcing it to be skipped, we should also
consume enough cycles to not inadvertently speed up the boot process.

Wave Race 64 Shindou Pak Taiou Version will freeze on the N64 logo if
the SCC count register, which increments at half the CPU clock rate, has
too small a value.

The idea of using RI_SELECT reads as a cue to consume extra cycles was
borrowed from MAME.

Thanks to @rasky for measuring the timing on real hardware.