### PR TITLE
add detection for shindou editions & correct N64 gamepad detection

### DIFF
--- a/ares/n64/si/si.cpp
+++ b/ares/n64/si/si.cpp
@@ -148,7 +148,7 @@ auto SI::scan() -> void {
     //status
     if(input[0] == 0x00 || input[0] == 0xff) {
       //controller
-      if(channel < 4) {
+      if(channel < 4 && controllers[channel]->device) {
         output[0] = 0x05;  //0x05 = gamepad; 0x02 = mouse
         output[1] = 0x00;
         output[2] = 0x02;  //0x02 = nothing present in controller slot

--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -561,6 +561,10 @@ auto Nintendo64::analyze(vector<u8>& data) -> string {
   if(id == "NWO") {mempak = true; rumble = true;}                        //World Driver Championship
   if(id == "NXF") {mempak = true; rumble = true;}                        //Xena Warrior Princess - The Talisman of Fate
 
+  //Special case for Shindou editions of Super Mario 64 & Wave Race 64
+  if(id == "NSM" && region_code == 'J' && revision == 3) {rumble = true;} //Super Mario 64: Shindou Edition (Rev 3)
+  if(id == "NWR" && region_code == 'J' && revision == 2) {rumble = true;} //Wave Race 64: Kawasaki Jet Ski Shindou Edition (Rev 2)
+
   //Rumble
   if(id == "NJQ") {rumble = true;}                                       //Batman - Return of the Joker
   if(id == "NCB") {rumble = true;}                                       //Charlie Blast's Territory


### PR DESCRIPTION
Add detection in mia for shindou editions of super mario 64 & wave race 64 which added rumble support

Also only report N64 gamepads that are actually connected