### PR TITLE
n64: fix PIF RAM init on cold boot, preserve RDRAM on warm reset

### DIFF
--- a/ares/n64/pi/pi.cpp
+++ b/ares/n64/pi/pi.cpp
@@ -35,34 +35,22 @@ auto PI::power(bool reset) -> void {
   bsd2 = {};
 
   //write CIC seeds into PIF RAM so that cartridge checksum function passes
-  //d0-d7  = CIC IPL2 seed
-  //d8-d15 = CIC IPL3 seed
-  //d17    = osResetType (0 = power; 1 = reset (NMI))
-  //d18    = osVersion
-  //d19    = osRomType (0 = Gamepak; 1 = 64DD)
   string cic = cartridge.cic();
+  n8 seed = 0x3f;
+  n1 version = 0;
+  if(cic == "CIC-NUS-6101" || cic == "CIC-NUS-7102") seed = 0x3f, version = 1;
+  if(cic == "CIC-NUS-6102" || cic == "CIC-NUS-7101") seed = 0x3f;
+  if(cic == "CIC-NUS-6103" || cic == "CIC-NUS-7103") seed = 0x78;
+  if(cic == "CIC-NUS-6105" || cic == "CIC-NUS-7105") seed = 0x91;
+  if(cic == "CIC-NUS-6106" || cic == "CIC-NUS-7106") seed = 0x85;
 
-  //FIXME: https://github.com/higan-emu/ares/issues/61
-  //This is currently a workaround to get both Battletanx (U) games to boot. PIF RAM offset 0x24 is where IPL2 reads a bunch of status information from the PIF. 
-  //"adding" 0x20000 is the same as setting bit 17. This bit is a flag that states whether the console is starting from cold boot, or NMI (a "soft" reset). 0=cold reset. 1=NMI.
-  //Additionally, similar to other bits of data from this word, this particular bit is shifted into the bit 0 position, and stored in CPU register s5 for possible use in IPL3 
-  //or further game code. Unfortunately the boot process is currently not well understood. This is likely masking an initialization error when powering on from a cold boot 
-  //within the emulator. If this issue is identified and addressed, then we should check and make use of the reset flag properly here (remove the comment from the next line). 
-  if(/*reset == */0) {
-    if(cic == "CIC-NUS-6101" || cic == "CIC-NUS-7102") ram.write<Word>(0x24, 0x00043f3f);
-    if(cic == "CIC-NUS-6102" || cic == "CIC-NUS-7101") ram.write<Word>(0x24, 0x00003f3f);
-    if(cic == "CIC-NUS-6103" || cic == "CIC-NUS-7103") ram.write<Word>(0x24, 0x0000783f);
-    if(cic == "CIC-NUS-6105" || cic == "CIC-NUS-7105") ram.write<Word>(0x24, 0x0000913f);
-    if(cic == "CIC-NUS-6106" || cic == "CIC-NUS-7106") ram.write<Word>(0x24, 0x0000853f);
-  }
-  else
-  {
-    if(cic == "CIC-NUS-6101" || cic == "CIC-NUS-7102") ram.write<Word>(0x24, 0x00063f3f);
-    if(cic == "CIC-NUS-6102" || cic == "CIC-NUS-7101") ram.write<Word>(0x24, 0x00023f3f);
-    if(cic == "CIC-NUS-6103" || cic == "CIC-NUS-7103") ram.write<Word>(0x24, 0x0002783f);
-    if(cic == "CIC-NUS-6105" || cic == "CIC-NUS-7105") ram.write<Word>(0x24, 0x0002913f);
-    if(cic == "CIC-NUS-6106" || cic == "CIC-NUS-7106") ram.write<Word>(0x24, 0x0002853f);
-  }
+  n32 data;
+  data.bit(0, 7) = 0x3f;     //CIC IPL2 seed
+  data.bit(8,15) = seed;     //CIC IPL3 seed
+  data.bit(17)   = reset;    //osResetType (0 = power; 1 = reset (NMI))
+  data.bit(18)   = version;  //osVersion
+  data.bit(19)   = 0;        //osRomType (0 = Gamepak; 1 = 64DD)
+  ram.write<Word>(0x24, data);
 }
 
 }

--- a/ares/n64/rdram/rdram.cpp
+++ b/ares/n64/rdram/rdram.cpp
@@ -24,8 +24,10 @@ auto RDRAM::unload() -> void {
 }
 
 auto RDRAM::power(bool reset) -> void {
-  ram.fill();
-  for(auto& chip : chips) chip = {};
+  if(!reset) {
+    ram.fill();
+    for(auto& chip : chips) chip = {};
+  }
 }
 
 }


### PR DESCRIPTION
A recent workaround for BattleTanx caused a regression in Perfect Dark.
Essentially, it was always telling games that they had been started by a
warm reset rather than a cold boot. Perfect Dark expects data to be
preserved in RDRAM across resets and fails to get as far as drawing
something on the screen if it isn't there.

This change reverts the workaround so that Perfect Dark will perform the
full initialization required after a cold boot. Luckily, this will not
regress the BattleTanx games, as they were fixed by my last change
(making sure IPL3 consumes a sufficient number of cycles). This change
also skips clearing RDRAM on resets, which is again required by Perfect
Dark and possibly other games.