### PR TITLE
n64: default to 3 controllers for Jeopardy!

### DIFF
--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -60,55 +60,25 @@ auto Nintendo64::load() -> bool {
     port->connect();
   }
 
-  string rumble = game->pak->attribute("rumble"); 
-  if(auto port = root->find<ares::Node::Port>("Controller Port 1")) {
-    auto peripheral = port->allocate("Gamepad");
-    port->connect();
-    if(auto port = peripheral->find<ares::Node::Port>("Pak")) { 
-      if(game->pak->attribute("mempak") == "yes")
-      {
-        gamepad = mia::Pak::create("Nintendo 64");
-        gamepad->pak->append("save.pak", 32_KiB);
-        gamepad->load("save.pak", ".pak", game->location);
-        port->allocate("Controller Pak");
-        port->connect();
-      } else if(rumble == "yes") {
-        gamepad.reset();
-        port->allocate("Rumble Pak");
-        port->connect();
-      }
-    }
-  }
+  auto controllers = 4;
+  //Jeopardy! does not accept any input if > 3 controllers are plugged in at boot.
+  if(game->pak->attribute("id") == "NJOE") controllers = min(controllers, 3);
 
-  if(auto port = root->find<ares::Node::Port>("Controller Port 2")) {
-    auto peripheral = port->allocate("Gamepad");
-    port->connect();
-    if(auto port = peripheral->find<ares::Node::Port>("Pak")) {
-      if(rumble == "yes") {
-        port->allocate("Rumble Pak");
-        port->connect();
-      }
-    }
-  }
-
-  if(auto port = root->find<ares::Node::Port>("Controller Port 3")) {
-    auto peripheral = port->allocate("Gamepad");
-    port->connect();
-    if(auto port = peripheral->find<ares::Node::Port>("Pak")) {
-      if(rumble == "yes") {
-        port->allocate("Rumble Pak");
-        port->connect();
-      }
-    }
-  }
-
-  if(auto port = root->find<ares::Node::Port>("Controller Port 4")) {
-    auto peripheral = port->allocate("Gamepad");
-    port->connect();
-    if(auto port = peripheral->find<ares::Node::Port>("Pak")) {
-      if(rumble == "yes") {
-        port->allocate("Rumble Pak");
-        port->connect();
+  for(auto id : range(controllers)) {
+    if(auto port = root->find<ares::Node::Port>({"Controller Port ", 1 + id})) {
+      auto peripheral = port->allocate("Gamepad");
+      port->connect();
+      if(auto port = peripheral->find<ares::Node::Port>("Pak")) {
+        if(id == 0 && game->pak->attribute("mempak").boolean()) {
+          gamepad = mia::Pak::create("Nintendo 64");
+          gamepad->pak->append("save.pak", 32_KiB);
+          gamepad->load("save.pak", ".pak", game->location);
+          port->allocate("Controller Pak");
+          port->connect();
+        } else if(game->pak->attribute("rumble").boolean()) {
+          port->allocate("Rumble Pak");
+          port->connect();
+        }
       }
     }
   }

--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -21,10 +21,11 @@ auto Nintendo64::load(string location) -> bool {
   if(!document) return false;
 
   pak = new vfs::directory;
+  pak->setAttribute("id",     document["game/id"].string());
   pak->setAttribute("title",  document["game/title"].string());
   pak->setAttribute("region", document["game/region"].string());
-  pak->setAttribute("mempak", document["game/mempak"].string());
-  pak->setAttribute("rumble", document["game/rumble"].string());
+  pak->setAttribute("mempak", (bool)document["game/mempak"]);
+  pak->setAttribute("rumble", (bool)document["game/rumble"]);
   pak->setAttribute("cic",    document["game/board/cic"].string());
   pak->append("manifest.bml", manifest);
   pak->append("program.rom",  rom);
@@ -583,8 +584,10 @@ auto Nintendo64::analyze(vector<u8>& data) -> string {
   s +={"  title:    ", Medium::name(location), "\n"};
   s +={"  region:   ", region, "\n"};
   s +={"  id:       ", id, region_code, "\n"};
-  s +={"  mempak:   ", mempak ? "yes" : "no", "\n"};
-  s +={"  rumble:   ", rumble ? "yes" : "no", "\n"};
+  if(mempak)
+  s += "  mempak\n";
+  if(rumble)
+  s += "  rumble\n";
   if(revision < 4) {
   s +={"  revision: 1.", revision, "\n"};
   }


### PR DESCRIPTION
Jeopardy! only supports up to 3 players, and if four controllers are
plugged in when the game starts, it performs an out of bounds array
access that breaks further input logic. The only workaround is to unplug
a controller and reset the system. To make this game work well in ares
out of the box, we should connect no more than 3 controllers by default.

I opted to put a check specifically in desktop-ui because this is
fundamentally a mismatch between a specific game and a design choice (to
default to 4 controllers) in the desktop-ui frontend. It didn't feel
right to add a dedicated attribute to mia that did not describe a
feature of the cartridge itself and would not be generally applicable
other games (unlike rumble and memory pak support).

This change also brings the rumble and memory pak attributes in line
with the implementation of boolean attributes for other systems. There
is no functional change, though it will affect generated manifests if
they are/were persisted to disk.