### PR TITLE
n64: decrease SI DMA delay

### DIFF
--- a/ares/n64/si/io.cpp
+++ b/ares/n64/si/io.cpp
@@ -57,7 +57,7 @@ auto SI::writeWord(u32 address, u32 data_) -> void {
     //SI_PIF_ADDRESS_READ64B
     io.readAddress = data.bit(0,31) & ~1;
     io.dmaBusy = 1;
-    queue.insert(Queue::SI_DMA_Read, 131072);
+    queue.insert(Queue::SI_DMA_Read, 2304);
   }
 
   if(address == 2) {
@@ -72,7 +72,7 @@ auto SI::writeWord(u32 address, u32 data_) -> void {
     //SI_PIF_ADDRESS_WRITE64B
     io.writeAddress = data.bit(0,31) & ~1;
     io.dmaBusy = 1;
-    queue.insert(Queue::SI_DMA_Write, 131072);
+    queue.insert(Queue::SI_DMA_Write, 2304);
   }
 
   if(address == 5) {


### PR DESCRIPTION
Reduce the (minimum) number of cycles between an SI DMA request and the
completion of said request from 131072 to 2304 cycles. This is the
duration used in other emulators, and it is in agreement with the
observed behavior of Turok, which can only tolerate a delay between 215
and 3888 cycles (subject to current timings in ares).

In addition to fixing input in Turok - Dinosaur Hunter, this change gets
the following games past the intro:
- Donkey Kong 64 (w/ major graphical issues)
- Forsaken 64
- Hercules - The Legendary Journeys
- Triple Play 2000