### PR TITLE
md: various fixes, mostly vdp related

### DIFF
--- a/ares/ares/ares.hpp
+++ b/ares/ares/ares.hpp
@@ -46,7 +46,7 @@ namespace ares {
 
   //incremented only when serialization format changes
   static const u32    SerializerSignature = 0x31545342;  //"BST1" (little-endian)
-  static const string SerializerVersion   = "123";
+  static const string SerializerVersion   = "123.1";
 
   namespace VFS {
     using Pak = shared_pointer<vfs::directory>;

--- a/ares/component/processor/m68000/instruction.cpp
+++ b/ares/component/processor/m68000/instruction.cpp
@@ -1,6 +1,10 @@
 auto M68000::instruction() -> void {
-  r.ird = r.ir;
-  return instructionTable[r.ird]();
+  if(!r.stop) {
+    r.ird = r.ir;
+    return instructionTable[r.ird]();
+  } else {
+     wait(1);
+  }
 }
 
 M68000::M68000() {

--- a/ares/component/processor/m68000/m68000.cpp
+++ b/ares/component/processor/m68000/m68000.cpp
@@ -49,6 +49,7 @@ auto M68000::supervisor() -> bool {
 }
 
 auto M68000::exception(u32 exception, u32 vector, u32 priority) -> void {
+  r.stop  = false;
   idle(10);  //todo: not accurate
 
   auto pc = r.pc;

--- a/ares/md/vdp/dma.cpp
+++ b/ares/md/vdp/dma.cpp
@@ -35,7 +35,7 @@ auto VDP::DMA::load() -> void {
 auto VDP::DMA::fill() -> void {
   auto data = vdp.fifo.slots[0].data;
   switch(vdp.command.target) {
-  case 1: vdp.vram.writeByte(vdp.command.address, data >> 8); break;
+  case 1: vdp.vram.writeByte(vdp.command.address ^ 1, data >> 8); break;
   case 3: vdp.cram.write(vdp.command.address, data); break;
   case 5: vdp.vsram.write(vdp.command.address, data); break;
   }
@@ -53,13 +53,13 @@ auto VDP::DMA::fill() -> void {
 auto VDP::DMA::copy() -> void {
   if(!read) {
     read = 1;
-    data = vdp.vram.readByte(source);
+    data = vdp.vram.readByte(source ^ 1);
     return;
   }
 
   read = 0;
-  vdp.vram.writeByte(vdp.command.address, data);
-  vdp.debugger.dmaCopy(source, vdp.command.target, vdp.command.address, data);
+  vdp.vram.writeByte(vdp.command.address ^ 1, data);
+  vdp.debugger.dmaCopy(source, vdp.command.target, vdp.command.address ^ 1, data);
 
   source.bit(0,15)++;
   vdp.command.address += vdp.command.increment;

--- a/ares/md/vdp/fifo.cpp
+++ b/ares/md/vdp/fifo.cpp
@@ -10,12 +10,12 @@ auto VDP::FIFO::run() -> bool {
   if(slots[0].target == 1 && vdp.vram.mode == 0) {
     if(slots[0].lower) {
       slots[0].lower = 0;
-      vdp.vram.writeByte(slots[0].address & ~1 | 1, slots[0].data.byte(0));
+      vdp.vram.writeByte(slots[0].address ^ 1, slots[0].data.byte(0));
       return true;
     }
     if(slots[0].upper) {
       slots[0].upper = 0;
-      vdp.vram.writeByte(slots[0].address & ~1 | 0, slots[0].data.byte(1));
+      vdp.vram.writeByte(slots[0].address, slots[0].data.byte(1));
       if(vdp.command.pending && vdp.dma.mode == 2 && vdp.dma.wait) {
         vdp.dma.wait = 0;   // start pending DMA fill (do not advance fifo)
       } else {
@@ -65,8 +65,8 @@ auto VDP::FIFO::run() -> bool {
 
   slots[0].lower = 0;
   slots[0].upper = 0;
-  debug(unusual, "[VDP::FIFO] write target = 0x", hex(slots[0].target));
-  cpu.debugger.interrupt({"VDP FIFO ", hex(slots[0].target)});
+  //debug(unusual, "[VDP::FIFO] write target = 0x", hex(slots[0].target));
+  //cpu.debugger.interrupt({"VDP FIFO ", hex(slots[0].target)});
   return advance(), true;
 }
 
@@ -79,10 +79,6 @@ auto VDP::FIFO::write(n4 target, n17 address, n16 data) -> void {
       if(apu.active()) apu.step(1);
     }
     bus.release(Bus::VDPFIFO);
-  }
-
-  if(address.bit(0) && target == 1) {
-    data = data << 8 | data >> 8;
   }
 
   for(auto& slot : slots) {

--- a/ares/md/vdp/io.cpp
+++ b/ares/md/vdp/io.cpp
@@ -13,6 +13,7 @@ auto VDP::read(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
 
   //counters
   case 0xc00008 ... 0xc0000f: {
+    if(io.counterLatch) return state.counterLatchValue;
     auto vcounter = state.vcounter;
     if(io.interlaceMode.bit(0)) {
       if(io.interlaceMode.bit(1)) vcounter <<= 1;
@@ -207,6 +208,7 @@ auto VDP::writeControlPort(n16 data) -> void {
   //mode register 1
   case 0x00: {
     io.displayOverlayEnable  = data.bit(0);
+    if(!io.counterLatch && data.bit(1)) state.counterLatchValue = read(1,1,0xC00008,0);
     io.counterLatch          = data.bit(1);
     io.videoMode4            = data.bit(2);
     irq.hblank.enable        = data.bit(4);

--- a/ares/md/vdp/io.cpp
+++ b/ares/md/vdp/io.cpp
@@ -180,23 +180,21 @@ auto VDP::writeControlPort(n16 data) -> void {
     command.address.bit(14,16) = data.bit(0,2);
     command.target.bit(2,3)    = data.bit(4,5);
     command.ready              = data.bit(6) | command.target.bit(0);
-    command.pending            = data.bit(7) & dma.enable;
+    command.pending           |= data.bit(7) & dma.enable;
 
-    if(prefetch.full()) {
-      prefetch.read(command.target, command.address);
-    }
+    prefetch.read(command.target, command.address);
 
     dma.wait = dma.mode == 2;
     dma.synchronize();
     return;
   }
 
-  command.address.bit(0,13) = data.bit(0,13);
   command.target.bit(0,1)   = data.bit(14,15);
   command.ready             = 1;
 
   //command write (hi)
   if(data.bit(14,15) != 2) {
+    command.address.bit(0,13) = data.bit(0,13);
     command.latch = 1;
     return;
   }

--- a/ares/md/vdp/serialization.cpp
+++ b/ares/md/vdp/serialization.cpp
@@ -47,6 +47,7 @@ auto VDP::serialize(serializer& s) -> void {
   s(latch.displayWidth);
   s(latch.clockSelect);
 
+  s(state.counterLatchValue);
   s(state.hcounter);
   s(state.vcounter);
   s(state.field);

--- a/ares/md/vdp/vdp.hpp
+++ b/ares/md/vdp/vdp.hpp
@@ -487,6 +487,7 @@ private:
   } latch;
 
   struct State {
+    n16 counterLatchValue;
     n8 hcounter;
     n9 vcounter;
     n1 field;

--- a/ares/md/vdp/vdp.hpp
+++ b/ares/md/vdp/vdp.hpp
@@ -200,7 +200,7 @@ struct VDP : Thread {
     n2  mode;
     n22 source;
     n16 length;
-    n8  data;
+    n16 data;
     n1  wait;
     n1  read;
     n1  enable;


### PR DESCRIPTION
1. Fix VRAM byte write order (errors due to odd address access). [fixed: #45, #116]
2. Maintain correct VDP state in certain situations when writing to the control port.
3. Reimplement DMA fills according to VDP research by Nemesis. This includes the undocumented fills to CRAM and VSRAM which are sourced from arbitrary FIFO data.
4. Implement HV-counter latch functionality.
5. Implement functionality of the M68k STOP instruction. [fixed: #109]