### PR TITLE
debugger: fix address masking in instruction tracer

### DIFF
--- a/ares/ares/node/debugger/tracer/instruction.hpp
+++ b/ares/ares/node/debugger/tracer/instruction.hpp
@@ -28,7 +28,7 @@ struct Instruction : Tracer {
   }
 
   auto address(u32 address) -> bool {
-    address &= (1u << _addressBits) - 1;  //mask upper bits of address
+    address &= (1ull << _addressBits) - 1;  //mask upper bits of address
     _address = address;
     address >>= _addressMask;  //clip unneeded alignment bits (to reduce _masks size)
 
@@ -57,7 +57,7 @@ struct Instruction : Tracer {
   //call when writing to executable RAM to support self-modifying code.
   auto invalidate(u32 address) -> void {
     if(unlikely(_mask && updateMasks())) {
-      address &= (1u << _addressBits) - 1;
+      address &= (1ull << _addressBits) - 1;
       address >>= _addressMask;
       _masks[address >> 3] &= ~(1 << (address & 7));
     }


### PR DESCRIPTION
This change corrects masking for 32 bit addresses.

Per the C++ standard on shift operators: "The behavior is undefined if
the right operand is negative, or greater than or equal to the width of
the promoted left operand."