### PR TITLE
n64: implement perfect PI DMA write

### DIFF
--- a/ares/n64/pi/dma.cpp
+++ b/ares/n64/pi/dma.cpp
@@ -1,4 +1,5 @@
 auto PI::dmaRead() -> void {
+  io.readLength = (io.readLength | 1) + 1;
   for(u32 address = 0; address < io.readLength; address += 2) {
     u16 data = bus.read<Half>(io.dramAddress + address);
     bus.write<Half>(io.pbusAddress + address, data);
@@ -9,10 +10,38 @@ auto PI::dmaRead() -> void {
 }
 
 auto PI::dmaWrite() -> void {
-  for(u32 address = 0; address < io.writeLength; address += 2) {
-    u16 data = bus.read<Half>(io.pbusAddress + address);
-    bus.write<Half>(io.dramAddress + address, data);
+  u8 mem[128];
+  bool first_block = true;
+  i32 length = io.writeLength+1;
+
+  io.writeLength = 0x7F;
+  if (length <= 8) io.writeLength -= io.dramAddress&7;
+
+  while (length > 0) {
+    u32 dest = io.dramAddress & 0x7FFFFE;
+    i32 misalign = dest & 7;
+    i32 block_len = 128 - misalign;
+    i32 cur_len = min(length, block_len);
+
+    length -= cur_len;
+    if (length.bit(0)) length += 1;
+
+    i32 rom_len = (cur_len + 1) & ~1;
+    for (u32 i = 0; i < rom_len; i++)
+      mem[i] = bus.read<Byte>(io.pbusAddress++);
+
+    if (first_block) {
+      if (cur_len == block_len-1) cur_len++;
+      cur_len = max(cur_len-misalign, 0);
+    }
+
+    for (u32 i = 0; i < cur_len; i++)
+      bus.write<Byte>(io.dramAddress++, mem[i]);
+    io.dramAddress = (io.dramAddress + 7) & ~7;
+
+    first_block = false;
   }
+
   io.dmaBusy = 0;
   io.interrupt = 1;
   mi.raise(MI::IRQ::PI);

--- a/ares/n64/pi/io.cpp
+++ b/ares/n64/pi/io.cpp
@@ -96,14 +96,14 @@ auto PI::writeWord(u32 address, u32 data_) -> void {
 
   if(address == 2) {
     //PI_READ_LENGTH
-    io.readLength = (n24(data) | 1) + 1;
+    io.readLength = n24(data);
     io.dmaBusy = 1;
     queue.insert(Queue::PI_DMA_Read, io.readLength * 9);
   }
 
   if(address == 3) {
     //PI_WRITE_LENGTH
-    io.writeLength = (n24(data) | 1) + 1;
+    io.writeLength = n24(data);
     io.dmaBusy = 1;
     queue.insert(Queue::PI_DMA_Write, io.writeLength * 9);
   }


### PR DESCRIPTION
This commit implement perfect PI DMA write. The PI DMA is normally used
for 8-byte aligned transfers, which is where it constantly works. The
hardware does contain a half-baked, buggy support for 2-byte aligned
transfers and odd-size lengths. I have extensively investigated the
behavior of every single quirk, and produced a test ROM that Ares
passes after this commit (timing is still off, but that's for another
day):

https://github.com/rasky/n64_pi_dma_test

The implementation is the same that I've previously submitted to cen64,
adapted for the ares codebase.