### PR TITLE
n64: implement accurate timer interrupt in recompiler

### DIFF
--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -723,6 +723,7 @@ struct CPU : Thread {
 
     bump_allocator allocator;
     Pool* pools[1 << 21];  //2_MiB * sizeof(void*) == 16_MiB
+    bool earlyExit = false;
   } recompiler{*this};
 
   struct Disassembler {

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -35,6 +35,9 @@ struct CPU : Thread {
   auto step(u32 clocks) -> void;
   auto synchronize() -> void;
 
+  auto checkTimerInterrupt() -> void;
+  u32 prevClock = 0;
+
   auto instruction() -> void;
   auto instructionEpilogue() -> bool;
 


### PR DESCRIPTION
Previously, the timer interrupt was only being checked at the end of
each recompiler blocks, so each interrupt was potentially delayed until
next branch. Now, it is checked as part of CPU::step so it is
cycle-accurate. If the timer interrupt is triggered, the recompiler
is early-exited so that the interrupt can actually occur precisely
at the right moment.

On top of that, the previous code had also a overflow-checking bug,
so it failed to trigger an interrupt when executing a block in which
the counter overflown and compare was reached at the same time.