### PR TITLE
scheduler: use 64-bit counters on all platforms

### DIFF
--- a/ares/ares/scheduler/scheduler.cpp
+++ b/ares/ares/scheduler/scheduler.cpp
@@ -23,8 +23,8 @@ inline auto Scheduler::uniqueID() const -> u32 {
 }
 
 //find the clock time of the furthest behind thread.
-inline auto Scheduler::minimum() const -> uintmax {
-  uintmax minimum = (uintmax)-1;
+inline auto Scheduler::minimum() const -> u64 {
+  u64 minimum = (u64)-1;
   for(auto& thread : _threads) {
     minimum = min(minimum, thread->_clock - thread->_uniqueID);
   }
@@ -32,8 +32,8 @@ inline auto Scheduler::minimum() const -> uintmax {
 }
 
 //find the clock time of the furthest ahead thread.
-inline auto Scheduler::maximum() const -> uintmax {
-  uintmax maximum = 0;
+inline auto Scheduler::maximum() const -> u64 {
+  u64 maximum = 0;
   for(auto& thread : _threads) {
     maximum = max(maximum, thread->_clock - thread->_uniqueID);
   }

--- a/ares/ares/scheduler/scheduler.hpp
+++ b/ares/ares/scheduler/scheduler.hpp
@@ -16,8 +16,8 @@ struct Scheduler {
   auto threads() const -> u32;
   auto thread(u32 threadID) const -> maybe<Thread&>;
   auto uniqueID() const -> u32;
-  auto minimum() const -> uintmax;
-  auto maximum() const -> uintmax;
+  auto minimum() const -> u64;
+  auto maximum() const -> u64;
 
   auto append(Thread& thread) -> bool;
   auto remove(Thread& thread) -> void;

--- a/ares/ares/scheduler/thread.cpp
+++ b/ares/ares/scheduler/thread.cpp
@@ -24,9 +24,9 @@ inline Thread::~Thread() {
 
 inline auto Thread::active() const -> bool { return co_active() == _handle; }
 inline auto Thread::handle() const -> cothread_t { return _handle; }
-inline auto Thread::frequency() const -> uintmax { return _frequency; }
-inline auto Thread::scalar() const -> uintmax { return _scalar; }
-inline auto Thread::clock() const -> uintmax { return _clock; }
+inline auto Thread::frequency() const -> u64 { return _frequency; }
+inline auto Thread::scalar() const -> u64 { return _scalar; }
+inline auto Thread::clock() const -> u64 { return _clock; }
 
 inline auto Thread::setHandle(cothread_t handle) -> void {
   _handle = handle;
@@ -37,11 +37,11 @@ inline auto Thread::setFrequency(double frequency) -> void {
   _scalar = Second / _frequency;
 }
 
-inline auto Thread::setScalar(uintmax scalar) -> void {
+inline auto Thread::setScalar(u64 scalar) -> void {
   _scalar = scalar;
 }
 
-inline auto Thread::setClock(uintmax clock) -> void {
+inline auto Thread::setClock(u64 clock) -> void {
   _clock = clock;
 }
 

--- a/ares/ares/scheduler/thread.hpp
+++ b/ares/ares/scheduler/thread.hpp
@@ -1,8 +1,8 @@
 struct Scheduler;
 
 struct Thread {
-  enum : uintmax { Second = (uintmax)-1 >> 1 };
-  enum : uintmax { Size = 16_KiB * sizeof(void*) };
+  enum : u64 { Second = (u64)-1 >> 1 };
+  enum : u64 { Size = 16_KiB * sizeof(void*) };
 
   struct EntryPoint {
     cothread_t handle = nullptr;
@@ -20,14 +20,14 @@ struct Thread {
   explicit operator bool() const { return _handle; }
   auto active() const -> bool;
   auto handle() const -> cothread_t;
-  auto frequency() const -> uintmax;
-  auto scalar() const -> uintmax;
-  auto clock() const -> uintmax;
+  auto frequency() const -> u64;
+  auto scalar() const -> u64;
+  auto clock() const -> u64;
 
   auto setHandle(cothread_t handle) -> void;
   auto setFrequency(double frequency) -> void;
-  auto setScalar(uintmax scalar) -> void;
-  auto setClock(uintmax clock) -> void;
+  auto setScalar(u64 scalar) -> void;
+  auto setClock(u64 clock) -> void;
 
   auto create(double frequency, function<void ()> entryPoint) -> void;
   auto restart(function<void ()> entryPoint) -> void;
@@ -42,9 +42,9 @@ struct Thread {
 protected:
   cothread_t _handle = nullptr;
   u32 _uniqueID = 0;
-  uintmax _frequency = 0;
-  uintmax _scalar = 0;
-  uintmax _clock = 0;
+  u64 _frequency = 0;
+  u64 _scalar = 0;
+  u64 _clock = 0;
 
   friend class Scheduler;
 };

--- a/nall/arithmetic.hpp
+++ b/nall/arithmetic.hpp
@@ -16,12 +16,12 @@ namespace nall {
   template<> struct ArithmeticNatural< 16> { using type = u16;  };
   template<> struct ArithmeticNatural< 32> { using type = u32;  };
   template<> struct ArithmeticNatural< 64> { using type = u64;  };
-  #if INTMAX_BITS >= 128
+  #if defined(__SIZEOF_INT128__)
   template<> struct ArithmeticNatural<128> { using type = u128; };
   #endif
 }
 
-#if INTMAX_BITS < 128
+#if !defined(__SIZEOF_INT128__)
 #define PairBits 128
 #define TypeBits  64
 #define HalfBits  32

--- a/nall/arithmetic/unsigned.hpp
+++ b/nall/arithmetic/unsigned.hpp
@@ -33,7 +33,7 @@ inline auto ror(T lhs, U rhs, enable_if_t<is_unsigned<T>::value>* = 0) -> T {
   return lhs >> rhs | lhs << sizeof(T) * 8 - rhs;
 }
 
-#if INTMAX_BITS >= 128
+#if defined(__SIZEOF_INT128__)
 inline auto operator"" _u128(const char* s) -> u128 {
   u128 p = 0;
   if(s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) {

--- a/nall/stdint.hpp
+++ b/nall/stdint.hpp
@@ -26,19 +26,13 @@
   #include <stdint.h>
 #endif
 
-//note: (u)intmax actually mean it: use as many bits as is possible
 #if defined(__SIZEOF_INT128__)
   using  int128_t =   signed __int128;
   using uint128_t = unsigned __int128;
-
-  #define INTMAX_BITS 128
-  using  intmax =  int128_t;
-  using uintmax = uint128_t;
-#else
-  #define INTMAX_BITS 64
-  using  intmax =  intmax_t;
-  using uintmax = uintmax_t;
 #endif
+
+using  intmax =  intmax_t;
+using uintmax = uintmax_t;
 
 using  intptr =  intptr_t;
 using uintptr = uintptr_t;


### PR DESCRIPTION
Currently ares is using 128-bit counters when the built-in __int128 type
is available. Near's notes on this topic conceded that it wasn't really
necessary, but defended it by stating there was no speed penalty on
64-bit architectures.

Unfortunately, LLVM's 128-bit integer support is buggy when compiling
for Windows targets. I've filed a bug report and am optimistic this will
eventually be fixed, but to prevent people from being burned when
compiling ares themselves, it would be safer to avoid the built-in
__int128 type entirely.

This change imposes 64-bit counters on all architectures for
consistency. It redefines the nall (u)intmax types to match the standard
(u)intmax_t types, though there is no longer anything in ares using them
at the moment.