### PR TITLE
MD: Supporting default 3-button Control Pad

### DIFF
--- a/desktop-ui/emulator/mega-drive.cpp
+++ b/desktop-ui/emulator/mega-drive.cpp
@@ -15,7 +15,18 @@ MegaDrive::MegaDrive() {
   for(auto id : range(2)) {
     InputPort port{string{"Controller Port ", 1 + id}};
 
-  { InputDevice device{"Fighting Pad"};
+    { InputDevice device{"Control Pad"};
+    device.digital("Up",    virtualPorts[id].pad.up);
+    device.digital("Down",  virtualPorts[id].pad.down);
+    device.digital("Left",  virtualPorts[id].pad.left);
+    device.digital("Right", virtualPorts[id].pad.right);
+    device.digital("A",     virtualPorts[id].pad.a);
+    device.digital("B",     virtualPorts[id].pad.b);
+    device.digital("C",     virtualPorts[id].pad.c);
+    device.digital("Start", virtualPorts[id].pad.start);
+    port.append(device); }
+
+    { InputDevice device{"Fighting Pad"};
     device.digital("Up",    virtualPorts[id].pad.up);
     device.digital("Down",  virtualPorts[id].pad.down);
     device.digital("Left",  virtualPorts[id].pad.left);
@@ -77,12 +88,12 @@ auto MegaDrive::load() -> bool {
   }
 
   if(auto port = root->find<ares::Node::Port>("Controller Port 1")) {
-    port->allocate("Fighting Pad");
+    port->allocate("Control Pad");
     port->connect();
   }
 
   if(auto port = root->find<ares::Node::Port>("Controller Port 2")) {
-    port->allocate("Fighting Pad");
+    port->allocate("Control Pad");
     port->connect();
   }
 


### PR DESCRIPTION
And defaulting it, as some older games depend on it to this kind of input to work properly.
eg.:  

* Forgotten Worlds
https://youtu.be/ngHDIFQHFyQ

This also solves https://github.com/higan-emu/ares/issues/177

Fighting pad is still supported just need to be selected in Mega Drive->Controller Port