### PR TITLE
recompiler: fix instructionEpilogue() test

### DIFF
--- a/ares/component/processor/sh2/cached.cpp
+++ b/ares/component/processor/sh2/cached.cpp
@@ -47,7 +47,7 @@ auto SH2::Recompiler::emit(u32 address) -> Block* {
     address += 2;
     if(hasBranched || (address & 0xfe) == 0) break;  //block boundary
     hasBranched = branched;
-    test(rax, rax);
+    test(al, al);
     jz(imm8(1));
     ret();
   }

--- a/ares/component/processor/sh2/recompiler.cpp
+++ b/ares/component/processor/sh2/recompiler.cpp
@@ -78,7 +78,7 @@ auto SH2::Recompiler::emit(u32 address) -> Block* {
     address += 2;
     if(hasBranched || (address & 0xfe) == 0) break;  //block boundary
     hasBranched = branched;
-    test(rax, rax);
+    test(al, al);
     jnz(epilogue);
   }
   jmp(epilogue);

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -63,7 +63,7 @@ auto CPU::Recompiler::emit(u32 address) -> Block* {
     address += 4;
     if(hasBranched || (address & 0xfc) == 0) break;  //block boundary
     hasBranched = branched;
-    test(rax, rax);
+    test(al, al);
     jnz(epilogue);
   }
   jmp(epilogue);

--- a/ares/n64/rsp/recompiler.cpp
+++ b/ares/n64/rsp/recompiler.cpp
@@ -77,7 +77,7 @@ auto RSP::Recompiler::emit(u32 address) -> Block* {
     address += 4;
     if(hasBranched || (address & 0xffc) == 0) break;  //IMEM boundary
     hasBranched = branched;
-    test(rax, rax);
+    test(al, al);
     jnz(epilogue);
   }
   jmp(epilogue);

--- a/ares/ps1/cpu/recompiler.cpp
+++ b/ares/ps1/cpu/recompiler.cpp
@@ -58,7 +58,7 @@ auto CPU::Recompiler::emit(u32 address) -> Block* {
     address += 4;
     if(hasBranched || (address & 0xfc) == 0) break;  //block boundary
     hasBranched = branched;
-    test(rax, rax);
+    test(al, al);
     jnz(epilogue);
   }
   jmp(epilogue);


### PR DESCRIPTION
instructionEpilogue() returns a bool, but all recompilers were
performing a 64-bit test on the return value. If sizeof(bool) == 1, only
the bottom 8 bits are guaranteed to be valid.