### PR TITLE
recompiler: use fixed bss allocation for code caches

### DIFF
--- a/ares/GNUmakefile
+++ b/ares/GNUmakefile
@@ -10,9 +10,10 @@ else
   $(error "ares is a library and cannot be built directly.")
 endif
 
-ares.objects := ares
+ares.objects := ares ares-fixed-allocator
 
 $(object.path)/ares.o: $(ares.path)/ares/ares.cpp
+$(object.path)/ares-fixed-allocator.o: $(ares.path)/ares/memory/fixed-allocator.cpp
 
 ifeq ($(vulkan),true)
   flags += -DVULKAN

--- a/ares/ares/ares.hpp
+++ b/ares/ares/ares.hpp
@@ -74,6 +74,7 @@ namespace ares {
 #include <ares/debug/debug.hpp>
 #include <ares/node/node.hpp>
 #include <ares/platform.hpp>
+#include <ares/memory/fixed-allocator.hpp>
 #include <ares/memory/readable.hpp>
 #include <ares/memory/writable.hpp>
 #include <ares/resource/resource.hpp>

--- a/ares/ares/memory/fixed-allocator.cpp
+++ b/ares/ares/memory/fixed-allocator.cpp
@@ -1,0 +1,16 @@
+#include <ares/ares.hpp>
+
+namespace ares::Memory {
+
+alignas(4096) u8 fixedBuffer[1_GiB];
+
+FixedAllocator::FixedAllocator() {
+  _allocator.resize(sizeof(fixedBuffer), 0, fixedBuffer);
+}
+
+auto FixedAllocator::get() -> bump_allocator& {
+  static FixedAllocator allocator;
+  return allocator._allocator;
+}
+
+}

--- a/ares/ares/memory/fixed-allocator.hpp
+++ b/ares/ares/memory/fixed-allocator.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace ares::Memory {
+
+struct FixedAllocator {
+  static auto get() -> bump_allocator&;
+
+private:
+  FixedAllocator();
+
+  bump_allocator _allocator;
+};
+
+}

--- a/ares/component/processor/sh2/sh2.cpp
+++ b/ares/component/processor/sh2/sh2.cpp
@@ -47,7 +47,8 @@ auto SH2::power(bool reset) -> void {
   cache.power();
 
   if constexpr(Accuracy::Recompiler) {
-    recompiler.allocator.resize(512_MiB, bump_allocator::executable | bump_allocator::zero_fill);
+    auto buffer = ares::Memory::FixedAllocator::get().acquire(512_MiB);
+    recompiler.allocator.resize(512_MiB, bump_allocator::executable | bump_allocator::zero_fill, buffer);
     recompiler.reset();
   }
 }

--- a/ares/md/m32x/m32x.cpp
+++ b/ares/md/m32x/m32x.cpp
@@ -44,6 +44,9 @@ auto M32X::save() -> void {
 }
 
 auto M32X::power(bool reset) -> void {
+  if constexpr(SH2::Accuracy::Recompiler) {
+    ares::Memory::FixedAllocator::get().release();
+  }
   sdram.fill(0);
   shm.power(reset);
   shs.power(reset);

--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -138,7 +138,8 @@ auto CPU::power(bool reset) -> void {
   context.setMode();
 
   if constexpr(Accuracy::CPU::Recompiler) {
-    recompiler.allocator.resize(512_MiB, bump_allocator::executable | bump_allocator::zero_fill);
+    auto buffer = ares::Memory::FixedAllocator::get().acquire(512_MiB);
+    recompiler.allocator.resize(512_MiB, bump_allocator::executable | bump_allocator::zero_fill, buffer);
     recompiler.reset();
   }
 }

--- a/ares/n64/rsp/rsp.cpp
+++ b/ares/n64/rsp/rsp.cpp
@@ -112,7 +112,8 @@ auto RSP::power(bool reset) -> void {
   }
 
   if constexpr(Accuracy::RSP::Recompiler) {
-    recompiler.allocator.resize(512_MiB, bump_allocator::executable | bump_allocator::zero_fill);
+    auto buffer = ares::Memory::FixedAllocator::get().acquire(512_MiB);
+    recompiler.allocator.resize(512_MiB, bump_allocator::executable | bump_allocator::zero_fill, buffer);
     recompiler.reset();
   }
 }

--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -129,6 +129,9 @@ auto System::save() -> void {
 auto System::power(bool reset) -> void {
   for(auto& setting : node->find<Node::Setting::Setting>()) setting->setLatch();
 
+  if constexpr(Accuracy::CPU::Recompiler || Accuracy::RSP::Recompiler) {
+    ares::Memory::FixedAllocator::get().release();
+  }
   queue.reset();
   cartridge.power(reset);
   rdram.power(reset);

--- a/ares/ps1/cpu/cpu.cpp
+++ b/ares/ps1/cpu/cpu.cpp
@@ -257,7 +257,8 @@ auto CPU::power(bool reset) -> void {
   gte.sf = 0;
 
   if constexpr(Accuracy::CPU::Recompiler) {
-    recompiler.allocator.resize(512_MiB, bump_allocator::executable | bump_allocator::zero_fill);
+    auto buffer = ares::Memory::FixedAllocator::get().acquire(512_MiB);
+    recompiler.allocator.resize(512_MiB, bump_allocator::executable | bump_allocator::zero_fill, buffer);
     recompiler.reset();
   }
 }

--- a/ares/ps1/system/system.cpp
+++ b/ares/ps1/system/system.cpp
@@ -113,6 +113,9 @@ auto System::save() -> void {
 auto System::power(bool reset) -> void {
   for(auto& setting : node->find<Node::Setting::Setting>()) setting->setLatch();
 
+  if constexpr(Accuracy::CPU::Recompiler) {
+    ares::Memory::FixedAllocator::get().release();
+  }
   bios.setWaitStates(6, 12, 24);
   memory.power(reset);
   cpu.power(reset);


### PR DESCRIPTION
Place code caches in the bss section to guarantee proximity to the text
section in order to improve branch prediction and eventually so we can
reliably utilize IP-relative branch instructions.

There is now a fixed 1 GB buffer that is shared by all system cores with
recompilers (m32x, n64, ps1). Because the linker will place it in bss,
it will consume no space in the executable on disk, and operating
systems should be clever enough to avoid comitting physical pages until
it is actually in use. The buffer is defined in a separate translation
unit and only referenced from under compile-time recompiler checks, so
it should be left out by the linker when recompilers are disabled.