### PR TITLE
recompiler: use direct branches, reduce function epilog duplication

### DIFF
--- a/ares/component/processor/sh2/recompiler.cpp
+++ b/ares/component/processor/sh2/recompiler.cpp
@@ -51,9 +51,10 @@ auto SH2::Recompiler::emit(u32 address) -> Block* {
   mov(rbx, imm64(&self.R[0]));
   mov(rbp, imm64(&self));
 
-  jmp(imm8(ABI::Windows ? 11 : 5));
+  auto entry = declareLabel();
+  jmp8(entry);
 
-  u32 epilogue = size();
+  auto epilogue = defineLabel();
 
   if constexpr(ABI::Windows) {
     add(rsp, imm8(0x40));
@@ -64,6 +65,8 @@ auto SH2::Recompiler::emit(u32 address) -> Block* {
   pop(rbp);
   pop(rbx);
   ret();
+
+  defineLabel(entry);
 
   bool hasBranched = 0;
   while(true) {
@@ -76,9 +79,9 @@ auto SH2::Recompiler::emit(u32 address) -> Block* {
     if(hasBranched || (address & 0xfe) == 0) break;  //block boundary
     hasBranched = branched;
     test(rax, rax);
-    jnz(imm32(epilogue - size() - 6));
+    jnz(epilogue);
   }
-  jmp(imm32(epilogue - size() - 5));
+  jmp(epilogue);
 
   allocator.reserve(size());
   return block;

--- a/ares/component/processor/sh2/sh2.hpp
+++ b/ares/component/processor/sh2/sh2.hpp
@@ -277,7 +277,6 @@ struct SH2 {
     template<typename V, typename... P>
     alwaysinline auto call(V (SH2::*function)(P...)) -> void {
       static_assert(sizeof...(P) <= 5);
-      mov(rax, imm64(function));
       if constexpr(ABI::SystemV) {
         mov(rdi, rbp);
       }
@@ -289,7 +288,7 @@ struct SH2 {
         if constexpr(sizeof...(P) >= 1) mov(rdx, rsi);
         mov(rcx, rbp);
       }
-      call(rax);
+      call(imm64{function}, rax);
     }
 
     bump_allocator allocator;

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -2058,7 +2058,6 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
 template<typename V, typename... P>
 auto CPU::Recompiler::call(V (CPU::*function)(P...)) -> void {
   static_assert(sizeof...(P) <= 5);
-  mov(rax, imm64(function));
   if constexpr(ABI::SystemV) {
     mov(rdi, rbp);
   }
@@ -2070,5 +2069,5 @@ auto CPU::Recompiler::call(V (CPU::*function)(P...)) -> void {
     if constexpr(sizeof...(P) >= 1) mov(rdx, rsi);
     mov(rcx, rbp);
   }
-  call(rax);
+  call(imm64{function}, rax);
 }

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -32,9 +32,10 @@ auto CPU::Recompiler::emit(u32 address) -> Block* {
   mov(rbp, imm64(&self));
   mov(r13, imm64(&self.fpu.r[0] + 16));
 
-  jmp(imm8(ABI::Windows ? 11 : 5));
+  auto entry = declareLabel();
+  jmp8(entry);
 
-  u32 epilogue = size();
+  auto epilogue = defineLabel();
 
   if constexpr(ABI::Windows) {
     add(rsp, imm8(0x40));
@@ -45,6 +46,8 @@ auto CPU::Recompiler::emit(u32 address) -> Block* {
   pop(rbp);
   pop(rbx);
   ret();
+
+  defineLabel(entry);
 
   bool hasBranched = 0;
   while(true) {
@@ -61,9 +64,9 @@ auto CPU::Recompiler::emit(u32 address) -> Block* {
     if(hasBranched || (address & 0xfc) == 0) break;  //block boundary
     hasBranched = branched;
     test(rax, rax);
-    jnz(imm32(epilogue - size() - 6));
+    jnz(epilogue);
   }
-  jmp(imm32(epilogue - size() - 5));
+  jmp(epilogue);
 
   allocator.reserve(size());
 //print(hex(PC, 8L), " ", instructions, " ", size(), "\n");

--- a/ares/n64/rsp/recompiler.cpp
+++ b/ares/n64/rsp/recompiler.cpp
@@ -1444,7 +1444,6 @@ auto RSP::Recompiler::emitSWC2(u32 instruction) -> bool {
 template<typename V, typename... P>
 auto RSP::Recompiler::call(V (RSP::*function)(P...)) -> void {
   static_assert(sizeof...(P) <= 5);
-  mov(rax, imm64(function));
   if constexpr(ABI::SystemV) {
     mov(rdi, rbp);
   }
@@ -1456,5 +1455,5 @@ auto RSP::Recompiler::call(V (RSP::*function)(P...)) -> void {
     if constexpr(sizeof...(P) >= 1) mov(rdx, rsi);
     mov(rcx, rbp);
   }
-  call(rax);
+  call(imm64{function}, rax);
 }

--- a/ares/n64/rsp/recompiler.cpp
+++ b/ares/n64/rsp/recompiler.cpp
@@ -49,6 +49,20 @@ auto RSP::Recompiler::emit(u32 address) -> Block* {
   mov(rbp, imm64(&self));
   mov(r13, imm64(&self.vpu.r[0]));
 
+  jmp(imm8(ABI::Windows ? 11 : 5));
+
+  u32 epilogue = size();
+
+  if constexpr(ABI::Windows) {
+    add(rsp, imm8(0x40));
+    pop(rdi);
+    pop(rsi);
+  }
+  pop(r13);
+  pop(rbp);
+  pop(rbx);
+  ret();
+
   bool hasBranched = 0;
   while(true) {
     u32 instruction = self.imem.read<Word>(address);
@@ -61,26 +75,9 @@ auto RSP::Recompiler::emit(u32 address) -> Block* {
     if(hasBranched || (address & 0xffc) == 0) break;  //IMEM boundary
     hasBranched = branched;
     test(rax, rax);
-    jz(imm8(ABI::Windows ? 11 : 5));
-    if constexpr(ABI::Windows) {
-      add(rsp, imm8(0x40));
-      pop(rdi);
-      pop(rsi);
-    }
-    pop(r13);
-    pop(rbp);
-    pop(rbx);
-    ret();
+    jnz(imm32(epilogue - size() - 6));
   }
-  if constexpr(ABI::Windows) {
-    add(rsp, imm8(0x40));
-    pop(rdi);
-    pop(rsi);
-  }
-  pop(r13);
-  pop(rbp);
-  pop(rbx);
-  ret();
+  jmp(imm32(epilogue - size() - 5));
 
   allocator.reserve(size());
 //print(hex(PC, 8L), " ", instructions, " ", size(), "\n");

--- a/ares/ps1/cpu/recompiler.cpp
+++ b/ares/ps1/cpu/recompiler.cpp
@@ -1114,7 +1114,6 @@ auto CPU::Recompiler::emitGTE(u32 instruction) -> bool {
 template<typename V, typename... P>
 auto CPU::Recompiler::call(V (CPU::*function)(P...)) -> void {
   static_assert(sizeof...(P) <= 5);
-  mov(rax, imm64(function));
   if constexpr(ABI::SystemV) {
     mov(rdi, rbp);
   }
@@ -1126,5 +1125,5 @@ auto CPU::Recompiler::call(V (CPU::*function)(P...)) -> void {
     if constexpr(sizeof...(P) >= 1) mov(rdx, rsi);
     mov(rcx, rbp);
   }
-  call(rax);
+  call(imm64{function}, rax);
 }

--- a/nall/array-span.hpp
+++ b/nall/array-span.hpp
@@ -63,12 +63,12 @@ template<typename T> struct array_span : array_view<T> {
     super::_size--;
   }
 
-  auto span(u32 offset, u32 length) const -> type {
+  auto span(u32 offset, u32 length) -> type {
     #ifdef DEBUG
     struct out_of_bounds {};
     if(offset + length >= super::_size) throw out_of_bounds{};
     #endif
-    return {super::_data + offset, length};
+    return {(T*)super::_data + offset, length};
   }
 
   //array_span<u8> specializations

--- a/nall/recompiler/amd64/emitter.hpp
+++ b/nall/recompiler/amd64/emitter.hpp
@@ -59,6 +59,10 @@ alwaysinline auto bind(array_span<u8> span) {
   emit.origin = span;
 }
 
+alwaysinline auto distance(u64 target) const -> s64 {
+  return target - (u64)emit.span.data();
+}
+
 alwaysinline auto size() const -> u32 {
   return emit.span.data() - emit.origin.data();
 }

--- a/nall/recompiler/amd64/encoder-calls-systemv.hpp
+++ b/nall/recompiler/amd64/encoder-calls-systemv.hpp
@@ -5,69 +5,63 @@
   template<typename C, typename R, typename... P>
   alwaysinline auto call(auto (C::*function)(P...) -> R, C* object) {
     sub(rsp, imm8{0x08});
-    mov(rax, imm64{function});
     mov(rdi, imm64{object});
-    call(rax);
+    call(imm64{function}, rax);
     add(rsp, imm8{0x08});
   }
 
   template<typename C, typename R, typename... P, typename P0>
   alwaysinline auto call(auto (C::*function)(P...) -> R, C* object, P0 p0) {
     sub(rsp, imm8{0x08});
-    mov(rax, imm64{function});
     mov(rdi, imm64{object});
     mov(rsi, imm64{p0});
-    call(rax);
+    call(imm64{function}, rax);
     add(rsp, imm8{0x08});
   }
 
   template<typename C, typename R, typename... P, typename P0, typename P1>
   alwaysinline auto call(auto (C::*function)(P...) -> R, C* object, P0 p0, P1 p1) {
     sub(rsp, imm8{0x08});
-    mov(rax, imm64{function});
     mov(rdi, imm64{object});
     mov(rsi, imm64{p0});
     mov(rdx, imm64{p1});
-    call(rax);
+    call(imm64{function}, rax);
     add(rsp, imm8{0x08});
   }
 
   template<typename C, typename R, typename... P, typename P0, typename P1, typename P2>
   alwaysinline auto call(auto (C::*function)(P...) -> R, C* object, P0 p0, P1 p1, P2 p2) {
     sub(rsp, imm8{0x08});
-    mov(rax, imm64{function});
     mov(rdi, imm64{object});
     mov(rsi, imm64{p0});
     mov(rdx, imm64{p1});
     mov(rcx, imm64{p2});
-    call(rax);
+    call(imm64{function}, rax);
     add(rsp, imm8{0x08});
   }
 
   template<typename C, typename R, typename... P, typename P0, typename P1, typename P2, typename P3>
   alwaysinline auto call(auto (C::*function)(P...) -> R, C* object, P0 p0, P1 p1, P2 p2, P3 p3) {
     sub(rsp, imm8{0x08});
-    mov(rax, imm64{function});
     mov(rdi, imm64{object});
     mov(rsi, imm64{p0});
     mov(rdx, imm64{p1});
     mov(rcx, imm64{p2});
     mov(r8, imm64{p3});
-    call(rax);
+    call(imm64{function}, rax);
     add(rsp, imm8{0x08});
   }
 
   template<typename C, typename R, typename... P, typename P0, typename P1, typename P2, typename P3, typename P4>
   alwaysinline auto call(auto (C::*function)(P...) -> R, C* object, P0 p0, P1 p1, P2 p2, P3 p3, P4 p4) {
     sub(rsp, imm8{0x08});
-    mov(rax, imm64{function});
     mov(rdi, imm64{object});
     mov(rsi, imm64{p0});
     mov(rdx, imm64{p1});
     mov(rcx, imm64{p2});
     mov(r8, imm64{p3});
     mov(r9, imm64{p4});
-    call(rax);
+    call(imm64{function}, rax);
     add(rsp, imm8{0x08});
   }
 //};

--- a/nall/recompiler/amd64/encoder-calls-windows.hpp
+++ b/nall/recompiler/amd64/encoder-calls-windows.hpp
@@ -6,8 +6,7 @@
   alwaysinline auto call(auto (C::*function)(P...) -> R, C* object) {
     sub(rsp, imm8{0x28});
     mov(rcx, imm64{object});
-    mov(rax, imm64{function});
-    call(rax);
+    call(imm64{function}, rax);
     add(rsp, imm8{0x28});
   }
 
@@ -16,8 +15,7 @@
     sub(rsp, imm8{0x28});
     mov(rcx, imm64{object});
     mov(rdx, imm64{p0});
-    mov(rax, imm64{function});
-    call(rax);
+    call(imm64{function}, rax);
     add(rsp, imm8{0x28});
   }
 
@@ -27,8 +25,7 @@
     mov(rcx, imm64{object});
     mov(rdx, imm64{p0});
     mov(r8, imm64{p1});
-    mov(rax, imm64{function});
-    call(rax);
+    call(imm64{function}, rax);
     add(rsp, imm8{0x28});
   }
 
@@ -39,8 +36,7 @@
     mov(rdx, imm64{p0});
     mov(r8, imm64{p1});
     mov(r9, imm64{p2});
-    mov(rax, imm64{function});
-    call(rax);
+    call(imm64{function}, rax);
     add(rsp, imm8{0x28});
   }
 
@@ -53,8 +49,7 @@
     mov(r9, imm64{p2});
     mov(rax, imm64{p3});
     mov(dis8{rsp, 0x20}, rax);
-    mov(rax, imm64{function});
-    call(rax);
+    call(imm64{function}, rax);
     add(rsp, imm8{0x38});
   }
 
@@ -69,8 +64,7 @@
     mov(dis8{rsp, 0x20}, rax);
     mov(rax, imm64{p4});
     mov(dis8{rsp, 0x28}, rax);
-    mov(rax, imm64{function});
-    call(rax);
+    call(imm64{function}, rax);
     add(rsp, imm8{0x38});
   }
 //};

--- a/nall/recompiler/amd64/encoder-instructions.hpp
+++ b/nall/recompiler/amd64/encoder-instructions.hpp
@@ -737,17 +737,26 @@
   #define op(code) \
     emit.byte(code); \
     emit.byte(it.data);
-  alwaysinline auto jmp(imm8 it) { op(0xeb); }
-  alwaysinline auto jnz(imm8 it) { op(0x75); }
-  alwaysinline auto jz (imm8 it) { op(0x74); }
+  #define r imm8 it{resolve(l, 1, 1)}
+  alwaysinline auto jmp (imm8 it) {    op(0xeb); }
+  alwaysinline auto jmp8(label l) { r; op(0xeb); }
+  alwaysinline auto jnz (imm8 it) {    op(0x75); }
+  alwaysinline auto jnz8(label l) { r; op(0x75); }
+  alwaysinline auto jz  (imm8 it) {    op(0x74); }
+  alwaysinline auto jz8 (label l) { r; op(0x74); }
+  #undef r
   #undef op
 
   #define op(code) \
     emit.byte(0x0f); \
     emit.byte(code); \
     emit.dword(it.data);
-  alwaysinline auto jnz(imm32 it) { op(0x85); }
-  alwaysinline auto jz (imm32 it) { op(0x84); }
+  #define r imm32 it{resolve(l, 2, 4)}
+  alwaysinline auto jnz(imm32 it) {    op(0x85); }
+  alwaysinline auto jnz(label l)  { r; op(0x85); }
+  alwaysinline auto jz (imm32 it) {    op(0x84); }
+  alwaysinline auto jz (label l)  { r; op(0x84); }
+  #undef r
   #undef op
 
   //op reg8
@@ -846,5 +855,10 @@
     } else {
       call(imm32{dist});
     }
+  }
+
+  //jmp label (pseudo-op)
+  alwaysinline auto jmp(label l) {
+    jmp(imm32{resolve(l, 1, 4)});
   }
 //};

--- a/nall/recompiler/amd64/encoder-instructions.hpp
+++ b/nall/recompiler/amd64/encoder-instructions.hpp
@@ -14,6 +14,12 @@
     emit.dword(it.data);
   }
 
+  //jmp imm32
+  alwaysinline auto jmp(imm32 it) {
+    emit.byte(0xe9);
+    emit.dword(it.data);
+  }
+
   //call reg64
   alwaysinline auto call(reg64 rt) {
     emit.rex(0, 0, 0, rt & 8);
@@ -734,6 +740,14 @@
   alwaysinline auto jmp(imm8 it) { op(0xeb); }
   alwaysinline auto jnz(imm8 it) { op(0x75); }
   alwaysinline auto jz (imm8 it) { op(0x74); }
+  #undef op
+
+  #define op(code) \
+    emit.byte(0x0f); \
+    emit.byte(code); \
+    emit.dword(it.data);
+  alwaysinline auto jnz(imm32 it) { op(0x85); }
+  alwaysinline auto jz (imm32 it) { op(0x84); }
   #undef op
 
   //op reg8

--- a/nall/recompiler/amd64/encoder-instructions.hpp
+++ b/nall/recompiler/amd64/encoder-instructions.hpp
@@ -8,6 +8,12 @@
   alwaysinline auto stc()  { emit.byte(0xf9); }
   alwaysinline auto ret()  { emit.byte(0xc3); }
 
+  //call imm32
+  alwaysinline auto call(imm32 it) {
+    emit.byte(0xe8);
+    emit.dword(it.data);
+  }
+
   //call reg64
   alwaysinline auto call(reg64 rt) {
     emit.rex(0, 0, 0, rt & 8);
@@ -816,4 +822,15 @@
   alwaysinline auto sets (dis8 dt) { op(0x98); }
   alwaysinline auto setz (dis8 dt) { op(0x94); }
   #undef op
+
+  //call imm64 (pseudo-op)
+  alwaysinline auto call(imm64 target, reg64 scratch) {
+    s64 dist = distance(target.data) - 5;
+    if(dist < INT32_MIN || dist > INT32_MAX) {
+      mov(scratch, target);
+      call(scratch);
+    } else {
+      call(imm32{dist});
+    }
+  }
 //};


### PR DESCRIPTION
Combined with #200, these changes net an additional ~15% performance improvement for the n64 core.