### PR TITLE
mega-cd fixes + a 32x tweak

### DIFF
--- a/ares/md/mcd/bus-external.cpp
+++ b/ares/md/mcd/bus-external.cpp
@@ -37,14 +37,6 @@ auto MCD::writeExternal(n1 upper, n1 lower, n22 address, n16 data) -> void {
   if(!MegaCD()) return;
   address.bit(18,20) = 0;  //mirrors
 
-  if(address >= 0x000000 && address <= 0x01ffff) {
-    if(address == 0x70 && upper) io.vectorLevel4.byte(3) = data.byte(1);
-    if(address == 0x70 && lower) io.vectorLevel4.byte(2) = data.byte(0);
-    if(address == 0x72 && upper) io.vectorLevel4.byte(1) = data.byte(1);
-    if(address == 0x72 && lower) io.vectorLevel4.byte(0) = data.byte(0);
-    return;
-  }
-
   if(address >= 0x020000 && address <= 0x03ffff) {
     address = io.pramBank << 17 | (n17)address;
     if(upper) pram[address >> 1].byte(1) = data.byte(1);

--- a/ares/md/mcd/bus-external.cpp
+++ b/ares/md/mcd/bus-external.cpp
@@ -16,17 +16,17 @@ auto MCD::readExternal(n1 upper, n1 lower, n22 address, n16 data) -> n16 {
   if(address >= 0x200000 && address <= 0x23ffff) {
     if(io.wramMode == 0) {
     //if(io.wramSwitch == 1) return data;
-      address = (n18)address;
+      address = (n18)address >> 1;
     } else {
-      address = !io.wramSelect << 17 | (n17)address;
+      address = (n17)address & ~1 | io.wramSelect;
     }
-    if(!vdp.dma.active) return wram[address >> 1];
+    if(!vdp.dma.active) return wram[address];
 
     //VDP DMA from Mega CD word RAM to VDP VRAM responds with a one-access delay
     //note: it is believed that the first transfer is the CPU prefetch, which isn't emulated here
     //games manually correct the first word transferred after VDP DMAs from word RAM
     data = io.wramLatch;
-    io.wramLatch = wram[address >> 1];
+    io.wramLatch = wram[address];
     return data;
   }
 
@@ -55,12 +55,12 @@ auto MCD::writeExternal(n1 upper, n1 lower, n22 address, n16 data) -> void {
   if(address >= 0x200000 && address <= 0x23ffff) {
     if(io.wramMode == 0) {
     //if(io.wramSwitch == 1) return;
-      address = (n18)address;
+      address = (n18)address >> 1;
     } else {
-      address = !io.wramSelect << 17 | (n17)address;
+      address = (n17)address & ~1 | io.wramSelect;
     }
-    if(upper) wram[address >> 1].byte(1) = data.byte(1);
-    if(lower) wram[address >> 1].byte(0) = data.byte(0);
+    if(upper) wram[address].byte(1) = data.byte(1);
+    if(lower) wram[address].byte(0) = data.byte(0);
     return;
   }
 }

--- a/ares/md/mcd/bus-internal.cpp
+++ b/ares/md/mcd/bus-internal.cpp
@@ -8,16 +8,16 @@ auto MCD::read(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
   if(address >= 0x080000 && address <= 0x0bffff) {
     if(io.wramMode == 0) {
     //if(io.wramSwitch == 0) return data;
-      address = (n18)address;
-      return wram[address >> 1];
+      address = (n18)address >> 1;
+      return wram[address];
     }
     return data;
   }
 
   if(address >= 0x0c0000 && address <= 0x0dffff) {
     if(io.wramMode == 1) {
-      address = io.wramSelect << 17 | (n17)address;
-      return wram[address >> 1];
+      address = (n17)address & ~1 | !io.wramSelect;
+      return wram[address];
     }
     return data;
   }
@@ -51,17 +51,17 @@ auto MCD::write(n1 upper, n1 lower, n24 address, n16 data) -> void {
   if(address >= 0x080000 && address <= 0x0bffff) {
     if(io.wramMode == 0) {
     //if(io.wramSwitch == 0) return;
-      address = (n18)address;
-      if(upper) wram[address >> 1].byte(1) = data.byte(1);
-      if(lower) wram[address >> 1].byte(0) = data.byte(0);
+      address = (n18)address >> 1;
+      if(upper) wram[address].byte(1) = data.byte(1);
+      if(lower) wram[address].byte(0) = data.byte(0);
     }
   }
 
   if(address >= 0x0c0000 && address <= 0x0dffff) {
     if(io.wramMode == 1) {
-      address = io.wramSelect << 17 | (n17)address;
-      if(upper) wram[address >> 1].byte(1) = data.byte(1);
-      if(lower) wram[address >> 1].byte(0) = data.byte(0);
+      address = (n17)address & ~1 | !io.wramSelect;
+      if(upper) wram[address].byte(1) = data.byte(1);
+      if(lower) wram[address].byte(0) = data.byte(0);
     }
   }
 

--- a/ares/md/mcd/io-external.cpp
+++ b/ares/md/mcd/io-external.cpp
@@ -26,7 +26,8 @@ auto MCD::readExternalIO(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
   }
 
   if(address == 0xa12006) {
-    data = bios.read(0x72 >> 1);
+    data.byte(1) = io.vectorLevel4.byte(1);
+    data.byte(0) = io.vectorLevel4.byte(0);
   }
 
   if(address == 0xa12008) {
@@ -92,7 +93,8 @@ auto MCD::writeExternalIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
   }
 
   if(address == 0xa12006) {
-    bios.program(0x72 >> 1, data);
+    if(upper) io.vectorLevel4.byte(1) = data.byte(1);
+    if(lower) io.vectorLevel4.byte(0) = data.byte(0);
   }
 
   if(address == 0xa12008) {

--- a/ares/md/mcd/mcd.cpp
+++ b/ares/md/mcd/mcd.cpp
@@ -196,8 +196,8 @@ auto MCD::power(bool reset) -> void {
 
   io.vectorLevel4.byte(3) = bios[0x70 >> 1].byte(1);
   io.vectorLevel4.byte(2) = bios[0x70 >> 1].byte(0);
-  io.vectorLevel4.byte(1) = bios[0x72 >> 1].byte(1);
-  io.vectorLevel4.byte(0) = bios[0x72 >> 1].byte(0);
+  io.vectorLevel4.byte(1) = ~0;
+  io.vectorLevel4.byte(0) = ~0;
 }
 
 }

--- a/ares/md/system/system.cpp
+++ b/ares/md/system/system.cpp
@@ -61,25 +61,25 @@ auto System::load(Node::System& root, string name) -> bool {
     information.name = "Mega Drive";
     information.mega32X = 0;
     information.megaCD = 0;
-    cpu.minCyclesBetweenSyncs = 4; // sync approx every 2-3 pixels
+    cpu.minCyclesBetweenSyncs = 4; // sync approx every 7 pixels
   }
   if(name.match("[Sega] Mega 32X (*)")) {
     information.name = "Mega Drive";
     information.mega32X = 1;
     information.megaCD = 0;
-    cpu.minCyclesBetweenSyncs = 40; // sync approx every 28 pixels
+    cpu.minCyclesBetweenSyncs = 15; // sync approx every 25-26 pixels
   }
   if(name.match("[Sega] Mega CD (*)")) {
     information.name = "Mega Drive";
     information.mega32X = 0;
     information.megaCD = 1;
-    cpu.minCyclesBetweenSyncs = 4; // sync approx every 2-3 pixels
+    cpu.minCyclesBetweenSyncs = 4; // sync approx every 7 pixels
   }
   if(name.match("[Sega] Mega CD 32X (*)")) {
     information.name = "Mega Drive";
     information.mega32X = 1;
     information.megaCD = 1;
-    cpu.minCyclesBetweenSyncs = 40; // sync approx every 28 pixels
+    cpu.minCyclesBetweenSyncs = 40; // sync approx every 70 pixels
   }
   if(name.find("NTSC-J")) {
     information.region = Region::NTSCJ;


### PR DESCRIPTION
1. Implement the actual shared access pattern on MCD's wordram in 1M mode. Fixes Lethal Enforcers II (CD).
2. Do MCD H-INT vectoring. Fixes Microcosm, Silpheed, Wing Commander, and many more!
3. Tighter 68k cpu sync for 32X emulation. Fixes Kolibri & FIFA Int'l Soccer '96 (32X) [ref: #180].