### PR TITLE
Adding the ares logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ares
 
+![ares logo](https://ares-emulator.github.io/images/logo.png)
+
 [![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://github.com/higan-emu/ares/blob/master/LICENSE)
 
 **ares** is a multi-system emulator that began development on October 14th, 2004.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# ares
-
 ![ares logo](https://ares-emulator.github.io/images/logo.png)
 
 [![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://github.com/higan-emu/ares/blob/master/LICENSE)


### PR DESCRIPTION
The resource comes directly from https://ares-emulator.github.io/
This ends the editions in the readme page.