### PR TITLE
recompiler: directly emit code for target ABI

### DIFF
--- a/ares/component/processor/sh2/recompiler.cpp
+++ b/ares/component/processor/sh2/recompiler.cpp
@@ -44,8 +44,6 @@ auto SH2::Recompiler::emit(u32 address) -> Block* {
   push(rbp);
   push(r13);
   if constexpr(ABI::Windows) {
-    push(rsi);
-    push(rdi);
     sub(rsp, imm8(0x40));
   }
   mov(rbx, imm64(&self.R[0]));
@@ -58,8 +56,6 @@ auto SH2::Recompiler::emit(u32 address) -> Block* {
 
   if constexpr(ABI::Windows) {
     add(rsp, imm8(0x40));
-    pop(rdi);
-    pop(rsi);
   }
   pop(r13);
   pop(rbp);
@@ -108,27 +104,27 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.B Rm,@(R0,Rn)
   case 0x04: {
-    mov(esi, Rn);
-    add(esi, R0);
-    mov(edx, Rm);
+    mov(ra1d, Rn);
+    add(ra1d, R0);
+    mov(ra2d, Rm);
     call(writeByte);
     return 0;
   }
 
   //MOV.W Rm,@(R0,Rn)
   case 0x05: {
-    mov(esi, Rn);
-    add(esi, R0);
-    mov(edx, Rm);
+    mov(ra1d, Rn);
+    add(ra1d, R0);
+    mov(ra2d, Rm);
     call(writeWord);
     return 0;
   }
 
   //MOV.L Rm,@(R0,Rn)
   case 0x06: {
-    mov(esi, Rn);
-    add(esi, R0);
-    mov(edx, Rm);
+    mov(ra1d, Rn);
+    add(ra1d, R0);
+    mov(ra2d, Rm);
     call(writeLong);
     return 0;
   }
@@ -144,8 +140,8 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.B @(R0,Rm),Rn
   case 0x0c: {
-    mov(esi, Rm);
-    add(esi, R0);
+    mov(ra1d, Rm);
+    add(ra1d, R0);
     call(readByte);
     movsx(eax, al);
     mov(Rn, eax);
@@ -154,8 +150,8 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.W @(R0,Rm),Rn
   case 0x0d: {
-    mov(esi, Rm);
-    add(esi, R0);
+    mov(ra1d, Rm);
+    add(ra1d, R0);
     call(readWord);
     movsx(eax, ax);
     mov(Rn, eax);
@@ -164,8 +160,8 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.L @(R0,Rm),Rn
   case 0x0e: {
-    mov(esi, Rm);
-    add(esi, R0);
+    mov(ra1d, Rm);
+    add(ra1d, R0);
     call(readLong);
     mov(Rn, eax);
     return 0;
@@ -173,13 +169,14 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MAC.L @Rm+,@Rn+
   case 0x0f: {
-    mov(esi, Rn);
+    auto skip = declareLabel();
+    mov(ra1d, Rn);
     addd(Rn, imm8(4));
     call(readLong);
     movsxd(rax, eax);
     push(rax);
     push(rax);
-    mov(esi, Rm);
+    mov(ra1d, Rm);
     addd(Rm, imm8(4));
     call(readLong);
     movsxd(rax, eax);
@@ -190,72 +187,73 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
     add(rdx, MAC);
     mov(al, S);
     test(al, al);
-    jz(imm8(8));
+    jz8(skip);
     sal(rdx, imm8(16));
     sar(rdx, imm8(16));
+    defineLabel(skip);
     mov(MAC, rdx);
     return 0;
   }
 
   //MOV.L Rm,@(disp,Rn)
   case 0x10 ... 0x1f: {
-    mov(esi, Rn);
-    add(esi, imm8(d4*4));
-    mov(edx, Rm);
+    mov(ra1d, Rn);
+    add(ra1d, imm8(d4*4));
+    mov(ra2d, Rm);
     call(writeLong);
     return 0;
   }
 
   //MOV.B Rm,@Rn
   case 0x20: {
-    mov(esi, Rn);
-    mov(edx, Rm);
+    mov(ra1d, Rn);
+    mov(ra2d, Rm);
     call(writeByte);
     return 0;
   }
 
   //MOV.W Rm,@Rn
   case 0x21: {
-    mov(esi, Rn);
-    mov(edx, Rm);
+    mov(ra1d, Rn);
+    mov(ra2d, Rm);
     call(writeWord);
     return 0;
   }
 
   //MOV.L Rm,@Rn
   case 0x22: {
-    mov(esi, Rn);
-    mov(edx, Rm);
+    mov(ra1d, Rn);
+    mov(ra2d, Rm);
     call(writeLong);
     return 0;
   }
 
   //MOV.B Rm,@-Rn
   case 0x24: {
-    mov(esi, Rn);
-    dec(esi);
-    mov(Rn, esi);
-    mov(edx, Rm);
+    mov(ra1d, Rn);
+    dec(ra1d);
+    mov(Rn, ra1d);
+    mov(ra2d, Rm);
     call(writeByte);
     return 0;
   }
 
   //MOV.W Rm,@-Rn
   case 0x25: {
-    mov(esi, Rn);
-    sub(esi, imm8(2));
-    mov(Rn, esi);
-    mov(edx, Rm);
+    mov(ra1d, Rn);
+    sub(ra1d, imm8(2));
+    mov(Rn, ra1d);
+    mov(ra2d, Rm);
     call(writeWord);
     return 0;
   }
 
   //MOV.L Rm,@-Rn
   case 0x26: {
-    mov(esi, Rn);
-    sub(esi, imm8(4));
-    mov(Rn, esi);
-    mov(edx, Rm);
+    mov(ra1d, Rn);
+    sub(ra1d, imm8(4));
+    mov(Rn, ra1d);
+    mov(ra2d, Rm);
     call(writeLong);
     return 0;
   }
@@ -374,6 +372,8 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //DIV1 Rm,Rn
   case 0x34: {
+    auto skip = declareLabel();
+    auto skip2 = declareLabel();
     mov(al, Q);
     mov(cl, al);
     mov(eax, Rn);
@@ -385,10 +385,12 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
     or(dl, al);
     mov(al, M);
     cmp(al, cl);
-    jnz(imm8(5));
+    jnz8(skip);
     sub(edx, Rm);
-    jmp(imm8(3));
+    jmp8(skip2);
+    defineLabel(skip);
     add(edx, Rm);
+    defineLabel(skip2);
     mov(Rn, edx);
     setc(dl);
     mov(al, Q);
@@ -503,13 +505,14 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MAC.W @Rm+,@Rn+
   case 0x4f: {
-    mov(esi, Rn);
+    auto skip = declareLabel();
+    mov(ra1d, Rn);
     addd(Rn, imm8(2));
     call(readWord);
     movsx(eax, ax);
     push(rax);
     push(rax);
-    mov(esi, Rm);
+    mov(ra1d, Rm);
     addd(Rm, imm8(2));
     call(readWord);
     movsx(eax, ax);
@@ -521,16 +524,17 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
     add(rdx, MAC);
     mov(al, S);
     test(al, al);
-    jz(imm8(3));
+    jz8(skip);
     movsxd(rdx, edx);
+    defineLabel(skip);
     mov(MAC, rdx);
     return 0;
   }
 
   //MOV.L @(disp,Rm),Rn
   case 0x50 ... 0x5f: {
-    mov(esi, Rm);
-    add(esi, imm8(d4*4));
+    mov(ra1d, Rm);
+    add(ra1d, imm8(d4*4));
     call(readLong);
     mov(Rn, eax);
     return 0;
@@ -538,7 +542,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.B @Rm,Rn
   case 0x60: {
-    mov(esi, Rm);
+    mov(ra1d, Rm);
     call(readByte);
     movsx(eax, al);
     mov(Rn, eax);
@@ -547,7 +551,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.W @Rm,Rn
   case 0x61: {
-    mov(esi, Rm);
+    mov(ra1d, Rm);
     call(readWord);
     movsx(eax, ax);
     mov(Rn, eax);
@@ -556,7 +560,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.L @Rm,Rn
   case 0x62: {
-    mov(esi, Rm);
+    mov(ra1d, Rm);
     call(readLong);
     mov(Rn, eax);
     return 0;
@@ -571,7 +575,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.B @Rm+,Rn
   case 0x64: {
-    mov(esi, Rm);
+    mov(ra1d, Rm);
     if(n != m) addd(Rm, imm8(1));
     call(readByte);
     movsx(eax, al);
@@ -581,7 +585,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.W @Rm+,Rn
   case 0x65: {
-    mov(esi, Rm);
+    mov(ra1d, Rm);
     if(n != m) addd(Rm, imm8(2));
     call(readWord);
     movsx(eax, ax);
@@ -591,7 +595,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.L @Rm+,Rn
   case 0x66: {
-    mov(esi, Rm);
+    mov(ra1d, Rm);
     if(n != m) addd(Rm, imm8(4));
     call(readLong);
     mov(Rn, eax);
@@ -691,8 +695,8 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.W @(disp,PC),Rn
   case 0x90 ... 0x9f: {
-    mov(esi, PC);
-    add(esi, imm32(d8*2));
+    mov(ra1d, PC);
+    add(ra1d, imm32(d8*2));
     call(readWord);
     movsx(eax, ax);
     mov(Rn, eax);
@@ -701,28 +705,28 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //BRA disp
   case 0xa0 ... 0xaf: {
-    mov(esi, PC);
-    add(esi, imm32(4 + (i12)d12 * 2));
-    mov(PPC, esi);
+    mov(eax, PC);
+    add(eax, imm32(4 + (i12)d12 * 2));
+    mov(PPC, eax);
     movb(PPM, imm8(Branch::Slot));
     return 1;
   }
 
   //BSR disp
   case 0xb0 ... 0xbf: {
-    mov(esi, PC);
-    mov(PR, esi);
-    add(esi, imm32(4 + (i12)d12 * 2));
-    mov(PPC, esi);
+    mov(eax, PC);
+    mov(PR, eax);
+    add(eax, imm32(4 + (i12)d12 * 2));
+    mov(PPC, eax);
     movb(PPM, imm8(Branch::Slot));
     return 1;
   }
 
   //MOV.L @(disp,PC),Rn
   case 0xd0 ... 0xdf: {
-    mov(esi, PC);
-    and(esi, imm8(~3));
-    add(esi, imm32(d8*4));
+    mov(ra1d, PC);
+    and(ra1d, imm8(~3));
+    add(ra1d, imm32(d8*4));
     call(readLong);
     mov(Rn, eax);
     return 0;
@@ -756,26 +760,26 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.B R0,@(disp,Rn)
   case 0x80: {
-    mov(esi, Rm);
-    add(esi, imm8(d4));
-    mov(edx, R0);
+    mov(ra1d, Rm);
+    add(ra1d, imm8(d4));
+    mov(ra2d, R0);
     call(writeByte);
     return 0;
   }
 
   //MOV.W R0,@(disp,Rn)
   case 0x81: {
-    mov(esi, Rm);
-    add(esi, imm8(d4*2));
-    mov(edx, R0);
+    mov(ra1d, Rm);
+    add(ra1d, imm8(d4*2));
+    mov(ra2d, R0);
     call(writeWord);
     return 0;
   }
 
   //MOV.B @(disp,Rn),R0
   case 0x84: {
-    mov(esi, Rm);
-    add(esi, imm8(d4));
+    mov(ra1d, Rm);
+    add(ra1d, imm8(d4));
     call(readByte);
     movsx(eax, al);
     mov(R0, eax);
@@ -784,8 +788,8 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.W @(disp,Rn),R0
   case 0x85: {
-    mov(esi, Rm);
-    add(esi, imm8(d4*2));
+    mov(ra1d, Rm);
+    add(ra1d, imm8(d4*2));
     call(readWord);
     movsx(eax, ax);
     mov(R0, eax);
@@ -802,75 +806,83 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //BT disp
   case 0x89: {
+    auto skip = declareLabel();
     mov(al, T);
     test(al, al);
-    jz(imm8(16));
-    mov(esi, PC);
-    add(esi, imm32(4 + (s8)d8 * 2));
-    mov(PPC, esi);
+    jz8(skip);
+    mov(eax, PC);
+    add(eax, imm32(4 + (s8)d8 * 2));
+    mov(PPC, eax);
     movb(PPM, imm8(Branch::Take));
+    defineLabel(skip);
     return 1;
   }
 
   //BF disp
   case 0x8b: {
+    auto skip = declareLabel();
     mov(al, T);
     test(al, al);
-    jnz(imm8(16));
-    mov(esi, PC);
-    add(esi, imm32(4 + (s8)d8 * 2));
-    mov(PPC, esi);
+    jnz8(skip);
+    mov(eax, PC);
+    add(eax, imm32(4 + (s8)d8 * 2));
+    mov(PPC, eax);
     movb(PPM, imm8(Branch::Take));
+    defineLabel(skip);
     return 1;
   }
 
   //BT/S disp
   case 0x8d: {
+    auto skip = declareLabel();
     mov(al, T);
     test(al, al);
-    jz(imm8(16));
-    mov(esi, PC);
-    add(esi, imm32(4 + (s8)d8 * 2));
-    mov(PPC, esi);
+    jz8(skip);
+    mov(eax, PC);
+    add(eax, imm32(4 + (s8)d8 * 2));
+    mov(PPC, eax);
     movb(PPM, imm8(Branch::Slot));
+    defineLabel(skip);
     return 1;
   }
 
   //BF/S disp
   case 0x8f: {
+    auto skip = declareLabel();
     mov(al, T);
     test(al, al);
-    jnz(imm8(16));
-    mov(esi, PC);
-    add(esi, imm32(4 + (s8)d8 * 2));
-    mov(PPC, esi);
+    jnz8(skip);
+    mov(eax, PC);
+    add(eax, imm32(4 + (s8)d8 * 2));
+    mov(PPC, eax);
     movb(PPM, imm8(Branch::Slot));
+    defineLabel(skip);
     return 1;
   }
 
   //MOV.B R0,@(disp,GBR)
   case 0xc0: {
-    mov(esi, GBR);
-    add(esi, imm32(d8));
-    mov(edx, R0);
+    mov(ra1d, GBR);
+    add(ra1d, imm32(d8));
+    mov(ra2d, R0);
     call(writeByte);
     return 0;
   }
 
   //MOV.W R0,@(disp,GBR)
   case 0xc1: {
-    mov(esi, GBR);
-    add(esi, imm32(d8*2));
-    mov(edx, R0);
+    mov(ra1d, GBR);
+    add(ra1d, imm32(d8*2));
+    mov(ra2d, R0);
     call(writeWord);
     return 0;
   }
 
   //MOV.L R0,@(disp,GBR)
   case 0xc2: {
-    mov(esi, GBR);
-    add(esi, imm32(d8*4));
-    mov(edx, R0);
+    mov(ra1d, GBR);
+    add(ra1d, imm32(d8*4));
+    mov(ra2d, R0);
     call(writeLong);
     return 0;
   }
@@ -893,16 +905,18 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
     mov(al, M);
     shl(eax, imm8(9));
     or(edx, eax);
-    mov(esi, R15);
+    mov(ra2d, edx);
+    mov(ra1d, R15);
     addd(R15, imm8(4));
     call(writeLong);
     mov(edx, PC);
     add(edx, imm8(2));
-    mov(esi, R15);
+    mov(ra2d, edx);
+    mov(ra1d, R15);
     addd(R15, imm8(4));
     call(writeLong);
-    mov(esi, VBR);
-    add(esi, imm32(i * 4));
+    mov(ra1d, VBR);
+    add(ra1d, imm32(i * 4));
     call(readLong);
     add(eax, imm8(4));
     mov(PPC, eax);
@@ -912,8 +926,8 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.B @(disp,GBR),R0
   case 0xc4: {
-    mov(esi, GBR);
-    add(esi, imm32(d8));
+    mov(ra1d, GBR);
+    add(ra1d, imm32(d8));
     call(readByte);
     movsx(eax, al);
     mov(R0, eax);
@@ -922,8 +936,8 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.W @(disp,GBR),R0
   case 0xc5: {
-    mov(esi, GBR);
-    add(esi, imm32(d8*2));
+    mov(ra1d, GBR);
+    add(ra1d, imm32(d8*2));
     call(readWord);
     movsx(eax, ax);
     mov(R0, eax);
@@ -932,8 +946,8 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.L @(disp,GBR),R0
   case 0xc6: {
-    mov(esi, GBR);
-    add(esi, imm32(d8*4));
+    mov(ra1d, GBR);
+    add(ra1d, imm32(d8*4));
     call(readLong);
     mov(R0, rax);
     return 0;
@@ -941,16 +955,18 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOVA @(disp,PC),R0
   case 0xc7: {
+    auto skip = declareLabel();
     mov(eax, PC);
     and(al, imm8(~3));
     add(eax, imm32(d8*4));
     mov(R0, eax);
     mov(eax, PPM);
     test(eax, eax);
-    jz(imm8(7));
+    jz8(skip);
     mov(eax, R0);
     sub(eax, imm8(2));
     mov(R0, eax);
+    defineLabel(skip);
     return 0;
   }
 
@@ -988,8 +1004,8 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //TST.B #imm,@(R0,GBR)
   case 0xcc: {
-    mov(esi, GBR);
-    add(esi, R0);
+    mov(ra1d, GBR);
+    add(ra1d, R0);
     call(readByte);
     and(al, imm8(i));
     setz(T);
@@ -998,39 +1014,39 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //AND.B #imm,@(R0,GBR)
   case 0xcd: {
-    mov(esi, GBR);
-    add(esi, R0);
+    mov(ra1d, GBR);
+    add(ra1d, R0);
     call(readByte);
     and(al, imm8(i));
-    mov(edx, eax);
-    mov(esi, GBR);
-    add(esi, R0);
+    mov(ra2d, eax);
+    mov(ra1d, GBR);
+    add(ra1d, R0);
     call(writeByte);
     return 0;
   }
 
   //XOR.B #imm,@(R0,GBR)
   case 0xce: {
-    mov(esi, GBR);
-    add(esi, R0);
+    mov(ra1d, GBR);
+    add(ra1d, R0);
     call(readByte);
     xor(al, imm8(i));
-    mov(edx, eax);
-    mov(esi, GBR);
-    add(esi, R0);
+    mov(ra2d, eax);
+    mov(ra1d, GBR);
+    add(ra1d, R0);
     call(writeByte);
     return 0;
   }
 
   //OR.B #imm,@(R0,GBR)
   case 0xcf: {
-    mov(esi, GBR);
-    add(esi, R0);
+    mov(ra1d, GBR);
+    add(ra1d, R0);
     call(readByte);
     or(al, imm8(i));
-    mov(edx, eax);
-    mov(esi, GBR);
-    add(esi, R0);
+    mov(ra2d, eax);
+    mov(ra1d, GBR);
+    add(ra1d, R0);
     call(writeByte);
     return 0;
   }
@@ -1052,6 +1068,8 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //STC SR,Rn
   case 0x002: {
+    auto skip = declareLabel();
+    auto skip2 = declareLabel();
     xor(edx, edx);
     xor(eax, eax);
     mov(al, T);
@@ -1064,23 +1082,25 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
     or(dl, al);
     mov(al, Q);
     test(al, al);
-    jz(imm8(6));
+    jz8(skip);
     or(edx, imm32(0x100));
+    defineLabel(skip);
     mov(al, M);
     test(al, al);
-    jz(imm8(6));
+    jz8(skip2);
     or(edx, imm32(0x200));
+    defineLabel(skip2);
     mov(Rn, edx);
     return 0;
   }
 
   //BSRF Rm
   case 0x003: {
-    mov(esi, PC);
-    mov(PR, esi);
-    add(esi, Rm);
-    add(esi, imm8(4));
-    mov(PPC, esi);
+    mov(eax, PC);
+    mov(PR, eax);
+    add(eax, Rm);
+    add(eax, imm8(4));
+    mov(PPC, eax);
     movb(PPM, imm8(Branch::Slot));
     return 1;
   }
@@ -1115,10 +1135,10 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //BRAF Rm
   case 0x023: {
-    mov(esi, PC);
-    add(esi, Rm);
-    add(esi, imm8(4));
-    mov(PPC, esi);
+    mov(eax, PC);
+    add(eax, Rm);
+    add(eax, imm8(4));
+    mov(PPC, eax);
     movb(PPM, imm8(Branch::Slot));
     return 1;
   }
@@ -1162,16 +1182,18 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //STS.L MACH,@-Rn
   case 0x402: {
-    mov(esi, Rn);
-    sub(esi, imm8(4));
-    mov(Rn, esi);
-    mov(edx, MACH);
+    mov(ra1d, Rn);
+    sub(ra1d, imm8(4));
+    mov(Rn, ra1d);
+    mov(ra2d, MACH);
     call(writeLong);
     return 0;
   }
 
   //STC.L SR,@-Rn
   case 0x403: {
+    auto skip = declareLabel();
+    auto skip2 = declareLabel();
     xor(edx, edx);
     xor(eax, eax);
     mov(al, T);
@@ -1184,15 +1206,18 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
     or(dl, al);
     mov(al, Q);
     test(al, al);
-    jz(imm8(6));
+    jz8(skip);
     or(edx, imm32(0x100));
+    defineLabel(skip);
     mov(al, M);
     test(al, al);
-    jz(imm8(6));
+    jz8(skip2);
     or(edx, imm32(0x200));
-    mov(esi, Rn);
-    sub(esi, imm8(4));
-    mov(Rn, esi);
+    defineLabel(skip2);
+    mov(ra2d, edx);
+    mov(ra1d, Rn);
+    sub(ra1d, imm8(4));
+    mov(Rn, ra1d);
     call(writeLong);
     return 0;
   }
@@ -1221,7 +1246,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //LDS.L @Rm+,MACH
   case 0x406: {
-    mov(esi, Rn);
+    mov(ra1d, Rn);
     addd(Rn, imm8(4));
     call(readLong);
     mov(MACH, rax);
@@ -1230,7 +1255,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //LDC.L @Rm+,SR
   case 0x407: {
-    mov(esi, Rn);
+    mov(ra1d, Rn);
     addd(Rn, imm8(4));
     call(readLong);
     mov(edx, eax);
@@ -1280,11 +1305,11 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //JSR @Rm
   case 0x40b: {
-    mov(esi, PC);
-    mov(PR, esi);
-    mov(esi, Rm);
-    add(esi, imm8(4));
-    mov(PPC, esi);
+    mov(eax, PC);
+    mov(PR, eax);
+    mov(eax, Rm);
+    add(eax, imm8(4));
+    mov(PPC, eax);
     movb(PPM, imm8(Branch::Slot));
     return 1;
   }
@@ -1334,20 +1359,20 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //STS.L MACL,@-Rn
   case 0x412: {
-    mov(esi, Rn);
-    sub(esi, imm8(4));
-    mov(Rn, esi);
-    mov(edx, MACL);
+    mov(ra1d, Rn);
+    sub(ra1d, imm8(4));
+    mov(Rn, ra1d);
+    mov(ra2d, MACL);
     call(writeLong);
     return 0;
   }
 
   //STC.L GBR,@-Rn
   case 0x413: {
-    mov(esi, Rn);
-    sub(esi, imm8(4));
-    mov(Rn, esi);
-    mov(edx, GBR);
+    mov(ra1d, Rn);
+    sub(ra1d, imm8(4));
+    mov(Rn, ra1d);
+    mov(ra2d, GBR);
     call(writeLong);
     return 0;
   }
@@ -1362,7 +1387,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //LDS.L @Rm+,MACL
   case 0x416: {
-    mov(esi, Rm);
+    mov(ra1d, Rm);
     addd(Rm, imm8(4));
     call(readLong);
     mov(MACL, eax);
@@ -1371,7 +1396,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //LDS.L @Rm+,GBR
   case 0x417: {
-    mov(esi, Rm);
+    mov(ra1d, Rm);
     addd(Rm, imm8(4));
     call(readLong);
     mov(GBR, eax);
@@ -1403,9 +1428,9 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //TAS @Rn
   case 0x41b: {
-    mov(esi, Rn);
-    and(esi, imm32(0x1fff'ffff));
-    or(esi, imm32(0x2000'0000));
+    mov(ra1d, Rn);
+    and(ra1d, imm32(0x1fff'ffff));
+    or(ra1d, imm32(0x2000'0000));
     call(readByte);
     mov(cl, al);
     test(al, al);
@@ -1413,10 +1438,10 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
     mov(T, al);
     mov(al, cl);
     or(al, imm8(0x80));
-    mov(edx, eax);
-    mov(esi, Rn);
-    and(esi, imm32(0x1fff'ffff));
-    or(esi, imm32(0x2000'0000));
+    mov(ra2d, eax);
+    mov(ra1d, Rn);
+    and(ra1d, imm32(0x1fff'ffff));
+    or(ra1d, imm32(0x2000'0000));
     call(writeByte);
     return 0;
   }
@@ -1452,20 +1477,20 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //STS.L PR,@-Rn
   case 0x422: {
-    mov(esi, Rn);
-    sub(esi, imm8(4));
-    mov(Rn, esi);
-    mov(edx, PR);
+    mov(ra1d, Rn);
+    sub(ra1d, imm8(4));
+    mov(Rn, ra1d);
+    mov(ra2d, PR);
     call(writeLong);
     return 0;
   }
 
   //STC.L VBR,@-Rn
   case 0x423: {
-    mov(esi, Rn);
-    sub(esi, imm8(4));
-    mov(Rn, esi);
-    mov(edx, VBR);
+    mov(ra1d, Rn);
+    sub(ra1d, imm8(4));
+    mov(Rn, ra1d);
+    mov(ra2d, VBR);
     call(writeLong);
     return 0;
   }
@@ -1504,7 +1529,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //LDS.L @Rm+,PR
   case 0x426: {
-    mov(esi, Rm);
+    mov(ra1d, Rm);
     addd(Rm, imm8(4));
     call(readLong);
     mov(PR, eax);
@@ -1513,7 +1538,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //LDC.L @Rm+,VBR
   case 0x427: {
-    mov(esi, Rm);
+    mov(ra1d, Rm);
     addd(Rm, imm8(4));
     call(readLong);
     mov(VBR, eax);
@@ -1545,9 +1570,9 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //JMP @Rm
   case 0x42b: {
-    mov(esi, Rm);
-    add(esi, imm8(4));
-    mov(PPC, esi);
+    mov(eax, Rm);
+    add(eax, imm8(4));
+    mov(PPC, eax);
     movb(PPM, imm8(Branch::Slot));
     return 1;
   }
@@ -1581,9 +1606,9 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //RTS
   case 0x000b: {
-    mov(esi, PR);
-    add(esi, imm8(4));
-    mov(PPC, esi);
+    mov(eax, PR);
+    add(eax, imm8(4));
+    mov(PPC, eax);
     movb(PPM, imm8(Branch::Slot));
     return 1;
   }
@@ -1606,12 +1631,16 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //SLEEP
   case 0x001b: {
+    auto skip = declareLabel();
+    auto skip2 = declareLabel();
     mov(eax, ET);
     test(al, al);
-    jnz(imm8(6));
+    jnz8(skip);
     subd(PC, imm8(2));
-    jmp(imm8(4));
+    jmp8(skip2);
+    defineLabel(skip);
     movb(ET, imm8(0));
+    defineLabel(skip2);
     return 1;
   }
 
@@ -1624,12 +1653,12 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //RTE
   case 0x002b: {
-    mov(esi, R15);
+    mov(ra1d, R15);
     addd(R15, imm8(4));
     call(readLong);
     mov(PPC, eax);
     movb(PPM, imm8(Branch::Slot));
-    mov(esi, R15);
+    mov(ra1d, R15);
     addd(R15, imm8(4));
     call(readLong);
     mov(edx, eax);

--- a/ares/component/processor/sh2/sh2.hpp
+++ b/ares/component/processor/sh2/sh2.hpp
@@ -277,17 +277,11 @@ struct SH2 {
     template<typename V, typename... P>
     alwaysinline auto call(V (SH2::*function)(P...)) -> void {
       static_assert(sizeof...(P) <= 5);
-      if constexpr(ABI::SystemV) {
-        mov(rdi, rbp);
-      }
       if constexpr(ABI::Windows) {
-        if constexpr(sizeof...(P) >= 5) mov(dis8(rsp, 0x28), r9);
-        if constexpr(sizeof...(P) >= 4) mov(dis8(rsp, 0x20), r8);
-        if constexpr(sizeof...(P) >= 3) mov(r9, rcx);
-        if constexpr(sizeof...(P) >= 2) mov(r8, rdx);
-        if constexpr(sizeof...(P) >= 1) mov(rdx, rsi);
-        mov(rcx, rbp);
+        if constexpr(sizeof...(P) >= 5) mov(dis8(rsp, 0x28), ra5);
+        if constexpr(sizeof...(P) >= 4) mov(dis8(rsp, 0x20), ra4);
       }
+      mov(ra0, rbp);
       call(imm64{function}, rax);
     }
 

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -24,8 +24,6 @@ auto CPU::Recompiler::emit(u32 address) -> Block* {
   push(rbp);
   push(r13);
   if constexpr(ABI::Windows) {
-    push(rsi);
-    push(rdi);
     sub(rsp, imm8(0x40));
   }
   mov(rbx, imm64(&self.ipu.r[0] + 16));
@@ -39,8 +37,6 @@ auto CPU::Recompiler::emit(u32 address) -> Block* {
 
   if constexpr(ABI::Windows) {
     add(rsp, imm8(0x40));
-    pop(rdi);
-    pop(rsi);
   }
   pop(r13);
   pop(rbp);
@@ -105,76 +101,76 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //J n26
   case 0x02: {
-    mov(esi, imm32(n26));
+    mov(ra1d, imm32(n26));
     call(&CPU::J);
     return 1;
   }
 
   //JAL n26
   case 0x03: {
-    mov(esi, imm32(n26));
+    mov(ra1d, imm32(n26));
     call(&CPU::JAL);
     return 1;
   }
 
   //BEQ Rs,Rt,i16
   case 0x04: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rs);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(i16));
     call(&CPU::BEQ);
     return 1;
   }
 
   //BNE Rs,Rt,i16
   case 0x05: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rs);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(i16));
     call(&CPU::BNE);
     return 1;
   }
 
   //BLEZ Rs,i16
   case 0x06: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BLEZ);
     return 1;
   }
 
   //BGTZ Rs,i16
   case 0x07: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BGTZ);
     return 1;
   }
 
   //ADDI Rt,Rs,i16
   case 0x08: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::ADDI);
     return 0;
   }
 
   //ADDIU Rt,Rs,i16
   case 0x09: {
-    mov(esi, Rs);
-    add(esi, imm32(i16));
-    movsxd(rsi, esi);
-    mov(Rt, rsi);
+    mov(eax, Rs);
+    add(eax, imm32(i16));
+    movsxd(rax, eax);
+    mov(Rt, rax);
     return 0;
   }
 
   //SLTI Rt,Rs,i16
   case 0x0a: {
-    mov(rsi, Rs);
-    mov(edx, imm32(i16));
-    movsxd(rdx, edx);
-    cmp(rsi, rdx);
+    mov(rax, Rs);
+    mov(ecx, imm32(i16));
+    movsxd(rcx, ecx);
+    cmp(rax, rcx);
     setl(al);
     movzx(eax, al);
     mov(Rt, rax);
@@ -183,10 +179,10 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //SLTIU Rt,Rs,i16
   case 0x0b: {
-    mov(rsi, Rs);
-    mov(edx, imm32(i16));
-    movsxd(rdx, edx);
-    cmp(rsi, rdx);
+    mov(rax, Rs);
+    mov(ecx, imm32(i16));
+    movsxd(rcx, ecx);
+    cmp(rax, rcx);
     setb(al);
     movzx(eax, al);
     mov(Rt, rax);
@@ -195,33 +191,33 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //ANDI Rt,Rs,n16
   case 0x0c: {
-    mov(rsi, Rs);
-    and(rsi, imm32(n16));
-    mov(Rt, rsi);
+    mov(rax, Rs);
+    and(rax, imm32(n16));
+    mov(Rt, rax);
     return 0;
   }
 
   //ORI Rt,Rs,n16
   case 0x0d: {
-    mov(rsi, Rs);
-    or(rsi, imm32(n16));
-    mov(Rt, rsi);
+    mov(rax, Rs);
+    or(rax, imm32(n16));
+    mov(Rt, rax);
     return 0;
   }
 
   //XORI Rt,Rs,n16
   case 0x0e: {
-    mov(rsi, Rs);
-    xor(rsi, imm32(n16));
-    mov(Rt, rsi);
+    mov(rax, Rs);
+    xor(rax, imm32(n16));
+    mov(Rt, rax);
     return 0;
   }
 
   //LUI Rt,n16
   case 0x0f: {
-    mov(esi, imm32(n16 << 16));
-    movsxd(rsi, esi);
-    mov(Rt, rsi);
+    mov(eax, imm32(n16 << 16));
+    movsxd(rax, eax);
+    mov(Rt, rax);
     return 0;
   }
 
@@ -249,70 +245,70 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //BEQL Rs,Rt,i16
   case 0x14: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rs);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(i16));
     call(&CPU::BEQL);
     return 1;
   }
 
   //BNEL Rs,Rt,i16
   case 0x15: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rs);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(i16));
     call(&CPU::BNEL);
     return 1;
   }
 
   //BLEZL Rs,i16
   case 0x16: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BLEZL);
     return 1;
   }
 
   //BGTZL Rs,i16
   case 0x17: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BGTZL);
     return 1;
   }
 
   //DADDI Rt,Rs,i16
   case 0x18: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::DADDI);
     return 0;
   }
 
   //DADDIU Rt,Rs,i16
   case 0x19: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::DADDIU);
     return 0;
   }
 
   //LDL Rt,Rs,i16
   case 0x1a: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LDL);
     return 0;
   }
 
   //LDR Rt,Rs,i16
   case 0x1b: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LDR);
     return 0;
   }
@@ -325,162 +321,162 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //LB Rt,Rs,i16
   case 0x20: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LB);
     return 0;
   }
 
   //LH Rt,Rs,i16
   case 0x21: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LH);
     return 0;
   }
 
   //LWL Rt,Rs,i16
   case 0x22: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LWL);
     return 0;
   }
 
   //LW Rt,Rs,i16
   case 0x23: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LW);
     return 0;
   }
 
   //LBU Rt,Rs,i16
   case 0x24: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LBU);
     return 0;
   }
 
   //LHU Rt,Rs,i16
   case 0x25: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LHU);
     return 0;
   }
 
   //LWR Rt,Rs,i16
   case 0x26: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LWR);
     return 0;
   }
 
   //LWU Rt,Rs,i16
   case 0x27: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LWU);
     return 0;
   }
 
   //SB Rt,Rs,i16
   case 0x28: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SB);
     return 0;
   }
 
   //SH Rt,Rs,i16
   case 0x29: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SH);
     return 0;
   }
 
   //SWL Rt,Rs,i16
   case 0x2a: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SWL);
     return 0;
   }
 
   //SW Rt,Rs,i16
   case 0x2b: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SW);
     return 0;
   }
 
   //SDL Rt,Rs,i16
   case 0x2c: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SDL);
     return 0;
   }
 
   //SDR Rt,Rs,i16
   case 0x2d: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SDR);
     return 0;
   }
 
   //SWR Rt,Rs,i16
   case 0x2e: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SWR);
     return 0;
   }
 
   //CACHE op(offset),base
   case 0x2f: {
-    mov(esi, imm32(instruction >> 16 & 31));
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    mov(ra1d, imm32(instruction >> 16 & 31));
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::CACHE);
     return 0;
   }
 
   //LL Rt,Rs,i16
   case 0x30: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LL);
     return 0;
   }
 
   //LWC1 Ft,Rs,i16
   case 0x31: {
-    mov(esi, imm32(Ftn));
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    mov(ra1d, imm32(Ftn));
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LWC1);
     return 0;
   }
@@ -499,18 +495,18 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //LLD Rt,Rs,i16
   case 0x34: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LLD);
     return 0;
   }
 
   //LDC1 Ft,Rs,i16
   case 0x35: {
-    mov(esi, imm32(Ftn));
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    mov(ra1d, imm32(Ftn));
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LDC1);
     return 0;
   }
@@ -523,27 +519,27 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //LD Rt,Rs,i16
   case 0x37: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LD);
     return 0;
   }
 
   //SC Rt,Rs,i16
   case 0x38: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SC);
     return 0;
   }
 
   //SWC1 Ft,Rs,i16
   case 0x39: {
-    mov(esi, imm32(Ftn));
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    mov(ra1d, imm32(Ftn));
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SWC1);
     return 0;
   }
@@ -562,18 +558,18 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //SCD Rt,Rs,i16
   case 0x3c: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SCD);
     return 0;
   }
 
   //SDC1 Ft,Rs,i16
   case 0x3d: {
-    mov(esi, imm32(Ftn));
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    mov(ra1d, imm32(Ftn));
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SDC1);
     return 0;
   }
@@ -586,9 +582,9 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //SD Rt,Rs,i16
   case 0x3f: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SD);
     return 0;
   }
@@ -603,10 +599,10 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //SLL Rd,Rt,Sa
   case 0x00: {
-    mov(esi, Rt);
-    shl(esi, imm8(Sa));
-    movsxd(rsi, esi);
-    mov(Rd, rsi);
+    mov(eax, Rt);
+    shl(eax, imm8(Sa));
+    movsxd(rax, eax);
+    mov(Rd, rax);
     return 0;
   }
 
@@ -618,30 +614,30 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //SRL Rd,Rt,Sa
   case 0x02: {
-    mov(esi, Rt);
-    shr(esi, imm8(Sa));
-    movsxd(rsi, esi);
-    mov(Rd, rsi);
+    mov(eax, Rt);
+    shr(eax, imm8(Sa));
+    movsxd(rax, eax);
+    mov(Rd, rax);
     return 0;
   }
 
   //SRA Rd,Rt,Sa
   case 0x03: {
-    mov(esi, Rt);
-    sar(esi, imm8(Sa));
-    movsxd(rsi, esi);
-    mov(Rd, rsi);
+    mov(eax, Rt);
+    sar(eax, imm8(Sa));
+    movsxd(rax, eax);
+    mov(Rd, rax);
     return 0;
   }
 
   //SLLV Rd,Rt,Rs
   case 0x04: {
-    mov(esi, Rt);
+    mov(eax, Rt);
     mov(cl, Rs);
     and(cl, imm8(31));
-    shl(esi, cl);
-    movsxd(rsi, esi);
-    mov(Rd, rsi);
+    shl(eax, cl);
+    movsxd(rax, eax);
+    mov(Rd, rax);
     return 0;
   }
 
@@ -653,37 +649,37 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //SRLV Rd,Rt,RS
   case 0x06: {
-    mov(esi, Rt);
+    mov(eax, Rt);
     mov(cl, Rs);
     and(cl, imm8(31));
-    shr(esi, cl);
-    movsxd(rsi, esi);
-    mov(Rd, rsi);
+    shr(eax, cl);
+    movsxd(rax, eax);
+    mov(Rd, rax);
     return 0;
   }
 
   //SRAV Rd,Rt,Rs
   case 0x07: {
-    mov(esi, Rt);
+    mov(eax, Rt);
     mov(cl, Rs);
     and(cl, imm8(31));
-    sar(esi, cl);
-    movsxd(rsi, esi);
-    mov(Rd, rsi);
+    sar(eax, cl);
+    movsxd(rax, eax);
+    mov(Rd, rax);
     return 0;
   }
 
   //JR Rs
   case 0x08: {
-    lea(rsi, Rs);
+    lea(ra1, Rs);
     call(&CPU::JR);
     return 1;
   }
 
   //JALR Rd,Rs
   case 0x09: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
     call(&CPU::JALR);
     return 1;
   }
@@ -748,9 +744,9 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //DSLLV Rd,Rt,Rs
   case 0x14: {
-    lea(rsi, Rd);
-    lea(rdx, Rt);
-    lea(rcx, Rs);
+    lea(ra1, Rd);
+    lea(ra2, Rt);
+    lea(ra3, Rs);
     call(&CPU::DSLLV);
     return 0;
   }
@@ -763,152 +759,152 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //DSRLV Rd,Rt,Rs
   case 0x16: {
-    lea(rsi, Rd);
-    lea(rdx, Rt);
-    lea(rcx, Rs);
+    lea(ra1, Rd);
+    lea(ra2, Rt);
+    lea(ra3, Rs);
     call(&CPU::DSRLV);
     return 0;
   }
 
   //DSRAV Rd,Rt,Rs
   case 0x17: {
-    lea(rsi, Rd);
-    lea(rdx, Rt);
-    lea(rcx, Rs);
+    lea(ra1, Rd);
+    lea(ra2, Rt);
+    lea(ra3, Rs);
     call(&CPU::DSRAV);
     return 0;
   }
 
   //MULT Rs,Rt
   case 0x18: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::MULT);
     return 0;
   }
 
   //MULTU Rs,Rt
   case 0x19: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::MULTU);
     return 0;
   }
 
   //DIV Rs,Rt
   case 0x1a: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::DIV);
     return 0;
   }
 
   //DIVU Rs,Rt
   case 0x1b: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::DIVU);
     return 0;
   }
 
   //DMULT Rs,Rt
   case 0x1c: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::DMULT);
     return 0;
   }
 
   //DMULTU Rs,Rt
   case 0x1d: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::DMULTU);
     return 0;
   }
 
   //DDIV Rs,Rt
   case 0x1e: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::DDIV);
     return 0;
   }
 
   //DDIVU Rs,Rt
   case 0x1f: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::DDIVU);
     return 0;
   }
 
   //ADD Rd,Rs,Rt
   case 0x20: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
-    lea(rcx, Rt);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
+    lea(ra3, Rt);
     call(&CPU::ADD);
     return 0;
   }
 
   //ADDU Rd,Rs,Rt
   case 0x21: {
-    mov(esi, Rs);
-    add(esi, Rt);
-    movsxd(rsi, esi);
-    mov(Rd, rsi);
+    mov(eax, Rs);
+    add(eax, Rt);
+    movsxd(rax, eax);
+    mov(Rd, rax);
     return 0;
   }
 
   //SUB Rd,Rs,Rt
   case 0x22: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
-    lea(rcx, Rt);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
+    lea(ra3, Rt);
     call(&CPU::SUB);
     return 0;
   }
 
   //SUBU Rd,Rs,Rt
   case 0x23: {
-    mov(esi, Rs);
-    sub(esi, Rt);
-    movsxd(rsi, esi);
-    mov(Rd, rsi);
+    mov(eax, Rs);
+    sub(eax, Rt);
+    movsxd(rax, eax);
+    mov(Rd, rax);
     return 0;
   }
 
   //AND Rd,Rs,Rt
   case 0x24: {
-    mov(rsi, Rs);
-    and(rsi, Rt);
-    mov(Rd, rsi);
+    mov(rax, Rs);
+    and(rax, Rt);
+    mov(Rd, rax);
     return 0;
   }
 
   //OR Rd,Rs,Rt
   case 0x25: {
-    mov(rsi, Rs);
-    or(rsi, Rt);
-    mov(Rd, rsi);
+    mov(rax, Rs);
+    or(rax, Rt);
+    mov(Rd, rax);
     return 0;
   }
 
   //XOR Rd,Rs,Rt
   case 0x26: {
-    mov(rsi, Rs);
-    xor(rsi, Rt);
-    mov(Rd, rsi);
+    mov(rax, Rs);
+    xor(rax, Rt);
+    mov(Rd, rax);
     return 0;
   }
 
   //NOR Rd,Rs,Rt
   case 0x27: {
-    mov(rsi, Rs);
-    or(rsi, Rt);
-    not(rsi);
-    mov(Rd, rsi);
+    mov(rax, Rs);
+    or(rax, Rt);
+    not(rax);
+    mov(Rd, rax);
     return 0;
   }
 
@@ -920,8 +916,8 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //SLT Rd,Rs,Rt
   case 0x2a: {
-    mov(rsi, Rs);
-    cmp(rsi, Rt);
+    mov(rax, Rs);
+    cmp(rax, Rt);
     setl(al);
     movzx(eax, al);
     mov(Rd, rax);
@@ -930,8 +926,8 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //SLTU Rd,Rs,Rt
   case 0x2b: {
-    mov(rsi, Rs);
-    cmp(rsi, Rt);
+    mov(rax, Rs);
+    cmp(rax, Rt);
     setb(al);
     movzx(eax, al);
     mov(Rd, rax);
@@ -940,76 +936,76 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //DADD Rd,Rs,Rt
   case 0x2c: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
-    lea(rcx, Rt);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
+    lea(ra3, Rt);
     call(&CPU::DADD);
     return 0;
   }
 
   //DADDU Rd,Rs,Rt
   case 0x2d: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
-    lea(rcx, Rt);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
+    lea(ra3, Rt);
     call(&CPU::DADDU);
     return 0;
   }
 
   //DSUB Rd,Rs,Rt
   case 0x2e: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
-    lea(rcx, Rt);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
+    lea(ra3, Rt);
     call(&CPU::DSUB);
     return 0;
   }
 
   //DSUBU Rd,Rs,Rt
   case 0x2f: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
-    lea(rcx, Rt);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
+    lea(ra3, Rt);
     call(&CPU::DSUBU);
     return 0;
   }
 
   //TGE Rs,Rt
   case 0x30: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::TGE);
     return 0;
   }
 
   //TGEU Rs,Rt
   case 0x31: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::TGEU);
     return 0;
   }
 
   //TLT Rs,Rt
   case 0x32: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::TLT);
     return 0;
   }
 
   //TLTU Rs,Rt
   case 0x33: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::TLTU);
     return 0;
   }
 
   //TEQ Rs,Rt
   case 0x34: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::TEQ);
     return 0;
   }
@@ -1022,8 +1018,8 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //TNE Rs,Rt
   case 0x36: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::TNE);
     return 0;
   }
@@ -1036,9 +1032,9 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //DSLL Rd,Rt,Sa
   case 0x38: {
-    lea(rsi, Rd);
-    lea(rdx, Rt);
-    mov(ecx, imm32(Sa));
+    lea(ra1, Rd);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(Sa));
     call(&CPU::DSLL);
     return 0;
   }
@@ -1051,27 +1047,27 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //DSRL Rd,Rt,Sa
   case 0x3a: {
-    lea(rsi, Rd);
-    lea(rdx, Rt);
-    mov(ecx, imm32(Sa));
+    lea(ra1, Rd);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(Sa));
     call(&CPU::DSRL);
     return 0;
   }
 
   //DSRA Rd,Rt,Sa
   case 0x3b: {
-    lea(rsi, Rd);
-    lea(rdx, Rt);
-    mov(ecx, imm32(Sa));
+    lea(ra1, Rd);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(Sa));
     call(&CPU::DSRA);
     return 0;
   }
 
   //DSLL32 Rd,Rt,Sa
   case 0x3c: {
-    lea(rsi, Rd);
-    lea(rdx, Rt);
-    mov(ecx, imm32(Sa+32));
+    lea(ra1, Rd);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(Sa+32));
     call(&CPU::DSLL);
     return 0;
   }
@@ -1084,18 +1080,18 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //DSRL32 Rd,Rt,Sa
   case 0x3e: {
-    lea(rsi, Rd);
-    lea(rdx, Rt);
-    mov(ecx, imm32(Sa+32));
+    lea(ra1, Rd);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(Sa+32));
     call(&CPU::DSRL);
     return 0;
   }
 
   //DSRA32 Rd,Rt,Sa
   case 0x3f: {
-    lea(rsi, Rd);
-    lea(rdx, Rt);
-    mov(ecx, imm32(Sa+32));
+    lea(ra1, Rd);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(Sa+32));
     call(&CPU::DSRA);
     return 0;
   }
@@ -1110,32 +1106,32 @@ auto CPU::Recompiler::emitREGIMM(u32 instruction) -> bool {
 
   //BLTZ Rs,i16
   case 0x00: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BLTZ);
     return 0;
   }
 
   //BGEZ Rs,i16
   case 0x01: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BGEZ);
     return 0;
   }
 
   //BLTZL Rs,i16
   case 0x02: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BLTZL);
     return 0;
   }
 
   //BGEZL Rs,i16
   case 0x03: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BGEZL);
     return 0;
   }
@@ -1148,40 +1144,40 @@ auto CPU::Recompiler::emitREGIMM(u32 instruction) -> bool {
 
   //TGEI Rs,i16
   case 0x08: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::TGEI);
     return 0;
   }
 
   //TGEIU Rs,i16
   case 0x09: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::TGEIU);
     return 0;
   }
 
   //TLTI Rs,i16
   case 0x0a: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::TLTI);
     return 0;
   }
 
   //TLTIU Rs,i16
   case 0x0b: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::TLTIU);
     return 0;
   }
 
   //TEQI Rs,i16
   case 0x0c: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::TEQI);
     return 0;
   }
@@ -1194,8 +1190,8 @@ auto CPU::Recompiler::emitREGIMM(u32 instruction) -> bool {
 
   //TNEI Rs,i16
   case 0x0e: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::TNEI);
     return 0;
   }
@@ -1208,32 +1204,32 @@ auto CPU::Recompiler::emitREGIMM(u32 instruction) -> bool {
 
   //BLTZAL Rs,i16
   case 0x10: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BLTZAL);
     return 0;
   }
 
   //BGEZAL Rs,i16
   case 0x11: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BGEZAL);
     return 0;
   }
 
   //BLTZALL Rs,i16
   case 0x12: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BLTZALL);
     return 0;
   }
 
   //BGEZALL Rs,i16
   case 0x13: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BGEZALL);
     return 0;
   }
@@ -1254,16 +1250,16 @@ auto CPU::Recompiler::emitSCC(u32 instruction) -> bool {
 
   //MFC0 Rt,Rd
   case 0x00: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Rdn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Rdn));
     call(&CPU::MFC0);
     return 0;
   }
 
   //DMFC0 Rt,Rd
   case 0x01: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Rdn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Rdn));
     call(&CPU::DMFC0);
     return 0;
   }
@@ -1276,16 +1272,16 @@ auto CPU::Recompiler::emitSCC(u32 instruction) -> bool {
 
   //MTC0 Rt,Rd
   case 0x04: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Rdn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Rdn));
     call(&CPU::MTC0);
     return 0;
   }
 
   //DMTC0 Rt,Rd
   case 0x05: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Rdn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Rdn));
     call(&CPU::DMTC0);
     return 0;
   }
@@ -1340,24 +1336,24 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
 
   //MFC1 Rt,Fs
   case 0x00: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Fsn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Fsn));
     call(&CPU::MFC1);
     return 0;
   }
 
   //DMFC1 Rt,Fs
   case 0x01: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Fsn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Fsn));
     call(&CPU::DMFC1);
     return 0;
   }
 
   //CFC1 Rt,Rd
   case 0x02: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Rdn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Rdn));
     call(&CPU::CFC1);
     return 0;
   }
@@ -1370,24 +1366,24 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
 
   //MTC1 Rt,Fs
   case 0x04: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Fsn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Fsn));
     call(&CPU::MTC1);
     return 0;
   }
 
   //DMTC1 Rt,Fs
   case 0x05: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Fsn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Fsn));
     call(&CPU::DMTC1);
     return 0;
   }
 
   //CTC1 Rt,Rd
   case 0x06: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Rdn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Rdn));
     call(&CPU::CTC1);
     return 0;
   }
@@ -1400,9 +1396,9 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
 
   //BC1 offset
   case 0x08: {
-    mov(esi, imm32(instruction >> 16 & 1));
-    mov(edx, imm32(instruction >> 17 & 1));
-    mov(ecx, imm32(i16));
+    mov(ra1d, imm32(instruction >> 16 & 1));
+    mov(ra2d, imm32(instruction >> 17 & 1));
+    mov(ra3d, imm32(i16));
     call(&CPU::BC1);
     return 1;
   }
@@ -1420,284 +1416,284 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
 
   //FADD.S Fd,Fs,Ft
   case 0x00: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
-    mov(ecx, imm32(Ftn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
+    mov(ra3d, imm32(Ftn));
     call(&CPU::FADD_S);
     return 0;
   }
 
   //FSUB.S Fd,Fs,Ft
   case 0x01: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
-    mov(ecx, imm32(Ftn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
+    mov(ra3d, imm32(Ftn));
     call(&CPU::FSUB_S);
     return 0;
   }
 
   //FMUL.S Fd,Fs,Ft
   case 0x02: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
-    mov(ecx, imm32(Ftn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
+    mov(ra3d, imm32(Ftn));
     call(&CPU::FMUL_S);
     return 0;
   }
 
   //FDIV.S Fd,Fs,Ft
   case 0x03: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
-    mov(ecx, imm32(Ftn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
+    mov(ra3d, imm32(Ftn));
     call(&CPU::FDIV_S);
     return 0;
   }
 
   //FSQRT.S Fd,Fs
   case 0x04: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FSQRT_S);
     return 0;
   }
 
   //FABS.S Fd,Fs
   case 0x05: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FABS_S);
     return 0;
   }
 
   //FMOV.S Fd,Fs
   case 0x06: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FMOV_S);
     return 0;
   }
 
   //FNEG.S Fd,Fs
   case 0x07: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FNEG_S);
     return 0;
   }
 
   //FROUND.L.S Fd,Fs
   case 0x08: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FROUND_L_S);
     return 0;
   }
 
   //FTRUNC.L.S Fd,Fs
   case 0x09: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FTRUNC_L_S);
     return 0;
   }
 
   //FCEIL.L.S Fd,Fs
   case 0x0a: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FCEIL_L_S);
     return 0;
   }
 
   //FFLOOR.L.S Fd,Fs
   case 0x0b: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FFLOOR_L_S);
     return 0;
   }
 
   //FROUND.W.S Fd,Fs
   case 0x0c: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FROUND_W_S);
     return 0;
   }
 
   //FTRUNC.W.S Fd,Fs
   case 0x0d: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FTRUNC_W_S);
     return 0;
   }
 
   //FCEIL.W.S Fd,Fs
   case 0x0e: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FCEIL_W_S);
     return 0;
   }
 
   //FFLOOR.W.S Fd,Fs
   case 0x0f: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FFLOOR_W_S);
     return 0;
   }
 
   //FCVT.D.S Fd,Fs
   case 0x21: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FCVT_D_S);
     return 0;
   }
 
   //FCVT.W.S Fd,Fs
   case 0x24: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FCVT_W_S);
     return 0;
   }
 
   //FCVT.L.S Fd,Fs
   case 0x25: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FCVT_L_S);
     return 0;
   }
 
   //FC.F.S Fs,Ft
   case 0x30: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_F_S);
     return 0;
   }
 
   //FC.UN.S Fs,Ft
   case 0x31: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_UN_S);
     return 0;
   }
 
   //FC.EQ.S Fs,Ft
   case 0x32: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_EQ_S);
     return 0;
   }
 
   //FC.UEQ.S Fs,Ft
   case 0x33: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_UEQ_S);
     return 0;
   }
 
   //FC.OLT.S Fs,Ft
   case 0x34: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_OLT_S);
     return 0;
   }
 
   //FC.ULT.S Fs,Ft
   case 0x35: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_ULT_S);
     return 0;
   }
 
   //FC.OLE.S Fs,Ft
   case 0x36: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_OLE_S);
     return 0;
   }
 
   //FC.ULE.S Fs,Ft
   case 0x37: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_ULE_S);
     return 0;
   }
 
   //FC.SF.S Fs,Ft
   case 0x38: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_SF_S);
     return 0;
   }
 
   //FC.NGLE.S Fs,Ft
   case 0x39: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_NGLE_S);
     return 0;
   }
 
   //FC.SEQ.S Fs,Ft
   case 0x3a: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_SEQ_S);
     return 0;
   }
 
   //FC.NGL.S Fs,Ft
   case 0x3b: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_NGL_S);
     return 0;
   }
 
   //FC.LT.S Fs,Ft
   case 0x3c: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_LT_S);
     return 0;
   }
 
   //FC.NGE.S Fs,Ft
   case 0x3d: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_NGE_S);
     return 0;
   }
 
   //FC.LE.S Fs,Ft
   case 0x3e: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_LE_S);
     return 0;
   }
 
   //FC.NGT.S Fs,Ft
   case 0x3f: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_NGT_S);
     return 0;
   }
@@ -1709,284 +1705,284 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
 
   //FADD.D Fd,Fs,Ft
   case 0x00: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
-    mov(ecx, imm32(Ftn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
+    mov(ra3d, imm32(Ftn));
     call(&CPU::FADD_D);
     return 0;
   }
 
   //FSUB.D Fd,Fs,Ft
   case 0x01: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
-    mov(ecx, imm32(Ftn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
+    mov(ra3d, imm32(Ftn));
     call(&CPU::FSUB_D);
     return 0;
   }
 
   //FMUL.D Fd,Fs,Ft
   case 0x02: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
-    mov(ecx, imm32(Ftn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
+    mov(ra3d, imm32(Ftn));
     call(&CPU::FMUL_D);
     return 0;
   }
 
   //FDIV.D Fd,Fs,Ft
   case 0x03: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
-    mov(ecx, imm32(Ftn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
+    mov(ra3d, imm32(Ftn));
     call(&CPU::FDIV_D);
     return 0;
   }
 
   //FSQRT.D Fd,Fs
   case 0x04: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FSQRT_D);
     return 0;
   }
 
   //FABS.D Fd,Fs
   case 0x05: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FABS_D);
     return 0;
   }
 
   //FMOV.D Fd,Fs
   case 0x06: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FMOV_D);
     return 0;
   }
 
   //FNEG.D Fd,Fs
   case 0x07: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FNEG_D);
     return 0;
   }
 
   //FROUND.L.D Fd,Fs
   case 0x08: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FROUND_L_D);
     return 0;
   }
 
   //FTRUNC.L.D Fd,Fs
   case 0x09: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FTRUNC_L_D);
     return 0;
   }
 
   //FCEIL.L.D Fd,Fs
   case 0x0a: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FCEIL_L_D);
     return 0;
   }
 
   //FFLOOR.L.D Fd,Fs
   case 0x0b: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FFLOOR_L_D);
     return 0;
   }
 
   //FROUND.W.D Fd,Fs
   case 0x0c: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FROUND_W_D);
     return 0;
   }
 
   //FTRUNC.W.D Fd,Fs
   case 0x0d: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FTRUNC_W_D);
     return 0;
   }
 
   //FCEIL.W.D Fd,Fs
   case 0x0e: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FCEIL_W_D);
     return 0;
   }
 
   //FFLOOR.W.D Fd,Fs
   case 0x0f: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FFLOOR_W_D);
     return 0;
   }
 
   //FCVT.S.D Fd,Fs
   case 0x20: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FCVT_S_D);
     return 0;
   }
 
   //FCVT.W.D Fd,Fs
   case 0x24: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FCVT_W_D);
     return 0;
   }
 
   //FCVT.L.D Fd,Fs
   case 0x25: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FCVT_L_D);
     return 0;
   }
 
   //FC.F.D Fs,Ft
   case 0x30: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_F_D);
     return 0;
   }
 
   //FC.UN.D Fs,Ft
   case 0x31: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_UN_D);
     return 0;
   }
 
   //FC.EQ.D Fs,Ft
   case 0x32: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_EQ_D);
     return 0;
   }
 
   //FC.UEQ.D Fs,Ft
   case 0x33: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_UEQ_D);
     return 0;
   }
 
   //FC.OLT.D Fs,Ft
   case 0x34: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_OLT_D);
     return 0;
   }
 
   //FC.ULT.D Fs,Ft
   case 0x35: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_ULT_D);
     return 0;
   }
 
   //FC.OLE.D Fs,Ft
   case 0x36: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_OLE_D);
     return 0;
   }
 
   //FC.ULE.D Fs,Ft
   case 0x37: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_ULE_D);
     return 0;
   }
 
   //FC.SF.D Fs,Ft
   case 0x38: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_SF_D);
     return 0;
   }
 
   //FC.NGLE.D Fs,Ft
   case 0x39: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_NGLE_D);
     return 0;
   }
 
   //FC.SEQ.D Fs,Ft
   case 0x3a: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_SEQ_D);
     return 0;
   }
 
   //FC.NGL.D Fs,Ft
   case 0x3b: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_NGL_D);
     return 0;
   }
 
   //FC.LT.D Fs,Ft
   case 0x3c: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_LT_D);
     return 0;
   }
 
   //FC.NGE.D Fs,Ft
   case 0x3d: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_NGE_D);
     return 0;
   }
 
   //FC.LE.D Fs,Ft
   case 0x3e: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_LE_D);
     return 0;
   }
 
   //FC.NGT.D Fs,Ft
   case 0x3f: {
-    mov(esi, imm32(Fsn));
-    mov(edx, imm32(Ftn));
+    mov(ra1d, imm32(Fsn));
+    mov(ra2d, imm32(Ftn));
     call(&CPU::FC_NGT_D);
     return 0;
   }
@@ -1998,16 +1994,16 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
 
   //FCVT.S.W Fd,Fs
   case 0x20: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FCVT_S_W);
     return 0;
   }
 
   //FCVT.D.W Fd,Fs
   case 0x21: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FCVT_D_W);
     return 0;
   }
@@ -2019,16 +2015,16 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
 
   //FCVT.S.L
   case 0x20: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FCVT_S_L);
     return 0;
   }
 
   //FCVT.D.L
   case 0x21: {
-    mov(esi, imm32(Fdn));
-    mov(edx, imm32(Fsn));
+    mov(ra1d, imm32(Fdn));
+    mov(ra2d, imm32(Fsn));
     call(&CPU::FCVT_D_L);
     return 0;
   }
@@ -2058,16 +2054,10 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
 template<typename V, typename... P>
 auto CPU::Recompiler::call(V (CPU::*function)(P...)) -> void {
   static_assert(sizeof...(P) <= 5);
-  if constexpr(ABI::SystemV) {
-    mov(rdi, rbp);
-  }
   if constexpr(ABI::Windows) {
-    if constexpr(sizeof...(P) >= 5) mov(dis8(rsp, 0x28), r9);
-    if constexpr(sizeof...(P) >= 4) mov(dis8(rsp, 0x20), r8);
-    if constexpr(sizeof...(P) >= 3) mov(r9, rcx);
-    if constexpr(sizeof...(P) >= 2) mov(r8, rdx);
-    if constexpr(sizeof...(P) >= 1) mov(rdx, rsi);
-    mov(rcx, rbp);
+    if constexpr(sizeof...(P) >= 5) mov(dis8(rsp, 0x28), ra5);
+    if constexpr(sizeof...(P) >= 4) mov(dis8(rsp, 0x20), ra4);
   }
+  mov(ra0, rbp);
   call(imm64{function}, rax);
 }

--- a/ares/n64/rsp/recompiler.cpp
+++ b/ares/n64/rsp/recompiler.cpp
@@ -41,8 +41,6 @@ auto RSP::Recompiler::emit(u32 address) -> Block* {
   push(rbp);
   push(r13);
   if constexpr(ABI::Windows) {
-    push(rsi);
-    push(rdi);
     sub(rsp, imm8(0x40));
   }
   mov(rbx, imm64(&self.ipu.r[0]));
@@ -56,8 +54,6 @@ auto RSP::Recompiler::emit(u32 address) -> Block* {
 
   if constexpr(ABI::Windows) {
     add(rsp, imm8(0x40));
-    pop(rdi);
-    pop(rsi);
   }
   pop(r13);
   pop(rbp);
@@ -119,64 +115,64 @@ auto RSP::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //J n26
   case 0x02: {
-    mov(esi, imm32(n26));
+    mov(ra1d, imm32(n26));
     call(&RSP::J);
     return 1;
   }
 
   //JAL n26
   case 0x03: {
-    mov(esi, imm32(n26));
+    mov(ra1d, imm32(n26));
     call(&RSP::JAL);
     return 1;
   }
 
   //BEQ Rs,Rt,i16
   case 0x04: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rs);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(i16));
     call(&RSP::BEQ);
     return 1;
   }
 
   //BNE Rs,Rt,i16
   case 0x05: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rs);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(i16));
     call(&RSP::BNE);
     return 1;
   }
 
   //BLEZ Rs,i16
   case 0x06: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&RSP::BLEZ);
     return 1;
   }
 
   //BGTZ Rs,i16
   case 0x07: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&RSP::BGTZ);
     return 1;
   }
 
   //ADDIU Rt,Rs,i16
   case 0x08 ... 0x09: {
-    mov(esi, Rs);
-    add(esi, imm32(i16));
-    mov(Rt, esi);
+    mov(eax, Rs);
+    add(eax, imm32(i16));
+    mov(Rt, eax);
     return 0;
   }
 
   //SLTI Rt,Rs,i16
   case 0x0a: {
-    mov(esi, Rs);
-    cmp(esi, imm32(i16));
+    mov(eax, Rs);
+    cmp(eax, imm32(i16));
     setl(al);
     movzx(eax, al);
     mov(Rt, eax);
@@ -185,8 +181,8 @@ auto RSP::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //SLTIU Rt,Rs,i16
   case 0x0b: {
-    mov(esi, Rs);
-    cmp(esi, imm32(i16));
+    mov(eax, Rs);
+    cmp(eax, imm32(i16));
     setb(al);
     movzx(eax, al);
     mov(Rt, eax);
@@ -195,32 +191,32 @@ auto RSP::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //ANDI Rt,Rs,n16
   case 0x0c: {
-    mov(esi, Rs);
-    and(esi, imm32(n16));
-    mov(Rt, esi);
+    mov(eax, Rs);
+    and(eax, imm32(n16));
+    mov(Rt, eax);
     return 0;
   }
 
   //ORI Rt,Rs,n16
   case 0x0d: {
-    mov(esi, Rs);
-    or(esi, imm32(n16));
-    mov(Rt, esi);
+    mov(eax, Rs);
+    or(eax, imm32(n16));
+    mov(Rt, eax);
     return 0;
   }
 
   //XORI Rt,Rs,n16
   case 0x0e: {
-    mov(esi, Rs);
-    xor(esi, imm32(n16));
-    mov(Rt, esi);
+    mov(eax, Rs);
+    xor(eax, imm32(n16));
+    mov(Rt, eax);
     return 0;
   }
 
   //LUI Rt,n16
   case 0x0f: {
-    mov(esi, imm32(n16 << 16));
-    mov(Rt, esi);
+    mov(eax, imm32(n16 << 16));
+    mov(Rt, eax);
     return 0;
   }
 
@@ -246,18 +242,18 @@ auto RSP::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //LB Rt,Rs,i16
   case 0x20: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&RSP::LB);
     return 0;
   }
 
   //LH Rt,Rs,i16
   case 0x21: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&RSP::LH);
     return 0;
   }
@@ -269,27 +265,27 @@ auto RSP::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //LW Rt,Rs,i16
   case 0x23: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&RSP::LW);
     return 0;
   }
 
   //LBU Rt,Rs,i16
   case 0x24: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&RSP::LBU);
     return 0;
   }
 
   //LHU Rt,Rs,i16
   case 0x25: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&RSP::LHU);
     return 0;
   }
@@ -301,18 +297,18 @@ auto RSP::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //SB Rt,Rs,i16
   case 0x28: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&RSP::SB);
     return 0;
   }
 
   //SH Rt,Rs,i16
   case 0x29: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&RSP::SH);
     return 0;
   }
@@ -324,9 +320,9 @@ auto RSP::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //SW Rt,Rs,i16
   case 0x2b: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&RSP::SW);
     return 0;
   }
@@ -366,9 +362,9 @@ auto RSP::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //SLL Rd,Rt,Sa
   case 0x00: {
-    mov(esi, Rt);
-    shl(esi, imm8(Sa));
-    mov(Rd, esi);
+    mov(eax, Rt);
+    shl(eax, imm8(Sa));
+    mov(Rd, eax);
     return 0;
   }
 
@@ -379,27 +375,27 @@ auto RSP::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //SRL Rd,Rt,Sa
   case 0x02: {
-    mov(esi, Rt);
-    shr(esi, imm8(Sa));
-    mov(Rd, esi);
+    mov(eax, Rt);
+    shr(eax, imm8(Sa));
+    mov(Rd, eax);
     return 0;
   }
 
   //SRA Rd,Rt,Sa
   case 0x03: {
-    mov(esi, Rt);
-    sar(esi, imm8(Sa));
-    mov(Rd, esi);
+    mov(eax, Rt);
+    sar(eax, imm8(Sa));
+    mov(Rd, eax);
     return 0;
   }
 
   //SLLV Rd,Rt,Rs
   case 0x04: {
-    mov(esi, Rt);
+    mov(eax, Rt);
     mov(ecx, Rs);
     and(cl, imm8(31));
-    shl(esi, cl);
-    mov(Rd, esi);
+    shl(eax, cl);
+    mov(Rd, eax);
     return 0;
   }
 
@@ -410,35 +406,35 @@ auto RSP::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //SRLV Rd,Rt,Rs
   case 0x06: {
-    mov(esi, Rt);
+    mov(eax, Rt);
     mov(ecx, Rs);
     and(cl, imm8(31));
-    shr(esi, cl);
-    mov(Rd, esi);
+    shr(eax, cl);
+    mov(Rd, eax);
     return 0;
   }
 
   //SRAV Rd,Rt,Rs
   case 0x07: {
-    mov(esi, Rt);
+    mov(eax, Rt);
     mov(ecx, Rs);
     and(cl, imm8(31));
-    sar(esi, cl);
-    mov(Rd, esi);
+    sar(eax, cl);
+    mov(Rd, eax);
     return 0;
   }
 
   //JR Rs
   case 0x08: {
-    lea(rsi, Rs);
+    lea(ra1, Rs);
     call(&RSP::JR);
     return 1;
   }
 
   //JALR Rd,Rs
   case 0x09: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
     call(&RSP::JALR);
     return 1;
   }
@@ -461,50 +457,50 @@ auto RSP::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //ADDU Rd,Rs,Rt
   case 0x20 ... 0x21: {
-    mov(esi, Rs);
-    add(esi, Rt);
-    mov(Rd, esi);
+    mov(eax, Rs);
+    add(eax, Rt);
+    mov(Rd, eax);
     return 0;
   }
 
   //SUBU Rd,Rs,Rt
   case 0x22 ... 0x23: {
-    mov(esi, Rs);
-    sub(esi, Rt);
-    mov(Rd, esi);
+    mov(eax, Rs);
+    sub(eax, Rt);
+    mov(Rd, eax);
     return 0;
   }
 
   //AND Rd,Rs,Rt
   case 0x24: {
-    mov(esi, Rs);
-    and(esi, Rt);
-    mov(Rd, esi);
+    mov(eax, Rs);
+    and(eax, Rt);
+    mov(Rd, eax);
     return 0;
   }
 
   //OR Rd,Rs,Rt
   case 0x25: {
-    mov(esi, Rs);
-    or(esi, Rt);
-    mov(Rd, esi);
+    mov(eax, Rs);
+    or(eax, Rt);
+    mov(Rd, eax);
     return 0;
   }
 
   //XOR Rd,Rs,Rt
   case 0x26: {
-    mov(esi, Rs);
-    xor(esi, Rt);
-    mov(Rd, esi);
+    mov(eax, Rs);
+    xor(eax, Rt);
+    mov(Rd, eax);
     return 0;
   }
 
   //NOR Rd,Rs,Rt
   case 0x27: {
-    mov(esi, Rs);
-    or(esi, Rt);
-    not(esi);
-    mov(Rd, esi);
+    mov(eax, Rs);
+    or(eax, Rt);
+    not(eax);
+    mov(Rd, eax);
     return 0;
   }
 
@@ -515,8 +511,8 @@ auto RSP::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //SLT Rd,Rs,Rt
   case 0x2a: {
-    mov(esi, Rs);
-    cmp(esi, Rt);
+    mov(eax, Rs);
+    cmp(eax, Rt);
     setl(al);
     movzx(eax, al);
     mov(Rd, eax);
@@ -525,8 +521,8 @@ auto RSP::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //SLTU Rd,Rs,Rt
   case 0x2b: {
-    mov(esi, Rs);
-    cmp(esi, Rt);
+    mov(eax, Rs);
+    cmp(eax, Rt);
     setb(al);
     movzx(eax, al);
     mov(Rd, eax);
@@ -548,16 +544,16 @@ auto RSP::Recompiler::emitREGIMM(u32 instruction) -> bool {
 
   //BLTZ Rs,i16
   case 0x00: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&RSP::BLTZ);
     return 1;
   }
 
   //BGEZ Rs,i16
   case 0x01: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&RSP::BGEZ);
     return 1;
   }
@@ -569,16 +565,16 @@ auto RSP::Recompiler::emitREGIMM(u32 instruction) -> bool {
 
   //BLTZAL Rs,i16
   case 0x10: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&RSP::BLTZAL);
     return 1;
   }
 
   //BGEZAL Rs,i16
   case 0x11: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&RSP::BGEZAL);
     return 1;
   }
@@ -598,8 +594,8 @@ auto RSP::Recompiler::emitSCC(u32 instruction) -> bool {
 
   //MFC0 Rt,Rd
   case 0x00: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Rdn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Rdn));
     call(&RSP::MFC0);
     return 0;
   }
@@ -611,8 +607,8 @@ auto RSP::Recompiler::emitSCC(u32 instruction) -> bool {
 
   //MTC0 Rt,Rd
   case 0x04: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Rdn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Rdn));
     call(&RSP::MTC0);
     return 0;
   }
@@ -633,9 +629,9 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
 
   //MFC2 Rt,Vs(e)
   case 0x00: {
-    lea(rsi, Rt);
-    lea(rdx, Vs);
-    mov(ecx, imm32(E));
+    lea(ra1, Rt);
+    lea(ra2, Vs);
+    mov(ra3d, imm32(E));
     call(&RSP::MFC2);
     return 0;
   }
@@ -647,8 +643,8 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
 
   //CFC2 Rt,Rd
   case 0x02: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Rdn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Rdn));
     call(&RSP::CFC2);
     return 0;
   }
@@ -660,9 +656,9 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
 
   //MTC2 Rt,Vs(e)
   case 0x04: {
-    lea(rsi, Rt);
-    lea(rdx, Vs);
-    mov(ecx, imm32(E));
+    lea(ra1, Rt);
+    lea(ra2, Vs);
+    mov(ra3d, imm32(E));
     call(&RSP::MTC2);
     return 0;
   }
@@ -674,8 +670,8 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
 
   //CTC2 Rt,Rd
   case 0x06: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Rdn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Rdn));
     call(&RSP::CTC2);
     return 0;
   }
@@ -694,177 +690,177 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
 
   //VMULF Vd,Vs,Vt(e)
   case 0x00: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VMULF<0>);
     return 0;
   }
 
   //VMULU Vd,Vs,Vt(e)
   case 0x01: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VMULF<1>);
     return 0;
   }
 
   //VRNDP Vd,Vs,Vt(e)
   case 0x02: {
-    lea(rsi, Vd);
-    mov(edx, imm32(Vsn));
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    mov(ra2d, imm32(Vsn));
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VRND<1>);
     return 0;
   }
 
   //VMULQ Vd,Vs,Vt(e)
   case 0x03: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VMULQ);
     return 0;
   }
 
   //VMUDL Vd,Vs,Vt(e)
   case 0x04: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VMUDL);
     return 0;
   }
 
   //VMUDM Vd,Vs,Vt(e)
   case 0x05: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VMUDM);
     return 0;
   }
 
   //VMUDN Vd,Vs,Vt(e)
   case 0x06: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VMUDN);
     return 0;
   }
 
   //VMUDH Vd,Vs,Vt(e)
   case 0x07: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VMUDH);
     return 0;
   }
 
   //VMACF Vd,Vs,Vt(e)
   case 0x08: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VMACF<0>);
     return 0;
   }
 
   //VMACU Vd,Vs,Vt(e)
   case 0x09: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VMACF<1>);
     return 0;
   }
 
   //VRNDN Vd,Vs,Vt(e)
   case 0x0a: {
-    lea(rsi, Vd);
-    mov(edx, imm32(Vsn));
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    mov(ra2d, imm32(Vsn));
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VRND<0>);
     return 0;
   }
 
   //VMACQ Vd
   case 0x0b: {
-    lea(rsi, Vd);
+    lea(ra1, Vd);
     call(&RSP::VMACQ);
     return 0;
   }
 
   //VMADL Vd,Vs,Vt(e)
   case 0x0c: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VMADL);
     return 0;
   }
 
   //VMADM Vd,Vs,Vt(e)
   case 0x0d: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VMADM);
     return 0;
   }
 
   //VMADN Vd,Vs,Vt(e)
   case 0x0e: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VMADN);
     return 0;
   }
 
   //VMADH Vd,Vs,Vt(e)
   case 0x0f: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VMADH);
     return 0;
   }
 
   //VADD Vd,Vs,Vt(e)
   case 0x10: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VADD);
     return 0;
   }
 
   //VSUB Vd,Vs,Vt(e)
   case 0x11: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VSUB);
     return 0;
   }
@@ -876,30 +872,30 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
 
   //VABS Vd,Vs,Vt(e)
   case 0x13: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VABS);
     return 0;
   }
 
   //VADDC Vd,Vs,Vt(e)
   case 0x14: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VADDC);
     return 0;
   }
 
   //VSUBC Vd,Vs,Vt(e)
   case 0x15: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VSUBC);
     return 0;
   }
@@ -911,9 +907,9 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
 
   //VSAR Vd,Vs,E
   case 0x1d: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    mov(ecx, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    mov(ra3d, imm32(E));
     call(&RSP::VSAR);
     return 0;
   }
@@ -925,140 +921,140 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
 
   //VLT Vd,Vs,Vt(e)
   case 0x20: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VLT);
     return 0;
   }
 
   //VEQ Vd,Vs,Vt(e)
   case 0x21: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VEQ);
     return 0;
   }
 
   //VNE Vd,Vs,Vt(e)
   case 0x22: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VNE);
     return 0;
   }
 
   //VGE Vd,Vs,Vt(e)
   case 0x23: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VGE);
     return 0;
   }
 
   //VCL Vd,Vs,Vt(e)
   case 0x24: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VCL);
     return 0;
   }
 
   //VCH Vd,Vs,Vt(e)
   case 0x25: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VCH);
     return 0;
   }
 
   //VCR Vd,Vs,Vt(e)
   case 0x26: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VCR);
     return 0;
   }
 
   //VMRG Vd,Vs,Vt(e)
   case 0x27: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VMRG);
     return 0;
   }
 
   //VAND Vd,Vs,Vt(e)
   case 0x28: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VAND);
     return 0;
   }
 
   //VNAND Vd,Vs,Vt(e)
   case 0x29: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VNAND);
     return 0;
   }
 
   //VOR Vd,Vs,Vt(e)
   case 0x2a: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VOR);
     return 0;
   }
 
   //VNOR Vd,Vs,Vt(e)
   case 0x2b: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VNOR);
     return 0;
   }
 
   //VXOR Vd,Vs,Vt(e)
   case 0x2c: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VXOR);
     return 0;
   }
 
   //VNXOR Vd,Vs,Vt(e)
   case 0x2d: {
-    lea(rsi, Vd);
-    lea(rdx, Vs);
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    lea(ra2, Vs);
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VNXOR);
     return 0;
   }
@@ -1070,70 +1066,70 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
 
   //VCRP Vd(de),Vt(e)
   case 0x30: {
-    lea(rsi, Vd);
-    mov(edx, imm32(DE));
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    mov(ra2d, imm32(DE));
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VRCP<0>);
     return 0;
   }
 
   //VRCPL Vd(de),Vt(e)
   case 0x31: {
-    lea(rsi, Vd);
-    mov(edx, imm32(DE));
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    mov(ra2d, imm32(DE));
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VRCP<1>);
     return 0;
   }
 
   //VRCPH Vd(de),Vt(e)
   case 0x32: {
-    lea(rsi, Vd);
-    mov(edx, imm32(DE));
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    mov(ra2d, imm32(DE));
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VRCPH);
     return 0;
   }
 
   //VMOV Vd(de),Vt(e)
   case 0x33: {
-    lea(rsi, Vd);
-    mov(edx, imm32(DE));
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    mov(ra2d, imm32(DE));
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VMOV);
     return 0;
   }
 
   //VRSQ Vd(de),Vt(e)
   case 0x34: {
-    lea(rsi, Vd);
-    mov(edx, imm32(DE));
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    mov(ra2d, imm32(DE));
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VRSQ<0>);
     return 0;
   }
 
   //VRSQL Vd(de),Vt(e)
   case 0x35: {
-    lea(rsi, Vd);
-    mov(edx, imm32(DE));
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    mov(ra2d, imm32(DE));
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VRSQ<1>);
     return 0;
   }
 
   //VRSQH Vd(de),Vt(e)
   case 0x36: {
-    lea(rsi, Vd);
-    mov(edx, imm32(DE));
-    lea(rcx, Vt);
-    mov(r8d, imm32(E));
+    lea(ra1, Vd);
+    mov(ra2d, imm32(DE));
+    lea(ra3, Vt);
+    mov(ra4d, imm32(E));
     call(&RSP::VRSQH);
     return 0;
   }
@@ -1162,100 +1158,100 @@ auto RSP::Recompiler::emitLWC2(u32 instruction) -> bool {
 
   //LBV Vt(e),Rs,i7
   case 0x00: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::LBV);
     return 0;
   }
 
   //LSV Vt(e),Rs,i7
   case 0x01: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::LSV);
     return 0;
   }
 
   //LLV Vt(e),Rs,i7
   case 0x02: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::LLV);
     return 0;
   }
 
   //LDV Vt(e),Rs,i7
   case 0x03: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::LDV);
     return 0;
   }
 
   //LQV Vt(e),Rs,i7
   case 0x04: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::LQV);
     return 0;
   }
 
   //LRV Vt(e),Rs,i7
   case 0x05: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::LRV);
     return 0;
   }
 
   //LPV Vt(e),Rs,i7
   case 0x06: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::LPV);
     return 0;
   }
 
   //LUV Vt(e),Rs,i7
   case 0x07: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::LUV);
     return 0;
   }
 
   //LHV Vt(e),Rs,i7
   case 0x08: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::LHV);
     return 0;
   }
 
   //LFV Vt(e),Rs,i7
   case 0x09: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::LFV);
     return 0;
   }
@@ -1267,10 +1263,10 @@ auto RSP::Recompiler::emitLWC2(u32 instruction) -> bool {
 
   //LTV Vt(e),Rs,i7
   case 0x0b: {
-    mov(esi, imm32(Vtn));
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    mov(ra1d, imm32(Vtn));
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::LTV);
     return 0;
   }
@@ -1294,120 +1290,120 @@ auto RSP::Recompiler::emitSWC2(u32 instruction) -> bool {
 
   //SBV Vt(e),Rs,i7
   case 0x00: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::SBV);
     return 0;
   }
 
   //SSV Vt(e),Rs,i7
   case 0x01: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::SSV);
     return 0;
   }
 
   //SLV Vt(e),Rs,i7
   case 0x02: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::SLV);
     return 0;
   }
 
   //SDV Vt(e),Rs,i7
   case 0x03: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::SDV);
     return 0;
   }
 
   //SQV Vt(e),Rs,i7
   case 0x04: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::SQV);
     return 0;
   }
 
   //SRV Vt(e),Rs,i7
   case 0x05: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::SRV);
     return 0;
   }
 
   //SPV Vt(e),Rs,i7
   case 0x06: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::SPV);
     return 0;
   }
 
   //SUV Vt(e),Rs,i7
   case 0x07: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::SUV);
     return 0;
   }
 
   //SHV Vt(e),Rs,i7
   case 0x08: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::SHV);
     return 0;
   }
 
   //SFV Vt(e),Rs,i7
   case 0x09: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::SFV);
     return 0;
   }
 
   //SWV Vt(e),Rs,i7
   case 0x0a: {
-    lea(rsi, Vt);
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    lea(ra1, Vt);
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::SWV);
     return 0;
   }
 
   //STV Vt(e),Rs,i7
   case 0x0b: {
-    mov(esi, imm32(Vtn));
-    mov(edx, imm32(E));
-    lea(rcx, Rs);
-    mov(r8d, imm32(i7));
+    mov(ra1d, imm32(Vtn));
+    mov(ra2d, imm32(E));
+    lea(ra3, Rs);
+    mov(ra4d, imm32(i7));
     call(&RSP::STV);
     return 0;
   }
@@ -1444,16 +1440,10 @@ auto RSP::Recompiler::emitSWC2(u32 instruction) -> bool {
 template<typename V, typename... P>
 auto RSP::Recompiler::call(V (RSP::*function)(P...)) -> void {
   static_assert(sizeof...(P) <= 5);
-  if constexpr(ABI::SystemV) {
-    mov(rdi, rbp);
-  }
   if constexpr(ABI::Windows) {
-    if constexpr(sizeof...(P) >= 5) mov(dis8(rsp, 0x28), r9);
-    if constexpr(sizeof...(P) >= 4) mov(dis8(rsp, 0x20), r8);
-    if constexpr(sizeof...(P) >= 3) mov(r9, rcx);
-    if constexpr(sizeof...(P) >= 2) mov(r8, rdx);
-    if constexpr(sizeof...(P) >= 1) mov(rdx, rsi);
-    mov(rcx, rbp);
+    if constexpr(sizeof...(P) >= 5) mov(dis8(rsp, 0x28), ra5);
+    if constexpr(sizeof...(P) >= 4) mov(dis8(rsp, 0x20), ra4);
   }
+  mov(ra0, rbp);
   call(imm64{function}, rax);
 }

--- a/ares/ps1/cpu/recompiler.cpp
+++ b/ares/ps1/cpu/recompiler.cpp
@@ -24,8 +24,6 @@ auto CPU::Recompiler::emit(u32 address) -> Block* {
   push(rbp);
   push(r13);
   if constexpr(ABI::Windows) {
-    push(rsi);
-    push(rdi);
     sub(rsp, imm8(0x40));
   }
   mov(rbx, imm64(&self.ipu.r[0]));
@@ -38,8 +36,6 @@ auto CPU::Recompiler::emit(u32 address) -> Block* {
 
   if constexpr(ABI::Windows) {
     add(rsp, imm8(0x40));
-    pop(rdi);
-    pop(rsi);
   }
   pop(r13);
   pop(rbp);
@@ -94,119 +90,119 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //J n26
   case 0x02: {
-    mov(esi, imm32(n26));
+    mov(ra1d, imm32(n26));
     call(&CPU::J);
     return 1;
   }
 
   //JAL n26
   case 0x03: {
-    mov(esi, imm32(n26));
+    mov(ra1d, imm32(n26));
     call(&CPU::JAL);
     return 1;
   }
 
   //BEQ Rs,Rt,i16
   case 0x04: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rs);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(i16));
     call(&CPU::BEQ);
     return 1;
   }
 
   //BNE Rs,Rt,i16
   case 0x05: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rs);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(i16));
     call(&CPU::BNE);
     return 1;
   }
 
   //BLEZ Rs,i16
   case 0x06: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BLEZ);
     return 1;
   }
 
   //BGTZ Rs,i16
   case 0x07: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BGTZ);
     return 1;
   }
 
   //ADDI Rt,Rs,i16
   case 0x08: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::ADDI);
     return 0;
   }
 
   //ADDIU Rt,Rs,i16
   case 0x09: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::ADDIU);
     return 0;
   }
 
   //SLTI Rt,Rs,i16
   case 0x0a: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SLTI);
     return 0;
   }
 
   //SLTIU Rt,Rs,i16
   case 0x0b: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SLTIU);
     return 0;
   }
 
   //ANDI Rt,Rs,n16
   case 0x0c: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(n16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(n16));
     call(&CPU::ANDI);
     return 0;
   }
 
   //ORI Rt,Rs,n16
   case 0x0d: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(n16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(n16));
     call(&CPU::ORI);
     return 0;
   }
 
   //XORI Rt,Rs,n16
   case 0x0e: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(n16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(n16));
     call(&CPU::XORI);
     return 0;
   }
 
   //LUI Rt,n16
   case 0x0f: {
-    lea(rsi, Rt);
-    mov(edx, imm32(n16));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(n16));
     call(&CPU::LUI);
     return 0;
   }
@@ -241,63 +237,63 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //LB Rt,Rs,i16
   case 0x20: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LB);
     return 0;
   }
 
   //LH Rt,Rs,i16
   case 0x21: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LH);
     return 0;
   }
 
   //LWL Rt,Rs,i16
   case 0x22: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LWL);
     return 0;
   }
 
   //LW Rt,Rs,i16
   case 0x23: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LW);
     return 0;
   }
 
   //LBU Rt,Rs,i16
   case 0x24: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LBU);
     return 0;
   }
 
   //LHU Rt,Rs,i16
   case 0x25: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LHU);
     return 0;
   }
 
   //LWR Rt,Rs,i16
   case 0x26: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LWR);
     return 0;
   }
@@ -310,36 +306,36 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //SB Rt,Rs,i16
   case 0x28: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SB);
     return 0;
   }
 
   //SH Rt,Rs,i16
   case 0x29: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SH);
     return 0;
   }
 
   //SWL Rt,Rs,i16
   case 0x2a: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SWL);
     return 0;
   }
 
   //SW Rt,Rs,i16
   case 0x2b: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SW);
     return 0;
   }
@@ -352,9 +348,9 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //SWR Rt,Rs,i16
   case 0x2e: {
-    lea(rsi, Rt);
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    lea(ra1, Rt);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SWR);
     return 0;
   }
@@ -367,36 +363,36 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //LWC0 Rt,Rs,i16
   case 0x30: {
-    mov(esi, imm32(Rtn));
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    mov(ra1d, imm32(Rtn));
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LWC0);
     return 0;
   }
 
   //LWC1 Rt,Rs,i16
   case 0x31: {
-    mov(esi, imm32(Rtn));
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    mov(ra1d, imm32(Rtn));
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LWC1);
     return 0;
   }
 
   //LWC2 Rt,Rs,i16
   case 0x32: {
-    mov(esi, imm32(Rtn));
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    mov(ra1d, imm32(Rtn));
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LWC2);
     return 0;
   }
 
   //LWC3 Rt,Rs,i16
   case 0x33: {
-    mov(esi, imm32(Rtn));
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    mov(ra1d, imm32(Rtn));
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::LWC3);
     return 0;
   }
@@ -409,36 +405,36 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //SWC0 Rt,Rs,i16
   case 0x38: {
-    mov(esi, imm32(Rtn));
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    mov(ra1d, imm32(Rtn));
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SWC0);
     return 0;
   }
 
   //SWC1 Rt,Rs,i16
   case 0x39: {
-    mov(esi, imm32(Rtn));
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    mov(ra1d, imm32(Rtn));
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SWC1);
     return 0;
   }
 
   //SWC2 Rt,Rs,i16
   case 0x3a: {
-    mov(esi, imm32(Rtn));
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    mov(ra1d, imm32(Rtn));
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SWC2);
     return 0;
   }
 
   //SWC3 Rt,Rs,i16
   case 0x3b: {
-    mov(esi, imm32(Rtn));
-    lea(rdx, Rs);
-    mov(ecx, imm32(i16));
+    mov(ra1d, imm32(Rtn));
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i16));
     call(&CPU::SWC3);
     return 0;
   }
@@ -459,9 +455,9 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //SLL Rd,Rt,Sa
   case 0x00: {
-    lea(rsi, Rd);
-    lea(rdx, Rt);
-    mov(ecx, imm32(Sa));
+    lea(ra1, Rd);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(Sa));
     call(&CPU::SLL);
     return 0;
   }
@@ -474,27 +470,27 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //SRL Rd,Rt,Sa
   case 0x02: {
-    lea(rsi, Rd);
-    lea(rdx, Rt);
-    mov(ecx, imm32(Sa));
+    lea(ra1, Rd);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(Sa));
     call(&CPU::SRL);
     return 0;
   }
 
   //SRA Rd,Rt,Sa
   case 0x03: {
-    lea(rsi, Rd);
-    lea(rdx, Rt);
-    mov(ecx, imm32(Sa));
+    lea(ra1, Rd);
+    lea(ra2, Rt);
+    mov(ra3d, imm32(Sa));
     call(&CPU::SRA);
     return 0;
   }
 
   //SLLV Rd,Rt,Rs
   case 0x04: {
-    lea(rsi, Rd);
-    lea(rdx, Rt);
-    lea(rcx, Rs);
+    lea(ra1, Rd);
+    lea(ra2, Rt);
+    lea(ra3, Rs);
     call(&CPU::SLLV);
     return 0;
   }
@@ -507,33 +503,33 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //SRLV Rd,Rt,Rs
   case 0x06: {
-    lea(rsi, Rd);
-    lea(rdx, Rt);
-    lea(rcx, Rs);
+    lea(ra1, Rd);
+    lea(ra2, Rt);
+    lea(ra3, Rs);
     call(&CPU::SRLV);
     return 0;
   }
 
   //SRAV Rd,Rt,Rs
   case 0x07: {
-    lea(rsi, Rd);
-    lea(rdx, Rt);
-    lea(rcx, Rs);
+    lea(ra1, Rd);
+    lea(ra2, Rt);
+    lea(ra3, Rs);
     call(&CPU::SRAV);
     return 0;
   }
 
   //JR Rs
   case 0x08: {
-    lea(rsi, Rs);
+    lea(ra1, Rs);
     call(&CPU::JR);
     return 1;
   }
 
   //JALR Rd,Rs
   case 0x09: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
     call(&CPU::JALR);
     return 1;
   }
@@ -564,28 +560,28 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //MFHI Rd
   case 0x10: {
-    lea(rsi, Rd);
+    lea(ra1, Rd);
     call(&CPU::MFHI);
     return 0;
   }
 
   //MTHI Rs
   case 0x11: {
-    lea(rsi, Rs);
+    lea(ra1, Rs);
     call(&CPU::MTHI);
     return 0;
   }
 
   //MFLO Rd
   case 0x12: {
-    lea(rsi, Rd);
+    lea(ra1, Rd);
     call(&CPU::MFLO);
     return 0;
   }
 
   //MTLO Rs
   case 0x13: {
-    lea(rsi, Rs);
+    lea(ra1, Rs);
     call(&CPU::MTLO);
     return 0;
   }
@@ -598,32 +594,32 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //MULT Rs,Rt
   case 0x18: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::MULT);
     return 0;
   }
 
   //MULTU Rs,Rt
   case 0x19: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::MULTU);
     return 0;
   }
 
   //DIV Rs,Rt
   case 0x1a: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::DIV);
     return 0;
   }
 
   //DIVU Rs,Rt
   case 0x1b: {
-    lea(rsi, Rs);
-    lea(rdx, Rt);
+    lea(ra1, Rs);
+    lea(ra2, Rt);
     call(&CPU::DIVU);
     return 0;
   }
@@ -636,72 +632,72 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //ADD Rd,Rs,Rt
   case 0x20: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
-    lea(rcx, Rt);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
+    lea(ra3, Rt);
     call(&CPU::ADD);
     return 0;
   }
 
   //ADDU Rd,Rs,Rt
   case 0x21: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
-    lea(rcx, Rt);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
+    lea(ra3, Rt);
     call(&CPU::ADDU);
     return 0;
   }
 
   //SUB Rd,Rs,Rt
   case 0x22: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
-    lea(rcx, Rt);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
+    lea(ra3, Rt);
     call(&CPU::SUB);
     return 0;
   }
 
   //SUBU Rd,Rs,Rt
   case 0x23: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
-    lea(rcx, Rt);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
+    lea(ra3, Rt);
     call(&CPU::SUBU);
     return 0;
   }
 
   //AND Rd,Rs,Rt
   case 0x24: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
-    lea(rcx, Rt);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
+    lea(ra3, Rt);
     call(&CPU::AND);
     return 0;
   }
 
   //OR Rd,Rs,Rt
   case 0x25: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
-    lea(rcx, Rt);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
+    lea(ra3, Rt);
     call(&CPU::OR);
     return 0;
   }
 
   //XOR Rd,Rs,Rt
   case 0x26: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
-    lea(rcx, Rt);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
+    lea(ra3, Rt);
     call(&CPU::XOR);
     return 0;
   }
 
   //NOR Rd,Rs,Rt
   case 0x27: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
-    lea(rcx, Rt);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
+    lea(ra3, Rt);
     call(&CPU::NOR);
     return 0;
   }
@@ -714,18 +710,18 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //SLT Rd,Rs,Rt
   case 0x2a: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
-    lea(rcx, Rt);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
+    lea(ra3, Rt);
     call(&CPU::SLT);
     return 0;
   }
 
   //SLTU Rd,Rs,Rt
   case 0x2b: {
-    lea(rsi, Rd);
-    lea(rdx, Rs);
-    lea(rcx, Rt);
+    lea(ra1, Rd);
+    lea(ra2, Rs);
+    lea(ra3, Rt);
     call(&CPU::SLTU);
     return 0;
   }
@@ -749,8 +745,8 @@ auto CPU::Recompiler::emitREGIMM(u32 instruction) -> bool {
   case 0x08: case 0x0a: case 0x0c: case 0x0e:
   case 0x12: case 0x14: case 0x16: case 0x18:
   case 0x1a: case 0x1c: case 0x1e: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BLTZ);
     return 1;
   }
@@ -760,24 +756,24 @@ auto CPU::Recompiler::emitREGIMM(u32 instruction) -> bool {
   case 0x09: case 0x0b: case 0x0d: case 0x0f:
   case 0x13: case 0x15: case 0x17: case 0x19:
   case 0x1b: case 0x1d: case 0x1f: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BGEZ);
     return 1;
   }
 
   //BLTZAL Rs,i16
   case 0x10: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BLTZAL);
     return 1;
   }
 
   //BGEZAL Rs,i16
   case 0x11: {
-    lea(rsi, Rs);
-    mov(edx, imm32(i16));
+    lea(ra1, Rs);
+    mov(ra2d, imm32(i16));
     call(&CPU::BGEZAL);
     return 1;
   }
@@ -792,8 +788,8 @@ auto CPU::Recompiler::emitSCC(u32 instruction) -> bool {
 
   //MFC0 Rt,Rd
   case 0x00: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Rdn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Rdn));
     call(&CPU::MFC0);
     return 0;
   }
@@ -806,8 +802,8 @@ auto CPU::Recompiler::emitSCC(u32 instruction) -> bool {
 
   //MTC0 Rt,Rd
   case 0x04: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Rdn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Rdn));
     call(&CPU::MTC0);
     return 0;
   }
@@ -838,8 +834,8 @@ auto CPU::Recompiler::emitGTE(u32 instruction) -> bool {
 
   //MFC2 Rt,Rd
   case 0x00: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Rdn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Rdn));
     call(&CPU::MFC2);
     return 0;
   }
@@ -852,8 +848,8 @@ auto CPU::Recompiler::emitGTE(u32 instruction) -> bool {
 
   //CFC2 Rt,Rd
   case 0x02: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Rdn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Rdn));
     call(&CPU::CFC2);
     return 0;
   }
@@ -866,8 +862,8 @@ auto CPU::Recompiler::emitGTE(u32 instruction) -> bool {
 
   //MTC2 Rt,Rd
   case 0x04: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Rdn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Rdn));
     call(&CPU::MTC2);
     return 0;
   }
@@ -880,8 +876,8 @@ auto CPU::Recompiler::emitGTE(u32 instruction) -> bool {
 
   //CTC2 Rt,Rd
   case 0x06: {
-    lea(rsi, Rt);
-    mov(edx, imm32(Rdn));
+    lea(ra1, Rt);
+    mov(ra2d, imm32(Rdn));
     call(&CPU::CTC2);
     return 0;
   }
@@ -903,16 +899,16 @@ auto CPU::Recompiler::emitGTE(u32 instruction) -> bool {
 
   //RTPS Lm,Sf (mirror)
   case 0x00: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::RTPS);
     return 0;
   }
 
   //RTPS Lm,Sf
   case 0x01: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::RTPS);
     return 0;
   }
@@ -925,123 +921,123 @@ auto CPU::Recompiler::emitGTE(u32 instruction) -> bool {
 
   //OP Lm,Sf
   case 0x0c: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::OP);
     return 0;
   }
 
   //DPCS Lm,Sf
   case 0x10: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::DPCS);
     return 0;
   }
 
   //INTPL Lm,Sf
   case 0x11: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::INTPL);
     return 0;
   }
 
   //MVMVA Lm,Tv,Mv,Mm,Sf
   case 0x12: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Tv));
-    mov(ecx, imm32(Mv));
-    mov(r8d, imm32(Mm));
-    mov(r9d, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Tv));
+    mov(ra3d, imm32(Mv));
+    mov(ra4d, imm32(Mm));
+    mov(ra5d, imm32(Sf));
     call(&CPU::MVMVA);
     return 0;
   }
 
   //NCDS Lm,Sf
   case 0x13: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::NCDS);
     return 0;
   }
 
   //CDP Lm,Sf
   case 0x14: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::CDP);
     return 0;
   }
 
   //NCDT Lm,Sf
   case 0x16: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::NCDT);
     return 0;
   }
 
   //DCPL Lm,Sf (mirror)
   case 0x1a: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::DCPL);
     return 0;
   }
 
   //NCCS Lm,Sf
   case 0x1b: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::NCCS);
     return 0;
   }
 
   //CC Lm,Sf
   case 0x1c: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::CC);
     return 0;
   }
 
   //NCS Lm,Sf
   case 0x1e: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::NCS);
     return 0;
   }
 
   //NCT Lm,Sf
   case 0x20: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::NCT);
     return 0;
   }
 
   //SQR Lm,Sf
   case 0x28: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::SQR);
     return 0;
   }
 
   //DCPL Lm,Sf
   case 0x29: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::DCPL);
     return 0;
   }
 
   //DPCT Lm,Sf
   case 0x2a: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::DPCT);
     return 0;
   }
@@ -1060,32 +1056,32 @@ auto CPU::Recompiler::emitGTE(u32 instruction) -> bool {
 
   //RTPT Lm,Sf
   case 0x30: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::RTPT);
     return 0;
   }
 
   //GPF Lm,Sf
   case 0x3d: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::GPF);
     return 0;
   }
 
   //GPL Lm,Sf
   case 0x3e: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::GPL);
     return 0;
   }
 
   //NCCT Lm,Sf
   case 0x3f: {
-    mov(esi, imm32(Lm));
-    mov(edx, imm32(Sf));
+    mov(ra1d, imm32(Lm));
+    mov(ra2d, imm32(Sf));
     call(&CPU::NCCT);
     return 0;
   }
@@ -1114,16 +1110,10 @@ auto CPU::Recompiler::emitGTE(u32 instruction) -> bool {
 template<typename V, typename... P>
 auto CPU::Recompiler::call(V (CPU::*function)(P...)) -> void {
   static_assert(sizeof...(P) <= 5);
-  if constexpr(ABI::SystemV) {
-    mov(rdi, rbp);
-  }
   if constexpr(ABI::Windows) {
-    if constexpr(sizeof...(P) >= 5) mov(dis8(rsp, 0x28), r9);
-    if constexpr(sizeof...(P) >= 4) mov(dis8(rsp, 0x20), r8);
-    if constexpr(sizeof...(P) >= 3) mov(r9, rcx);
-    if constexpr(sizeof...(P) >= 2) mov(r8, rdx);
-    if constexpr(sizeof...(P) >= 1) mov(rdx, rsi);
-    mov(rcx, rbp);
+    if constexpr(sizeof...(P) >= 5) mov(dis8(rsp, 0x28), ra5);
+    if constexpr(sizeof...(P) >= 4) mov(dis8(rsp, 0x20), ra4);
   }
+  mov(ra0, rbp);
   call(imm64{function}, rax);
 }

--- a/nall/recompiler/amd64/encoder-calls-systemv.hpp
+++ b/nall/recompiler/amd64/encoder-calls-systemv.hpp
@@ -1,6 +1,21 @@
 #pragma once
 
 //{
+  //register aliases for function arguments
+  static constexpr reg32 ra0d = reg32::edi;
+  static constexpr reg32 ra1d = reg32::esi;
+  static constexpr reg32 ra2d = reg32::edx;
+  static constexpr reg32 ra3d = reg32::ecx;
+  static constexpr reg32 ra4d = reg32::r8d;
+  static constexpr reg32 ra5d = reg32::r9d;
+
+  static constexpr reg64 ra0 = reg64::rdi;
+  static constexpr reg64 ra1 = reg64::rsi;
+  static constexpr reg64 ra2 = reg64::rdx;
+  static constexpr reg64 ra3 = reg64::rcx;
+  static constexpr reg64 ra4 = reg64::r8;
+  static constexpr reg64 ra5 = reg64::r9;
+
   //virtual instructions to call member functions
   template<typename C, typename R, typename... P>
   alwaysinline auto call(auto (C::*function)(P...) -> R, C* object) {

--- a/nall/recompiler/amd64/encoder-calls-windows.hpp
+++ b/nall/recompiler/amd64/encoder-calls-windows.hpp
@@ -1,6 +1,21 @@
 #pragma once
 
 //{
+  //register aliases for function arguments
+  static constexpr reg32 ra0d = reg32::ecx;
+  static constexpr reg32 ra1d = reg32::edx;
+  static constexpr reg32 ra2d = reg32::r8d;
+  static constexpr reg32 ra3d = reg32::r9d;
+  static constexpr reg32 ra4d = reg32::r10d;  //actually passed on stack
+  static constexpr reg32 ra5d = reg32::r11d;  //actually passed on stack
+
+  static constexpr reg64 ra0 = reg64::rcx;
+  static constexpr reg64 ra1 = reg64::rdx;
+  static constexpr reg64 ra2 = reg64::r8;
+  static constexpr reg64 ra3 = reg64::r9;
+  static constexpr reg64 ra4 = reg64::r10;  //actually passed on stack
+  static constexpr reg64 ra5 = reg64::r11;  //actually passed on stack
+
   //virtual instructions to call member functions
   template<typename C, typename R, typename... P>
   alwaysinline auto call(auto (C::*function)(P...) -> R, C* object) {


### PR DESCRIPTION
Previously, the recompilers in ares would assume the System V calling
convention, then emit extra moves on Windows to handle the differences
in register usage. Now, they directly populate the registers used by the
target system for passing parameters to functions. This is achieved
with register aliases set for the appropriate ABI at compile time.

Furthermore, registers that are nonvolatile only on Windows - rsi and
rdi - are no longer used as temporaries, removing the need to save and
restore them in recompiled code blocks.

This accounts for roughly a 10% reduction in recompiled code size on
Windows while making functionally no difference to other systems.