### PR TITLE
fc: support for irem boards

### DIFF
--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -26,6 +26,7 @@ namespace Board {
 #include "hvc-uxrom.cpp"
 #include "irem-g101.cpp"
 #include "irem-h3001.cpp"
+#include "irem-if12.cpp"
 #include "irem-lrog017.cpp"
 #include "irem-tam-s1.cpp"
 #include "sunsoft-1.cpp"
@@ -57,6 +58,7 @@ auto Interface::create(string board) -> Interface* {
   if(!p) p = HVC_UxROM::create(board);
   if(!p) p = IremG101::create(board);
   if(!p) p = IremH3001::create(board);
+  if(!p) p = IremIF12::create(board);
   if(!p) p = IremLROG017::create(board);
   if(!p) p = IremTAMS1::create(board);
   if(!p) p = JalecoJF::create(board);

--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -25,6 +25,7 @@ namespace Board {
 #include "hvc-txrom.cpp"
 #include "hvc-uxrom.cpp"
 #include "irem-g101.cpp"
+#include "irem-h3001.cpp"
 #include "irem-tam-s1.cpp"
 #include "sunsoft-1.cpp"
 #include "sunsoft-2.cpp"
@@ -54,6 +55,7 @@ auto Interface::create(string board) -> Interface* {
   if(!p) p = HVC_TxROM::create(board);
   if(!p) p = HVC_UxROM::create(board);
   if(!p) p = IremG101::create(board);
+  if(!p) p = IremH3001::create(board);
   if(!p) p = IremTAMS1::create(board);
   if(!p) p = JalecoJF::create(board);
   if(!p) p = Jaleco_JF11_JF14::create(board);

--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -24,6 +24,7 @@ namespace Board {
 #include "hvc-sxrom.cpp"
 #include "hvc-txrom.cpp"
 #include "hvc-uxrom.cpp"
+#include "irem-g101.cpp"
 #include "irem-tam-s1.cpp"
 #include "sunsoft-1.cpp"
 #include "sunsoft-2.cpp"
@@ -52,6 +53,7 @@ auto Interface::create(string board) -> Interface* {
   if(!p) p = HVC_SxROM::create(board);
   if(!p) p = HVC_TxROM::create(board);
   if(!p) p = HVC_UxROM::create(board);
+  if(!p) p = IremG101::create(board);
   if(!p) p = IremTAMS1::create(board);
   if(!p) p = JalecoJF::create(board);
   if(!p) p = Jaleco_JF11_JF14::create(board);

--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -26,6 +26,7 @@ namespace Board {
 #include "hvc-uxrom.cpp"
 #include "irem-g101.cpp"
 #include "irem-h3001.cpp"
+#include "irem-lrog017.cpp"
 #include "irem-tam-s1.cpp"
 #include "sunsoft-1.cpp"
 #include "sunsoft-2.cpp"
@@ -56,6 +57,7 @@ auto Interface::create(string board) -> Interface* {
   if(!p) p = HVC_UxROM::create(board);
   if(!p) p = IremG101::create(board);
   if(!p) p = IremH3001::create(board);
+  if(!p) p = IremLROG017::create(board);
   if(!p) p = IremTAMS1::create(board);
   if(!p) p = JalecoJF::create(board);
   if(!p) p = Jaleco_JF11_JF14::create(board);

--- a/ares/fc/cartridge/board/irem-g101.cpp
+++ b/ares/fc/cartridge/board/irem-g101.cpp
@@ -28,29 +28,22 @@ struct IremG101 : Interface {
 
   auto readPRG(n32 address, n8 data) -> n8 override {
     if(address < 0x6000) return data;
+    if(address < 0x8000 && !programRAM) return data;
     if(address < 0x8000) return programRAM.read((n13)address);
 
     n5 bank;
-    if(programMode) {
-      switch(address >> 13 & 3) {
-      case 0: bank = 0x1e; break;
-      case 1: bank = programBank[1]; break;
-      case 2: bank = programBank[0]; break;
-      case 3: bank = 0x1f; break;
-      }
-    } else {
-      switch(address >> 13 & 3) {
-      case 0: bank = programBank[0]; break;
-      case 1: bank = programBank[1]; break;
-      case 2: bank = 0x1e; break;
-      case 3: bank = 0x1f; break;
-      }
+    switch(address >> 13 & 3) {
+    case 0: bank = (programMode == 0 ? programBank[0] : (n5)0x1e); break;
+    case 1: bank = programBank[1]; break;
+    case 2: bank = (programMode == 1 ? programBank[0] : (n5)0x1e); break;
+    case 3: bank = 0x1f; break;
     }
     return programROM.read(bank << 13 | (n13)address);
   }
 
   auto writePRG(n32 address, n8 data) -> void override {
     if(address < 0x6000) return;
+    if(address < 0x8000 && !programRAM) return;
     if(address < 0x8000) return programRAM.write((n13)address, data);
 
     switch(address & 0xf000) {

--- a/ares/fc/cartridge/board/irem-g101.cpp
+++ b/ares/fc/cartridge/board/irem-g101.cpp
@@ -1,0 +1,99 @@
+struct IremG101 : Interface {
+  static auto create(string id) -> Interface* {
+    if(id == "IREM-G101" ) return new IremG101(Revision::G101);
+    if(id == "IREM-G101A") return new IremG101(Revision::G101A);
+    return nullptr;
+  }
+
+  Memory::Readable<n8> programROM;
+  Memory::Writable<n8> programRAM;
+  Memory::Readable<n8> characterROM;
+
+  enum class Revision : u32 {
+    G101,
+    G101A,
+  } revision;
+
+  IremG101(Revision revision) : revision(revision) {}
+
+  auto load() -> void override {
+    Interface::load(programROM, "program.rom");
+    Interface::load(programRAM, "save.ram");
+    Interface::load(characterROM, "character.rom");
+  }
+
+  auto save() -> void override {
+    Interface::save(programRAM, "save.ram");
+  }
+
+  auto readPRG(n32 address, n8 data) -> n8 override {
+    if(address < 0x6000) return data;
+    if(address < 0x8000) return programRAM.read((n13)address);
+
+    n5 bank;
+    if(programMode) {
+      switch(address >> 13 & 3) {
+      case 0: bank = 0x1e; break;
+      case 1: bank = programBank[1]; break;
+      case 2: bank = programBank[0]; break;
+      case 3: bank = 0x1f; break;
+      }
+    } else {
+      switch(address >> 13 & 3) {
+      case 0: bank = programBank[0]; break;
+      case 1: bank = programBank[1]; break;
+      case 2: bank = 0x1e; break;
+      case 3: bank = 0x1f; break;
+      }
+    }
+    return programROM.read(bank << 13 | (n13)address);
+  }
+
+  auto writePRG(n32 address, n8 data) -> void override {
+    if(address < 0x6000) return;
+    if(address < 0x8000) return programRAM.write((n13)address, data);
+
+    switch(address & 0xf000) {
+    case 0x8000: programBank[0] = data.bit(0,4); break;
+    case 0xa000: programBank[1] = data.bit(0,4); break;
+    case 0xb000: characterBank[address & 7] = data; break;
+    case 0x9000:
+      if(revision == Revision::G101) {
+        mirror = data.bit(0);
+        programMode = data.bit(1);
+      }
+      break;
+	  }
+  }
+
+  auto addressCIRAM(n32 address) const -> n32 {
+    if(revision == Revision::G101A) return (n10)address;
+    return address >> mirror & 0x0400 | (n10)address;
+  }
+
+  auto readCHR(n32 address, n8 data) -> n8 override {
+    if(address & 0x2000) return ppu.readCIRAM(addressCIRAM(address));
+    if(characterROM) {
+      n8 bank = characterBank[address >> 10 & 7];
+      return characterROM.read(bank << 10 | (n10)address);
+    }
+    return data;
+  }
+
+  auto writeCHR(n32 address, n8 data) -> void override {
+    if(address & 0x2000) return ppu.writeCIRAM(addressCIRAM(address), data);
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(programRAM);
+    s(programBank);
+    s(characterBank);
+    s(programMode);
+    s(mirror);
+  }
+
+  n5 programBank[2];
+  n8 characterBank[8];
+  n1 programMode;
+  n1 mirror;
+};

--- a/ares/fc/cartridge/board/irem-h3001.cpp
+++ b/ares/fc/cartridge/board/irem-h3001.cpp
@@ -24,20 +24,11 @@ struct IremH3001 : Interface {
     if(address < 0x8000) return data;
 
     n6 bank;
-    if(programMode) {
-      switch(address >> 13 & 3) {
-      case 0: bank = 0x3e; break;
-      case 1: bank = programBank[1]; break;
-      case 2: bank = programBank[0]; break;
-      case 3: bank = 0x3f; break;
-      }
-    } else {
-      switch(address >> 13 & 3) {
-      case 0: bank = programBank[0]; break;
-      case 1: bank = programBank[1]; break;
-      case 2: bank = 0x3e; break;
-      case 3: bank = 0x3f; break;
-      }
+    switch(address >> 13 & 3) {
+    case 0: bank = (programMode == 0 ? programBank[0] : (n6)0x3e); break;
+    case 1: bank = programBank[1]; break;
+    case 2: bank = (programMode == 1 ? programBank[0] : (n6)0x3e); break;
+    case 3: bank = 0x3f; break;
     }
     return programROM.read(bank << 13 | (n13)address);
   }

--- a/ares/fc/cartridge/board/irem-h3001.cpp
+++ b/ares/fc/cartridge/board/irem-h3001.cpp
@@ -1,0 +1,116 @@
+struct IremH3001 : Interface {
+  static auto create(string id) -> Interface* {
+    if(id == "IREM-H3001") return new IremH3001;
+    return nullptr;
+  }
+
+  Memory::Readable<n8> programROM;
+  Memory::Readable<n8> characterROM;
+
+  auto load() -> void override {
+    Interface::load(programROM, "program.rom");
+    Interface::load(characterROM, "character.rom");
+  }
+
+  auto main() -> void override {
+    if(irqEnable) {
+      if(irqCounter && --irqCounter == 0) irqLine = 1;
+    }
+    cpu.irqLine(irqLine);
+    tick();
+  }
+
+  auto readPRG(n32 address, n8 data) -> n8 override {
+    if(address < 0x8000) return data;
+
+    n6 bank;
+    if(programMode) {
+      switch(address >> 13 & 3) {
+      case 0: bank = 0x3e; break;
+      case 1: bank = programBank[1]; break;
+      case 2: bank = programBank[0]; break;
+      case 3: bank = 0x3f; break;
+      }
+    } else {
+      switch(address >> 13 & 3) {
+      case 0: bank = programBank[0]; break;
+      case 1: bank = programBank[1]; break;
+      case 2: bank = 0x3e; break;
+      case 3: bank = 0x3f; break;
+      }
+    }
+    return programROM.read(bank << 13 | (n13)address);
+  }
+
+  auto writePRG(n32 address, n8 data) -> void override {
+    if(address < 0x8000) return;
+
+    switch(address) {
+    case 0x8000: programBank[0] = data.bit(0,5); break;
+    case 0xa000: programBank[1] = data.bit(0,5); break;
+    case 0xb000: characterBank[0] = data; break;
+    case 0xb001: characterBank[1] = data; break;
+    case 0xb002: characterBank[2] = data; break;
+    case 0xb003: characterBank[3] = data; break;
+    case 0xb004: characterBank[4] = data; break;
+    case 0xb005: characterBank[5] = data; break;
+    case 0xb006: characterBank[6] = data; break;
+    case 0xb007: characterBank[7] = data; break;
+    case 0x9000: programMode = data.bit(7); break;
+    case 0x9001: mirror = data.bit(6,7); break;
+    case 0x9003:
+      irqEnable = data.bit(7);
+      irqLine = 0;
+      break;
+    case 0x9004:
+      irqCounter = irqLatch;
+      irqLine = 0;
+      break;
+    case 0x9005: irqLatch = irqLatch.bit(0,7)  << 0 | data << 8; break;
+    case 0x9006: irqLatch = irqLatch.bit(8,15) << 8 | data << 0; break;
+    }
+  }
+
+  auto addressCIRAM(n32 address) const -> n32 {
+    switch(mirror) {
+    case 0: return address >> 0 & 0x0400 | (n10)address;
+    case 1: return (n10)address;
+    case 2: return address >> 1 & 0x0400 | (n10)address;
+    case 3: return (n10)address;
+    }
+    unreachable;
+  }
+
+  auto readCHR(n32 address, n8 data) -> n8 override {
+    if(address & 0x2000) return ppu.readCIRAM(addressCIRAM(address));
+    if(characterROM) {
+      n8 bank = characterBank[address >> 10 & 7];
+      return characterROM.read(bank << 10 | (n10)address);
+    }
+    return data;
+  }
+
+  auto writeCHR(n32 address, n8 data) -> void override {
+    if(address & 0x2000) return ppu.writeCIRAM(addressCIRAM(address), data);
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(programBank);
+    s(characterBank);
+    s(programMode);
+    s(mirror);
+    s(irqLatch);
+    s(irqCounter);
+    s(irqEnable);
+    s(irqLine);
+  }
+
+  n6  programBank[2];
+  n8  characterBank[8];
+  n1  programMode;
+  n2  mirror;
+  n16 irqLatch;
+  n16 irqCounter;
+  n1  irqEnable;
+  n1  irqLine;
+};

--- a/ares/fc/cartridge/board/irem-if12.cpp
+++ b/ares/fc/cartridge/board/irem-if12.cpp
@@ -1,0 +1,66 @@
+struct IremIF12 : Interface {
+  static auto create(string id) -> Interface* {
+    if(id == "IREM-IF-12"  ) return new IremIF12(Revision::IF12);
+    if(id == "JALECO-JF-16") return new IremIF12(Revision::JF16);
+    return nullptr;
+  }
+
+  Memory::Readable<n8> programROM;
+  Memory::Readable<n8> characterROM;
+
+  enum class Revision : u32 {
+    IF12,
+    JF16,
+  } revision;
+
+  IremIF12(Revision revision) : revision(revision) {}
+
+  auto load() -> void override {
+    Interface::load(programROM, "program.rom");
+    Interface::load(characterROM, "character.rom");
+  }
+
+  auto readPRG(n32 address, n8 data) -> n8 override {
+    if(address < 0x8000) return data;
+
+    n3 bank;
+    switch(address >> 14 & 1) {
+    case 0: bank = programBank; break;
+    case 1: bank = 7; break;
+    }
+    return programROM.read(bank << 14 | (n14)address);
+  }
+
+  auto writePRG(n32 address, n8 data) -> void override {
+    if(address < 0x8000) return;
+    programBank   = data.bit(0,2);
+    mirror        = data.bit(3);
+    characterBank = data.bit(4,7);
+  }
+
+  auto addressCIRAM(n32 address) const -> n32 {
+    if(revision == Revision::JF16) {
+      return mirror << 10 | (n10)address;
+    }
+    return address >> !mirror & 0x0400 | (n10)address;
+  }
+
+  auto readCHR(n32 address, n8 data) -> n8 override {
+    if(address & 0x2000) return ppu.readCIRAM(addressCIRAM(address));
+    return characterROM.read(characterBank << 13 | (n13)address);
+  }
+
+  auto writeCHR(n32 address, n8 data) -> void override {
+    if(address & 0x2000) return ppu.writeCIRAM(addressCIRAM(address), data);
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(mirror);
+    s(programBank);
+    s(characterBank);
+  }
+
+  n1 mirror;
+  n3 programBank;
+  n4 characterBank;
+};

--- a/ares/fc/cartridge/board/irem-lrog017.cpp
+++ b/ares/fc/cartridge/board/irem-lrog017.cpp
@@ -1,0 +1,61 @@
+struct IremLROG017 : Interface {
+  static auto create(string id) -> Interface* {
+    if(id == "IREM-LROG017") return new IremLROG017;
+    return nullptr;
+  }
+
+  Memory::Readable<n8> programROM;
+  Memory::Readable<n8> characterROM;
+  Memory::Writable<n8> characterRAM;
+
+  auto load() -> void override {
+    Interface::load(programROM, "program.rom");
+    Interface::load(characterROM, "character.rom");
+    Interface::load(characterRAM, "character.ram");
+  }
+
+  auto save() -> void override {
+    Interface::save(characterRAM, "character.ram");
+  }
+
+  auto readPRG(n32 address, n8 data) -> n8 override {
+    if(address < 0x8000) return data;
+    return programROM.read(programBank << 15 | (n15)address);
+  }
+
+  auto writePRG(n32 address, n8 data) -> void override {
+    if(address < 0x8000) return;
+    programBank   = data.bit(0,3);
+    characterBank = data.bit(4,7);
+  }
+
+  auto addressCHR(n32 address) const -> n32 {
+    if(address < 0x1000) return 1 << 11 | (n11)address;
+    if(address < 0x1800) return 2 << 11 | (n11)address;
+    if(address < 0x2000) return 3 << 11 | (n11)address;
+    if(address < 0x2800) return 0 << 11 | (n11)address;
+    unreachable;
+  }
+
+  auto readCHR(n32 address, n8 data) -> n8 override {
+    if(address < 0x0800) return characterROM.read(characterBank << 11 | (n11)address);
+    if(address < 0x2800) return characterRAM.read(addressCHR(address));
+    if(address < 0x3000) return ppu.readCIRAM((n11)address);
+    return data;
+  }
+
+  auto writeCHR(n32 address, n8 data) -> void override {
+    if(address < 0x0800) return;
+    if(address < 0x2800) return characterRAM.write(addressCHR(address), data);
+    if(address < 0x3000) return ppu.writeCIRAM((n11)address, data);
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(characterRAM);
+    s(programBank);
+    s(characterBank);
+  }
+
+  n4 programBank;
+  n4 characterBank;
+};

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -1,5 +1,5 @@
 database
-  revision: 2021-10-30
+  revision: 2021-10-31
 
 game
   sha256: 4ef61de405406bfa9eeaf19ed1d882444c41bb606ac78673b7ec8ee323d0e073
@@ -9,6 +9,25 @@ game
   board:  IREM-G101A
     chip
       type: G101
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 407e54848ad9991399f0383118f138d3a0532bb03bb488ed856deb7f2eb4efbf
+  name:   Uchuusen Cosmo Carrier
+  title:  Uchuusen Cosmo Carrier
+  region: NTSC-J
+  board:  JALECO-JF-16
     memory
       type: ROM
       size: 0x10

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -1,0 +1,24 @@
+database
+  revision: 2021-10-30
+
+game
+  sha256: 4ef61de405406bfa9eeaf19ed1d882444c41bb606ac78673b7ec8ee323d0e073
+  name:   Major League
+  title:  Major League
+  region: NTSC-J
+  board:  IREM-G101A
+    chip
+      type: G101
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -327,6 +327,11 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     s += "    chip type=VRC1\n";
     break;
 
+  case  77:
+    s += "  board:  IREM-LROG017\n";
+    chrram = 8192;
+    break;
+
   case  80:
     s += "  board:  TAITO-X1-005\n";
     s += "    chip type=X1-005\n";

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -332,6 +332,10 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     chrram = 8192;
     break;
 
+  case  78:
+    s += "  board:  IREM-IF-12\n";
+    break;
+
   case  80:
     s += "  board:  TAITO-X1-005\n";
     s += "    chip type=X1-005\n";

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -262,6 +262,12 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     prgram = 8192;
     break;
 
+  case  32:
+    s += "  board:  IREM-G101\n";
+    s += "    chip type=G101\n";
+    prgram = 8192;
+    break;
+
   case  33:
     s += "  board:  TAITO-TC0190\n";
     s += "    chip type=TC0190\n";

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -283,6 +283,11 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     s += "    chip type=TC0690\n";
     break;
 
+  case  65:
+    s += "  board:  IREM-H3001\n";
+    s += "    chip type=H3001\n";
+    break;
+
   case  66:
     s += "  board:  HVC-GNROM\n";
     s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -124,6 +124,10 @@ auto Famicom::analyzeFDS(vector<u8>& data) -> string {
 
 //iNES
 auto Famicom::analyzeINES(vector<u8>& data) -> string {
+  string hash = Hash::SHA256({data.data() + 16, data.size() - 16}).digest();
+  string manifest = Medium::manifestDatabase(hash);
+  if(manifest) return manifest;
+
   u32 mapper = ((data[7] >> 4) << 4) | (data[6] >> 4);
   u32 mirror = ((data[6] & 0x08) >> 2) | (data[6] & 0x01);
   u32 prgrom = data[4] * 0x4000;
@@ -131,7 +135,6 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
   u32 prgram = 0u;
   u32 chrram = chrrom == 0u ? 8192u : 0u;
   u32 eeprom = 0u;
-  string hash = Hash::SHA256({data.data() + 16, data.size() - 16}).digest();
 
   string s;
   s += "game\n";


### PR DESCRIPTION
Support added for Irem G101, H3001, LROG017 and IF-12 boards.

Irem G101 (iNES mapper 32):
- Ai Sensei no Oshiete - Watashi no Hoshi (Japan)
- Image Fight (Japan)
- Kaiketsu Yancha Maru 2 - Karakuri Land (Japan)
- Major League (Japan)
- Meikyuu-jima (Japan)
- Perman (Japan)
- Perman Part 2 - Himitsu Kessha Madoodan o Taose! (Japan)

Irem H3001 (iNES mapper 65):
- Daiku no Gen-san 2 - Akage no Dan no Gyakushuu (Japan)
- Kaiketsu Yancha Maru 3 - Taiketsu! Zouringen (Japan)
- Spartan X 2 (Japan)

Irem LROG017 (iNES mapper 77):
- Napoleon Senki (Japan)

Irem IF-12 (iNES mapper 78):
- Holy Diver (Japan)
- Uchuusen Cosmo Carrier (Japan)

The iNES mapper 78 merges two unrelated boards from different companies. I don't really like implementing one as a revision of the other, so I may split them when I look into Jaleco boards.

There are special configurations of boards G101 and IF-12 that can only be detected with NES 2.0 submappers or by hash. With this pr I started a Famicom database, as I think it's the cleanest way to organize fc boards. I'm adding special cases to it at the moment and will move the special cases already managed in code to it, but it should probably be extended to the full library eventually. A database has the advantage of completely ignoring iNES headers and always load the rom with correct configuration, which is important as there are many roms with incorrect headers floating around. Please, let me know if another solution if preferred.

The roadmap with these prs is to add all the officially licensed fc boards to ares, then I will try to fix the remainig bugs on the core.