### PR TITLE
fc: fixes for konami vrc-2/4/7

### DIFF
--- a/ares/fc/cartridge/board/konami-vrc2.cpp
+++ b/ares/fc/cartridge/board/konami-vrc2.cpp
@@ -1,6 +1,7 @@
 struct KonamiVRC2 : Interface {
   static auto create(string id) -> Interface* {
-    if(id == "KONAMI-VRC-2") return new KonamiVRC2;
+    if(id == "KONAMI-VRC-2" ) return new KonamiVRC2(Revision::VRC2);
+    if(id == "KONAMI-VRC-2A") return new KonamiVRC2(Revision::VRC2A);
     return nullptr;
   }
 
@@ -8,6 +9,13 @@ struct KonamiVRC2 : Interface {
   Memory::Writable<n8> programRAM;
   Memory::Readable<n8> characterROM;
   Memory::Writable<n8> characterRAM;
+
+  enum class Revision : u32 {
+    VRC2,
+    VRC2A,
+  } revision;
+
+  KonamiVRC2(Revision revision) : revision(revision) {}
 
   auto load() -> void override {
     Interface::load(programROM, "program.rom");
@@ -98,6 +106,7 @@ struct KonamiVRC2 : Interface {
 
   auto addressCHR(n32 address) const -> n32 {
     n8 bank = characterBank[address >> 10];
+    if(revision == Revision::VRC2A) bank >>= 1;
     return bank << 10 | (n10)address;
   }
 

--- a/ares/fc/cartridge/board/konami-vrc3.cpp
+++ b/ares/fc/cartridge/board/konami-vrc3.cpp
@@ -43,6 +43,7 @@ struct KonamiVRC3 : Interface {
 
   auto readPRG(n32 address, n8 data) -> n8 override {
     if(address < 0x6000) return data;
+    if(address < 0x8000 && !programRAM) return data;
     if(address < 0x8000) return programRAM.read((n13)address);
 
     n4 bank = (address < 0xc000 ? programBank : (n4)0xf);
@@ -52,6 +53,7 @@ struct KonamiVRC3 : Interface {
 
   auto writePRG(n32 address, n8 data) -> void override {
     if(address < 0x6000) return;
+    if(address < 0x8000 && !programRAM) return;
     if(address < 0x8000) return programRAM.write((n13)address, data);
 
     switch(address & 0xf000) {

--- a/ares/fc/cartridge/board/konami-vrc4.cpp
+++ b/ares/fc/cartridge/board/konami-vrc4.cpp
@@ -52,6 +52,7 @@ struct KonamiVRC4 : Interface {
 
   auto readPRG(n32 address, n8 data) -> n8 override {
     if(address < 0x6000) return data;
+    if(address < 0x8000 && !programRAM) return data;
     if(address < 0x8000) return programRAM.read((n13)address);
 
     n5 bank, banks = programROM.size() >> 13;
@@ -67,6 +68,7 @@ struct KonamiVRC4 : Interface {
 
   auto writePRG(n32 address, n8 data) -> void override {
     if(address < 0x6000) return;
+    if(address < 0x8000 && !programRAM) return;
     if(address < 0x8000) return programRAM.write((n13)address, data);
 
     bool a0 = address & pinA0;

--- a/ares/fc/cartridge/board/konami-vrc6.cpp
+++ b/ares/fc/cartridge/board/konami-vrc6.cpp
@@ -147,12 +147,14 @@ struct KonamiVRC6 : Interface {
 
   auto readPRG(n32 address, n8 data) -> n8 override {
     if(address < 0x6000) return data;
+    if(address < 0x8000 && !programRAM) return data;
     if(address < 0x8000) return programRAM.read((n13)address);
     return programROM.read(addressPRG(address));
   }
 
   auto writePRG(n32 address, n8 data) -> void override {
     if(address < 0x6000) return;
+    if(address < 0x8000 && !programRAM) return;
     if(address < 0x8000) return programRAM.write((n13)address, data);
 
     bool a0 = address & pinA0;

--- a/ares/fc/cartridge/board/konami-vrc7.cpp
+++ b/ares/fc/cartridge/board/konami-vrc7.cpp
@@ -16,6 +16,7 @@ struct KonamiVRC7 : Interface {
     Interface::load(programRAM, "save.ram");
     Interface::load(characterROM, "character.rom");
     Interface::load(characterRAM, "character.ram");
+    pinA0 = 1 << pak->attribute("pinout/a0").natural();
 
     stream = cartridge.node->append<Node::Audio::Stream>("YM2413");
     stream->setChannels(1);
@@ -90,27 +91,31 @@ struct KonamiVRC7 : Interface {
     if(address < 0x8000 && !programRAM) return;
     if(address < 0x8000) return programRAM.write(address, data);
 
+    bool a0 = address & pinA0;
+    address &= 0xf020;
+    address |= a0;
+
     switch(address) {
     case 0x8000: programBank[0] = data; break;
-    case 0x8010: programBank[1] = data; break;
+    case 0x8001: programBank[1] = data; break;
     case 0x9000: programBank[2] = data; break;
-    case 0x9010: ym2413.address(data); break;
-    case 0x9030: ym2413.write(data); break;
+    case 0x9001: ym2413.address(data); break;
+    case 0x9021: ym2413.write(data); break;
     case 0xa000: characterBank[0] = data; break;
-    case 0xa010: characterBank[1] = data; break;
+    case 0xa001: characterBank[1] = data; break;
     case 0xb000: characterBank[2] = data; break;
-    case 0xb010: characterBank[3] = data; break;
+    case 0xb001: characterBank[3] = data; break;
     case 0xc000: characterBank[4] = data; break;
-    case 0xc010: characterBank[5] = data; break;
+    case 0xc001: characterBank[5] = data; break;
     case 0xd000: characterBank[6] = data; break;
-    case 0xd010: characterBank[7] = data; break;
+    case 0xd001: characterBank[7] = data; break;
     case 0xe000:
       if(disableFM && !data.bit(6)) ym2413.power(1);
       mirror = data.bit(0,1);
       disableFM = data.bit(6);
       ramWritable = data.bit(7);
       break;
-    case 0xe010:
+    case 0xe001:
       irqLatch = data;
       break;
     case 0xf000:
@@ -123,7 +128,7 @@ struct KonamiVRC7 : Interface {
       }
       irqLine = 0;
       break;
-    case 0xf010:
+    case 0xf001:
       irqEnable = irqAcknowledge;
       irqLine = 0;
       break;
@@ -195,4 +200,7 @@ struct KonamiVRC7 : Interface {
   i16 irqScalar;
   n1  irqLine;
   n6  divider;
+
+//unserialized:
+  n8 pinA0;
 };

--- a/ares/fc/cartridge/board/konami-vrc7.cpp
+++ b/ares/fc/cartridge/board/konami-vrc7.cpp
@@ -71,6 +71,7 @@ struct KonamiVRC7 : Interface {
 
   auto readPRG(n32 address, n8 data) -> n8 override {
     if(address < 0x6000) return data;
+    if(address < 0x8000 && !programRAM) return data;
     if(address < 0x8000) return programRAM.read(address);
 
     n8 bank;
@@ -86,6 +87,7 @@ struct KonamiVRC7 : Interface {
 
   auto writePRG(n32 address, n8 data) -> void override {
     if(address < 0x6000) return;
+    if(address < 0x8000 && !programRAM) return;
     if(address < 0x8000) return programRAM.write(address, data);
 
     switch(address) {

--- a/ares/fc/cartridge/board/sunsoft-5b.cpp
+++ b/ares/fc/cartridge/board/sunsoft-5b.cpp
@@ -66,7 +66,7 @@ struct Sunsoft5B : Interface {
     bank &= 0x3f;
 
     if(ramSelect) {
-      if(!ramEnable) return data;
+      if(!ramEnable || !programRAM) return data;
       return programRAM.read((n13)address);
     }
 
@@ -76,7 +76,7 @@ struct Sunsoft5B : Interface {
 
   auto writePRG(n32 address, n8 data) -> void override {
     if((address & 0xe000) == 0x6000) {
-      programRAM.write((n13)address, data);
+      if(programRAM) programRAM.write((n13)address, data);
     }
 
     if(address == 0x8000) {

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -479,6 +479,34 @@ game
       content: Character
 
 game
+  sha256: a45d30c949f9d0942700826e4433ebad39e08da8252ecb541cae9d495928d63f
+  name:   Lagrange Point
+  title:  Lagrange Point
+  region: NTSC-J
+  board:  KONAMI-VRC-7
+    chip
+      type: VRC7
+      pinout
+        a0: 4
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 4ef61de405406bfa9eeaf19ed1d882444c41bb606ac78673b7ec8ee323d0e073
   name:   Major League
   title:  Major League
@@ -663,6 +691,29 @@ game
       pinout
         a0: 2
         a1: 3
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: dabde0dbf12d01237350cf6ad6463ce79651ac1e80d57b7b3b55c1819e72fd8a
+  name:   Tiny Toon Adventures 2 - Montana Land e Youkoso
+  title:  Tiny Toon Adventures 2 - Montana Land e Youkoso
+  region: NTSC-J
+  board:  KONAMI-VRC-7
+    chip
+      type: VRC7
+      pinout
+        a0: 3
     memory
       type: ROM
       size: 0x10

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -2,6 +2,182 @@ database
   revision: 2021-11-02
 
 game
+  sha256: c70f0f5d4054ce7c4850259879c9823add73ccc234ddcf96d95681bb78bd2c58
+  name:   Akumajou Densetsu
+  title:  Akumajou Densetsu
+  region: NTSC-J
+  board:  KONAMI-VRC-6
+    chip
+      type: VRC6
+      pinout
+        a0: 0
+        a1: 1
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ff5b96853cf67171918aad5157661dc223e0002e0373e2580cee2e207bb0a682
+  name:   Akumajou Special - Boku Dracula-kun
+  title:  Akumajou Special - Boku Dracula-kun
+  region: NTSC-J
+  board:  KONAMI-VRC-4
+    chip
+      type: VRC4
+      pinout
+        a0: 2
+        a1: 3
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 92c481350b63c57385834dfa0ab02aeb527df7e80cec14a3e1a1a77118cd38d1
+  name:   Bio Miracle Bokutte Upa
+  title:  Bio Miracle Bokutte Upa
+  region: NTSC-J
+  board:  KONAMI-VRC-4
+    chip
+      type: VRC4
+      pinout
+        a0: 1
+        a1: 0
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 62c9d4e0578cb1e615ce9bb2c8ebc15b1e8de4c928c5c07ba9a85c11aa36ae4d
+  name:   Contra
+  title:  Contra
+  region: NTSC-J
+  board:  KONAMI-VRC-2
+    chip
+      type: VRC2
+      pinout
+        a0: 0
+        a1: 1
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b504d0ebff8aa6439f1f9606526d8739f5007c1fdac31f9550caa7ca26edce16
+  name:   Crisis Force
+  title:  Crisis Force
+  region: NTSC-J
+  board:  KONAMI-VRC-4
+    chip
+      type: VRC4
+      pinout
+        a0: 2
+        a1: 3
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x800
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 8f7a7ce842ce3135e1cfaea50da3029e7fe8de28384c8db45ef8371ba42b45a9
+  name:   Dragon Scroll - Yomigaerishi Maryuu
+  title:  Dragon Scroll - Yomigaerishi Maryuu
+  region: NTSC-J
+  board:  KONAMI-VRC-2
+    chip
+      type: VRC2
+      pinout
+        a0: 0
+        a1: 1
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 761df2c2e04f9ffec5eec59afd821bd74af3b155546519d649876aad37160c06
+  name:   Esper Dream 2 - Aratanaru Tatakai
+  title:  Esper Dream 2 - Aratanaru Tatakai
+  region: NTSC-J
+  board:  KONAMI-VRC-6
+    chip
+      type: VRC6
+      pinout
+        a0: 1
+        a1: 0
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: c8c0b6c21bdda7503bab7592aea0f945a0259c18504bb241aafb1eabe65846f3
   name:   Family BASIC V3
   title:  Family BASIC V3
@@ -24,6 +200,190 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: 270b84c1f6fcac20f2ce66bdf702882d44fc5345cdf76ff62d7823ccda9f2cba
+  name:   Ganbare Goemon 2
+  title:  Ganbare Goemon 2
+  region: NTSC-J
+  board:  KONAMI-VRC-2
+    chip
+      type: VRC2
+      pinout
+        a0: 0
+        a1: 1
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 2613db1559a07137af1f3cfda4175ac09be465604c651956dd98d971aedae6bc
+  name:   Ganbare Goemon Gaiden - Kieta Ougon Kiseru
+  title:  Ganbare Goemon Gaiden - Kieta Ougon Kiseru
+  region: NTSC-J
+  board:  KONAMI-VRC-2
+    chip
+      type: VRC2
+      pinout
+        a0: 1
+        a1: 0
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 7c27ab834d0dcc03498d46d9944c9ea5498b1a7af9606a835217e141e2b3c662
+  name:   Ganbare Goemon Gaiden - Kieta Ougon Kiseru (Rev 1)
+  title:  Ganbare Goemon Gaiden - Kieta Ougon Kiseru (Rev 1)
+  region: NTSC-J
+  board:  KONAMI-VRC-2
+    chip
+      type: VRC2
+      pinout
+        a0: 1
+        a1: 0
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 50770ffec21bd47eadc9b502b73323f976e48e6f8f589a6717300119bde99de3
+  name:   Ganbare Goemon Gaiden 2 - Tenka no Zaihou
+  title:  Ganbare Goemon Gaiden 2 - Tenka no Zaihou
+  region: NTSC-J
+  board:  KONAMI-VRC-4
+    chip
+      type: VRC4
+      pinout
+        a0: 6
+        a1: 7
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: a5697c59cdbd3859662199825c50cb338762c379c700701f75cdf157b3c13829
+  name:   Ganbare Pennant Race!
+  title:  Ganbare Pennant Race!
+  region: NTSC-J
+  board:  KONAMI-VRC-2A
+    chip
+      type: VRC2
+      pinout
+        a0: 1
+        a1: 0
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 963ef31970fb4f7aa84dbfa2eacf96c084effeaeb8ba276387fb9875e4daf7c5
+  name:   Getsu Fuuma Den
+  title:  Getsu Fuuma Den
+  region: NTSC-J
+  board:  KONAMI-VRC-2
+    chip
+      type: VRC2
+      pinout
+        a0: 0
+        a1: 1
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 2974ad16b994cfdc9418310ced6c7f4ed64433063d12439a7b37a816f797dd0e
+  name:   Gradius II
+  title:  Gradius II
+  region: NTSC-J
+  board:  KONAMI-VRC-4
+    chip
+      type: VRC4
+      pinout
+        a0: 1
+        a1: 0
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x800
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -65,6 +425,54 @@ game
       type: RAM
       size: 0x2000
       content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e9c28ba4b940583e4a486ac5b401ac42e9aafa909d27c798f4fb3fc0045a3971
+  name:   Jarinko Chie - Bakudan Musume no Shiawase Sagashi
+  title:  Jarinko Chie - Bakudan Musume no Shiawase Sagashi
+  region: NTSC-J
+  board:  KONAMI-VRC-2
+    chip
+      type: VRC2
+      pinout
+        a0: 0
+        a1: 1
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: d13fa0e0694a8318d7a7c51c759c254415bf1b41869a4cc04d3233062f7256ae
+  name:   Konami Wai Wai World
+  title:  Konami Wai Wai World
+  region: NTSC-J
+  board:  KONAMI-VRC-2
+    chip
+      type: VRC2
+      pinout
+        a0: 0
+        a1: 1
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
     memory
       type: ROM
       size: 0x20000
@@ -117,6 +525,182 @@ game
       content: Character
 
 game
+  sha256: 97ff1ac9e6061ba5fb02b4626abf3521f84ee1542fa8093d617ede08dbb17cdc
+  name:   Mouryou Senki Madara
+  title:  Mouryou Senki Madara
+  region: NTSC-J
+  board:  KONAMI-VRC-6
+    chip
+      type: VRC6
+      pinout
+        a0: 1
+        a1: 0
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 7c9ac15848defca1f6977a167e50e80e6a59c7cad040c5190629f29c2998ea16
+  name:   Parodius Da!
+  title:  Parodius Da!
+  region: NTSC-J
+  board:  KONAMI-VRC-4
+    chip
+      type: VRC4
+      pinout
+        a0: 2
+        a1: 3
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 6b5f7dbd2c4e7512b27e8492a8af8ad08701ba125e0fe7d4ac679f5782f7eb9b
+  name:   Racer Mini Yonku - Japan Cup
+  title:  Racer Mini Yonku - Japan Cup
+  region: NTSC-J
+  board:  KONAMI-VRC-4
+    chip
+      type: VRC4
+      pinout
+        a0: 1
+        a1: 0
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 6fff1bfc89bb2f3c160b88736990c764920b0c44107b265f642a50324ca3adfb
+  name:   Teenage Mutant Ninja Turtles
+  title:  Teenage Mutant Ninja Turtles
+  region: NTSC-J
+  board:  KONAMI-VRC-4
+    chip
+      type: VRC4
+      pinout
+        a0: 3
+        a1: 2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 76b488345b40aa2868e6d4b4f2f06fdaf626601ec76daf9da15c41800ecc5be8
+  name:   Teenage Mutant Ninja Turtles 2 - The Manhattan Project
+  title:  Teenage Mutant Ninja Turtles 2 - The Manhattan Project
+  region: NTSC-J
+  board:  KONAMI-VRC-4
+    chip
+      type: VRC4
+      pinout
+        a0: 3
+        a1: 2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 4b80a1db42ecde039f01c52a74146887f9dfc2ad54fe3706bcdf625ec3e2de97
+  name:   Tiny Toon Adventures
+  title:  Tiny Toon Adventures
+  region: NTSC-J
+  board:  KONAMI-VRC-4
+    chip
+      type: VRC4
+      pinout
+        a0: 2
+        a1: 3
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 092db8cfadf0a96c67dd0734c966c47dfb80ffb830485d8ee702284ae8eac4aa
+  name:   TwinBee 3 - Poko Poko Daimaou
+  title:  TwinBee 3 - Poko Poko Daimaou
+  region: NTSC-J
+  board:  KONAMI-VRC-2A
+    chip
+      type: VRC2
+      pinout
+        a0: 1
+        a1: 0
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 407e54848ad9991399f0383118f138d3a0532bb03bb488ed856deb7f2eb4efbf
   name:   Uchuusen Cosmo Carrier
   title:  Uchuusen Cosmo Carrier
@@ -129,6 +713,30 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 375a2fef345cabaab35ad7cc238b2cf0298cbf93f047ea57a79c3dae598b4287
+  name:   Wai Wai World 2 - SOS!! Paseri Jou
+  title:  Wai Wai World 2 - SOS!! Paseri Jou
+  region: NTSC-J
+  board:  KONAMI-VRC-4
+    chip
+      type: VRC4
+      pinout
+        a0: 1
+        a1: 2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
       content: Program
     memory
       type: ROM

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -351,6 +351,7 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
   case  85:
     s += "  board:  KONAMI-VRC-7\n";
     s += "    chip type=VRC7\n";
+    s += "      pinout a0=4\n";
     prgram = 8192;
     break;
 

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -221,20 +221,30 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     break;
 
   case  21:
-  case  23:
-  case  25:
-    //VRC4
     s += "  board:  KONAMI-VRC-4\n";
     s += "    chip type=VRC4\n";
-    s += "      pinout a0=1 a1=0\n";
+    s += "      pinout a0=1 a1=2\n";
     prgram = 8192;
     break;
 
   case  22:
-    //VRC2
+    s += "  board:  KONAMI-VRC-2A\n";
+    s += "    chip type=VRC2\n";
+    s += "      pinout a0=1 a1=0\n";
+    break;
+
+  case  23:
     s += "  board:  KONAMI-VRC-2\n";
     s += "    chip type=VRC2\n";
     s += "      pinout a0=0 a1=1\n";
+    prgram = 8192;
+    break;
+
+  case  25:
+    s += "  board:  KONAMI-VRC-4\n";
+    s += "    chip type=VRC4\n";
+    s += "      pinout a0=1 a1=0\n";
+    prgram = 8192;
     break;
 
   case  24:


### PR DESCRIPTION
A round of fixes for Konami VRC-2/4/7 chips.

Games fixed - Konami VRC-2/4 (iNES mappers 21/22/23/25):
- Akumajou Special - Boku Dracula-kun (Japan)
- Contra (Japan)
- Crisis Force (Japan)
- Dragon Scroll - Yomigaerishi Maryuu (Japan)
- Ganbare Goemon 2 (Japan)
- Ganbare Goemon Gaiden 2 - Tenka no Zaihou (Japan)
- Ganbare Pennant Race! (Japan)
- Getsu Fuuma Den (Japan)
- Jarinko Chie - Bakudan Musume no Shiawase Sagashi (Japan)
- Konami Wai Wai World (Japan)
- Parodius Da! (Japan)
- Teenage Mutant Ninja Turtles (Japan)
- Teenage Mutant Ninja Turtles 2 - The Manhattan Project (Japan)
- Tiny Toon Adventures (Japan)
- TwinBee 3 - Poko Poko Daimaou (Japan)
- Wai Wai World 2 - SOS!! Paseri Jou (Japan)

Games fixed - Konami VRC-7 (iNES mapper 85):
- Tiny Toon Adventures 2 - Montana Land e Youkoso (Japan)


Konami VRC2 and VRC4 boards have incompatible layouts which differs on the address lines connected to the VRC. The current VRC implementation already has support to assign pinout, but the defaults for the different iNES mappers are wrong. Also the configuration for every game can only be detected with NES 2.0 submappers, so games are added to the database with their correct pinout. This, combined with a revision of VRC2 emulated, fixes #146.

Pinout support added to VRC7 too, this (and the correct pinout assigned in database) fixes the game "Tiny Toon Adventures 2".