### PR TITLE
mia: prefer known rom extensions in zip archives

### DIFF
--- a/mia/pak/pak.cpp
+++ b/mia/pak/pak.cpp
@@ -10,6 +10,18 @@ auto Pak::name(string location) const -> string {
   return Location::prefix(location);
 }
 
+auto Pak::read(string location) -> vector<u8> {
+  //attempt to match known extensions
+  auto extensions = this->extensions();
+  for(auto& extension : extensions) extension.prepend("*.");
+  auto memory = read(location, extensions);
+
+  //failing that, read whatever exists
+  if(!memory) memory = read(location, {"*"});
+
+  return memory;
+}
+
 auto Pak::read(string location, vector<string> match) -> vector<u8> {
   vector<u8> memory;
   vector<u8> patch;
@@ -30,11 +42,13 @@ auto Pak::read(string location, vector<string> match) -> vector<u8> {
           }
           if(memory) break;
         }
-        //support BPS patches inside the ZIP archive
-        for(auto& file : archive.file) {
-          if(file.name.imatch("*.bps")) {
-            patch = archive.extract(file);
-            break;
+        if(memory) {
+          //support BPS patches inside the ZIP archive
+          for(auto& file : archive.file) {
+            if(file.name.imatch("*.bps")) {
+              patch = archive.extract(file);
+              break;
+            }
           }
         }
       }

--- a/mia/pak/pak.hpp
+++ b/mia/pak/pak.hpp
@@ -9,7 +9,8 @@ struct Pak {
   virtual auto save(string location = {}) -> bool { return true; }
 
   auto name(string location) const -> string;
-  auto read(string location, vector<string> match = {"*"}) -> vector<u8>;
+  auto read(string location) -> vector<u8>;
+  auto read(string location, vector<string> match) -> vector<u8>;
   auto append(vector<u8>& data, string location) -> bool;
   auto load(string name, string extension, string location = {}) -> bool;
   auto save(string name, string extension, string location = {}) -> bool;


### PR DESCRIPTION
Instead of just reading the first file from a zip archive, prefer files
that match known rom extensions. Extra files such as readmes should not
interfere with the loading of the game.

Fixes #260