### PR TITLE
ms, sfc: fix light gun related crashes

### DIFF
--- a/ares/ares/node/video/screen.cpp
+++ b/ares/ares/node/video/screen.cpp
@@ -36,6 +36,7 @@ auto Screen::main(uintptr_t) -> void {
 auto Screen::quit() -> void {
   _kill = true;
   _thread.join();
+  _sprites.reset();
 }
 
 auto Screen::power() -> void {

--- a/ares/ms/controller/light-phaser/light-phaser.cpp
+++ b/ares/ms/controller/light-phaser/light-phaser.cpp
@@ -11,7 +11,7 @@ LightPhaser::LightPhaser(Node::Port parent) {
 }
 
 LightPhaser::~LightPhaser() {
-  vdp.screen->detach(sprite);
+  if(vdp.screen) vdp.screen->detach(sprite);
 }
 
 auto LightPhaser::read() -> n7 {

--- a/ares/sfc/controller/justifier/justifier.cpp
+++ b/ares/sfc/controller/justifier/justifier.cpp
@@ -16,7 +16,7 @@ Justifier::Justifier(Node::Port parent) {
 
 Justifier::~Justifier() {
   cpu.peripherals.removeByValue(this);
-  ppu.screen->detach(sprite);
+  if(ppu.screen) ppu.screen->detach(sprite);
 }
 
 auto Justifier::main() -> void {

--- a/ares/sfc/controller/justifiers/justifiers.cpp
+++ b/ares/sfc/controller/justifiers/justifiers.cpp
@@ -25,8 +25,10 @@ Justifiers::Justifiers(Node::Port parent) {
 
 Justifiers::~Justifiers() {
   cpu.peripherals.removeByValue(this);
-  ppu.screen->detach(sprite1);
-  ppu.screen->detach(sprite2);
+  if(ppu.screen) {
+    ppu.screen->detach(sprite1);
+    ppu.screen->detach(sprite2);
+  }
 }
 
 auto Justifiers::main() -> void {

--- a/ares/sfc/controller/super-scope/super-scope.cpp
+++ b/ares/sfc/controller/super-scope/super-scope.cpp
@@ -30,7 +30,7 @@ SuperScope::SuperScope(Node::Port parent) {
 
 SuperScope::~SuperScope() {
   cpu.peripherals.removeByValue(this);
-  ppu.screen->detach(sprite);
+  if(ppu.screen) ppu.screen->detach(sprite);
 }
 
 auto SuperScope::main() -> void {


### PR DESCRIPTION
Fix unloading systems with light gun peripherals active. The code
responsible for removing crosshair sprites was dereferencing a null
pointer. This cleanup now occurs in Screen::quit() when unloading.

This fixes #273