### PR TITLE
hiro: track window focus via messages, not polling

### DIFF
--- a/hiro/windows/window.cpp
+++ b/hiro/windows/window.cpp
@@ -62,7 +62,7 @@ auto pWindow::append(sStatusBar statusBar) -> void {
 }
 
 auto pWindow::focused() const -> bool {
-  return (GetForegroundWindow() == hwnd);
+  return focus;
 }
 
 auto pWindow::frameMargin() const -> Geometry {
@@ -327,6 +327,16 @@ auto pWindow::windowProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) -> m
     if(wparam == SC_SCREENSAVE || wparam == SC_MONITORPOWER) {
       if(!Application::screenSaver()) return 0;
     }
+  }
+
+  if(msg == WM_SETFOCUS) {
+    focus = true;
+    return false;
+  }
+
+  if(msg == WM_KILLFOCUS) {
+    focus = false;
+    return false;
   }
 
   return {};

--- a/hiro/windows/window.hpp
+++ b/hiro/windows/window.hpp
@@ -51,6 +51,7 @@ struct pWindow : pObject {
   HBRUSH hbrush = nullptr;
   COLORREF hbrushColor = 0;
   Geometry windowedGeometry{128, 128, 256, 256};
+  bool focus = false;
 };
 
 }


### PR DESCRIPTION
On Windows, track WM_SETFOCUS and WM_KILLFOCUS messages to determine
focused status rather than polling with GetForegroundWindow(). The
latter involves a syscall and causes noticeable slowdown when called
repeatedly, such as when GameBoy games poll joypad status in a loop.