### PR TITLE
fc: Support for Color Dreams board

### DIFF
--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -1,6 +1,7 @@
 namespace Board {
 
 #include "bandai-fcg.cpp"
+#include "colordreams-74x377.cpp"
 #include "gtrom.cpp"
 #include "jaleco-jf05.cpp"
 #include "jaleco-jf11.cpp"
@@ -46,6 +47,7 @@ namespace Board {
 auto Interface::create(string board) -> Interface* {
   Interface* p = nullptr;
   if(!p) p = BandaiFCG::create(board);
+  if(!p) p = ColorDreams_74x377::create(board);
   if(!p) p = GTROM::create(board);
   if(!p) p = HVC_AxROM::create(board);
   if(!p) p = HVC_BNROM::create(board);

--- a/ares/fc/cartridge/board/colordreams-74x377.cpp
+++ b/ares/fc/cartridge/board/colordreams-74x377.cpp
@@ -1,0 +1,66 @@
+struct ColorDreams_74x377 : Interface {
+  static auto create(string id) -> Interface* {
+    if(id == "COLORDREAMS-74*377") return new ColorDreams_74x377();
+    return nullptr;
+  }
+
+  Memory::Readable<n8> programROM;
+  Memory::Readable<n8> characterROM;
+  Memory::Writable<n8> characterRAM;
+
+  auto load() -> void override {
+    Interface::load(programROM, "program.rom");
+    Interface::load(characterROM, "character.rom");
+    Interface::load(characterRAM, "character.ram");
+    mirror = pak->attribute("mirror") == "vertical";
+  }
+
+  auto save() -> void override {
+    Interface::save(characterRAM, "character.ram");
+  }
+
+  auto readPRG(n32 address, n8 data) -> n8 override {
+    if(address < 0x8000) return data;
+    return programROM.read(programBank << 15 | (n15)address);
+  }
+
+  auto writePRG(n32 address, n8 data) -> void override {
+    if(address < 0x8000) return;
+    programBank = data.bit(0,1);
+    characterBank = data.bit(4,7);
+  }
+
+  auto readCHR(n32 address, n8 data) -> n8 override {
+    if(address & 0x2000) {
+      address = address >> !mirror & 0x0400 | (n10)address;
+      return ppu.readCIRAM(address);
+    }
+    address = characterBank << 13 | (n13)address;
+    if(characterROM) return characterROM.read(address);
+    if(characterRAM) return characterRAM.read(address);
+    return data;
+  }
+
+  auto writeCHR(n32 address, n8 data) -> void override {
+    if(address & 0x2000) {
+      address = address >> !mirror & 0x0400 | (n10)address;
+      return ppu.writeCIRAM(address, data);
+    }
+    address = characterBank << 13 | (n13)address;
+    if(characterRAM) return characterRAM.write(address, data);
+  }
+
+  auto power() -> void override {
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(characterRAM);
+    s(programBank);
+    s(characterBank);
+    s(mirror);
+  }
+
+  n2 programBank;
+  n4 characterBank;
+  n1 mirror;
+};

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -199,6 +199,11 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     prgram = 8192;
     break;
 
+  case  11:
+    s += "  board:  COLORDREAMS-74*377\n";
+    s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
+    break;
+
   case  16:
     s += "  board:  BANDAI-FCG\n";
     s += "    chip type=LZ93D50\n";


### PR DESCRIPTION
Support added for the Color Dreams board (iNES mapper 11) used for unlicensed games by Color Dreams, Wisdom Tree, Bunch Games. I haven't tried all games, but the one I have tried seems to work at least at the first stages.

