### PR TITLE
fc: support for bandai 74x161 boards

### DIFF
--- a/ares/fc/cartridge/board/bandai-74161.cpp
+++ b/ares/fc/cartridge/board/bandai-74161.cpp
@@ -1,0 +1,64 @@
+struct Bandai74161 : Interface {
+  static auto create(string id) -> Interface* {
+    if(id == "BANDAI-74161" ) return new Bandai74161(Revision::B74161);
+    if(id == "BANDAI-74161A") return new Bandai74161(Revision::B74161A);
+    return nullptr;
+  }
+
+  Memory::Readable<n8> programROM;
+  Memory::Readable<n8> characterROM;
+
+  enum class Revision : u32 {
+    B74161,
+    B74161A,
+  } revision;
+
+  Bandai74161(Revision revision) : revision(revision) {}
+
+  auto load() -> void override {
+    Interface::load(programROM, "program.rom");
+    Interface::load(characterROM, "character.rom");
+    mirror = pak->attribute("mirror") == "vertical";
+  }
+
+  auto readPRG(n32 address, n8 data) -> n8 override {
+    if(address < 0x8000) return data;
+    n3 bank = (address < 0xc000 ? programBank : (n3)0x7);
+    return programROM.read(bank << 14 | (n14)address);
+  }
+
+  auto writePRG(n32 address, n8 data) -> void override {
+    if(address < 0x8000) return;
+    characterBank = data.bit(0,3);
+    programBank   = data.bit(4,6);
+    nametableBank = data.bit(7);
+  }
+
+  auto addressCIRAM(n32 address) const -> n32 {
+    if(revision == Revision::B74161A) {
+      return nametableBank << 10 | (n10)address;
+    }
+    return address >> !mirror & 0x0400 | (n10)address;
+  }
+
+  auto readCHR(n32 address, n8 data) -> n8 override {
+    if(address & 0x2000) return ppu.readCIRAM(addressCIRAM(address));
+    return characterROM.read(characterBank << 13 | (n13)address);
+  }
+
+  auto writeCHR(n32 address, n8 data) -> void override {
+    if(address & 0x2000) return ppu.writeCIRAM(addressCIRAM(address), data);
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(mirror);
+    s(programBank);
+    s(characterBank);
+    s(nametableBank);
+  }
+
+  n1 mirror;
+  n3 programBank;
+  n4 characterBank;
+  n1 nametableBank;
+};

--- a/ares/fc/cartridge/board/bandai-fcg.cpp
+++ b/ares/fc/cartridge/board/bandai-fcg.cpp
@@ -6,123 +6,80 @@ struct BandaiFCG : Interface {
 
   Memory::Readable<n8> programROM;
   Memory::Readable<n8> characterROM;
-  Memory::Writable<n8> characterRAM;
-  M24C eeprom;
 
   auto load() -> void override {
     Interface::load(programROM, "program.rom");
     Interface::load(characterROM, "character.rom");
-    Interface::load(characterRAM, "character.ram");
-    if(auto fp = pak->read("save.eeprom")) {
-      eeprom.load(M24C::Type::X24C01);
-      fp->read({eeprom.memory, eeprom.size()});
-    }
-  }
-
-  auto save() -> void override {
-    Interface::save(characterRAM, "save.ram");
-    if(auto fp = pak->write("save.eeprom")) {
-      fp->write({eeprom.memory, eeprom.size()});
-    }
   }
 
   auto main() -> void override {
-    if(irqCounterEnable) {
+    if(irqEnable) {
       if(--irqCounter == 0xffff) {
         cpu.irqLine(1);
-        irqCounterEnable = false;
+        irqEnable = false;
       }
     }
     tick();
   }
 
-  auto addressCIRAM(n32 address) const -> n32 {
-    switch(mirror) {
-    case 0: return address >> 0 & 0x0400 | address & 0x03ff;
-    case 1: return address >> 1 & 0x0400 | address & 0x03ff;
-    case 2: return 0x0000 | address & 0x03ff;
-    case 3: return 0x0400 | address & 0x03ff;
-    }
-    unreachable;
-  }
-
   auto readPRG(n32 address, n8 data) -> n8 override {
-    if(address >= 0x6000 && address <= 0x7fff) {
-      data.bit(4) = eeprom.read();
-      return data;
-    }
-
-    if(address & 0x8000) {
-      n1 region = bool(address & 0x4000);
-      n4 bank = (region == 0 ? programBank : (n4)0x0f);
-      return programROM.read(bank << 14 | (n14)address);
-    }
-
-    return data;
+    if(address < 0x8000) return data;
+    n4 bank = (address < 0xc000 ? programBank : (n4)0x0f);
+    return programROM.read(bank << 14 | (n14)address);
   }
 
   auto writePRG(n32 address, n8 data) -> void override {
-    if(address >= 0x6000) {
-      switch(address & 0xf) {
-      case 0x0: characterBank[0] = data; break;
-      case 0x1: characterBank[1] = data; break;
-      case 0x2: characterBank[2] = data; break;
-      case 0x3: characterBank[3] = data; break;
-      case 0x4: characterBank[4] = data; break;
-      case 0x5: characterBank[5] = data; break;
-      case 0x6: characterBank[6] = data; break;
-      case 0x7: characterBank[7] = data; break;
-      case 0x8: programBank = data.bit(0,3); break;
-      case 0x9: mirror = data.bit(0,1); break;
-      case 0xa:
-        cpu.irqLine(0);
-        irqCounterEnable = data.bit(0);
-        irqCounter = irqLatch;
-        break;
-      case 0xb: irqLatch.byte(0) = data; break;
-      case 0xc: irqLatch.byte(1) = data; break;
-      case 0xd:
-        eeprom.clock = data.bit(5);
-        eeprom.data  = data.bit(6);
-        eeprom.write();
-        break;
-      }
+    switch(address & 0xe00f) {
+    case 0x6000: characterBank[0] = data; break;
+    case 0x6001: characterBank[1] = data; break;
+    case 0x6002: characterBank[2] = data; break;
+    case 0x6003: characterBank[3] = data; break;
+    case 0x6004: characterBank[4] = data; break;
+    case 0x6005: characterBank[5] = data; break;
+    case 0x6006: characterBank[6] = data; break;
+    case 0x6007: characterBank[7] = data; break;
+    case 0x6008: programBank = data.bit(0,3); break;
+    case 0x6009: mirror = data.bit(0,1); break;
+    case 0x600a:
+      irqEnable = data.bit(0);
+      cpu.irqLine(0);
+      break;
+    case 0x600b: irqCounter.byte(0) = data; break;
+    case 0x600c: irqCounter.byte(1) = data; break;
     }
+  }
+
+  auto addressCIRAM(n32 address) const -> n32 {
+    switch(mirror) {
+    case 0: return address >> 0 & 0x0400 | (n10)address;
+    case 1: return address >> 1 & 0x0400 | (n10)address;
+    case 2: return 0x0000 | (n10)address;
+    case 3: return 0x0400 | (n10)address;
+    }
+    unreachable;
   }
 
   auto readCHR(n32 address, n8 data) -> n8 override {
     if(address & 0x2000) return ppu.readCIRAM(addressCIRAM(address));
     address = characterBank[address >> 10] << 10 | (n10)address;
-    if(characterROM) return characterROM.read(address);
-    if(characterRAM) return characterRAM.read(address);
-    return data;
+    return characterROM.read(address);
   }
 
   auto writeCHR(n32 address, n8 data) -> void override {
     if(address & 0x2000) return ppu.writeCIRAM(addressCIRAM(address), data);
-    address = characterBank[address >> 10] << 10 | (n10)address;
-    if(characterRAM) return characterRAM.write(address, data);
-  }
-
-  auto power() -> void override {
-    eeprom.power();
   }
 
   auto serialize(serializer& s) -> void override {
-    s(characterRAM);
-    s(eeprom);
     s(characterBank);
     s(programBank);
     s(mirror);
-    s(irqCounterEnable);
+    s(irqEnable);
     s(irqCounter);
-    s(irqLatch);
   }
 
   n8  characterBank[8];
   n4  programBank;
   n2  mirror;
-  n1  irqCounterEnable;
+  n1  irqEnable;
   n16 irqCounter;
-  n16 irqLatch;
 };

--- a/ares/fc/cartridge/board/bandai-lz93d50.cpp
+++ b/ares/fc/cartridge/board/bandai-lz93d50.cpp
@@ -1,0 +1,132 @@
+struct BandaiLZ93D50 : Interface {
+  static auto create(string id) -> Interface* {
+    if(id == "BANDAI-LZ93D50") return new BandaiLZ93D50;
+    return nullptr;
+  }
+
+  Memory::Readable<n8> programROM;
+  Memory::Writable<n8> programRAM;
+  Memory::Readable<n8> characterROM;
+  Memory::Writable<n8> characterRAM;
+  M24C eeprom;
+
+  auto load() -> void override {
+    Interface::load(programROM, "program.rom");
+    Interface::load(programRAM, "save.ram");
+    Interface::load(characterROM, "character.rom");
+    Interface::load(characterRAM, "character.ram");
+    if(auto fp = pak->read("save.eeprom")) {
+      eeprom.load(M24C::Type::X24C01);
+      fp->read({eeprom.memory, eeprom.size()});
+    }
+  }
+
+  auto save() -> void override {
+    Interface::save(programRAM, "save.ram");
+    Interface::save(characterRAM, "character.ram");
+    if(auto fp = pak->write("save.eeprom")) {
+      fp->write({eeprom.memory, eeprom.size()});
+    }
+  }
+
+  auto main() -> void override {
+    if(irqEnable) {
+      if(--irqCounter == 0xffff) {
+        cpu.irqLine(1);
+        irqEnable = false;
+      }
+    }
+    tick();
+  }
+
+  auto readPRG(n32 address, n8 data) -> n8 override {
+    if(address < 0x6000) return data;
+    if(address < 0x8000) {
+      if(programRAM) return programRAM.read((n13)address);
+      if(eeprom) data.bit(4) = eeprom.read();
+      return data;
+    }
+
+    n4 bank = (address < 0xc000 ? programBank : (n4)0xf);
+    return programROM.read(bank << 14 | (n14)address);
+  }
+
+  auto writePRG(n32 address, n8 data) -> void override {
+    if(address < 0x6000) return;
+    if(address < 0x8000) {
+      if(programRAM) return programRAM.write((n13)address, data);
+    }
+
+    switch(address & 0x800f) {
+    case 0x8000: characterBank[0] = data; break;
+    case 0x8001: characterBank[1] = data; break;
+    case 0x8002: characterBank[2] = data; break;
+    case 0x8003: characterBank[3] = data; break;
+    case 0x8004: characterBank[4] = data; break;
+    case 0x8005: characterBank[5] = data; break;
+    case 0x8006: characterBank[6] = data; break;
+    case 0x8007: characterBank[7] = data; break;
+    case 0x8008: programBank = data.bit(0,3); break;
+    case 0x8009: mirror = data.bit(0,1); break;
+    case 0x800a:
+      irqEnable = data.bit(0);
+      irqCounter = irqLatch;
+      cpu.irqLine(0);
+      break;
+    case 0x800b: irqLatch.byte(0) = data; break;
+    case 0x800c: irqLatch.byte(1) = data; break;
+    case 0x800d:
+      if(eeprom) {
+        eeprom.clock = data.bit(5);
+        eeprom.data  = data.bit(6);
+        eeprom.write();
+      }
+      break;
+    }
+  }
+
+  auto addressCIRAM(n32 address) const -> n32 {
+    switch(mirror) {
+    case 0: return address >> 0 & 0x0400 | (n10)address;
+    case 1: return address >> 1 & 0x0400 | (n10)address;
+    case 2: return 0x0000 | (n10)address;
+    case 3: return 0x0400 | (n10)address;
+    }
+    unreachable;
+  }
+
+  auto readCHR(n32 address, n8 data) -> n8 override {
+    if(address & 0x2000) return ppu.readCIRAM(addressCIRAM(address));
+    if(characterRAM) return characterRAM.read(address);
+    address = characterBank[address >> 10] << 10 | (n10)address;
+    return characterROM.read(address);
+  }
+
+  auto writeCHR(n32 address, n8 data) -> void override {
+    if(address & 0x2000) return ppu.writeCIRAM(addressCIRAM(address), data);
+    if(characterRAM) return characterRAM.write(address, data);
+  }
+
+  auto power() -> void override {
+    eeprom.power();
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(programRAM);
+    s(characterRAM);
+    s(eeprom);
+    s(characterBank);
+    s(programBank);
+    s(mirror);
+    s(irqEnable);
+    s(irqCounter);
+    s(irqLatch);
+  }
+
+  n8  characterBank[8];
+  n4  programBank;
+  n2  mirror;
+  n1  irqEnable;
+  n16 irqCounter;
+  n16 irqLatch;
+};

--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -2,6 +2,7 @@ namespace Board {
 
 #include "bandai-74161.cpp"
 #include "bandai-fcg.cpp"
+#include "bandai-lz93d50.cpp"
 #include "colordreams-74x377.cpp"
 #include "gtrom.cpp"
 #include "jaleco-jf05.cpp"
@@ -49,6 +50,7 @@ auto Interface::create(string board) -> Interface* {
   Interface* p = nullptr;
   if(!p) p = Bandai74161::create(board);
   if(!p) p = BandaiFCG::create(board);
+  if(!p) p = BandaiLZ93D50::create(board);
   if(!p) p = ColorDreams_74x377::create(board);
   if(!p) p = GTROM::create(board);
   if(!p) p = HVC_AxROM::create(board);

--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -1,5 +1,6 @@
 namespace Board {
 
+#include "bandai-74161.cpp"
 #include "bandai-fcg.cpp"
 #include "colordreams-74x377.cpp"
 #include "gtrom.cpp"
@@ -46,6 +47,7 @@ namespace Board {
 
 auto Interface::create(string board) -> Interface* {
   Interface* p = nullptr;
+  if(!p) p = Bandai74161::create(board);
   if(!p) p = BandaiFCG::create(board);
   if(!p) p = ColorDreams_74x377::create(board);
   if(!p) p = GTROM::create(board);

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -44,6 +44,27 @@ game
       content: Character
 
 game
+  sha256: fec392d252eda8203bfaee45c95ccfc8c1689b90ab6de5cce3f45320d9c69c74
+  name:   Akuma-kun - Makai no Wana (Japan)
+  title:  Akuma-kun - Makai no Wana (Japan)
+  region: NTSC-J
+  board:  BANDAI-FCG
+    chip
+      type: FCG
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: c70f0f5d4054ce7c4850259879c9823add73ccc234ddcf96d95681bb78bd2c58
   name:   Akumajou Densetsu (Japan)
   title:  Akumajou Densetsu (Japan)
@@ -832,6 +853,27 @@ game
       content: Character
 
 game
+  sha256: 3f243f6cf4b33d25d76c7cf9459e82bcd5367aa001f4c36fdf1c5728429bed0a
+  name:   Crayon Shin-chan - Ora to Poi Poi (Japan)
+  title:  Crayon Shin-chan - Ora to Poi Poi (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: b504d0ebff8aa6439f1f9606526d8739f5007c1fdac31f9550caa7ca26edce16
   name:   Crisis Force (Japan)
   title:  Crisis Force (Japan)
@@ -1151,6 +1193,27 @@ game
       volatile
 
 game
+  sha256: d36b8989cbaf9ceafd91d15edd7b990dce6f9aede1bf9ac696ea8d288ec53d44
+  name:   Dragon Ball - Daimaou Fukkatsu (Japan)
+  title:  Dragon Ball - Daimaou Fukkatsu (Japan)
+  region: NTSC-J
+  board:  BANDAI-FCG
+    chip
+      type: FCG
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 656a10fd06a7d75df48bfc452a6610db1c4e115b552c2811b037336db506cdf5
   name:   Dragon Ball - Le Secret du Dragon (France)
   title:  Dragon Ball - Le Secret du Dragon (France)
@@ -1212,6 +1275,173 @@ game
       type: ROM
       size: 0x8000
       content: Character
+
+game
+  sha256: 4d48c60b8bb151d76a08f9af9aab2fff7e5b2b763192aa6fa0512ffd0db97fc6
+  name:   Dragon Ball 3 - Gokuu Den (Japan)
+  title:  Dragon Ball 3 - Gokuu Den (Japan)
+  region: NTSC-J
+  board:  BANDAI-FCG
+    chip
+      type: FCG
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 47acdebfe2beb53eb7cba0ca2920d5d19ff297ebe4c6373635d352111ad94ddb
+  name:   Dragon Ball 3 - Gokuu Den (Japan) (Rev 1)
+  title:  Dragon Ball 3 - Gokuu Den (Japan) (Rev 1)
+  region: NTSC-J
+  board:  BANDAI-FCG
+    chip
+      type: FCG
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 4654f20e7b6dc8bea64b7d0be9aa4f75a4276b4d7f4bc9a06c39172b9e5ae9bf
+  name:   Dragon Ball Z - Kyoushuu! Saiya Jin (Japan)
+  title:  Dragon Ball Z - Kyoushuu! Saiya Jin (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+    memory
+      type: EEPROM
+      size: 0x80
+      content: Save
+
+game
+  sha256: a0a735282c3ba19f743b7ff2a7178a83cb9dfaf60c6e6c233d5b85c76003b974
+  name:   Dragon Ball Z Gaiden - Saiya Jin Zetsumetsu Keikaku (Japan)
+  title:  Dragon Ball Z Gaiden - Saiya Jin Zetsumetsu Keikaku (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+    memory
+      type: EEPROM
+      size: 0x100
+      content: Save
+
+game
+  sha256: 54d19b5d717bcc6367989e77eb30c7a820b2772aa311d4cca7b235f448cbce0a
+  name:   Dragon Ball Z II - Gekishin Freeza!! (Japan)
+  title:  Dragon Ball Z II - Gekishin Freeza!! (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+    memory
+      type: EEPROM
+      size: 0x100
+      content: Save
+
+game
+  sha256: 5287ce3be3b449abead802a5512029b11acb7a1ed10af6303f7fbd575d31af0f
+  name:   Dragon Ball Z II - Gekishin Freeza!! (Japan) (Rev 1)
+  title:  Dragon Ball Z II - Gekishin Freeza!! (Japan) (Rev 1)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+    memory
+      type: EEPROM
+      size: 0x100
+      content: Save
+
+game
+  sha256: bb88e85c73125466ebf4943715c66bbe77175d234842a0c9ea542f3cfcf2c528
+  name:   Dragon Ball Z III - Ressen Jinzou Ningen (Japan)
+  title:  Dragon Ball Z III - Ressen Jinzou Ningen (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+    memory
+      type: EEPROM
+      size: 0x100
+      content: Save
 
 game
   sha256: b1a7377282123b3b18107e0d929666af8831bebde78ceaf7fe410c2132cd61ce
@@ -1416,6 +1646,27 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 342f0e5ad45d040e538e6b1c576d02c264e7982d2b440afcb4f12cedccbb11de
+  name:   Famicom Jump - Eiyuu Retsuden (Japan)
+  title:  Famicom Jump - Eiyuu Retsuden (Japan)
+  region: NTSC-J
+  board:  BANDAI-FCG
+    chip
+      type: FCG
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
       content: Program
     memory
       type: ROM
@@ -3457,27 +3708,6 @@ game
       content: Character
 
 game
-  sha256: dc541137d79000fe3e0bdf5ce35b687a5b137c3a09160c5742599b4ff257cfae
-  name:   Madoola no Tsubasa (Japan)
-  title:  Madoola no Tsubasa (Japan)
-  region: NTSC-J
-  board:  SUNSOFT-1
-    mirror
-      mode: vertical
-    memory
-      type: ROM
-      size: 0x10
-      content: iNES
-    memory
-      type: ROM
-      size: 0x8000
-      content: Program
-    memory
-      type: ROM
-      size: 0x8000
-      content: Character
-
-game
   sha256: 8c801e6fb86ff4174d7c02cd576a1ada260130b403d09ddc76f6aeae9792bf12
   name:   Lupin Sansei - Pandora no Isan (Japan)
   title:  Lupin Sansei - Pandora no Isan (Japan)
@@ -3501,6 +3731,27 @@ game
       content: Character
 
 game
+  sha256: dc541137d79000fe3e0bdf5ce35b687a5b137c3a09160c5742599b4ff257cfae
+  name:   Madoola no Tsubasa (Japan)
+  title:  Madoola no Tsubasa (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-1
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 497c3015516cb6ae2f20d70b8fb1b70b8c4cfcd64e118992c438cfe7b0579f2b
   name:   Magic John (Japan)
   title:  Magic John (Japan)
@@ -3520,6 +3771,81 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 06dd2c356d2e09929525827f10dda83030a24e743b2648833dc0c56b39edce2f
+  name:   Magical Taruruuto-kun - Fantastic World!! (Japan)
+  title:  Magical Taruruuto-kun - Fantastic World!! (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+    memory
+      type: EEPROM
+      size: 0x80
+      content: Save
+
+game
+  sha256: a1a4e50c09c3983e79a9a1098202a82d82426eaf2e3d898b4a4a8dd55d38e2e7
+  name:   Magical Taruruuto-kun - Fantastic World!! (Japan) (Rev 1)
+  title:  Magical Taruruuto-kun - Fantastic World!! (Japan) (Rev 1)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+    memory
+      type: EEPROM
+      size: 0x80
+      content: Save
+
+game
+  sha256: f4295cfe1d7d75fd5eebe972e4a63cb626ffb90008ace74377518ef4762d29c0
+  name:   Magical Taruruuto-kun 2 - Mahou Daibouken (Japan)
+  title:  Magical Taruruuto-kun 2 - Mahou Daibouken (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+    memory
+      type: EEPROM
+      size: 0x80
+      content: Save
 
 game
   sha256: 4ef61de405406bfa9eeaf19ed1d882444c41bb606ac78673b7ec8ee323d0e073
@@ -3635,6 +3961,27 @@ game
   board:  IREM-G101
     chip
       type: G101
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: f7d8a3732396d928d80dafd32a3873c71a10434fa31b05e4882b28a774c4bcb9
+  name:   Meimon! Daisan Yakyuubu (Japan)
+  title:  Meimon! Daisan Yakyuubu (Japan)
+  region: NTSC-J
+  board:  BANDAI-FCG
+    chip
+      type: FCG
     memory
       type: ROM
       size: 0x10
@@ -4324,6 +4671,27 @@ game
       content: Character
 
 game
+  sha256: 98433ab0b15d19d23c544c2237988abf4a489914e63e18efc28fe2d92ae8c84a
+  name:   Nishimura Kyoutarou Mystery - Blue Train Satsujin Jiken (Japan)
+  title:  Nishimura Kyoutarou Mystery - Blue Train Satsujin Jiken (Japan)
+  region: NTSC-J
+  board:  BANDAI-FCG
+    chip
+      type: FCG
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: adf95de2cdff7b606ceedf5908679ef9bb8ffeec37d3d1dad3446ef85ca17026
   name:   Operation Wolf (Japan)
   title:  Operation Wolf (Japan)
@@ -4865,6 +5233,31 @@ game
       content: Character
 
 game
+  sha256: 03bb4abbbab7bc91844dd65b808d1281ae22f9e4460479b27dd9d9b186b40647
+  name:   Rokudenashi Blues (Japan)
+  title:  Rokudenashi Blues (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+    memory
+      type: EEPROM
+      size: 0x100
+      content: Save
+
+game
   sha256: 4d6e58f232dc1a592583889f858eac230b8e8921e715276e580073ab2dd18546
   name:   Saint Seiya - Ougon Densetsu (Japan)
   title:  Saint Seiya - Ougon Densetsu (Japan)
@@ -4891,6 +5284,27 @@ game
   board:  JALECO-JF-24A
     chip
       type: SS88006
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: fda768dba543b9dcdff48ffb1e241c944f34fbd1c12dfddc2cebea6835a62d1c
+  name:   Sakigake!! Otoko Juku - Shippuu Ichi Gou Sei (Japan)
+  title:  Sakigake!! Otoko Juku - Shippuu Ichi Gou Sei (Japan)
+  region: NTSC-J
+  board:  BANDAI-FCG
+    chip
+      type: FCG
     memory
       type: ROM
       size: 0x10
@@ -4954,6 +5368,106 @@ game
       type: ROM
       size: 0x10000
       content: Character
+
+game
+  sha256: cd6e7fb18348488f256d08d8c02802dea3980cdb5b46bd0ea200324b913c1a07
+  name:   SD Gundam Gaiden - Knight Gundam Monogatari (Japan)
+  title:  SD Gundam Gaiden - Knight Gundam Monogatari (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+    memory
+      type: EEPROM
+      size: 0x80
+      content: Save
+
+game
+  sha256: 976fa847a4e2ea4ec678539ddef9794a457c85c5c8f89f6cd12622c8476ab44f
+  name:   SD Gundam Gaiden - Knight Gundam Monogatari (Japan) (Rev 1)
+  title:  SD Gundam Gaiden - Knight Gundam Monogatari (Japan) (Rev 1)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+    memory
+      type: EEPROM
+      size: 0x80
+      content: Save
+
+game
+  sha256: c960e211e1859825d6de21fcde325816444cd63dd7212456eedb85884f2649ca
+  name:   SD Gundam Gaiden - Knight Gundam Monogatari 2 - Hikari no Knight (Japan)
+  title:  SD Gundam Gaiden - Knight Gundam Monogatari 2 - Hikari no Knight (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+    memory
+      type: EEPROM
+      size: 0x100
+      content: Save
+
+game
+  sha256: 4ea5d6ad94d5cf257819167aa87e45f38079d0194db4218a75a989ba6d5e3736
+  name:   SD Gundam Gaiden - Knight Gundam Monogatari 3 - Densetsu no Kishi Dan (Japan)
+  title:  SD Gundam Gaiden - Knight Gundam Monogatari 3 - Densetsu no Kishi Dan (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+    memory
+      type: EEPROM
+      size: 0x100
+      content: Save
 
 game
   sha256: 2d3d6f009b1f81640867a5b5102c10e4d26c8ad6280c30e43d65dcd1acce9fb3

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -173,6 +173,25 @@ game
       content: Character
 
 game
+  sha256: 8593b6ae7b19b2e767ad2c207c5a83dea90030414f45eef4c0dec3c3a5530364
+  name:   Arkanoid II (Japan)
+  title:  Arkanoid II (Japan)
+  region: NTSC-J
+  board:  BANDAI-74161A
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: f3601248633f47a0ef10723e42a1072c76dd487d7ddf943e618611bb7cfec737
   name:   Atlantis no Nazo (Japan)
   title:  Atlantis no Nazo (Japan)
@@ -1686,6 +1705,69 @@ game
       content: Character
 
 game
+  sha256: 0b13a37ba5cc35f743669b803d119dda47dd136d211be060614817830609eed9
+  name:   Family Trainer 4 - Jogging Race (Japan)
+  title:  Family Trainer 4 - Jogging Race (Japan)
+  region: NTSC-J
+  board:  BANDAI-74161
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d25bd1e575ca131e524236fb97ebea89ccfea42c09e0a16b404abdd747768a9f
+  name:   Family Trainer 5 - Meiro Daisakusen (Japan)
+  title:  Family Trainer 5 - Meiro Daisakusen (Japan)
+  region: NTSC-J
+  board:  BANDAI-74161
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 6257cc5bdee40b901305a1fa9d1537196378c5a96b02ec59260696e9390f8050
+  name:   Family Trainer 6 - Manhattan Police (Japan)
+  title:  Family Trainer 6 - Manhattan Police (Japan)
+  region: NTSC-J
+  board:  BANDAI-74161
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 95d3ae878eb2e0d0fd8a8dc55b7cf03524e5f1975cdcef4a90e8651da642c1a2
   name:   Family Trainer 9 - Fuuun Takeshi-jou 2 (Japan)
   title:  Family Trainer 9 - Fuuun Takeshi-jou 2 (Japan)
@@ -2130,6 +2212,25 @@ game
       size: 0x800
       content: Character
       volatile
+
+game
+  sha256: 992e63eef393060170d03c2558c7bc090428c8ed553ba496ddda6432fcbff0ac
+  name:   Gegege no Kitarou 2 - Youkai Gundan no Chousen (Japan)
+  title:  Gegege no Kitarou 2 - Youkai Gundan no Chousen (Japan)
+  region: NTSC-J
+  board:  BANDAI-74161A
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: c0f0fad3abcb7c284eca6bf17b263d22ea1749316d6321a8b83969bd4a7c22ee
@@ -2875,6 +2976,27 @@ game
   board:  IREM-H3001
     chip
       type: H3001
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 2241728a8072ccdf13c3bb913d2d16abd62bb43c71757d80a376c4f65cd060cf
+  name:   Kamen Rider Club (Japan)
+  title:  Kamen Rider Club (Japan)
+  region: NTSC-J
+  board:  BANDAI-74161
+    mirror
+      mode: vertical
     memory
       type: ROM
       size: 0x10
@@ -4377,6 +4499,25 @@ game
       content: Character
 
 game
+  sha256: 6eabf52d9e7250d74a8b2186dc0da2ae89771c207dcb5d905e0328b24c8984c4
+  name:   Pocket Zaurus - Juu Ouken no Nazo (Japan)
+  title:  Pocket Zaurus - Juu Ouken no Nazo (Japan)
+  region: NTSC-J
+  board:  BANDAI-74161A
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 1f5a86488d8bbc8fbc09fdb91a33fa2530ed124949a7001576e7c631f87bd9df
   name:   Power Blazer (Japan)
   title:  Power Blazer (Japan)
@@ -4724,6 +4865,25 @@ game
       content: Character
 
 game
+  sha256: 4d6e58f232dc1a592583889f858eac230b8e8921e715276e580073ab2dd18546
+  name:   Saint Seiya - Ougon Densetsu (Japan)
+  title:  Saint Seiya - Ougon Densetsu (Japan)
+  region: NTSC-J
+  board:  BANDAI-74161A
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 840723003ce183494e9aa5081462f085db2b3846b4680976b32bff0fae0d3968
   name:   Saiyuuki World 2 - Tenjoukai no Majin (Japan)
   title:  Saiyuuki World 2 - Tenjoukai no Majin (Japan)
@@ -5008,6 +5168,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 82d59a71189043d8a3e690b41a339c27cbc5e1343466fcc02f8cb66d9f6757f5
+  name:   Space Shadow (Japan)
+  title:  Space Shadow (Japan)
+  region: NTSC-J
+  board:  BANDAI-74161
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: dbd587ef5a12e03a336cda61cd120b4e8c585f45d82821e144ee8afdea9ee84e

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -1,5 +1,5 @@
 database
-  revision: 2021-11-10
+  revision: 2021-11-13
 
 game
   sha256: 21b10e8d4cf775aa1f4027c4afb4f64e72e221a506a485cf4ffdf98bed01a524
@@ -92,11 +92,92 @@ game
       content: Character
 
 game
+  sha256: 722096b8929442310bc268f9cfea10b26cff8a7e900197b54c73b4a8603b5d96
+  name:   Aladdin (Europe)
+  title:  Aladdin (Europe)
+  region: PAL
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5fe3435b99c10cd641e3f5509ec34e16559fdbd607e11b830f5a2ad572dff50f
+  name:   Arch Rivals - A Basketbrawl! (Europe)
+  title:  Arch Rivals - A Basketbrawl! (Europe)
+  region: PAL
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: bb834eb82f0ac53114035e6f353434a934d4aa47742644740de5fa8b2b033b5b
+  name:   Arch Rivals - A Basketbrawl! (USA)
+  title:  Arch Rivals - A Basketbrawl! (USA)
+  region: NTSC-U
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 7768ef85519c94dc40d09bc598121825d103fcf1d4927be59f597b0a3509d15f
   name:   Argus (Japan)
   title:  Argus (Japan)
   region: NTSC-J
   board:  JALECO-JF-07
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
+  sha256: f3601248633f47a0ef10723e42a1072c76dd487d7ddf943e618611bb7cfec737
+  name:   Atlantis no Nazo (Japan)
+  title:  Atlantis no Nazo (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-1
     mirror
       mode: vertical
     memory
@@ -199,6 +280,222 @@ game
       content: Character
 
 game
+  sha256: b5f98350a10270ed1675ac4c9abe986e54e71f9f58982526351f937857ac6c66
+  name:   Barcode World (Japan)
+  title:  Barcode World (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-5B
+    chip
+      type: 5B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 299075061656934b3a1610748af3eb2a1cf4008889615e0d78811507cf5f4924
+  name:   Batman (Japan)
+  title:  Batman (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-5B
+    chip
+      type: 5B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 24576b117dbbf9bed5738d7bde982ae5e335abc3998c42f171830a8973e86154
+  name:   Batman - Return of the Joker (Europe)
+  title:  Batman - Return of the Joker (Europe)
+  region: PAL
+  board:  SUNSOFT-5B
+    chip
+      type: 5B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 183ede1115b428b046ae223f27e2db366a5b62c43f52b6fced5f22a57d39e663
+  name:   Batman - Return of the Joker (USA)
+  title:  Batman - Return of the Joker (USA)
+  region: NTSC-U
+  board:  SUNSOFT-5B
+    chip
+      type: 5B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 3250141266d44dd7c134bb728d6a9a7ccfa77a5b12088b60a25feff34bdc1bcc
+  name:   Battletoads (Europe)
+  title:  Battletoads (Europe)
+  region: PAL
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 98acdd3df3ea257aec561804baf7ec7995d057b3723eb167a51f2029d8bdd009
+  name:   Battletoads (Japan)
+  title:  Battletoads (Japan)
+  region: NTSC-J
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 56d25e05dde2048c3a9b4e36ab5325091310ce2b65171615b5596fc542db66fa
+  name:   Battletoads (USA)
+  title:  Battletoads (USA)
+  region: NTSC-U
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0188e4f9d260b5ba3c1fa456469ec8ed6c4348b09f5ee37993d1351af270cd4c
+  name:   Battletoads-Double Dragon (Europe)
+  title:  Battletoads-Double Dragon (Europe)
+  region: PAL
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 4f67a81cc978e5aaf8aa03046c27ddc954f835e2110e346bc28d35f6b4ac61ca
+  name:   Battletoads-Double Dragon (USA)
+  title:  Battletoads-Double Dragon (USA)
+  region: NTSC-U
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: b9434d2f359f6e464da36fbcf6d9eb794b7edff03b89467d1609158f13bfef52
+  name:   Beetlejuice (USA)
+  title:  Beetlejuice (USA)
+  region: NTSC-U
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 92c481350b63c57385834dfa0ab02aeb527df7e80cec14a3e1a1a77118cd38d1
   name:   Bio Miracle Bokutte Upa (Japan)
   title:  Bio Miracle Bokutte Upa (Japan)
@@ -265,6 +562,26 @@ game
       content: Character
 
 game
+  sha256: 47dfae941b3c660be476bc28f199474b6c418431e3d493da4384a6aef3cc5016
+  name:   Cabal (USA)
+  title:  Cabal (USA)
+  region: NTSC-U
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 2ac39a3e3892cc4e4ec616348a9646be8c8cb8b229c9f5d8868e3a5a5c7e8397
   name:   Captain Saver (Japan)
   title:  Captain Saver (Japan)
@@ -284,6 +601,66 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: dd1b495734c4ce99d3cca16286ca07f9e75d22fae198fc2626a07cc52d59a80b
+  name:   Captain Skyhawk (Europe)
+  title:  Captain Skyhawk (Europe)
+  region: PAL
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 141cda262aad72971c00dd9a9655f32cee03e259d371bd8937a864e3300e9e58
+  name:   Captain Skyhawk (USA)
+  title:  Captain Skyhawk (USA)
+  region: NTSC-U
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: ffcce36b7ccbec820c664163441ec8c9b94742f250ffd01a10ac8489ce5c88ca
+  name:   Captain Skyhawk (USA) (Rev 1)
+  title:  Captain Skyhawk (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 59f228976854136f7988c309ad5baa68687b363df27810e28bb6959b771d5af6
@@ -372,6 +749,46 @@ game
       content: Character
 
 game
+  sha256: f34872482c6c1359b1b87373b620960590915e9805ac4e970666768cfc27172b
+  name:   Cobra Triangle (Europe)
+  title:  Cobra Triangle (Europe)
+  region: PAL
+  board:  HVC-ANROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: db26936868427b5b01b7823a781ec09ed15bb5dd06945bba0147ffb12215234b
+  name:   Cobra Triangle (USA)
+  title:  Cobra Triangle (USA)
+  region: NTSC-U
+  board:  HVC-ANROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 62c9d4e0578cb1e615ce9bb2c8ebc15b1e8de4c928c5c07ba9a85c11aa36ae4d
   name:   Contra (Japan)
   title:  Contra (Japan)
@@ -445,6 +862,88 @@ game
       content: Character
 
 game
+  sha256: aa9e3be1451ad009111c587cd2adb9275b052402461f27257617baa7d7cd6767
+  name:   Danny Sullivan's Indy Heat (Europe)
+  title:  Danny Sullivan's Indy Heat (Europe)
+  region: PAL
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 4cbf1c1d0be227127513065ccbc8ecf5e5ee61a7a58b6dea79ff01f0eb9f26af
+  name:   Danny Sullivan's Indy Heat (USA)
+  title:  Danny Sullivan's Indy Heat (USA)
+  region: NTSC-U
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0115356b0791cc8ddcb7d3163d6ef7aa664f3ff4e68dba561ffffb79eefcbca9
+  name:   Deadly Towers (USA)
+  title:  Deadly Towers (USA)
+  region: NTSC-U
+  board:  HVC-BNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: a18f143cce068d9df46473f968b31c65beb5246b521843b7653d5993b707d310
+  name:   Densetsu no Kishi - Elrond (Japan)
+  title:  Densetsu no Kishi - Elrond (Japan)
+  region: NTSC-J
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: d2140fc2e6354a9f4d0154dabac757e5559890edba4885799c1c979d8b7a8b20
   name:   Devil Man (Japan)
   title:  Devil Man (Japan)
@@ -464,6 +963,46 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 721c464598519132fbb62f74c39a5b0ef67d1b74ebc571e77d33b5b2b4fae8c4
+  name:   Digger - The Legend of the Lost City (USA)
+  title:  Digger - The Legend of the Lost City (USA)
+  region: NTSC-U
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 2203c9fa52130574d846635cc4f7bdb282f9f4696dbd9fb7bb20c0ced970925d
+  name:   Digger T. Rock - The Legend of the Lost City (Europe)
+  title:  Digger T. Rock - The Legend of the Lost City (Europe)
+  region: PAL
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 0cfdba2ec06229dfda9d68720d1ce45085e430e75f696092829d4a9325704b73
@@ -531,6 +1070,131 @@ game
       content: Character
 
 game
+  sha256: de15604ba1f819b12dd35dec557a5f20c9821210c4bc853c29c763466d0ede94
+  name:   Doraemon (Japan)
+  title:  Doraemon (Japan)
+  region: NTSC-J
+  board:  HVC-GNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: b7d636165bee933d258f3d0c832d23c38083d3984dc1bf3bc00dddc4d91a40db
+  name:   Doraemon (Japan) (Rev A)
+  title:  Doraemon (Japan) (Rev A)
+  region: NTSC-J
+  board:  HVC-GNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 56cb5897c539b6874e311a314767df85186184690f10d9982b02cb90ff606537
+  name:   Double Dare (USA)
+  title:  Double Dare (USA)
+  region: NTSC-U
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 656a10fd06a7d75df48bfc452a6610db1c4e115b552c2811b037336db506cdf5
+  name:   Dragon Ball - Le Secret du Dragon (France)
+  title:  Dragon Ball - Le Secret du Dragon (France)
+  region: PAL
+  board:  HVC-GNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: a2a08b732bfb304345c06b045ef8a3fd53c281c909f177182ff54e26581f6bfe
+  name:   Dragon Ball - Le Secret du Dragon (France) (Rev 1)
+  title:  Dragon Ball - Le Secret du Dragon (France) (Rev 1)
+  region: PAL
+  board:  HVC-GNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: e7181cc1e4789719f98ccd1d1857af35f7fb2b58bbf64007fd623c3d40ed6a9c
+  name:   Dragon Ball - Shen Long no Nazo (Japan)
+  title:  Dragon Ball - Shen Long no Nazo (Japan)
+  region: NTSC-J
+  board:  HVC-GNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: b1a7377282123b3b18107e0d929666af8831bebde78ceaf7fe410c2132cd61ce
   name:   Dragon Buster (Japan)
   title:  Dragon Buster (Japan)
@@ -572,6 +1236,27 @@ game
     memory
       type: ROM
       size: 0x10000
+      content: Character
+
+game
+  sha256: 038f2241fd6e58600ce234623be752cca47875ef7295fe92c30c328c81ffe7ec
+  name:   Dragon Power (USA)
+  title:  Dragon Power (USA)
+  region: NTSC-U
+  board:  HVC-GNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -645,6 +1330,31 @@ game
       content: Character
 
 game
+  sha256: 165a5cc2a460463e24b8596c9004434d7a50aab1d2bd0435c2047f618fbd1309
+  name:   Dynamite Batman (Japan)
+  title:  Dynamite Batman (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-5B
+    chip
+      type: 5B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: 761df2c2e04f9ffec5eec59afd821bd74af3b155546519d649876aad37160c06
   name:   Esper Dream 2 - Aratanaru Tatakai (Japan)
   title:  Esper Dream 2 - Aratanaru Tatakai (Japan)
@@ -694,6 +1404,31 @@ game
       content: Character
 
 game
+  sha256: 7586cdd8b742ba3c4f0ea3eefaa2f6f2215af197a5269e3de9026bcdf236e981
+  name:   Famicom Wars (Japan)
+  title:  Famicom Wars (Japan)
+  region: NTSC-J
+  board:  HVC-FKROM
+    chip
+      type: MMC4
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
   sha256: c8c0b6c21bdda7503bab7592aea0f945a0259c18504bb241aafb1eabe65846f3
   name:   Family BASIC V3 (Japan)
   title:  Family BASIC V3 (Japan)
@@ -716,6 +1451,27 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: d3bbb6a0600d527de22d1bd0494f727b2910e8efd814cc91e1233bf6025b1413
+  name:   Family Block (Japan)
+  title:  Family Block (Japan)
+  region: NTSC-J
+  board:  HVC-GNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -930,6 +1686,27 @@ game
       content: Character
 
 game
+  sha256: 95d3ae878eb2e0d0fd8a8dc55b7cf03524e5f1975cdcef4a90e8651da642c1a2
+  name:   Family Trainer 9 - Fuuun Takeshi-jou 2 (Japan)
+  title:  Family Trainer 9 - Fuuun Takeshi-jou 2 (Japan)
+  region: NTSC-J
+  board:  HVC-GNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 0b8796fc3f09e20bb570fc66bbf688c13e5dfe3cd4bec3bd5e834a0313fb9527
   name:   Famista '89 - Kaimaku Ban!! (Japan)
   title:  Famista '89 - Kaimaku Ban!! (Japan)
@@ -1033,6 +1810,97 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4a12bc4bec5b713862a75559c32dd6e4bb205ef2d997ad16eb16db02326b2c34
+  name:   Fantasy Zone (Japan)
+  title:  Fantasy Zone (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-2
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0b6b072ad31e0b7d66271ccd76c9ff4b08cb4dcee912c537e6ef81a962304e27
+  name:   Fantasy Zone II - Opa-Opa no Namida (Japan)
+  title:  Fantasy Zone II - Opa-Opa no Namida (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-3
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 60db7fd78cc849658a42ca648f0d294ebf21e477ddf0753f0e6bbffaad6192ab
+  name:   Fire Emblem - Ankoku Ryuu to Hikari no Tsurugi (Japan)
+  title:  Fire Emblem - Ankoku Ryuu to Hikari no Tsurugi (Japan)
+  region: NTSC-J
+  board:  HVC-FKROM
+    chip
+      type: MMC4
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 0d899d67c7a61b13151f465c38c63a0d2d6a42d6be2d4ecac0fef87d55d92f92
+  name:   Fire Emblem Gaiden (Japan)
+  title:  Fire Emblem Gaiden (Japan)
+  region: NTSC-J
+  board:  HVC-FKROM
+    chip
+      type: MMC4
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: ROM
       size: 0x20000
@@ -1311,6 +2179,27 @@ game
       content: Character
 
 game
+  sha256: 1bbe4b3e20a004a4f741018e31e6ae291772b8876d6fb6f01494c9c5b0917c6c
+  name:   Gimmick! (Japan)
+  title:  Gimmick! (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-5B
+    chip
+      type: 5B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 4ca57e0bff08c5308073382af56138f31fe60c30cea7ab5fb1e4863b86e0b5d7
   name:   Goal!! (Japan)
   title:  Goal!! (Japan)
@@ -1402,6 +2291,69 @@ game
       content: Character
 
 game
+  sha256: 029c4a8b572bdf3a655fb06a2e6ac67bd1c89c15d472d5078c8e77376c40102f
+  name:   Gremlin 2 - Shinshu Tanjou (Japan)
+  title:  Gremlin 2 - Shinshu Tanjou (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-5B
+    chip
+      type: 5B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 4628f32db9b826d19fe5dd8e2c45a9f70e1041f15b7b44b06dee2f01731566e8
+  name:   Gumshoe (USA, Europe)
+  title:  Gumshoe (USA, Europe)
+  region: NTSC-U
+  board:  HVC-GNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 02be25c6e4b9a0514b8d6299e93048e442866a74c092453cdc1748e45fbc02e5
+  name:   Hebereke (Japan)
+  title:  Hebereke (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-5B
+    chip
+      type: 5B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 429c833eb61c0728b0d9335c61f4bd8d3fb19c3bf8a18564917bf75526f104af
   name:   Heisei Tensai Bakabon (Japan)
   title:  Heisei Tensai Bakabon (Japan)
@@ -1441,6 +2393,52 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: 1d7d435fe2aa494f5752a3098d1d627b99f91b0c5ded99038f36e80c22d6a162
+  name:   Honoo no Toukyuuji - Dodge Danpei (Japan)
+  title:  Honoo no Toukyuuji - Dodge Danpei (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-5B
+    chip
+      type: 5B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: c5bd759e942ac617efaba493585294d85e5ce8fcb7686fceb6efc8944d6c954b
+  name:   Honoo no Toukyuuji - Dodge Danpei 2 (Japan)
+  title:  Honoo no Toukyuuji - Dodge Danpei 2 (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-5B
+    chip
+      type: 5B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
       content: Character
 
 game
@@ -1509,6 +2507,86 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 5af57c3a96a040db0c12dcf6f398e32ce7556c62dd2f148d30045443f1887883
+  name:   IronSword - Wizards & Warriors II (Europe)
+  title:  IronSword - Wizards & Warriors II (Europe)
+  region: PAL
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: aab5e0ecc46e575b1b396bd63d8fa4f3bd740061f3157a1d4afdf9f7f2dabd88
+  name:   IronSword - Wizards & Warriors II (USA)
+  title:  IronSword - Wizards & Warriors II (USA)
+  region: NTSC-U
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: cc7b41335ca8c0f3fb399e3647d5489effcdf804a5f45509e5f0f684b9edd947
+  name:   Ivan 'Ironman' Stewart's Super Off Road (Europe)
+  title:  Ivan 'Ironman' Stewart's Super Off Road (Europe)
+  region: PAL
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: acc3b89bcbe3ccc2ee29d0b2eb3fb9cec143236f48d88680b462c3dfab0784bf
+  name:   Ivan 'Ironman' Stewart's Super Off Road (USA)
+  title:  Ivan 'Ironman' Stewart's Super Off Road (USA)
+  region: NTSC-U
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: ea770788f68e4bb089e4205807931d64b83175a0106e7563d0a6d3ebac369991
@@ -1600,6 +2678,86 @@ game
       type: ROM
       size: 0x40000
       content: Character
+
+game
+  sha256: 4b744bf7205495f80cdf7c3230034ed40ef61a37ae9b716bccd8bad5af0ee166
+  name:   Jeopardy! (USA)
+  title:  Jeopardy! (USA)
+  region: NTSC-U
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 7f28fa007f219e4ee7e6c512ec58bc828b1ac4a3bc785f2f0ccf1d48437de5ce
+  name:   Jeopardy! (USA) (Rev 1)
+  title:  Jeopardy! (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0244b219abbde241e7982790d52fe7fd9af2e181ddeb5ad089a7cc77fe8026f5
+  name:   Jeopardy! 25th Anniversary Edition (USA)
+  title:  Jeopardy! 25th Anniversary Edition (USA)
+  region: NTSC-U
+  board:  HVC-ANROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5e2aac273c63b38925e47c2c69b32fdea10c11a78c6696514b5107f25f40ad6f
+  name:   Jeopardy! Junior Edition (USA)
+  title:  Jeopardy! Junior Edition (USA)
+  region: NTSC-U
+  board:  HVC-ANROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 740de2e292b8ba92ee87c2cac51ccdfa6a2e5bfe230078f3e02fd3f4f83af34d
@@ -1731,9 +2889,30 @@ game
       content: Character
 
 game
-  sha256: 253f10f7003d6093b58a7529a9c1b3dd18a8696adc0be3a055070887f1fee5b7
-  name:   Karnov (Japan) (Rev 1)
-  title:  Karnov (Japan) (Rev 1)
+  sha256: 683514860ec52aaab636ffcdef33c442270c85000190dfd4956cfb8f224ea7a3
+  name:   Kanshakudama Nage Kantarou no Toukaidou Gojuusan Tsugi (Japan)
+  title:  Kanshakudama Nage Kantarou no Toukaidou Gojuusan Tsugi (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-1
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
+  sha256: 9905d9999767b7428ba770f855e9b8904123c84fa46b9e6cc0a178fef3ad4e2c
+  name:   Karnov (Japan)
+  title:  Karnov (Japan)
   region: NTSC-J
   board:  NAMCO-118
     chip
@@ -1754,9 +2933,9 @@ game
       content: Character
 
 game
-  sha256: 9905d9999767b7428ba770f855e9b8904123c84fa46b9e6cc0a178fef3ad4e2c
-  name:   Karnov (Japan)
-  title:  Karnov (Japan)
+  sha256: 253f10f7003d6093b58a7529a9c1b3dd18a8696adc0be3a055070887f1fee5b7
+  name:   Karnov (Japan) (Rev 1)
+  title:  Karnov (Japan) (Rev 1)
   region: NTSC-J
   board:  NAMCO-118
     chip
@@ -1820,6 +2999,27 @@ game
     memory
       type: ROM
       size: 0x10000
+      content: Character
+
+game
+  sha256: 73982959bbf7dad73dd2e57b08ed79dbdcf7399aa87f0ca602995c366a3732bb
+  name:   Kidou Senshi Z Gundam - Hot Scramble (Japan)
+  title:  Kidou Senshi Z Gundam - Hot Scramble (Japan)
+  region: NTSC-J
+  board:  HVC-GNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -2094,6 +3294,26 @@ game
       content: Character
 
 game
+  sha256: cecc797ffc82c5764e89038262c00b325f44afc0d9fc4b5bef295ea227e1dd22
+  name:   Lion King, The (Europe)
+  title:  Lion King, The (Europe)
+  region: PAL
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 98331d734fb2ad1e619301e4558492517b6e47ab213e4dcec5b8d7c536c526b9
   name:   Lord of King, The (Japan)
   title:  Lord of King, The (Japan)
@@ -2112,6 +3332,27 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: dc541137d79000fe3e0bdf5ce35b687a5b137c3a09160c5742599b4ff257cfae
+  name:   Madoola no Tsubasa (Japan)
+  title:  Madoola no Tsubasa (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-1
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -2203,27 +3444,66 @@ game
       content: Character
 
 game
-  sha256: fa44773e3c2f1a435cbe7a8e098508b92cd79ba88c71f798b76c08aa0e257316
-  name:   Metro-Cross (Japan)
-  title:  Metro-Cross (Japan)
-  region: NTSC-J
-  board:  NAMCO-118
-    chip
-      type: 118
-    mirror
-      mode: vertical
+  sha256: 1be87ef4b1b6520b57bf91ea3f3b64d813a73b1f28e76df75994a964727eac62
+  name:   Marble Madness (Europe)
+  title:  Marble Madness (Europe)
+  region: PAL
+  board:  HVC-ANROM
     memory
       type: ROM
       size: 0x10
       content: iNES
     memory
       type: ROM
-      size: 0x8000
+      size: 0x20000
       content: Program
     memory
-      type: ROM
-      size: 0x8000
+      type: RAM
+      size: 0x2000
       content: Character
+      volatile
+
+game
+  sha256: d77ed527cf081019dc8e1cad72872ef3bd640114221b89f030e0c03229c54ddc
+  name:   Marble Madness (USA)
+  title:  Marble Madness (USA)
+  region: NTSC-U
+  board:  HVC-ANROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 4ac0926d1e4704e75e7dfc27c4d990ebdbe685002b9af1a80a385604f3cb162c
+  name:   Mashou (Japan)
+  title:  Mashou (Japan)
+  region: NTSC-J
+  board:  HVC-BNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: c9a294e5ac3490c346e24db8125761fac7e8ba57df0456a6dd29d62a34dbfda7
@@ -2247,6 +3527,29 @@ game
       content: Character
 
 game
+  sha256: fa44773e3c2f1a435cbe7a8e098508b92cd79ba88c71f798b76c08aa0e257316
+  name:   Metro-Cross (Japan)
+  title:  Metro-Cross (Japan)
+  region: NTSC-J
+  board:  NAMCO-118
+    chip
+      type: 118
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 32c6893e0f8a14714dd2082803cfde62f8981010d23fc9cf00a5a18066d063cb
   name:   Mezase! Top Pro - Green ni Kakeru Yume (Japan)
   title:  Mezase! Top Pro - Green ni Kakeru Yume (Japan)
@@ -2266,6 +3569,90 @@ game
       type: RAM
       size: 0x2000
       content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: eb2a2a5e15bb2b35b8284e15e85eede46de1765be9fa7d62c4d3fc6015e20bcc
+  name:   Mike Tyson's Punch-Out!! (Europe)
+  title:  Mike Tyson's Punch-Out!! (Europe)
+  region: PAL
+  board:  HVC-PNROM
+    chip
+      type: MMC2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 75424927a74dd2de318c166c0e1950f2bea14534d691cefe5efe23bbf6b5d550
+  name:   Mike Tyson's Punch-Out!! (Europe) (Rev 1)
+  title:  Mike Tyson's Punch-Out!! (Europe) (Rev 1)
+  region: PAL
+  board:  HVC-PNROM
+    chip
+      type: MMC2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 752f9d07450e6ec075b109f5be1b1933e8385ad687ceaf24f70a590767bb5a27
+  name:   Mike Tyson's Punch-Out!! (Japan, USA)
+  title:  Mike Tyson's Punch-Out!! (Japan, USA)
+  region: NTSC-J
+  board:  HVC-PNROM
+    chip
+      type: MMC2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 2ebab487204c42b0d9cf19c37bdc395e396226ca3eaa664907bf7f8216b3c4d3
+  name:   Mike Tyson's Punch-Out!! (Japan, USA) (Rev 1)
+  title:  Mike Tyson's Punch-Out!! (Japan, USA) (Rev 1)
+  region: NTSC-J
+  board:  HVC-PNROM
+    chip
+      type: MMC2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
     memory
       type: ROM
       size: 0x20000
@@ -2364,6 +3751,25 @@ game
       content: Character
 
 game
+  sha256: a3e9409fddd7b4eb6a30fb91aff75957b9f730a511c6be2087151dbb3e9b4852
+  name:   Mito Koumon - Sekai Manyuu Ki (Japan)
+  title:  Mito Koumon - Sekai Manyuu Ki (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-3
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 14868615d1ca04bf91cfa4ab5a9c55aef090cc957f786f9b337247047b7b179e
   name:   Moe Pro! '90 - Kandou Hen (Japan)
   title:  Moe Pro! '90 - Kandou Hen (Japan)
@@ -2448,27 +3854,6 @@ game
       content: Character
 
 game
-  sha256: 2c54c5e66cb960ee8647acbe086b2b3386fabf24f7f0d9d2d0e17bd19d681eda
-  name:   Moero!! Pro Tennis (Japan)
-  title:  Moero!! Pro Tennis (Japan)
-  region: NTSC-J
-  board:  JALECO-JF-17
-    mirror
-      mode: vertical
-    memory
-      type: ROM
-      size: 0x10
-      content: iNES
-    memory
-      type: ROM
-      size: 0x20000
-      content: Program
-    memory
-      type: ROM
-      size: 0x20000
-      content: Character
-
-game
   sha256: 21c904f1577720871d98e0b374b7bfd63e192d1707879cda986aa4cff4fb2e09
   name:   Moero!! Pro Soccer (Japan)
   title:  Moero!! Pro Soccer (Japan)
@@ -2483,6 +3868,27 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 2c54c5e66cb960ee8647acbe086b2b3386fabf24f7f0d9d2d0e17bd19d681eda
+  name:   Moero!! Pro Tennis (Japan)
+  title:  Moero!! Pro Tennis (Japan)
+  region: NTSC-J
+  board:  JALECO-JF-17
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
       content: Program
     memory
       type: ROM
@@ -2623,6 +4029,27 @@ game
       content: Character
 
 game
+  sha256: 3264e4c57ffaf64df816cc97b1d6d278042545a4be248f5c195d82037f0a9bfd
+  name:   Mr. Gimmick (Europe)
+  title:  Mr. Gimmick (Europe)
+  region: PAL
+  board:  SUNSOFT-5B
+    chip
+      type: 5B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: de6cb9b8644fe4c3477ba29a7ef1c6102f4ca0c18a7c909616442b9068f28ca3
   name:   Namco Prism Zone - Dream Master (Japan)
   title:  Namco Prism Zone - Dream Master (Japan)
@@ -2693,6 +4120,46 @@ game
       volatile
 
 game
+  sha256: dc71dadc3f4eae03f26ac4afec8ef044e7874ad8fdee1567a9b9b9e2c112669e
+  name:   NARC (USA)
+  title:  NARC (USA)
+  region: NTSC-U
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 58be6a811ee3370882160115253b610581e8b4af7228669eb3fbd56e7a13117c
+  name:   Nightmare on Elm Street, A (USA)
+  title:  Nightmare on Elm Street, A (USA)
+  region: NTSC-U
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 648cf7ac553517573cc9b3955ab50566a91974b2348154910bfa53ef15d55b56
   name:   Ninja Jajamaru - Ginga Daisakusen (Japan)
   title:  Ninja Jajamaru - Ginga Daisakusen (Japan)
@@ -2753,6 +4220,27 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: 035383efbc5131942ba7df721ba406fd57c08a9ff87e3aa6e6f3d272bda86c44
+  name:   Paris-Dakar Rally Special (Japan)
+  title:  Paris-Dakar Rally Special (Japan)
+  region: NTSC-J
+  board:  HVC-GNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -2979,6 +4467,90 @@ game
       content: Character
 
 game
+  sha256: 17f4b9a5c8175c2f6650d451e7d96f9ddd5b5dabfe87f8f8d6a84adcb1439bec
+  name:   Punch-Out!! (Europe)
+  title:  Punch-Out!! (Europe)
+  region: PAL
+  board:  HVC-PNROM
+    chip
+      type: MMC2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 542c826a30acd04fe26aa60ef6816572478cc1b41091574c5091bed61449d05f
+  name:   Punch-Out!! (Japan) (Gold Edition)
+  title:  Punch-Out!! (Japan) (Gold Edition)
+  region: NTSC-J
+  board:  HVC-PNROM
+    chip
+      type: MMC2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 635271fe654636ec37c882f76c5f8cd39b7b3a476c9aa75cefb548d82de8f896
+  name:   Punch-Out!! (USA)
+  title:  Punch-Out!! (USA)
+  region: NTSC-J
+  board:  HVC-PNROM
+    chip
+      type: MMC2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 1a8cafde15dd16dee6c651ff8ab8bbf5b977d1b7047cb84d913c0aab02727ef7
+  name:   Pyokotan no Daimeiro (Japan)
+  title:  Pyokotan no Daimeiro (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-5B
+    chip
+      type: 5B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 7cb999c28339dfca0fd4aff85aa93c7af87fb40698d4035ab5b23620b695940a
   name:   Quinty (Japan)
   title:  Quinty (Japan)
@@ -3023,6 +4595,86 @@ game
       type: ROM
       size: 0x8000
       content: Character
+
+game
+  sha256: 3941ec3db80fd2eabce48a4dc06c5d5411db47fede972a7660a76e583fcd8773
+  name:   R.C. Pro-Am (Europe)
+  title:  R.C. Pro-Am (Europe)
+  region: PAL
+  board:  HVC-AN1ROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: aec6beb5b7e4d291a2bef75cb6dc43dc4db34f0313d26a8582ddf61b5b6a67c5
+  name:   R.C. Pro-Am (USA)
+  title:  R.C. Pro-Am (USA)
+  region: NTSC-U
+  board:  HVC-AN1ROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 282c84315ccb22895a3831b2cea301c12a54ca645429e12bf641504060ad4556
+  name:   R.C. Pro-Am II (Europe)
+  title:  R.C. Pro-Am II (Europe)
+  region: PAL
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 730399227c1566636f2e3475c398924165b21d88fc3321f60b29f4e6321a3c9c
+  name:   R.C. Pro-Am II (USA)
+  title:  R.C. Pro-Am II (USA)
+  region: NTSC-U
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 6b5f7dbd2c4e7512b27e8492a8af8ad08701ba125e0fe7d4ac679f5782f7eb9b
@@ -3169,6 +4821,28 @@ game
       content: Character
 
 game
+  sha256: f7271a7030e2f5298f3931f08c84fdbe1dad3108aaf1259a766f05b80b12910a
+  name:   Shanghai (Japan)
+  title:  Shanghai (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-2
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 52b9b0d7137c458b2dc3a96e693af96ce044feedcdc1edf736c728a25e2fe4d8
   name:   Shin Moero!! Pro Yakyuu (Japan)
   title:  Shin Moero!! Pro Yakyuu (Japan)
@@ -3236,6 +4910,106 @@ game
       content: Character
 
 game
+  sha256: d217aae4c1eff6e05b09b6ed1828a1d1f01a047f6a7932818e985569f2d9ff7a
+  name:   Solar Jetman - Hunt for the Golden Warpship (Europe)
+  title:  Solar Jetman - Hunt for the Golden Warpship (Europe)
+  region: PAL
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 45a0fd35f3141c140fb8d1f652876011f28d772b987da123c597aa8c924437b2
+  name:   Solar Jetman - Hunt for the Golden Warpship (USA)
+  title:  Solar Jetman - Hunt for the Golden Warpship (USA)
+  region: NTSC-U
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5848c7e2009e2263184cd95fe060ff52d0554e6b1277666a76098cb7eaa673b9
+  name:   Solstice (Japan)
+  title:  Solstice (Japan)
+  region: NTSC-J
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: f4ced076b9ee9211c7fe95b58d1536ea173d102d08fbaee77728562f6fa4e7ab
+  name:   Solstice - The Quest for the Staff of Demnos (Europe)
+  title:  Solstice - The Quest for the Staff of Demnos (Europe)
+  region: PAL
+  board:  HVC-ANROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: e437dbafa7e20dd72412c869b9433901c3e9302cfa16b6e8379ecc56ae8dcc22
+  name:   Solstice - The Quest for the Staff of Demnos (USA)
+  title:  Solstice - The Quest for the Staff of Demnos (USA)
+  region: NTSC-U
+  board:  HVC-ANROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: dbd587ef5a12e03a336cda61cd120b4e8c585f45d82821e144ee8afdea9ee84e
   name:   Spartan X 2 (Japan)
   title:  Spartan X 2 (Japan)
@@ -3301,6 +5075,48 @@ game
       content: Character
 
 game
+  sha256: a361572ebc2e2cb2fb579b4de6d1f34e8a797eed3bee7142caadbf1bc35559cd
+  name:   Super Mario Bros. + Duck Hunt (Europe)
+  title:  Super Mario Bros. + Duck Hunt (Europe)
+  region: PAL
+  board:  HVC-GNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
+  sha256: 5dde385041aa7364c78205f2ba49615f416c701b6025e38aa1d7b9c4f99a62db
+  name:   Super Mario Bros. + Duck Hunt (USA)
+  title:  Super Mario Bros. + Duck Hunt (USA)
+  region: NTSC-U
+  board:  HVC-GNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
   sha256: 301d41b370e56cf3c57f22f760da55cb0dc726acf0a2b45182abe5e9dbe186a2
   name:   Super Xevious - Gump no Nazo (Japan)
   title:  Super Xevious - Gump no Nazo (Japan)
@@ -3346,6 +5162,27 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: ad34a5b9519724119c9def06f8b8c5be5454c4f99f13aade6d1fd5aefad76ddd
+  name:   Takahashi Meijin no Bugutte Honey (Japan)
+  title:  Takahashi Meijin no Bugutte Honey (Japan)
+  region: NTSC-J
+  board:  HVC-GNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -3418,6 +5255,25 @@ game
       content: Character
 
 game
+  sha256: 3ad469c7d183db6a9d9829802fc43a95d90aefd83ec8193d8d2da4aca36063c5
+  name:   Tenka no Goikenban - Mito Koumon (Japan)
+  title:  Tenka no Goikenban - Mito Koumon (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 2e76e65be48d2ae1ec6a91a83cc58468fc80cdf98ae34b99a1a71e633760b0a6
   name:   Tenkaichi Bushi - Keru Naguuru (Japan)
   title:  Tenkaichi Bushi - Keru Naguuru (Japan)
@@ -3481,6 +5337,67 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: e3be0290f198fceed633b037d9201aa4b95460617551b3a9fb5bb212b153a2d4
+  name:   Thunder & Lightning (USA)
+  title:  Thunder & Lightning (USA)
+  region: NTSC-U
+  board:  HVC-GNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 26de06cbb05dea83e8d3bcd0d3de345d3f17c64fa1f87bb20628935a97e59cdd
+  name:   Time Lord (Europe)
+  title:  Time Lord (Europe)
+  region: PAL
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 13353e4e94633eba066e024ea7050b0801a8ccbe4c03bd97656852df4d2f3359
+  name:   Time Lord (USA)
+  title:  Time Lord (USA)
+  region: NTSC-U
+  board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 4b80a1db42ecde039f01c52a74146887f9dfc2ad54fe3706bcdf625ec3e2de97
@@ -3809,6 +5726,286 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 88691067f122467f2dae85e40b927013b91fe848f88d694616ed2f26ab1f3f4d
+  name:   Wheel of Fortune (USA)
+  title:  Wheel of Fortune (USA)
+  region: NTSC-U
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 7157801d42484e58b81387c95f24d6e8acaa513fa588828398f5b7a69f2c14bd
+  name:   Wheel of Fortune (USA) (Rev 1)
+  title:  Wheel of Fortune (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 9178fba5cbb412cc6d437f301ab93ba8c897235a5c8f2985756d3441061ecbe2
+  name:   Wheel of Fortune - Family Edition (USA)
+  title:  Wheel of Fortune - Family Edition (USA)
+  region: NTSC-U
+  board:  HVC-ANROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 84e3a018cbaaf2311d7e9414112cb05cf3b43608de0b9f8a2f77bc4da33ce8e6
+  name:   Wheel of Fortune - Junior Edition (USA)
+  title:  Wheel of Fortune - Junior Edition (USA)
+  region: NTSC-U
+  board:  HVC-ANROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0dcd6d458d26cda8673abfc4110abde301fb34b44b7075d6453e97b7dcb42d12
+  name:   Wheel of Fortune Featuring Vanna White (USA)
+  title:  Wheel of Fortune Featuring Vanna White (USA)
+  region: NTSC-U
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 700ebc3c2dd27420bbdcccb987ba60d3f0680469101353de15a1b2bd565ac701
+  name:   Who Framed Roger Rabbit (USA)
+  title:  Who Framed Roger Rabbit (USA)
+  region: NTSC-U
+  board:  HVC-ANROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: a870c1add0839708b2524b5ca4ae64547001c13bbd664a51f998656936dd1075
+  name:   Wizards & Warriors (Europe)
+  title:  Wizards & Warriors (Europe)
+  region: PAL
+  board:  HVC-ANROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 3ba4f6fd63a74338e438df43ddd1195f8913d69c11f6668d3bbf23a2a3cea459
+  name:   Wizards & Warriors (USA)
+  title:  Wizards & Warriors (USA)
+  region: NTSC-U
+  board:  HVC-ANROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: d30e480e7a99b5c3d8fe8faecf0bc0a14a9b163025eca9bf787f600fa927bb89
+  name:   Wizards & Warriors (USA) (Rev 1)
+  title:  Wizards & Warriors (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-ANROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: c3d0fbc9395e2e0106c1ec6e11b15727c95d6424bf053dc8d24eeaa5f4889eb8
+  name:   Wizards & Warriors III - Kuros...Visions of Power (Europe)
+  title:  Wizards & Warriors III - Kuros...Visions of Power (Europe)
+  region: PAL
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 2fa3ee5f9ef17dcd63f2f3936dc79b95a71f9e58521080250d4b4e7efbd471d2
+  name:   Wizards & Warriors III - Kuros...Visions of Power (USA)
+  title:  Wizards & Warriors III - Kuros...Visions of Power (USA)
+  region: NTSC-U
+  board:  HVC-AOROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 6449c6d072fd1df14a346fbd17c11f76d7470185041b1181c36770ce11ae71e6
+  name:   World Games (USA)
+  title:  World Games (USA)
+  region: NTSC-U
+  board:  HVC-ANROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 306599be84494284eb8132aaceb7fc8e23ad0f9b410825b6271ebdbd8b4ed7c2
+  name:   WWF Wrestlemania (Europe)
+  title:  WWF Wrestlemania (Europe)
+  region: PAL
+  board:  HVC-ANROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: a6f98e57ffb4544152138f109b00d1016ae957f7d842f29b41e118045fd54056
+  name:   WWF Wrestlemania (USA)
+  title:  WWF Wrestlemania (USA)
+  region: NTSC-U
+  board:  HVC-ANROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 703411cb92283840c096d7e1e422582ecda18bd9b27604a253cb0b0702383043

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -205,9 +205,9 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     break;
 
   case  16:
-    s += "  board:  BANDAI-FCG\n";
+    s += "  board:  BANDAI-LZ93D50\n";
     s += "    chip type=LZ93D50\n";
-    eeprom = 128;
+    eeprom = 256;
     break;
 
   case  18:
@@ -420,7 +420,7 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     break;
 
   case 159:
-    s += "  board:  BANDAI-FCG\n";
+    s += "  board:  BANDAI-LZ93D50\n";
     s += "    chip type=LZ93D50\n";
     eeprom = 128;
     break;

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -305,6 +305,11 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     prgram = 8192;
     break;
 
+  case  70:
+    s += "  board:  BANDAI-74161\n";
+    s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
+    break;
+
   case  72:
     s += "  board:  JALECO-JF-17\n";
     s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
@@ -403,6 +408,10 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
   case  140:
     s += "  board:  JALECO-JF-11\n";
     s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
+    break;
+
+  case 152:
+    s += "  board:  BANDAI-74161A\n";
     break;
 
   case 154:


### PR DESCRIPTION
Suppor added for discrete logic Bandai boards.

Bandai 74x161 (iNES mappers 70/152):
- Arkanoid II (Japan)
- Family Trainer 4 - Jogging Race (Japan) *Required peripheral: Family Trainer Mat
- Family Trainer 5 - Meiro Daisakusen (Japan) *Required peripheral: Family Trainer Mat
- Family Trainer 6 - Manhattan Police (Japan) *Required peripheral: Family Trainer Mat
- Gegege no Kitarou 2 - Youkai Gundan no Chousen (Japan)
- Kamen Rider Club (Japan)
- Pocket Zaurus - Juu Ouken no Nazo (Japan)
- Saint Seiya - Ougon Densetsu (Japan)
- Space Shadow (Japan) *Required peripheral: Bandai Hyper Shot

In this pr I also split the implementation of Bandai FCG and LZ93D50; those chips are very similar, but I think they deserve different files for a more readable code and to describe its differences better.

Note that saving is broken on LZ93D50 games with X24C02 eeprom (about half the games on mapper 16). In its current form they are using a X24C01, this eeprom (besides of having half the size) is functionally different from X24C02. In fact "Dragon Ball Z III" is booting "by accident": the game sends commands on boot that the eeprom misunderstands, and its not ending in standby status by pure luck (that would produce an infinite loop in the game code). It's possible that these games don't work at all or hang on saving, "SD Gundam Gaiden 3" hangs on starting game probably related to this. Just using a M24C02 (already emulated) didn't work, I will look into this issue.