### PR TITLE
fc: Support for Action 52 board

### DIFF
--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -34,6 +34,7 @@ namespace Board {
 #include "irem-h3001.cpp"
 #include "irem-lrog017.cpp"
 #include "irem-tam-s1.cpp"
+#include "mlt-action52.cpp"
 #include "namco-118.cpp"
 #include "namco-340.cpp"
 #include "sunsoft-1.cpp"
@@ -82,6 +83,7 @@ auto Interface::create(string board) -> Interface* {
   if(!p) p = KonamiVRC5::create(board);
   if(!p) p = KonamiVRC6::create(board);
   if(!p) p = KonamiVRC7::create(board);
+  if(!p) p = MltAction52::create(board);
   if(!p) p = Namco118::create(board);
   if(!p) p = Namco340::create(board);
   if(!p) p = Sunsoft1::create(board);

--- a/ares/fc/cartridge/board/mlt-action52.cpp
+++ b/ares/fc/cartridge/board/mlt-action52.cpp
@@ -1,0 +1,75 @@
+struct MltAction52 : Interface {
+  static auto create(string id) -> Interface* {
+    if(id == "MLT-ACTION52") return new MltAction52();
+    return nullptr;
+  }
+
+  Memory::Readable<n8> programROM;
+  Memory::Readable<n8> characterROM;
+
+  auto load() -> void override {
+    Interface::load(programROM, "program.rom");
+    Interface::load(characterROM, "character.rom");
+  }
+
+ auto readPRG(n32 address, n8 data) -> n8 override {
+    if(address < 0x8000) return data;
+
+    n2 chipOffset;
+    switch(programChip) {
+    case 0: chipOffset = 0; break;
+    case 1: chipOffset = 1; break;
+    case 2: return data;
+    case 3: chipOffset = 2; break;
+    }
+
+    bool region = address.bit(14);
+    n5 bank = programMode ? programBank : (n5)(programBank & ~1 | region);
+    address = chipOffset << 19 | bank << 14 | (n14)address;
+    return programROM.read(address);
+  }
+
+  auto writePRG(n32 address, n8 data) -> void override {
+    if(address < 0x8000) return;
+
+    characterBank = address.bit(0,3) << 2 | data.bit(0,1);
+    programMode = address.bit(5);
+    programBank = address.bit(6,10);
+    programChip = address.bit(11,12);
+    mirror = address.bit(13);
+  }
+
+  auto readCHR(n32 address, n8 data) -> n8 override {
+    if(address & 0x2000) {
+      address = address >> mirror & 0x0400 | (n10)address;
+      return ppu.readCIRAM(address);
+    }
+    address = characterBank << 13 | (n13)address;
+    if(characterROM) return characterROM.read(address);
+    return data;
+  }
+
+  auto writeCHR(n32 address, n8 data) -> void override {
+    if(address & 0x2000) {
+      address = address >> mirror & 0x0400 | (n10)address;
+      return ppu.writeCIRAM(address, data);
+    }
+  }
+
+  auto power() -> void override {
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(characterBank);
+    s(programMode);
+    s(programBank);
+    s(programChip);
+    s(mirror);
+  }
+
+  n6 characterBank;
+  n1 programMode;
+  n5 programBank;
+  n2 programChip;
+  n1 mirror;
+};

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -447,6 +447,9 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     s += "    chip type=340\n";
     break;
 
+  case 228:
+    s += "  board:  MLT-ACTION52\n";
+    break;
   }
 
   s += "    memory\n";


### PR DESCRIPTION
Support added for the Active Enterprises board (iNES mapper 228) used by the infamous Action 52 and Cheetahmen II games. From what I tried so far it works as it should, if Action 52 could ever be said to be "working".

The original Action 52 board has four 512 KiB-sized PRG ROM slots, but only slots 0, 1 and 3 are connected to a ROM chip (slot 2 returns open bus) making the total amount of PRG ROM 1536 KiB. Standard iNES format dumps simply contain slot 0, 1 and 3 in that order, which the current mapper is hardcoded to expect.  It could be discussed if the generated manifest should reflect and document the slot system somehow and if the mapper should be generalized to allow custom slot configurations.