### PR TITLE
fc: support for some misc board variants

### DIFF
--- a/ares/fc/cartridge/board/hvc-cnrom.cpp
+++ b/ares/fc/cartridge/board/hvc-cnrom.cpp
@@ -1,22 +1,25 @@
 struct HVC_CNROM : Interface {
   static auto create(string id) -> Interface* {
-    if(id == "HVC-CNROM") return new HVC_CNROM;
+    if(id == "HVC-CNROM"    ) return new HVC_CNROM(Revision::CNROM);
+    if(id == "HVC-CNROM-SEC") return new HVC_CNROM(Revision::CNROMS);
     return nullptr;
   }
 
   Memory::Readable<n8> programROM;
   Memory::Readable<n8> characterROM;
-  Memory::Writable<n8> characterRAM;
+
+  enum class Revision : u32 {
+    CNROM,
+    CNROMS,
+  } revision;
+
+  HVC_CNROM(Revision revision) : revision(revision) {}
 
   auto load() -> void override {
     Interface::load(programROM, "program.rom");
     Interface::load(characterROM, "character.rom");
-    Interface::load(characterRAM, "character.ram");
     mirror = pak->attribute("mirror") == "vertical";
-  }
-
-  auto save() -> void override {
-    Interface::save(characterRAM, "character.ram");
+    key = pak->attribute("chip/key").natural();
   }
 
   auto readPRG(n32 address, n8 data) -> n8 override {
@@ -27,6 +30,7 @@ struct HVC_CNROM : Interface {
   auto writePRG(n32 address, n8 data) -> void override {
     if(address < 0x8000) return;
     characterBank = data.bit(0,1);
+    characterEnable = (data == key);
   }
 
   auto readCHR(n32 address, n8 data) -> n8 override {
@@ -34,10 +38,12 @@ struct HVC_CNROM : Interface {
       address = address >> !mirror & 0x0400 | (n10)address;
       return ppu.readCIRAM(address);
     }
+    if(revision == Revision::CNROMS) {
+      if(!characterEnable) return 0xff;
+      return characterROM.read((n13)address);
+    }
     address = characterBank << 13 | (n13)address;
-    if(characterROM) return characterROM.read(address);
-    if(characterRAM) return characterRAM.read(address);
-    return data;
+    return characterROM.read(address);
   }
 
   auto writeCHR(n32 address, n8 data) -> void override {
@@ -45,19 +51,17 @@ struct HVC_CNROM : Interface {
       address = address >> !mirror & 0x0400 | (n10)address;
       return ppu.writeCIRAM(address, data);
     }
-    address = characterBank << 13 | (n13)address;
-    if(characterRAM) return characterRAM.write(address, data);
-  }
-
-  auto power() -> void override {
   }
 
   auto serialize(serializer& s) -> void override {
-    s(characterRAM);
     s(mirror);
+    s(key);
     s(characterBank);
+    s(characterEnable);
   }
 
   n1 mirror;  //0 = horizontal, 1 = vertical
+  n8 key;
   n2 characterBank;
+  n1 characterEnable;
 };

--- a/ares/fc/cartridge/board/hvc-sxrom.cpp
+++ b/ares/fc/cartridge/board/hvc-sxrom.cpp
@@ -69,7 +69,13 @@ struct HVC_SxROM : Interface {  //MMC1
   HVC_SxROM(Revision revision) : revision(revision) {}
 
   auto load() -> void override {
+    auto chip = pak->attribute("chip");
     chipRevision = ChipRevision::MMC1B2;
+    if(chip == "MMC1"  ) chipRevision = ChipRevision::MMC1;
+    if(chip == "MMC1A" ) chipRevision = ChipRevision::MMC1A;
+    if(chip == "MMC1B1") chipRevision = ChipRevision::MMC1B1;
+    if(chip == "MMC1B3") chipRevision = ChipRevision::MMC1B3;
+    if(chip == "MMC1C" ) chipRevision = ChipRevision::MMC1C;
 
     Interface::load(programROM, "program.rom");
     Interface::load(programRAM, "save.ram");
@@ -180,7 +186,9 @@ struct HVC_SxROM : Interface {  //MMC1
           break;
         case 3:
           programBank = shiftValue.bit(0,3);
-          ramDisable = shiftValue.bit(4);
+          if(chipRevision > ChipRevision::MMC1A) {
+            ramDisable = shiftValue.bit(4);
+          }
           break;
         }
       }

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -1,5 +1,5 @@
 database
-  revision: 2021-11-18
+  revision: 2021-11-20
 
 game
   sha256: 21b10e8d4cf775aa1f4027c4afb4f64e72e221a506a485cf4ffdf98bed01a524
@@ -206,6 +206,27 @@ game
     memory
       type: ROM
       size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 54526dc9444c0eb4b0e5814f98b5e522bcb9881a6f2c0644fc7a21ca8c03502b
+  name:   Armadillo (Japan)
+  title:  Armadillo (Japan)
+  region: NTSC-J
+  board:  HVC-TLSROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
       content: Program
     memory
       type: ROM
@@ -1674,6 +1695,27 @@ game
       content: Character
 
 game
+  sha256: badedff174fd32fcaad914ea72d04763b828ed4d1d883e8c902cb668ea52b92a
+  name:   Eric Cantona Football Challenge - Goal! 2 (Europe)
+  title:  Eric Cantona Football Challenge - Goal! 2 (Europe)
+  region: PAL
+  board:  HVC-TLSROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 761df2c2e04f9ffec5eec59afd821bd74af3b155546519d649876aad37160c06
   name:   Esper Dream 2 - Aratanaru Tatakai (Japan)
   title:  Esper Dream 2 - Aratanaru Tatakai (Japan)
@@ -2648,6 +2690,27 @@ game
       content: Character
 
 game
+  sha256: 7911375ab98da4ac5c628ba4dfffcba8ba4fc13a341901aed120ab967be5e26c
+  name:   Goal! Two (USA)
+  title:  Goal! Two (USA)
+  region: NTSC-U
+  board:  HVC-TLSROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 4ca57e0bff08c5308073382af56138f31fe60c30cea7ab5fb1e4863b86e0b5d7
   name:   Goal!! (Japan)
   title:  Goal!! (Japan)
@@ -2823,6 +2886,58 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 0ba8c48be4033b02a28be9e7da664a03e3956ba381a3d45bf66e9c080df47167
+  name:   High Speed (Europe)
+  title:  High Speed (Europe)
+  region: PAL
+  board:  HVC-TQROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 710e907230bbd82143286b40a56a298b25cf326697a9f07bfd8e043c1936a4b1
+  name:   High Speed (USA)
+  title:  High Speed (USA)
+  region: NTSC-U
+  board:  HVC-TQROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 1c1ad2992f728c7fb6a8f3980b1a0f8e01e5b24a0c43c713300846d87be5987a
@@ -4778,6 +4893,27 @@ game
       volatile
 
 game
+  sha256: 4b382baa70cbc52977fd766f49a3c7c9a3239f0d9581cd961b8b26700c53247d
+  name:   NES Play Action Football (USA)
+  title:  NES Play Action Football (USA)
+  region: NTSC-U
+  board:  HVC-TLSROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 58be6a811ee3370882160115253b610581e8b4af7228669eb3fbd56e7a13117c
   name:   Nightmare on Elm Street, A (USA)
   title:  Nightmare on Elm Street, A (USA)
@@ -5021,6 +5157,58 @@ game
       content: Character
 
 game
+  sha256: 1067b39e520810e55300a4ec1c94f4dddee17e899090af30cf5d626058dbe531
+  name:   Pin Bot (Europe)
+  title:  Pin Bot (Europe)
+  region: PAL
+  board:  HVC-TQROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: f4ddb0f1a02f823ebed30b55547344de3c8fb9d87254ff993584373ecadd9141
+  name:   Pin Bot (USA)
+  title:  Pin Bot (USA)
+  region: NTSC-U
+  board:  HVC-TQROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: b7daa24069d54f56fb71e7659b4ad40a6e9f4695f73e7a0d0e56d5c80e2e6474
   name:   Pinball Quest (Japan)
   title:  Pinball Quest (Japan)
@@ -5110,6 +5298,27 @@ game
   board:  TAITO-TC0190
     chip
       type: TC0190
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3910ae7495a71e6a55f70ed31eb345d28d6e9d524fe88679719d831f8f2553ce
+  name:   Pro Sport Hockey (USA)
+  title:  Pro Sport Hockey (USA)
+  region: NTSC-U
+  board:  HVC-TLSROM
+    chip
+      type: MMC3B
     memory
       type: ROM
       size: 0x10
@@ -5427,6 +5636,32 @@ game
       content: Character
 
 game
+  sha256: bcc8a24ab99f85933ff2cd0787daab6093710ef04f95b4c7bec842961ee0e3ad
+  name:   Rad Racer II (USA)
+  title:  Rad Racer II (USA)
+  region: NTSC-U
+  board:  HVC-TVROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+    memory
+      type: RAM
+      size: 0x800
+      content: Character
+      volatile
+
+game
   sha256: f17df83a3e714c9f839dcd428d31a0b8b3cdb5fe1a78f24f43f158cb379720c1
   name:   Ring King (USA)
   title:  Ring King (USA)
@@ -5473,6 +5708,31 @@ game
       type: EEPROM
       size: 0x100
       content: Save
+
+game
+  sha256: ff5d21cadd406e368a622f940a272efcfc441c08aa736cf3a82fddd6e7d8a097
+  name:   RPG Jinsei Game (Japan)
+  title:  RPG Jinsei Game (Japan)
+  region: NTSC-J
+  board:  HVC-TKSROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 4d6e58f232dc1a592583889f858eac230b8e8921e715276e580073ab2dd18546
@@ -7105,5 +7365,30 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: ec1d85479d72847d3adbd76e2e79221143e6c9324d5647be2c4a11aa87123f75
+  name:   Ys III - Wanderers from Ys (Japan)
+  title:  Ys III - Wanderers from Ys (Japan)
+  region: NTSC-J
+  board:  HVC-TKSROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -4518,6 +4518,31 @@ game
       content: Character
 
 game
+  sha256: f2aef1a9ade54330ff821083fda7e03c7a5f93d77f4da359069d84f98ab1f852
+  name:   Money Game, The (Japan)
+  title:  Money Game, The (Japan)
+  region: NTSC-J
+  board:  HVC-SJROM
+    chip
+      type: MMC1A
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 97ff1ac9e6061ba5fb02b4626abf3521f84ee1542fa8093d617ede08dbb17cdc
   name:   Mouryou Senki Madara (Japan)
   title:  Mouryou Senki Madara (Japan)
@@ -5966,6 +5991,31 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a086ff08e7eae822285975d04f5d227f2434d5f1819969e233ff8670f7d57439
+  name:   Tatakae!! Rahmen Man - Sakuretsu Choujin 102 Gei (Japan)
+  title:  Tatakae!! Rahmen Man - Sakuretsu Choujin 102 Gei (Japan)
+  region: NTSC-J
+  board:  HVC-SKROM
+    chip
+      type: MMC1A
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: ROM
       size: 0x20000

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -234,6 +234,30 @@ game
       content: Character
 
 game
+  sha256: 2b4ac20082e2f45a8f8fd4922a0e995829719a523e118a9eec891c3206adf25b
+  name:   B-Wings (Japan)
+  title:  B-Wings (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM-SEC
+    chip
+      type: SECURITY
+      key:  0x33
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: a9d7e89bd4ea28cfd169e32c4516ef5d059e19afb9dfa4ede8412f2373dfb0a7
   name:   Babel no Tou (Japan)
   title:  Babel no Tou (Japan)
@@ -578,6 +602,30 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: acf054b0886a2ca74a0280fc36bc1d55e9845acc29759f1893c1da4c1389f9c2
+  name:   Bird Week (Japan)
+  title:  Bird Week (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM-SEC
+    chip
+      type: SECURITY
+      key:  0x0f
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -4092,6 +4140,54 @@ game
       content: Character
 
 game
+  sha256: 02d86ba60b7f43f9d04131522263e7560d9ad1d4cc474b909d487cc0d470ccc3
+  name:   Mighty Bomb Jack (Japan)
+  title:  Mighty Bomb Jack (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM-SEC
+    chip
+      type: SECURITY
+      key:  0x11
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: c011721745c92916542dd1c82f8b38def52e7aeb7dfdb02609cfd049f436b82a
+  name:   Mighty Bomb Jack (Japan) (Rev 1)
+  title:  Mighty Bomb Jack (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-CNROM-SEC
+    chip
+      type: SECURITY
+      key:  0x11
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: eb2a2a5e15bb2b35b8284e15e85eede46de1765be9fa7d62c4d3fc6015e20bcc
   name:   Mike Tyson's Punch-Out!! (Europe)
   title:  Mike Tyson's Punch-Out!! (Europe)
@@ -4786,6 +4882,54 @@ game
       content: Character
 
 game
+  sha256: 8b7bfbd2e0d636ff1683d08119c39f468f20074233b8c82c18b22956a4a9dd03
+  name:   Othello (Japan)
+  title:  Othello (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM-SEC
+    chip
+      type: SECURITY
+      key:  0x22
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 1eee67e8734bdfcdd380fd033b3b0e9e7a1781bb94fc57138afdce5fc327c5a4
+  name:   Othello (Japan) (Rev 1)
+  title:  Othello (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-CNROM-SEC
+    chip
+      type: SECURITY
+      key:  0x22
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 035383efbc5131942ba7df721ba406fd57c08a9ff87e3aa6e6f3d272bda86c44
   name:   Paris-Dakar Rally Special (Japan)
   title:  Paris-Dakar Rally Special (Japan)
@@ -5443,6 +5587,78 @@ game
       content: Character
 
 game
+  sha256: a5e173f9b25b9024807108afb59ca89fa3704cddb97ac2543f41bc4a6c02f4bd
+  name:   Sansuu 1 Nen - Keisan Game (Japan)
+  title:  Sansuu 1 Nen - Keisan Game (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM-SEC
+    chip
+      type: SECURITY
+      key:  0x22
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 77ddaff6948aa4d88cdacde3692c94e5cab92e3ec9ce86c6228ed973956f41ca
+  name:   Sansuu 2 Nen - Keisan Game (Japan)
+  title:  Sansuu 2 Nen - Keisan Game (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM-SEC
+    chip
+      type: SECURITY
+      key:  0x22
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: d2fa2e6d93bed19b33e4ab2163705ea8d69d4119baf1663dc155e3777e9b0e94
+  name:   Sansuu 3 Nen - Keisan Game (Japan)
+  title:  Sansuu 3 Nen - Keisan Game (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM-SEC
+    chip
+      type: SECURITY
+      key:  0x2a
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: cd6e7fb18348488f256d08d8c02802dea3980cdb5b46bd0ea200324b913c1a07
   name:   SD Gundam Gaiden - Knight Gundam Monogatari (Japan)
   title:  SD Gundam Gaiden - Knight Gundam Monogatari (Japan)
@@ -5565,6 +5781,30 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: 269c410730fde0184a39f3063fbccb06c2488ffb7b2638738b106fae8a2f0acb
+  name:   Seicross (Japan) (Rev 1)
+  title:  Seicross (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-CNROM-SEC
+    chip
+      type: SECURITY
+      key:  0x20
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -5839,6 +6079,30 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: a9cf92ec1a080faa195d0b3dcb48fbb5ee3362f0f2f14e14e4257def48ac4346
+  name:   Spy vs Spy (Japan)
+  title:  Spy vs Spy (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM-SEC
+    chip
+      type: SECURITY
+      key:  0x21
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -1674,6 +1674,32 @@ game
       content: Character
 
 game
+  sha256: dd031b72924e1d080f8758412c73224a274ae5e5a50d90310d578975df74101f
+  name:   Famicom Jump II - Saikyou no 7 Nin (Japan)
+  title:  Famicom Jump II - Saikyou no 7 Nin (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 7586cdd8b742ba3c4f0ea3eefaa2f6f2215af197a5269e3de9026bcdf236e981
   name:   Famicom Wars (Japan)
   title:  Famicom Wars (Japan)

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -1,5 +1,5 @@
 database
-  revision: 2021-11-13
+  revision: 2021-11-18
 
 game
   sha256: 21b10e8d4cf775aa1f4027c4afb4f64e72e221a506a485cf4ffdf98bed01a524
@@ -872,6 +872,28 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: e24d3c754dce20e27046afeacb2dfc217950d4be766ded80c20283392cb3891e
+  name:   Crazy Climber (Japan)
+  title:  Crazy Climber (Japan)
+  region: NTSC-J
+  board:  HVC-UNROMA
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: b504d0ebff8aa6439f1f9606526d8739f5007c1fdac31f9550caa7ca26edce16
@@ -5519,6 +5541,28 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: dbc22a40e8a79c5ccf1d6e5126c9b10bb3d9b3e708fe5316c298c3d03dbc7977
+  name:   Senjou no Ookami (Japan)
+  title:  Senjou no Ookami (Japan)
+  region: NTSC-J
+  board:  HVC-UN1ROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: f7271a7030e2f5298f3931f08c84fdbe1dad3108aaf1259a766f05b80b12910a

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -412,6 +412,18 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     s += "  board:  GTROM\n";
     break;
 
+  case 118:
+    s += "  board:  HVC-TKSROM\n";
+    s += "    chip type=MMC3B\n";
+    prgram = 8192;
+    break;
+
+  case 119:
+    s += "  board:  HVC-TQROM\n";
+    s += "    chip type=MMC3B\n";
+    chrram = 8192;
+    break;
+
   case  140:
     s += "  board:  JALECO-JF-11\n";
     s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -391,6 +391,11 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
     break;
 
+  case  94:
+    s += "  board:  HVC-UN1ROM\n";
+    s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
+    break;
+
   case  95:
     s += "  board:  NAMCO-3425\n";
     s += "    chip type=118\n";
@@ -429,6 +434,11 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     s += "  board:  BANDAI-LZ93D50\n";
     s += "    chip type=LZ93D50\n";
     eeprom = 128;
+    break;
+
+  case 180:
+    s += "  board:  HVC-UNROMA\n";
+    s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
     break;
 
   case 184:

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -414,6 +414,12 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     s += "  board:  BANDAI-74161A\n";
     break;
 
+  case 153:
+    s += "  board:  BANDAI-LZ93D50\n";
+    s += "    chip type=LZ93D50\n";
+    prgram = 8192;
+    break;
+
   case 154:
     s += "  board:  NAMCO-3453\n";
     s += "    chip type=118\n";

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -31,6 +31,7 @@ auto Famicom::load(string location) -> bool {
   pak->setAttribute("board", document["game/board"].string());
   pak->setAttribute("mirror", document["game/board/mirror/mode"].string());
   pak->setAttribute("chip", document["game/board/chip/type"].string());
+  pak->setAttribute("chip/key", document["game/board/chip/key"].string());
   pak->setAttribute("pinout/a0", document["game/board/chip/pinout/a0"].natural());
   pak->setAttribute("pinout/a1", document["game/board/chip/pinout/a1"].natural());
   pak->append("manifest.bml", manifest);
@@ -450,6 +451,12 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
 
   case 184:
     s += "  board:  SUNSOFT-1\n";
+    s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
+    break;
+
+  case 185:
+    s += "  board:  HVC-CNROM-SEC\n";
+    s += "    chip type=SECURITY key=0x11\n";
     s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
     break;
 

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -30,6 +30,7 @@ auto Famicom::load(string location) -> bool {
   pak->setAttribute("region", document["game/region"].string());
   pak->setAttribute("board", document["game/board"].string());
   pak->setAttribute("mirror", document["game/board/mirror/mode"].string());
+  pak->setAttribute("chip", document["game/board/chip/type"].string());
   pak->setAttribute("pinout/a0", document["game/board/chip/pinout/a0"].natural());
   pak->setAttribute("pinout/a1", document["game/board/chip/pinout/a1"].natural());
   pak->append("manifest.bml", manifest);
@@ -428,6 +429,12 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
   case 154:
     s += "  board:  NAMCO-3453\n";
     s += "    chip type=118\n";
+    break;
+
+  case 155:
+    s += "  board:  HVC-SXROM\n";
+    s += "    chip type=MMC1A\n";
+    prgram = 8192;
     break;
 
   case 159:


### PR DESCRIPTION
Support added for some fc board variants currently missing.

Bandai LZ93D50 + PRG/CHR RAM (iNES mapper 153):
- Famicom Jump II - Saikyou no 7 Nin (Japan)

Nintendo CNROM with security (iNES mapper 185):
- B-Wings (Japan)
- Bird Week (Japan)
- Mighty Bomb Jack (Japan)
- Othello (Japan)
- Sansuu 1 Nen - Keisan Game (Japan)
- Sansuu 2 Nen - Keisan Game (Japan)
- Sansuu 3 Nen - Keisan Game (Japan)
- Seicross (Japan) (Rev 1)
- Spy vs Spy (Japan)

Nintendo SxROM with MMC1A (iNES mapper 155):
- Money Game, The (Japan)
- Tatakae!! Rahmen Man - Sakuretsu Choujin 102 Gei (Japan)

Nintendo UNROM variants (iNES mappers 94/180):
- Crazy Climber (Japan)
- Senjou no Ookami (Japan)

Nintendo MMC3 variants (mappers 118/119):
- Armadillo (Japan)
- Eric Cantona Football Challenge - Goal! 2 (Europe)
- Goal! Two (USA)
- High Speed (USA/Europe)
- NES Play Action Football (USA)
- Pin Bot (USA/Europe)
- Pro Sport Hockey (USA)
- RPG Jinsei Game (Japan)
- Ys III - Wanderers from Ys (Japan)

Nintendo MMC3 variant TVROM (subset of iNES mapper 4):
- Rad Racer II (Japan)

In this pr support is added for reading chip type from manifest, used to implement iNES mapper 155, which requires MMC1A chip specifically.

Extending the same concept, support is added for CNROM boards with protection measures. These games enable / disable chr reads based on a value that differs by game, now included on manifest.