### PR TITLE
fc: support for more misc boards

### DIFF
--- a/ares/fc/cartridge/board/bandai-karaoke.cpp
+++ b/ares/fc/cartridge/board/bandai-karaoke.cpp
@@ -1,0 +1,69 @@
+struct BandaiKaraoke : Interface {
+  static auto create(string id) -> Interface* {
+    if(id == "BANDAI-KARAOKE") return new BandaiKaraoke;
+    return nullptr;
+  }
+
+  Memory::Readable<n8> programROM;
+  Memory::Readable<n8> optionROM;
+  Memory::Writable<n8> characterRAM;
+
+  auto load() -> void override {
+    Interface::load(programROM, "program.rom");
+    Interface::load(optionROM, "option.rom");
+    Interface::load(characterRAM, "character.ram");
+  }
+
+  auto save() -> void override {
+    Interface::save(characterRAM, "character.ram");
+  }
+
+  auto readPRG(n32 address, n8 data) -> n8 override {
+    if(address < 0x6000) return data;
+    if(address < 0x8000) {
+      data.bit(0) = 1; //A button
+      data.bit(1) = 1; //B button
+      //data.bit(2) = 1; //1-bit ADC
+      return data;
+    }
+
+    if(address < 0xc000) {
+      if(!optionEnable) return programROM.read(programBank << 14 | (n14)address);
+      if(optionROM) return optionROM.read(programBank << 14 | (n14)address);
+      return data;
+    }
+    return programROM.read(0xf << 14 | (n14)address);
+  }
+
+  auto writePRG(n32 address, n8 data) -> void override {
+    if(address < 0x8000) return;
+    programBank = data.bit(0,3);
+    optionEnable = !data.bit(4);
+    mirror = data.bit(5);
+  }
+
+  auto addressCIRAM(n32 address) -> n32 {
+    return address >> mirror & 0x0400 | (n10)address;
+  }
+
+  auto readCHR(n32 address, n8 data) -> n8 override {
+    if(address & 0x2000) return ppu.readCIRAM(addressCIRAM(address));
+    return characterRAM.read(address);
+  }
+
+  auto writeCHR(n32 address, n8 data) -> void override {
+    if(address & 0x2000) return ppu.writeCIRAM(addressCIRAM(address), data);
+    return characterRAM.write(address, data);
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(characterRAM);
+    s(programBank);
+    s(optionEnable);
+    s(mirror);
+  }
+
+  n4 programBank;
+  n1 optionEnable;
+  n1 mirror;
+};

--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -2,6 +2,7 @@ namespace Board {
 
 #include "bandai-74161.cpp"
 #include "bandai-fcg.cpp"
+#include "bandai-karaoke.cpp"
 #include "bandai-lz93d50.cpp"
 #include "colordreams-74x377.cpp"
 #include "gtrom.cpp"
@@ -52,6 +53,7 @@ auto Interface::create(string board) -> Interface* {
   Interface* p = nullptr;
   if(!p) p = Bandai74161::create(board);
   if(!p) p = BandaiFCG::create(board);
+  if(!p) p = BandaiKaraoke::create(board);
   if(!p) p = BandaiLZ93D50::create(board);
   if(!p) p = ColorDreams_74x377::create(board);
   if(!p) p = GTROM::create(board);

--- a/ares/fc/cartridge/board/hvc-cnrom.cpp
+++ b/ares/fc/cartridge/board/hvc-cnrom.cpp
@@ -2,15 +2,18 @@ struct HVC_CNROM : Interface {
   static auto create(string id) -> Interface* {
     if(id == "HVC-CNROM"    ) return new HVC_CNROM(Revision::CNROM);
     if(id == "HVC-CNROM-SEC") return new HVC_CNROM(Revision::CNROMS);
+    if(id == "HVC-CPROM"    ) return new HVC_CNROM(Revision::CPROM);
     return nullptr;
   }
 
   Memory::Readable<n8> programROM;
   Memory::Readable<n8> characterROM;
+  Memory::Writable<n8> characterRAM;
 
   enum class Revision : u32 {
     CNROM,
     CNROMS,
+    CPROM,
   } revision;
 
   HVC_CNROM(Revision revision) : revision(revision) {}
@@ -18,8 +21,13 @@ struct HVC_CNROM : Interface {
   auto load() -> void override {
     Interface::load(programROM, "program.rom");
     Interface::load(characterROM, "character.rom");
+    Interface::load(characterRAM, "character.ram");
     mirror = pak->attribute("mirror") == "vertical";
     key = pak->attribute("chip/key").natural();
+  }
+
+  auto save() -> void override {
+    Interface::save(characterRAM, "character.ram");
   }
 
   auto readPRG(n32 address, n8 data) -> n8 override {
@@ -38,6 +46,10 @@ struct HVC_CNROM : Interface {
       address = address >> !mirror & 0x0400 | (n10)address;
       return ppu.readCIRAM(address);
     }
+    if(revision == Revision::CPROM) {
+      n2 bank = (address < 0x1000) ? (n2)0 : characterBank;
+      return characterRAM.read(bank << 12 | (n12)address);
+    }
     if(revision == Revision::CNROMS) {
       if(!characterEnable) return 0xff;
       return characterROM.read((n13)address);
@@ -51,9 +63,14 @@ struct HVC_CNROM : Interface {
       address = address >> !mirror & 0x0400 | (n10)address;
       return ppu.writeCIRAM(address, data);
     }
+    if(revision == Revision::CPROM) {
+      n2 bank = (address < 0x1000) ? (n2)0 : characterBank;
+      return characterRAM.write(bank << 12 | (n12)address, data);
+    }
   }
 
   auto serialize(serializer& s) -> void override {
+    s(characterRAM);
     s(mirror);
     s(key);
     s(characterBank);

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -7587,6 +7587,28 @@ game
       content: Character
 
 game
+  sha256: 26ff208f2b133e66c602765778107c5938386c24fc03a197bbf9b2b659cb8792
+  name:   Videomation (USA)
+  title:  Videomation (USA)
+  region: NTSC-U
+  board:  HVC-CPROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: RAM
+      size: 0x4000
+      content: Character
+      volatile
+
+game
   sha256: 2737968efa4bdb5576a6ad36e08712ba76a752a0f88b741bf72a463b451a9dfe
   name:   Wagyan Land (Japan)
   title:  Wagyan Land (Japan)

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -3802,6 +3802,74 @@ game
       content: Character
 
 game
+  sha256: 048f6f1df73a1cef21de4de8b58ba0d12bfabdf64d106497faedaa7be1b85786
+  name:   Karaoke Studio (Japan)
+  title:  Karaoke Studio (Japan)
+  region: NTSC-J
+  board:  BANDAI-KARAOKE
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: c04e4c43095e7b0caf169ccf8b262b2bb71dcb07335b2ee9f5e30cfc5798f68f
+  name:   Karaoke Studio Senyou Cassette Vol. 1 (Japan)
+  title:  Karaoke Studio Senyou Cassette Vol. 1 (Japan)
+  region: NTSC-J
+  board:  BANDAI-KARAOKE
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Option
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 3cfadf91ec98e5bd108bf44422b517c444bf8974432010bc4fd780949126a68f
+  name:   Karaoke Studio Senyou Cassette Vol. 2 (Japan)
+  title:  Karaoke Studio Senyou Cassette Vol. 2 (Japan)
+  region: NTSC-J
+  board:  BANDAI-KARAOKE
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Option
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 9905d9999767b7428ba770f855e9b8904123c84fa46b9e6cc0a178fef3ad4e2c
   name:   Karnov (Japan)
   title:  Karnov (Japan)

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -1,5 +1,24 @@
 database
-  revision: 2021-11-22
+  revision: 2021-11-23
+
+game
+  sha256: 4fb12ad1c791c7ee8d5ec824eff871d71b43b92c4e93b45ed0b60f022459b917
+  name:   After Burner (Japan)
+  title:  After Burner (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-4
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
 
 game
   sha256: 21b10e8d4cf775aa1f4027c4afb4f64e72e221a506a485cf4ffdf98bed01a524
@@ -4373,6 +4392,29 @@ game
       content: Save
 
 game
+  sha256: 9935c7ef77152a4d91e757a02f2c58b05d3635d10d1f249129ea036fb945e69e
+  name:   Maharaja (Japan)
+  title:  Maharaja (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-4
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 4ef61de405406bfa9eeaf19ed1d882444c41bb606ac78673b7ec8ee323d0e073
   name:   Major League (Japan)
   title:  Major League (Japan)
@@ -5241,6 +5283,83 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: cb6cc5ceddb82e92fc36b8948588d19556706b3f89810395613ab21c0954aad9
+  name:   Nantettatte!! Baseball (Japan)
+  title:  Nantettatte!! Baseball (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-4
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4e693127c64f0194c04db3d5aace6c26499f7c42adb2645c7af3f872e5b34323
+  name:   Nantettatte!! Baseball + Ko-Game Cassette - '91 Kaimaku Hen (Japan)
+  title:  Nantettatte!! Baseball + Ko-Game Cassette - '91 Kaimaku Hen (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-4
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Option
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 32a4f87305a1d44a90aba8ee3bc0a314bfc6f7a71c7eca12d871845dcf409003
+  name:   Nantettatte!! Baseball + Ko-Game Cassette - OB All Star Hen (Japan)
+  title:  Nantettatte!! Baseball + Ko-Game Cassette - OB All Star Hen (Japan)
+  region: NTSC-J
+  board:  SUNSOFT-4
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Option
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: ROM
       size: 0x20000

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -45,6 +45,10 @@ auto Famicom::load(string location) -> bool {
     pak->append("program.rom", {view.data(), node["size"].natural()});
     view += node["size"].natural();
   }
+  if(auto node = document["game/board/memory(type=ROM,content=Option)"]) {
+    pak->append("option.rom", {view.data(), node["size"].natural()});
+    view += node["size"].natural();
+  }
   if(auto node = document["game/board/memory(type=ROM,content=Character)"]) {
     pak->append("character.rom", {view.data(), node["size"].natural()});
     view += node["size"].natural();
@@ -300,10 +304,6 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
 
   case  68:
     s += "  board:  SUNSOFT-4\n";
-    s += "    memory\n";
-    s += "      type: ROM\n";
-    s += "      size: 0x4000\n";
-    s += "      content: Option\n";
     prgram = 8192;
     break;
 

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -210,6 +210,12 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
     break;
 
+  case  13:
+    s += "  board:  HVC-CPROM\n";
+    s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
+    chrram = 16384;
+    break;
+
   case  16:
     s += "  board:  BANDAI-LZ93D50\n";
     s += "    chip type=LZ93D50\n";

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -484,6 +484,10 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
     break;
 
+  case 188:
+    s += "  board:  BANDAI-KARAOKE\n";
+    break;
+
   case 206:
     s += "  board:  NAMCO-118\n";
     s += "    chip type=118\n";


### PR DESCRIPTION
Some more fc boards missing.

Nintendo CPROM (iNES mapper 13):
- Videomation (USA)

Sunsoft 4 + external ROM (two games on iNES mapper 68):
- Nantettatte!! Baseball + Ko-Game Cassette - '91 Kaimaku Hen (Japan)
- Nantettatte!! Baseball + Ko-Game Cassette - OB All Star Hen (Japan)

Bandai Karaoke + external ROM (iNES mapper 188):
- Karaoke Studio (Japan)
- Karaoke Studio + Senyou Cassette Vol. 1 (Japan)
- Karaoke Studio + Senyou Cassette Vol. 2 (Japan)

Support for CPROM board fixes #290.

The game "Nantettatte!! Baseball" has an slot on the back for smaller cartridges, and current Sunsoft 4 implementation already has support for external ROM, just not correctly attached. I'm not sure what these cartridges add to the game (I'm guessing updated teams) but "OB All Star Hen" adds new music to title screen, so you can see (or hear) they are working now. Please note that this game requires a reset after first boot.

The game "Karaoke Studio" has a microphone permanently attached to the cartridge. This is not emulated, but you can still navigate menus and start songs. This game has a slot for add-on cartridges too, which is working; the .nes images for "Senyou Cassette" vols 1 and 2 are actually the base cartridge + external rom concatenated. Support for this board fixes #307.