### PR TITLE
component: fix m24c eeprom mode selection

### DIFF
--- a/ares/component/eeprom/m24c/m24c.cpp
+++ b/ares/component/eeprom/m24c/m24c.cpp
@@ -74,7 +74,7 @@ auto M24C::write() -> void {
   case Mode::Device:
     if(counter <= 8) {
       device = device << 1 | data();
-    } else if(!select()) {
+    } else if(select() != Acknowledge) {
       mode = Mode::Standby;
     } else if(device & 1) {
       mode = Mode::Read;

--- a/ares/fc/cartridge/board/bandai-lz93d50.cpp
+++ b/ares/fc/cartridge/board/bandai-lz93d50.cpp
@@ -16,8 +16,9 @@ struct BandaiLZ93D50 : Interface {
     Interface::load(characterROM, "character.rom");
     Interface::load(characterRAM, "character.ram");
     if(auto fp = pak->read("save.eeprom")) {
-      eeprom.load(M24C::Type::X24C01);
-      fp->read({eeprom.memory, eeprom.size()});
+      if(fp->size() == 128) eeprom.load(M24C::Type::X24C01);
+      if(fp->size() == 256) eeprom.load(M24C::Type::M24C02);
+      if(eeprom) fp->read({eeprom.memory, eeprom.size()});
     }
   }
 
@@ -25,7 +26,7 @@ struct BandaiLZ93D50 : Interface {
     Interface::save(programRAM, "save.ram");
     Interface::save(characterRAM, "character.ram");
     if(auto fp = pak->write("save.eeprom")) {
-      fp->write({eeprom.memory, eeprom.size()});
+      if(eeprom) fp->write({eeprom.memory, eeprom.size()});
     }
   }
 


### PR DESCRIPTION
Eeprom M24Cxx mode selection fixed, and support added for M24C02 on Bandai LZ93D50.

This should fix saving in the following famicom games:
- Dragon Ball Z Gaiden - Saiya Jin Zetsumetsu Keikaku (Japan)
- Dragon Ball Z II - Gekishin Freeza!! (Japan)
- Dragon Ball Z III - Ressen Jinzou Ningen (Japan)
- Rokudenashi Blues (Japan)
- SD Gundam Gaiden - Knight Gundam Monogatari 2 - Hikari no Knight (Japan)
- SD Gundam Gaiden - Knight Gundam Monogatari 3 - Densetsu no Kishi Dan (Japan) * Previously not working

Bandai LZ93D50 boards accept eeproms of 128 or 256 bytes and only the smaller one was handled, so some games didn't save and "SD Gundam Gaiden 3" was hanging on game start. But after attaching the correct eeprom I noticed none of the problems disappeared.

The game "SD Gundam Gaiden 3" was not working because of a bug on mode selection of M24Cxx eeprom: it tries to write to eeprom on game start, but the current implementation incorrectly selects standby mode making the game hang. This is fixed in this pr. The game works now, and creates a save that can be loaded and starts with the string "SDG3", so I think everything is good.

This eeprom family is shared with some megadrive games. I tested some of them and seem to work, and this should fix saving on these too, but didn't fix "NBA Jam" (I was hoping for it). Please note that I didn't widely test megadrive games.