### PR TITLE
fc: partial support for bandai oeka kids and datach

### DIFF
--- a/ares/fc/cartridge/board/bandai-oeka.cpp
+++ b/ares/fc/cartridge/board/bandai-oeka.cpp
@@ -1,0 +1,76 @@
+struct BandaiOeka : Interface {
+  static auto create(string id) -> Interface* {
+    if(id == "BANDAI-OEKA") return new BandaiOeka;
+    return nullptr;
+  }
+
+  Memory::Readable<n8> programROM;
+  Memory::Writable<n8> characterRAM;
+
+  auto load() -> void override {
+    Interface::load(programROM, "program.rom");
+    Interface::load(characterRAM, "character.ram");
+    mirror = pak->attribute("mirror") == "vertical";
+  }
+
+  auto save() -> void override {
+    Interface::save(characterRAM, "character.ram");
+  }
+
+  auto addressTest(n32 address) -> void {
+    if((characterAddress >> 12) != 2 && (address >> 12) == 2) {
+      characterBank.bit(0,1) = address >> 8 & 3;
+    }
+    characterAddress = address;
+  }
+
+  auto readPRG(n32 address, n8 data) -> n8 override {
+    if(address < 0x8000) return data;
+    return programROM.read(programBank << 15 | (n15)address);
+  }
+
+  auto writePRG(n32 address, n8 data) -> void override {
+    if(address == 0x2006) {
+      if(++characterLatch) addressTest(data << 8);
+    }
+    if(address < 0x8000) return;
+    programBank = data.bit(0,1);
+    characterBank.bit(2) = data.bit(2);
+  }
+
+  auto addressCHR(n32 address) const -> n32 {
+    n3 bank = (address < 0x1000) ? characterBank : n3(characterBank & 4 | 3);
+    return bank << 12 | (n12)address;
+  }
+
+  auto addressCIRAM(n32 address) const -> n32 {
+    return address >> !mirror & 0x0400 | (n10)address;
+  }
+
+  auto readCHR(n32 address, n8 data) -> n8 override {
+    addressTest(address);
+    if(address & 0x2000) return ppu.readCIRAM(addressCIRAM(address));
+    return characterRAM.read(addressCHR(address));
+  }
+
+  auto writeCHR(n32 address, n8 data) -> void override {
+    addressTest(address);
+    if(address & 0x2000) return ppu.writeCIRAM(addressCIRAM(address), data);
+    return characterRAM.write(addressCHR(address), data);
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(characterRAM);
+    s(mirror);
+    s(programBank);
+    s(characterBank);
+    s(characterLatch);
+    s(characterAddress);
+  }
+
+  n1  mirror;
+  n2  programBank;
+  n3  characterBank;
+  n1  characterLatch;
+  n32 characterAddress;
+};

--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -4,6 +4,7 @@ namespace Board {
 #include "bandai-fcg.cpp"
 #include "bandai-karaoke.cpp"
 #include "bandai-lz93d50.cpp"
+#include "bandai-oeka.cpp"
 #include "colordreams-74x377.cpp"
 #include "gtrom.cpp"
 #include "jaleco-jf05.cpp"
@@ -55,6 +56,7 @@ auto Interface::create(string board) -> Interface* {
   if(!p) p = BandaiFCG::create(board);
   if(!p) p = BandaiKaraoke::create(board);
   if(!p) p = BandaiLZ93D50::create(board);
+  if(!p) p = BandaiOeka::create(board);
   if(!p) p = ColorDreams_74x377::create(board);
   if(!p) p = GTROM::create(board);
   if(!p) p = HVC_AxROM::create(board);

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -1,5 +1,5 @@
 database
-  revision: 2021-11-23
+  revision: 2021-11-27
 
 game
   sha256: 4fb12ad1c791c7ee8d5ec824eff871d71b43b92c4e93b45ed0b60f022459b917
@@ -1092,6 +1092,188 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: cbc404d57879beca0b65b855b19fda9e017e7d8cc716941b52bbea8f8a6ee859
+  name:   Datach - Battle Rush - Build Up Robot Tournament (Japan)
+  title:  Datach - Battle Rush - Build Up Robot Tournament (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+    memory
+      type: EEPROM
+      size: 0x100
+      content: Save
+
+game
+  sha256: 0acc10d731fbd33ca07cc6c81ce44850b9668f743012260b526e1053d332e37b
+  name:   Datach - Crayon Shin-chan - Ora to Poi Poi (Japan)
+  title:  Datach - Crayon Shin-chan - Ora to Poi Poi (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+    memory
+      type: EEPROM
+      size: 0x100
+      content: Save
+
+game
+  sha256: a1370e7410a98a4a2de19f4872281a065b1d7d7cd7b5f2ba0da70504b4a1d52d
+  name:   Datach - Dragon Ball Z - Gekitou Tenkaichi Budoukai (Japan)
+  title:  Datach - Dragon Ball Z - Gekitou Tenkaichi Budoukai (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+    memory
+      type: EEPROM
+      size: 0x100
+      content: Save
+
+game
+  sha256: a7b1e4693093c8a155747f9023399ebb2537064e788970ecdcccee467108b62e
+  name:   Datach - J.League Super Top Players (Japan)
+  title:  Datach - J.League Super Top Players (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+    memory
+      type: EEPROM
+      size: 0x100
+      content: Save
+
+game
+  sha256: a6a909d829e3d9ef1a14d002f8ac3c59173420530d467c09fe338b28143f4308
+  name:   Datach - SD Gundam - Gundam Wars (Japan)
+  title:  Datach - SD Gundam - Gundam Wars (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+    memory
+      type: EEPROM
+      size: 0x100
+      content: Save
+
+game
+  sha256: 85f0ab77ae56df26e18bf55caafb795ec24712c168912f0963756fe4daa2ef65
+  name:   Datach - Ultraman Club - Supokon Fight! (Japan)
+  title:  Datach - Ultraman Club - Supokon Fight! (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+    memory
+      type: EEPROM
+      size: 0x100
+      content: Save
+
+game
+  sha256: acc54496853ce6306589790857b0d56145d8382bd00f5d0f40ecdfa2906ad349
+  name:   Datach - Yu Yu Hakusho - Bakutou Ankoku Bujutsukai (Japan)
+  title:  Datach - Yu Yu Hakusho - Bakutou Ankoku Bujutsukai (Japan)
+  region: NTSC-J
+  board:  BANDAI-LZ93D50
+    chip
+      type: LZ93D50
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+    memory
+      type: EEPROM
+      size: 0x100
+      content: Save
 
 game
   sha256: 0115356b0791cc8ddcb7d3163d6ef7aa664f3ff4e68dba561ffffb79eefcbca9

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -5582,6 +5582,50 @@ game
       content: Character
 
 game
+  sha256: 6f1d8f1b3c18ce3030188a3a8e6ba0231d84699e71ce8a6e02aaeabeb34f7b89
+  name:   Oeka Kids - Anpanman no Hiragana Daisuki (Japan)
+  title:  Oeka Kids - Anpanman no Hiragana Daisuki (Japan)
+  region: NTSC-J
+  board:  BANDAI-OEKA
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x8000
+      content: Character
+      volatile
+
+game
+  sha256: 9d93ed7137f0376edc07f64d482719b701765129b9e125b40fabc42f3a7ebaaf
+  name:   Oeka Kids - Anpanman to Oekaki Shiyou!! (Japan)
+  title:  Oeka Kids - Anpanman to Oekaki Shiyou!! (Japan)
+  region: NTSC-J
+  board:  BANDAI-OEKA
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x8000
+      content: Character
+      volatile
+
+game
   sha256: adf95de2cdff7b606ceedf5908679ef9bb8ffeec37d3d1dad3446ef85ca17026
   name:   Operation Wolf (Japan)
   title:  Operation Wolf (Japan)

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -468,6 +468,12 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     prgram = 8192;
     break;
 
+  case 157:
+    s += "  board:  BANDAI-LZ93D50\n";
+    s += "    chip type=LZ93D50\n";
+    eeprom = 256;
+    break;
+
   case 159:
     s += "  board:  BANDAI-LZ93D50\n";
     s += "    chip type=LZ93D50\n";

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -415,6 +415,12 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     s += "    chip type=118\n";
     break;
 
+  case  96:
+    s += "  board:  BANDAI-OEKA\n";
+    s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
+    chrram = 32768;
+    break;
+
   case  97:
     s += "  board:  IREM-TAM-S1\n";
     s += "    chip type=TAM-S1\n";


### PR DESCRIPTION
Partial support for Bandai Oeka Kids and Datach boards.

Bandai Oeka Kids (iNES mapper 96):
- Oeka Kids - Anpanman no Hiragana Daisuki (Japan)
- Oeka Kids - Anpanman to Oekaki Shiyou!! (Japan)

Bandai Datach (iNES mapper 157):
- Datach - Battle Rush - Build Up Robot Tournament (Japan)
- Datach - Crayon Shin-chan - Ora to Poi Poi (Japan)
- Datach - Dragon Ball Z - Gekitou Tenkaichi Budoukai (Japan)
- Datach - J.League Super Top Players (Japan)
- Datach - SD Gundam - Gundam Wars (Japan)
- Datach - Ultraman Club - Supokon Fight! (Japan)
- Datach - Yu Yu Hakusho - Bakutou Ankoku Bujutsukai (Japan)

Bandai Oeka Kids games boot and you can watch attract mode, but they require the "Oeka Kids Tablet" peripheral, not emulated.

Bandai "Datach Joint ROM system" is a device that inserts into the Famicom cartridge port and provides a barcode scanner and accepts its own custom game cartridges. The unit contains a LZ93D50 chip, 256 bytes eeprom and 8Kb for VRAM but no program ROM: the program is on the game cartridge. That means it is simply a regular LZ93D50 cartridge with barcode scanner support, and games boot in the current implementation. None of them are playable, as the barcode reader is part of the game. Also the game "Battle Rush" has a second eeprom on game cartridge; this is not emulated and the game sits on a black screen for about 20 seconds attempting to communicate with it before eventually give up trying and boots.

With this pr the only officially licensed boards missing I can think of are multicarts, and I am aware of less than 50 titles with issues on the full library (many more are unplayable because of required peripherals).

I am still looking for fixes for the remaining bugs on the fc core.