### PR TITLE
mia: Correct save type for Transformers: Beast Wars Transmetals (N64)

### DIFF
--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -574,9 +574,9 @@ auto Nintendo64::analyze(vector<u8>& data) -> string {
   if(id == "NMT") {rumble = true;}                                       //Magical Tetris Challenge
   if(id == "NM3") {rumble = true;}                                       //Monster Truck Madness 64
   if(id == "NRG") {rumble = true;}                                       //Rugrats - Scavenger Hunt [Treasure Hunt(E)]
-  if(id == "N0H") {rumble = true;}                                       //Transformers Beast Wars: Transmetals
+  if(id == "NOH") {rumble = true;}                                       //Transformers Beast Wars: Transmetals
   if(id == "NWF") {rumble = true;}                                       //Wheel of Fortune
-   
+
 
   string s;
   s += "game\n";


### PR DESCRIPTION
The current entry has 'N0H' with a zero, while it should be 'NOH' with a capital letter O.