### PR TITLE
fc: add bus conflicts to cnrom

### DIFF
--- a/ares/fc/cartridge/board/hvc-cnrom.cpp
+++ b/ares/fc/cartridge/board/hvc-cnrom.cpp
@@ -37,7 +37,7 @@ struct HVC_CNROM : Interface {
 
   auto writePRG(n32 address, n8 data) -> void override {
     if(address < 0x8000) return;
-    characterBank = data.bit(0,1);
+    characterBank = data & programROM.read((n15)address);
     characterEnable = (data == key);
   }
 

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -1,5 +1,282 @@
 database
-  revision: 2021-11-27
+  revision: 2021-12-10
+
+game
+  sha256: a75af9b5972f22056d016474234b03213e5d7932fb1e81890d58bd100bb8d0d2
+  name:   10-Yard Fight (Japan)
+  title:  10-Yard Fight (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 3669f979465f03cba7d55c9ad3080b8292557514ef0e7dba0b1de98313e6f392
+  name:   10-Yard Fight (Japan) (Rev 1)
+  title:  10-Yard Fight (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 8e844d77da01f86ace52823f1f974c9230f09e6a6cbf33a07abfe9beeff00292
+  name:   10-Yard Fight (USA, Europe)
+  title:  10-Yard Fight (USA, Europe)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: e868400409c70876b98dad2cca87b8e9ee31877b0cccbbd8405be5c54922722a
+  name:   1942 (Japan, USA)
+  title:  1942 (Japan, USA)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 9f54aafa367247b99c344ba9a0c58ad8fa8aceeeae1c304b8fefc9985c3c118c
+  name:   1943 - The Battle of Midway (USA)
+  title:  1943 - The Battle of Midway (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 28cdd5af3c441f361cfa3a21ec97a1ab08691dd5d73f7a10a372fbd1fffb8ba7
+  name:   1943 - The Battle of Valhalla (Japan)
+  title:  1943 - The Battle of Valhalla (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: c457644ccfb93f8978326e728931800283821e531edc409fca9c0167495319c4
+  name:   3-D WorldRunner (USA)
+  title:  3-D WorldRunner (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 3841ff3e5e2fc98f14c7ef4bdc8361fee2dd47cecb2ee21417515124e1f2a5b9
+  name:   4 Nin Uchi Mahjong (Japan)
+  title:  4 Nin Uchi Mahjong (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: f15abe86354979b3be0e862131147faf894be08d77964818bf82455aaa7d06e9
+  name:   4 Nin Uchi Mahjong (Japan) (Rev 1)
+  title:  4 Nin Uchi Mahjong (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 53bfc94fce46a25188f84f102810406f686a7fb13fb5e4ae8f13760106acb969
+  name:   Adventure Island (USA)
+  title:  Adventure Island (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 0b16539dccc9a914ad7ca908234842dbcdb9bad3860a503421c77bc17b34cbad
+  name:   Adventure Island Classic (Europe)
+  title:  Adventure Island Classic (Europe)
+  region: PAL
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 58d0f0e504b8450e7d2dfbe11948a244143bfe3065f7e78524633cce8ac73103
+  name:   Adventures of Dino Riki (USA)
+  title:  Adventures of Dino Riki (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: a0bc241936acf1993a300ab21c197a2647b6c072cfbb8e3f83424a9ab6655cc7
+  name:   Adventures of Gilligan's Island, The (USA)
+  title:  Adventures of Gilligan's Island, The (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 4fb12ad1c791c7ee8d5ec824eff871d71b43b92c4e93b45ed0b60f022459b917
@@ -40,6 +317,28 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 1b5857f9fd57d6f50d8d1e57db67203155fb2974ae426deac3398efef1dbf042
+  name:   Aigina no Yogen - Balubalouk no Densetsu Yori (Japan)
+  title:  Aigina no Yogen - Balubalouk no Densetsu Yori (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: caa7f0a9aa265625cc375ea6fe21d410b661476b5a665344eda1c5a9dff404f4
@@ -108,6 +407,28 @@ game
       content: Character
 
 game
+  sha256: 60b1aebdc0a19afc5d3e7dc4f09d8a968580e007197461a8a142656702c27f0d
+  name:   Akumajou Dracula (Japan)
+  title:  Akumajou Dracula (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: ff5b96853cf67171918aad5157661dc223e0002e0373e2580cee2e207bb0a682
   name:   Akumajou Special - Boku Dracula-kun (Japan)
   title:  Akumajou Special - Boku Dracula-kun (Japan)
@@ -144,6 +465,114 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 752eb500a872ce4dedfa419d673b738bde8342bdbe5304411b6d19607b155a5f
+  name:   Alfred Chicken (Europe)
+  title:  Alfred Chicken (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 4b088e1e78981308da68883cf8292337ff8d899bf82a78d17e7a7af2745846e7
+  name:   Alfred Chicken (USA)
+  title:  Alfred Chicken (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 7ae9746aa5c24c9c048b842879d93cae58c1c52be2ce1c3fbc749ab7ca2210bb
+  name:   Alpha Mission (Europe)
+  title:  Alpha Mission (Europe)
+  region: PAL
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 3addebdec132929ecad2a8612a4ba54ccc39b9ada2295692f836c6b48d015054
+  name:   Alpha Mission (USA)
+  title:  Alpha Mission (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: a978de5d5f343eacb0a6f12427327ecbe9b2e9cf881569aec7b838bd44237d84
+  name:   Amagon (USA)
+  title:  Amagon (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
       content: Program
     memory
       type: RAM
@@ -192,6 +621,72 @@ game
       volatile
 
 game
+  sha256: 751d3bf4722ce117d8ab7ff78059f42206ead5299716d91d5ff27d3900d555ad
+  name:   Archon (USA)
+  title:  Archon (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: a2efb3b288dedb5844b0ae9ac0cbf40aeb92638eacf860db4671043c53eb7d0c
+  name:   Arctic (Japan)
+  title:  Arctic (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: d1eaf7419760c908053e14716607e994e0c29143885b4ec8b285caf46f7945ba
+  name:   Argos no Senshi - Hachamecha Daishingeki (Japan)
+  title:  Argos no Senshi - Hachamecha Daishingeki (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 7768ef85519c94dc40d09bc598121825d103fcf1d4927be59f597b0a3509d15f
   name:   Argus (Japan)
   title:  Argus (Japan)
@@ -199,6 +694,48 @@ game
   board:  JALECO-JF-07
     mirror
       mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
+  sha256: c972cea7f55db3f92b775bd3878ce477feace79e3325e8bbcdd65fe780e2f50f
+  name:   Arkanoid (Japan)
+  title:  Arkanoid (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
+  sha256: a3763e702f8ae0818480cf0a8b2395d3f928c539f75e230ed43fa6b904fe6365
+  name:   Arkanoid (USA)
+  title:  Arkanoid (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
     memory
       type: ROM
       size: 0x10
@@ -232,6 +769,27 @@ game
       content: Character
 
 game
+  sha256: 381fcbe2b714c38fdeb4045d93f0867fe80f4a219077c3dc5a683a05a8b8e78a
+  name:   Arkista's Ring (USA)
+  title:  Arkista's Ring (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 54526dc9444c0eb4b0e5814f98b5e522bcb9881a6f2c0644fc7a21ca8c03502b
   name:   Armadillo (Japan)
   title:  Armadillo (Japan)
@@ -250,6 +808,156 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: 67e76511b467253a3a1a9caacd4febf7a97415c963ce0b4b4bc71539d6d1e528
+  name:   ASO - Armored Scrum Object (Japan)
+  title:  ASO - Armored Scrum Object (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 9680b586a90fa4d242abd8a48cc20ab551867e71a7a88b0f05b01056755da3f1
+  name:   Asterix (Europe)
+  title:  Asterix (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: e06b95487c293ec2e2d1516ee2c61f2b5b88665a609e64e3689a42934d038792
+  name:   Astro Robo Sasa (Japan)
+  title:  Astro Robo Sasa (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 1949e556f0d2d8cb8e97a2aeb476d03ab76a4cdfb1f3f3ff95260df410b89fe2
+  name:   Athena (Japan)
+  title:  Athena (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 2137d1621d29df50100f4d0fba3bafa0be56ccd0c832e44cd29dd7f0d75b374e
+  name:   Athena (USA)
+  title:  Athena (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: a0e0c22920d644e54cba9172cf55d6e8b96699ea1530da02cb4c2a6d2e9cb93a
+  name:   Athletic World (Europe)
+  title:  Athletic World (Europe)
+  region: PAL
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 9d01730c16c2cfd2813a47a8a46d6e02a6ff0bca8e3cdcf5a1771b50af204b80
+  name:   Athletic World (USA)
+  title:  Athletic World (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -272,6 +980,28 @@ game
       type: ROM
       size: 0x4000
       content: Character
+
+game
+  sha256: 5afb3469a79ba55b8b3e2c6932b37cbb544d0e15f2d15d1f61616308aa61ba93
+  name:   Attack Animal Gakuen (Japan)
+  title:  Attack Animal Gakuen (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 2b4ac20082e2f45a8f8fd4922a0e995829719a523e118a9eec891c3206adf25b
@@ -305,6 +1035,27 @@ game
   board:  NAMCO-118
     chip
       type: 118
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 2bd744ff0d76653b9e218f6cea37f86bbdc6bc9b7a816c5fa236594ed1eb496a
+  name:   Back to the Future (USA)
+  title:  Back to the Future (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
     mirror
       mode: horizontal
     memory
@@ -384,6 +1135,154 @@ game
       content: Character
 
 game
+  sha256: f930c9e01fa1df967c4986280c871a133e42f4b85acac988dda1f3fb1d1a2c5a
+  name:   Ballblazer (Japan)
+  title:  Ballblazer (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0bcd77e76d842c04a47f0dbc18c440da07da393400386fa13d6fdf59495a7be3
+  name:   Balloon Fight (Europe)
+  title:  Balloon Fight (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 3c8dde4541766bff7fc5b6d987e1ef985eb07375ede46bb3b48536ac133fd85a
+  name:   Balloon Fight (Japan)
+  title:  Balloon Fight (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 7328b2eb1c9fe06b98e0cba5c9058bf026e06a94900d490f79436d714eb48d6b
+  name:   Balloon Fight (USA)
+  title:  Balloon Fight (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 447aaf0fead8c05496ec01fc28d52c1845ae349d68a5cd808a61ccf738dde758
+  name:   Baltron (Japan)
+  title:  Baltron (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 5e3ba2658ab2ab87e63818b910c851d03be9ce303046111145bc57f47ed0344c
+  name:   Banana (Japan)
+  title:  Banana (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
+  sha256: 2a92f666ce73177eff8bfe987beac3f1c26e174c5f8737a358ed2e9a6e5915d7
+  name:   Bandai Golf - Challenge Pebble Beach (USA)
+  title:  Bandai Golf - Challenge Pebble Beach (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: b5f98350a10270ed1675ac4c9abe986e54e71f9f58982526351f937857ac6c66
   name:   Barcode World (Japan)
   title:  Barcode World (Japan)
@@ -406,6 +1305,48 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: a0fe077a6f0babf27b691e42db79cb4fc580a2f358f679b996fb17c2b0a68f59
+  name:   Baseball (Japan)
+  title:  Baseball (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: f22944452be3259aac853258759f469e7d2e2447c6178f26cc7bd0e89945bc04
+  name:   Baseball (USA, Europe)
+  title:  Baseball (USA, Europe)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -480,6 +1421,28 @@ game
       content: Character
 
 game
+  sha256: 97554aa222df3d12e4d877d6314f7d52b9628a9a081b8f47470d9fc0d569bee1
+  name:   Batsu & Terry - Makyou no Tetsujin Race (Japan)
+  title:  Batsu & Terry - Makyou no Tetsujin Race (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 263b133697e368b60a6a11a82d9f0ab0fca94da1bef8c5f823d593b4f2f64e7e
   name:   Battle Fleet (Japan)
   title:  Battle Fleet (Japan)
@@ -498,6 +1461,69 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: 64832bef6533d98f49e807c000537c8cb26ef94e6c3f871b8b6b35c5a11e427b
+  name:   BattleCity (Japan)
+  title:  BattleCity (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 3624c6ab3c9459270cab2a4e818709111ba1f9481b0f3448f8dc97006814809d
+  name:   Battleship (Europe)
+  title:  Battleship (Europe)
+  region: PAL
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: c49a5d7f565646d76bdc307ccb0202197f579b77c5bf5ea409b5cb29f72edf3a
+  name:   Battleship (USA)
+  title:  Battleship (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -621,6 +1647,71 @@ game
       volatile
 
 game
+  sha256: ce50bd0bdc0dc2f4766128b78618bee9524b670b7d55076b1e0de5fd0da417d5
+  name:   Best of the Best - Championship Karate (Europe)
+  title:  Best of the Best - Championship Karate (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 2366af9fc0512d39bfa6e908b4caa12be3d21225af49274ffe2ff51cf0b9c1e6
+  name:   Best of the Best - Championship Karate (USA)
+  title:  Best of the Best - Championship Karate (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: eba4b3082b0a4e648ecf6453937264364adff585d5d7fe2f38782957f876ac40
+  name:   Binary Land (Japan)
+  title:  Binary Land (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 92c481350b63c57385834dfa0ab02aeb527df7e80cec14a3e1a1a77118cd38d1
   name:   Bio Miracle Bokutte Upa (Japan)
   title:  Bio Miracle Bokutte Upa (Japan)
@@ -690,6 +1781,267 @@ game
       content: Character
 
 game
+  sha256: dfb5cf5f96aa5b0372b775abb0c089eafa04fac8ef894a006028a93fe503e5bc
+  name:   Black Bass II, The (Japan)
+  title:  Black Bass II, The (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: e36505a4d12f52c99a03391731e8fb7c305923be4c136acaf081cd72e1f4d7e0
+  name:   Black Bass, The (Japan)
+  title:  Black Bass, The (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 99806081ba58c0a108bcc61468972d4b2319de74d7dca1bba932f1a3bd2fe1cc
+  name:   Black Bass, The (USA)
+  title:  Black Bass, The (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: a599a86a7f99bde4692f70873c8b55c4097ec95d24619386075332044d321293
+  name:   Blades of Steel (Europe)
+  title:  Blades of Steel (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: abde6fc87b2d90e0b40cd3420d4b7381e1f23285efbbdc62fd27b59c591ad2cc
+  name:   Blades of Steel (USA)
+  title:  Blades of Steel (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: b350a470e11bb4dbc175d6e6750a0f853c9fc7dd1918974233016d8a491a761e
+  name:   Blues Brothers, The (Europe)
+  title:  Blues Brothers, The (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 46fb05f80167bd185bd6eef40e1f86a0dcdd36e250ef8e2b29a575550d75473a
+  name:   Blues Brothers, The (USA)
+  title:  Blues Brothers, The (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 822da78ef1ccb37bfa68373a83f7434960de388e4b5b53661b479953a5085322
+  name:   Bokosuka Wars (Japan)
+  title:  Bokosuka Wars (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: b1b26a572b3f545544d957bc3d0054a6dc4eb5b38a60404a3b1f512e17f14ca5
+  name:   Bomber King (Japan)
+  title:  Bomber King (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0d6cff6a7405f60b541322366b59c8be219e0f6414f72bc1af65dae39b611fdf
+  name:   Bomberman (Japan)
+  title:  Bomberman (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 2967746c2a434c97a074b14d894ea132fab8e443899f6ca870718eeee1669039
+  name:   Bomberman (USA)
+  title:  Bomberman (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 9f7cf8570641ea7041e20b86ceac0a9d4e55464acbd7a235007dd5bc77e61a95
+  name:   Booby Kids (Japan)
+  title:  Booby Kids (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: caab4e955514d17ff9b08251d09a52cf2fc1126788724e28c3ac3300599694c1
   name:   Bubble Bobble 2 (Japan)
   title:  Bubble Bobble 2 (Japan)
@@ -711,11 +2063,182 @@ game
       content: Character
 
 game
+  sha256: 2039530b64129093d9d99d5049cba5f934f3e4ce85c1f321db1c642d09e34042
+  name:   Buggy Popper (Japan)
+  title:  Buggy Popper (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: ba8c9990f378b941ea362858509182b2b009e5b463e9732dc0071392b6253c2b
+  name:   Bump 'n' Jump (USA)
+  title:  Bump 'n' Jump (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 56432c145198e788458813cd83d532b5aa12484f15871597dac45890bd9e1fa6
+  name:   BurgerTime (Japan)
+  title:  BurgerTime (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 8f349b0ed7d31a07ccdf26958de8219165eff7c9ad43801a82c5dcf831fd82c2
+  name:   BurgerTime (USA)
+  title:  BurgerTime (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 47dfae941b3c660be476bc28f199474b6c418431e3d493da4384a6aef3cc5016
   name:   Cabal (USA)
   title:  Cabal (USA)
   region: NTSC-U
   board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: e8caa41a47fc27320e9849842c79eb4b05ac82844a26b52a6ada694489a67fbd
+  name:   Cadillac (Japan)
+  title:  Cadillac (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: cfea236e0d0fe0e4430e8db23a1f5a9921a633fbd0b3d189c80a6f1a3a9464e4
+  name:   Caesars Palace (USA)
+  title:  Caesars Palace (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: b70849d2510e797c4207e17f97d0a1f0dab788855349daa864289563458494a7
+  name:   California Games (Europe)
+  title:  California Games (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: be20222704df7d5c8b7d2154a195920871ff01868478167a1f0c3590b9fd1ec9
+  name:   California Games (USA)
+  title:  California Games (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
     memory
       type: ROM
       size: 0x10
@@ -812,6 +2335,373 @@ game
       volatile
 
 game
+  sha256: f76f1779454a8a98168c2c26bc79058161cbaefb3006c8e6aa8c63d301a66f4f
+  name:   Casino Kid (USA)
+  title:  Casino Kid (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 87e479b14421fc4b56553937dc817789ebfb2987b0724c6790705f0361a955a7
+  name:   Casino Kid II (USA)
+  title:  Casino Kid II (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 042679ccdf356a96e2b879630740b4582acc05007811f5e362f759e58b47a770
+  name:   Castelian (Europe)
+  title:  Castelian (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 98ba2353111a0b2cf557b03d8b8c4f5c15d7be56e47182536d710913d62582fa
+  name:   Castelian (USA)
+  title:  Castelian (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 90d31073ffeaf38b9829806049df55a72a3aee75c21ab391571c8d8ede992e10
+  name:   Castle Excellent (Japan)
+  title:  Castle Excellent (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 6887230077d8eefa311d313672c31e7497211e21c5df78aa8d2030ea72471108
+  name:   Castle of Dragon (USA)
+  title:  Castle of Dragon (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 9abebd837287a38ab64153ff662b3bd79ebc8e55b07c2fc2fef8c15244517576
+  name:   Castlequest (USA)
+  title:  Castlequest (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: f747fd7ea95ee1ad2bd002b84096564a5940f326c55e04875e32d620cc048cd6
+  name:   Castlevania (Europe)
+  title:  Castlevania (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: a35e846379ff252594ace83da2a1a1cb0692717b931055d1f6603812f18ad5cd
+  name:   Castlevania (USA)
+  title:  Castlevania (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 7eba1637cd2fdbc4f0732eb5249e32d827dbdadbd7e165f961440af4310880dc
+  name:   Castlevania (USA) (Rev 1)
+  title:  Castlevania (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: b1703cd27771d1b3aef1016e5b2655dc858bb4d0f7cde00acfe3d629caa2a46f
+  name:   Chack'n Pop (Japan)
+  title:  Chack'n Pop (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: e27383b1bf0275fdd06acbde38889a58e14c52097742f7f042bc195b0d249699
+  name:   Challenger (Japan)
+  title:  Challenger (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: c3019ec38721f88b1dac09685e8e08d8d5cb316408ae17c02c20cb0b44b29b9a
+  name:   Championship Bowling (Japan)
+  title:  Championship Bowling (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: b012733f6be75e9ab7039d60cbfa2335e1f57f4e244ccde6ec451424de0203cd
+  name:   Championship Bowling (USA)
+  title:  Championship Bowling (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 9628f1e280d68c605df4cb5585950859954b0d138e79313f3f86d48717725e8b
+  name:   Championship Lode Runner (Japan)
+  title:  Championship Lode Runner (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: d5b039637a2315458f71ec57a287f93b3532e6243b712b55767f07dc83c5a3c9
+  name:   Championship Pool (USA)
+  title:  Championship Pool (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 60a13315624ef2449c8ff2d8e45cd2537b318ee15096f63509d2eea7b7c97428
+  name:   Chester Field - Ankoku Shin e no Chousen (Japan)
+  title:  Chester Field - Ankoku Shin e no Chousen (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 59f228976854136f7988c309ad5baa68687b363df27810e28bb6959b771d5af6
   name:   Chibi Maruko-chan - Uki Uki Shopping (Japan)
   title:  Chibi Maruko-chan - Uki Uki Shopping (Japan)
@@ -877,6 +2767,155 @@ game
       content: Character
 
 game
+  sha256: b9c403bff92da80c7fae034175e1eba22e43d3eeaf4a29624ead0a105c1d236b
+  name:   Chou Fuyuu Yousai Exed Exes (Japan)
+  title:  Chou Fuyuu Yousai Exed Exes (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: ff864226752752bfa608d4e3e6e1e89bd0044fe70e8c7cda6eb8e3de449e5fd2
+  name:   Choujikuu Yousai - Macross (Japan)
+  title:  Choujikuu Yousai - Macross (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 21a7f7a5a043ddc2017cd97b4088156b0d728271455966ab6748a79eddd3410e
+  name:   Chubby Cherub (USA)
+  title:  Chubby Cherub (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: c8328f85580f03676d4ed875ea0a985ed77ca68ade51d880481a415f65335ca0
+  name:   Chuugoku Senseijutsu (Japan)
+  title:  Chuugoku Senseijutsu (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 6f2fc666c34264b20854197391121374670710d716bea8798add7a5bf3ba7e78
+  name:   Circus Charlie (Japan)
+  title:  Circus Charlie (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 8f3095c5319f1b4176649beee65971d006d5fe328ad1cbbaebd528eb8c45d2d6
+  name:   City Adventure Touch - Mystery of Triangle (Japan)
+  title:  City Adventure Touch - Mystery of Triangle (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: bb5c6841973e6d0118241553c74c7a51f739e3f63b3d786bc20e6d44ca944f6f
+  name:   City Connection (Europe)
+  title:  City Connection (Europe)
+  region: PAL
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 72c69f068099e42844bfe17e7d37f439243fad10b283650cac041e78443e0300
   name:   City Connection (Japan)
   title:  City Connection (Japan)
@@ -895,6 +2934,70 @@ game
     memory
       type: ROM
       size: 0x4000
+      content: Character
+
+game
+  sha256: 590535e8cda84cb4054425539bc320c16307f141d688b57f258a162dedc8888f
+  name:   City Connection (USA)
+  title:  City Connection (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 69d26e6e849a103c2a553e62579f159bc8fcf7a4050fee0f7f97a4a64c2f9a4b
+  name:   Classic Concentration (USA)
+  title:  Classic Concentration (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: ed0a1a5ca7cf404116d0073e8ccd213a082d2ac50132f54f3c8621f3dbcdb248
+  name:   Clu Clu Land (World)
+  title:  Clu Clu Land (World)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -938,6 +3041,72 @@ game
       volatile
 
 game
+  sha256: e8bb5be4ada0b98229d370dab230b02946fb08942c7d85b265a5280107722587
+  name:   Color a Dinosaur (USA)
+  title:  Color a Dinosaur (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0512b4aa2220f74e40fe8652b758893fa87efb6c3407808f7dda0e1901017432
+  name:   Commando (USA)
+  title:  Commando (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 8ae9b624c08b86f6af41b5d58c328188c6df9c35868ae0763d75a22fbfb6c712
+  name:   Conan (USA)
+  title:  Conan (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 62c9d4e0578cb1e615ce9bb2c8ebc15b1e8de4c928c5c07ba9a85c11aa36ae4d
   name:   Contra (Japan)
   title:  Contra (Japan)
@@ -960,6 +3129,71 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: d41e28b1a33b3b6768e7c39c9fdfb1fda4b49940542d14085911fabd399e1ca9
+  name:   Contra (USA)
+  title:  Contra (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: fd8137b02b02fcc0bed2b3107a0d934ab2af13650f418d5c64f0e9913396d62f
+  name:   Cosmo Genesis (Japan)
+  title:  Cosmo Genesis (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: b46ba52d984e8674e9d69e525ee331dddedc697ea603d53aa3758c4db7b59a73
+  name:   Crackout (Europe)
+  title:  Crackout (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 3f243f6cf4b33d25d76c7cf9459e82bcd5367aa001f4c36fdf1c5728429bed0a
@@ -1033,6 +3267,27 @@ game
       content: Character
 
 game
+  sha256: ad1e14d08657d99c8b70f779931f62524b4beb529090b82b368925d8b642e40c
+  name:   Cybernoid - The Fighting Machine (USA)
+  title:  Cybernoid - The Fighting Machine (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: a1d9bcf389d6837581cd33a26b4e13917d084e3e69dbe89453e443fc9976fa22
   name:   Daiku no Gen-san 2 - Akage no Dan no Gyakushuu (Japan)
   title:  Daiku no Gen-san 2 - Akage no Dan no Gyakushuu (Japan)
@@ -1052,6 +3307,28 @@ game
       type: ROM
       size: 0x40000
       content: Character
+
+game
+  sha256: cb63bf5ee1cef6478c138a141cd244dfbeb341274be97848d98a8f0d8d0dcc2f
+  name:   Daiva - Imperial of Nirsartia (Japan)
+  title:  Daiva - Imperial of Nirsartia (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: aa9e3be1451ad009111c587cd2adb9275b052402461f27257617baa7d7cd6767
@@ -1079,6 +3356,49 @@ game
   title:  Danny Sullivan's Indy Heat (USA)
   region: NTSC-U
   board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 227e789fef94eabcf24a5ec9a3944de58b183bbc7d96140269d1c908f162b853
+  name:   Dash Galaxy in the Alien Asylum (USA)
+  title:  Dash Galaxy in the Alien Asylum (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: a67723c633d637fa5f9b76639c92b58552856f663d76a37c0eefdf06e41e3d53
+  name:   Dash Yarou (Japan)
+  title:  Dash Yarou (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
     memory
       type: ROM
       size: 0x10
@@ -1276,6 +3596,27 @@ game
       content: Save
 
 game
+  sha256: 2d7414a83f46370f8f76a7276357fdcd34c29c0cdb108b417da8c6c43095a90c
+  name:   De-Block (Japan)
+  title:  De-Block (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 0115356b0791cc8ddcb7d3163d6ef7aa664f3ff4e68dba561ffffb79eefcbca9
   name:   Deadly Towers (USA)
   title:  Deadly Towers (USA)
@@ -1298,6 +3639,27 @@ game
       volatile
 
 game
+  sha256: bf58512dc3bc427d14a6d851445801967cd14f3d02ae236eabceeb7928a55462
+  name:   Defender II (USA)
+  title:  Defender II (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: a18f143cce068d9df46473f968b31c65beb5246b521843b7653d5993b707d310
   name:   Densetsu no Kishi - Elrond (Japan)
   title:  Densetsu no Kishi - Elrond (Japan)
@@ -1318,6 +3680,27 @@ game
       volatile
 
 game
+  sha256: 44cd6b2aa05286c37e78bd04d15793018bb0656b24260e5c76fc5cfad39f699b
+  name:   Destination Earthstar (USA)
+  title:  Destination Earthstar (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: d2140fc2e6354a9f4d0154dabac757e5559890edba4885799c1c979d8b7a8b20
   name:   Devil Man (Japan)
   title:  Devil Man (Japan)
@@ -1336,6 +3719,154 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: a5ff0e0ab455b694fd3acf511e4b48fb3edfa3a3db49f7cf6df451c8c6304f9e
+  name:   Devil World (Europe)
+  title:  Devil World (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 2fb438d10854136ec40b50410475d575860e24bc23d7b8c2a9ca27b87d14ba46
+  name:   Devil World (Japan)
+  title:  Devil World (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: c0eb90e99bb35d9f5c6dd05dc38a7cb93d3d41701b66a0a0dca2ab4f314465dd
+  name:   Devil World (Japan) (Rev 1)
+  title:  Devil World (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 163479e2b1571538cf2f0f147bcbdebaab8ed8b0251f87dabd9bc4c80d786ea1
+  name:   Dick Tracy (USA)
+  title:  Dick Tracy (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 7c8b6add50b20e4612e3043df0671e701cd2aa163e4af864913e3940feee27f2
+  name:   Dig Dug (Japan)
+  title:  Dig Dug (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: dceca6fe26ef2e3cb2cf4100df50b6b6a5d37ef19193144e30dce01af823cf88
+  name:   Dig Dug II (Japan)
+  title:  Dig Dug II (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 1bf92138500e24a4e48da6d1f2eecbaeb3f36d28a425f06179fe9283381640e6
+  name:   Dig Dug II - Trouble in Paradise (USA)
+  title:  Dig Dug II - Trouble in Paradise (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -1515,6 +4046,216 @@ game
       content: Character
 
 game
+  sha256: dd108e55b60070b4c0147f7dba31844ed83065255466bfacd5038e6382483026
+  name:   Donkey Kong (Japan)
+  title:  Donkey Kong (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: aa408f5a6b97c0d738e7e8b489a5617ad4a9ecdee2b05c4ee504210ce31b2825
+  name:   Donkey Kong (World)
+  title:  Donkey Kong (World)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: b15b298dc37692d0bed2cbf922727ea48ed38bbd6cf3acdd28be6d2b9be344d3
+  name:   Donkey Kong 3 (World)
+  title:  Donkey Kong 3 (World)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 234c2f62cbc3c72eb7519425a1893229e19a3fd1b1630fb75f3e951960a300e5
+  name:   Donkey Kong Classics (USA, Europe)
+  title:  Donkey Kong Classics (USA, Europe)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
+  sha256: dc2de35d38659cf539821444c611d23837e4a5012ca745c3ba24225ad9001103
+  name:   Donkey Kong Jr. (Japan)
+  title:  Donkey Kong Jr. (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 950ebe68e7f74219b9e5e104200b03165d59c24264f02e32c12be967fd311ac2
+  name:   Donkey Kong Jr. (World)
+  title:  Donkey Kong Jr. (World)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 8e9c7a7953161db3633dc39b097e5f731a6bdcdf871d352e33db67a7acaeca92
+  name:   Donkey Kong Jr. + Jr. Lesson (Japan)
+  title:  Donkey Kong Jr. + Jr. Lesson (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 07dd16464d769429c651bd203ac2e74c7aa5852824482ca8877959d643bc8689
+  name:   Donkey Kong Jr. Math (USA, Europe)
+  title:  Donkey Kong Jr. Math (USA, Europe)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 1c09b9631d09c90957b0d53afd91c3274b1909ab2f8cbaef8b4bec99d3e4c1d3
+  name:   Donkey Kong Jr. no Sansuu Asobi (Japan)
+  title:  Donkey Kong Jr. no Sansuu Asobi (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 7bd2caf4a42f7d5c391433d2bec37bb2130e3a39dce55ee597ec14703cefc769
+  name:   Door Door (Japan)
+  title:  Door Door (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: de15604ba1f819b12dd35dec557a5f20c9821210c4bc853c29c763466d0ede94
   name:   Doraemon (Japan)
   title:  Doraemon (Japan)
@@ -1569,6 +4310,115 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 6afada48e468f951609d5178c4c4e0ae95028abbf5971affd60af3770a4ae20d
+  name:   Double Dribble (Europe)
+  title:  Double Dribble (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: f5517606d81d4e993d7fb86f11cae24c7b5029fd7184c7247771d6d7791e54ab
+  name:   Double Dribble (USA)
+  title:  Double Dribble (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: eb0e5f318e84e931a9bd663764c43fefa1a78565fa1328c1544b41bc8155ccb1
+  name:   Double Dribble (USA) (Rev 1)
+  title:  Double Dribble (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 7fd28fb7b132052ad13b9ac0b493b87dca3e0d9b12835219e730bbab0e5f6797
+  name:   Dough Boy (Japan)
+  title:  Dough Boy (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: a0b2ec9b44033fc4d2356259ad99a4f2dcdf5396da53efdfcb17a54c0e7fcdbe
+  name:   Dr. Chaos (USA)
+  title:  Dr. Chaos (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
       content: Program
     memory
       type: RAM
@@ -1935,6 +4785,49 @@ game
       content: Character
 
 game
+  sha256: 50b92595fe9198c333fe6912867f9db2de5c16a6c2fa72edcf1d797e1d8b79cb
+  name:   Dragon Quest (Japan)
+  title:  Dragon Quest (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: b0f0ce24890db516c01b1e748a8b4c68b38cebc404c2bc1c24a1ef6fe02ac5cc
+  name:   Dragon Quest II - Akuryou no Kamigami (Japan)
+  title:  Dragon Quest II - Akuryou no Kamigami (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 8f7a7ce842ce3135e1cfaea50da3029e7fe8de28384c8db45ef8371ba42b45a9
   name:   Dragon Scroll - Yomigaerishi Maryuu (Japan)
   title:  Dragon Scroll - Yomigaerishi Maryuu (Japan)
@@ -2005,6 +4898,267 @@ game
       content: Character
 
 game
+  sha256: e13e26aeaba4f4c247a52ebf10fedf49a00005c39bebf965b032ee0f69f764e2
+  name:   Dragon Unit (Japan)
+  title:  Dragon Unit (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5564e54943deddc6d290b256638c774aa379a0d33dcea3b0a4f0c4b9fc2034e3
+  name:   Dragon's Lair (USA)
+  title:  Dragon's Lair (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: e0ac33afd42ba32133be964b575d95e92571c7d05e51dde7b77cd757b23ac3ec
+  name:   Dropzone (Europe)
+  title:  Dropzone (Europe)
+  region: PAL
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 5ec7c3e91bfd5800073286ee978b1d152c19f924837788eb72700c7c01261fa4
+  name:   Druaga no Tou (Japan)
+  title:  Druaga no Tou (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 7026334a7e8742b61b450f4b3b182922c6a69fc723d7cd19c83db365f15e45ba
+  name:   Duck Hunt (World)
+  title:  Duck Hunt (World)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 7ea851afcc2127de0f4cd86e333b0bf78426a10d72576ad59fb60fd34e9d71fe
+  name:   DuckTales (Europe)
+  title:  DuckTales (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 8ba8baed01a9fbaf1e9ff29e0c9825db1963ac2aff211d6f1f3bcfd3839e2013
+  name:   DuckTales (USA)
+  title:  DuckTales (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: acbb22ffb5ec64215179167d25481344856008c13e20c8dec7144bbcea4a16ab
+  name:   DuckTales 2 (Europe)
+  title:  DuckTales 2 (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 7f42f8be18f7e2df8553cf73e597e2ea2d9ed71725cec20767eb3fe893f53dd3
+  name:   DuckTales 2 (France)
+  title:  DuckTales 2 (France)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 72fdd455db3984f7bf74a8c060383bab56dbfbf0f1ea04c2da0b68e1f37b4860
+  name:   DuckTales 2 (Germany)
+  title:  DuckTales 2 (Germany)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: bd8494ff12360bec955105f1236a85a0518179358bde0c6ac210353ca67e2633
+  name:   DuckTales 2 (Japan)
+  title:  DuckTales 2 (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 54c70628739c9cfab40b8d79555e9076adae34127ef369988ca91635b4a688bf
+  name:   DuckTales 2 (USA)
+  title:  DuckTales 2 (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 165a5cc2a460463e24b8596c9004434d7a50aab1d2bd0435c2047f618fbd1309
   name:   Dynamite Batman (Japan)
   title:  Dynamite Batman (Japan)
@@ -2028,6 +5182,154 @@ game
       type: ROM
       size: 0x40000
       content: Character
+
+game
+  sha256: 06b39ba8b3c4647ee8da49d7c6caa0156c111188263ab2d195540d3c5c0c8f7a
+  name:   Dynamite Bowl (Japan)
+  title:  Dynamite Bowl (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: f8aac8ca324c5d1a6f77dcc3c612d425c3fb7acbbb8f81c9c25a53fe87c0d1f7
+  name:   Dynamite Bowl (Japan) (Rev 1)
+  title:  Dynamite Bowl (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 7951287af48ef9f2e2b375934acff99fe1543aea39d2729d2863b38ab498e231
+  name:   Egypt (Japan)
+  title:  Egypt (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: d547ede369f2feb83c74cd9db27252234c4897d985112e6d61a1784cbfa1ff13
+  name:   Elevator Action (Japan)
+  title:  Elevator Action (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: e2c3b46774c6a8f110937197590f73341b36388cf7bd32e6a8180e35eb459424
+  name:   Elevator Action (Japan) (Rev 1)
+  title:  Elevator Action (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: e2824a71c74106326013915d9f8a67be22c367599feefd8da6538f62d5e6f5b0
+  name:   Elevator Action (USA)
+  title:  Elevator Action (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 58972627ec3840f560dfe9dd8aaa2daa1e359bb651be0f06793a75cb12e9de75
+  name:   Elnark no Zaihou (Japan)
+  title:  Elnark no Zaihou (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: badedff174fd32fcaad914ea72d04763b828ed4d1d883e8c902cb668ea52b92a
@@ -2072,6 +5374,28 @@ game
       content: Character
 
 game
+  sha256: 484a0212554be7ab115ec85ce6bce34932be9b3b9d2aba7f8dd9b9b8db6f89d0
+  name:   Esper Bouken Tai (Japan)
+  title:  Esper Bouken Tai (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 761df2c2e04f9ffec5eec59afd821bd74af3b155546519d649876aad37160c06
   name:   Esper Dream 2 - Aratanaru Tatakai (Japan)
   title:  Esper Dream 2 - Aratanaru Tatakai (Japan)
@@ -2100,6 +5424,48 @@ game
       content: Character
 
 game
+  sha256: 30f17f919c733cc3378719476137bac883ce8f888e2a1ec2db92ab9662d19f67
+  name:   Excitebike (Europe)
+  title:  Excitebike (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: e9f4c9d1b7c66c6af83f2db5d4f704cf5f4b3c86e26a49c05539237807d8875e
+  name:   Excitebike (Japan, USA)
+  title:  Excitebike (Japan, USA)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 19e1f9b0f4dfbfb126c936db4ffc266ad224a4dd611a4bfacab00547e521267f
   name:   Exciting Boxing (Japan)
   title:  Exciting Boxing (Japan)
@@ -2118,6 +5484,48 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: dbe92ea69c9df92854df3ef1ed3654a6ba443864b18a99daee3af47f081e669d
+  name:   Exerion (Japan)
+  title:  Exerion (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: e9aab85fd91822b9dc7a89997eda3415e45a07fe21580c0df4765ce392e63824
+  name:   F1 Race (Japan)
+  title:  F1 Race (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -2190,6 +5598,81 @@ game
     memory
       type: ROM
       size: 0x10000
+      content: Character
+
+game
+  sha256: 64253341616f822d596055a1ba3b070e9bc0f0d16658ee599902a39aa17c27ad
+  name:   Family BASIC (Japan)
+  title:  Family BASIC (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: RAM
+      size: 0x800
+      content: Save
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 277d06b71b7de4c9b3bd8b7114086532b951767f7fdf66883282a262beee84a8
+  name:   Family BASIC (Japan) (Rev 1)
+  title:  Family BASIC (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: RAM
+      size: 0x800
+      content: Save
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: a646dcaeb5f114176446d7106816623c5f5918739a4c16d651c5715c9825b6e9
+  name:   Family BASIC (Japan) (Rev 2)
+  title:  Family BASIC (Japan) (Rev 2)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: RAM
+      size: 0x800
+      content: Save
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -2427,6 +5910,28 @@ game
       content: Character
 
 game
+  sha256: 6ca3e8039408dc9aeaa633d18f763b1688a887ba92e1e5305fc65325455ccb86
+  name:   Family Quiz - 4-nin wa Rival (Japan)
+  title:  Family Quiz - 4-nin wa Rival (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: a4e66b5151eb098e98c1cbb63cf40c88deb01ccaad3c3ee876471d1e19bfad1b
   name:   Family Tennis (Japan)
   title:  Family Tennis (Japan)
@@ -2447,6 +5952,111 @@ game
     memory
       type: ROM
       size: 0x10000
+      content: Character
+
+game
+  sha256: d037f941dfde57d27240d161e3e37d6a49aebb4f49cf72924d9e25b9ce42452f
+  name:   Family Trainer 1 - Athletic World (Japan)
+  title:  Family Trainer 1 - Athletic World (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 03d85c9f7047a4cd0cd85e90f381d1e3fc42a539f451114700d4a257593a14ba
+  name:   Family Trainer 1 - Athletic World (Japan) (Rev 1)
+  title:  Family Trainer 1 - Athletic World (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 4730b775501c0566f4bd1485d3bbf5a874b877ff37fa617452390d2c89690de1
+  name:   Family Trainer 10 - Rairai Kyonsees (Japan)
+  title:  Family Trainer 10 - Rairai Kyonsees (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 72da13d5a63520d307b28beb096235b89a98d1d53993fb36625449e7588379a3
+  name:   Family Trainer 2 - Running Stadium (Japan)
+  title:  Family Trainer 2 - Running Stadium (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 27c6e9bf1de790ce831a4e9211c897fab813b2f4447a897efaad905f2488d761
+  name:   Family Trainer 3 - Aerobics Studio (Japan)
+  title:  Family Trainer 3 - Aerobics Studio (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -2510,6 +6120,48 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: 51b45f4d89580d376c6d5ad2f238109a50192ab65bd7e93afabe799980b2edf4
+  name:   Family Trainer 7 - Daiundoukai (Japan)
+  title:  Family Trainer 7 - Daiundoukai (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: fc345614df4d3881cce70a87938a434937e56dae489a2938dc494202ffb718f5
+  name:   Family Trainer 8 - Totsugeki! Fuuun Takeshi-jou (Japan)
+  title:  Family Trainer 8 - Totsugeki! Fuuun Takeshi-jou (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -2705,6 +6357,27 @@ game
       content: Character
 
 game
+  sha256: 84b643059bf2b4fb73c19f829ae8db16dfefb2b5ec306bb77ac2c2f69c239603
+  name:   Field Combat (Japan)
+  title:  Field Combat (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 9f9e96423a8a322cd79676dadb7d24a27733f834a88049bda3acc98c2d2df026
   name:   Final Lap (Japan)
   title:  Final Lap (Japan)
@@ -2776,6 +6449,155 @@ game
       content: Character
 
 game
+  sha256: eb3955503b404a5e82a4cd402c8dd5790bcacf1b6ccbd364f5b901f7477d4e18
+  name:   Fisher-Price - Firehouse Rescue (USA)
+  title:  Fisher-Price - Firehouse Rescue (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: f79c8ddedbf0b580275af140c8df015f2d23a7b43f3deee1c9dffd27424cb19a
+  name:   Fisher-Price - I Can Remember (USA)
+  title:  Fisher-Price - I Can Remember (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: c31d4984544dfee45ff2b2ca54120935f4858edfa81c689440c2ac31b269cde8
+  name:   Fisher-Price - Perfect Fit (USA)
+  title:  Fisher-Price - Perfect Fit (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 04264565cf33f4bd1b23a3f7a1be1487a548c7f6b85323c68af754b0927b0a56
+  name:   Fist of the North Star (USA)
+  title:  Fist of the North Star (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: cbf1a3133b6503f8d1bc7da75a4163b3b620ece6e53920c32ddfae6c644af109
+  name:   Flappy (Japan)
+  title:  Flappy (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 499256c09a99972fd335b93164bb2bb5ef0e16f87d0643a598d7f97067dd837b
+  name:   Fleet Commander (Japan)
+  title:  Fleet Commander (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 6e5bdfe7ee4cc4d949ea80016dbfb2b4322bbe193b5f28483ce7009e506efe40
+  name:   Flight of the Intruder (USA)
+  title:  Flight of the Intruder (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 41fea670ccfb999d2693ff2233466c632dd379a6ac07d9789d8a1259da714383
   name:   Flintstones, The - The Rescue of Dino & Hoppy (Japan)
   title:  Flintstones, The - The Rescue of Dino & Hoppy (Japan)
@@ -2794,6 +6616,176 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: 9cf38ba1905beea5c9477c4d8e5649f11c40a25272dd086e1b28604300951a2c
+  name:   Flipull - An Exciting Cube Game (Japan)
+  title:  Flipull - An Exciting Cube Game (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 944c6cb221eb0284712cc56563a19daffae9d2482dc0a3781186e4c115b13b1b
+  name:   Flipull - An Exciting Cube Game (Japan) (Rev 1)
+  title:  Flipull - An Exciting Cube Game (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: fd7523b5ec5769e4d782a9699a2253bd15d0036111b8ed26195238b35b74257d
+  name:   Flying Dragon - The Secret Scroll (USA)
+  title:  Flying Dragon - The Secret Scroll (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5e2db0db6b1d3d7fe1630a6bab38a66081e3266070a4dfac9c3ace9edf39375e
+  name:   Flying Hero (Japan)
+  title:  Flying Hero (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: eedcf3fae4fe66102a1bf1338a1ea3276f5aadb3c3bc5770dd1d260e2fc44bac
+  name:   Formation Z (Japan)
+  title:  Formation Z (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: aed54ef0f3473c116fe64fa13a42e85ba1882b19a9989b4f6e38d66fdf1c86ad
+  name:   Formation Z (Japan) (Rev A)
+  title:  Formation Z (Japan) (Rev A)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 7e94b4fe8c33439779bb653d007ba4678dd589636ffbc87d1535629578a64d5e
+  name:   Friday the 13th (USA)
+  title:  Friday the 13th (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: a100e00bcb5a738750dc1c0bac22c000f1a32be58c0eb1dcc9921ece3ae3c25c
+  name:   Front Line (Japan)
+  title:  Front Line (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -2819,6 +6811,133 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: 6280ffb211b03ccc928167c370c66c1b6fefc62c26b366327987a534e0305aec
+  name:   Fun House (USA)
+  title:  Fun House (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: dae646e7b91a55bb9d7fc6a7cfe4890d81ae89e68f9ccf44438dca67d83cb1de
+  name:   Galaga (Europe)
+  title:  Galaga (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: e6fe68b9f12578e74ba016ca146aaf8232b20475fb675c7d32e0ea4e47eb1cc8
+  name:   Galaga (Japan)
+  title:  Galaga (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: df49cc788fff36881fcf1d1cb22281d305260d4d8fbbe07ca2c4d699fe54843a
+  name:   Galaga - Demons of Death (USA)
+  title:  Galaga - Demons of Death (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 50178a2856f8ed3574b4e7fd45b9d1ec44c660d51fe9783d0012a19df5892cce
+  name:   Galaxian (Japan)
+  title:  Galaxian (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 783f574d71ffe7f47b939913cd81664386e52979889812dc125203a81d975d34
+  name:   Galaxian (Japan) (Rev A)
+  title:  Galaxian (Japan) (Rev A)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -2975,6 +7094,48 @@ game
       content: Character
 
 game
+  sha256: b5261429dbe18386f9348d9f297bda6bd0589f47a1b2ca879db1cde507384c37
+  name:   Ganso Saiyuuki - Super Monkey Daibouken (Japan)
+  title:  Ganso Saiyuuki - Super Monkey Daibouken (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: a2039efb5b5b8d4941c31ae0977dacccec5aaa72fe307ae36af2a454d30d9e26
+  name:   Garry Kitchen's Battletank (USA)
+  title:  Garry Kitchen's Battletank (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: fd2a8520314fb183e15fd62f48df97f92eb9c81140da4e6ab9ff0386e4797071
   name:   Gauntlet (USA)
   title:  Gauntlet (USA)
@@ -3001,6 +7162,27 @@ game
       volatile
 
 game
+  sha256: db08af62b038452ce1acfdcf455be09e5ef85274fa98591c0c6c9547c0f547c1
+  name:   Gegege no Kitarou - Youkai Daimakyou (Japan)
+  title:  Gegege no Kitarou - Youkai Daimakyou (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 992e63eef393060170d03c2558c7bc090428c8ed553ba496ddda6432fcbff0ac
   name:   Gegege no Kitarou 2 - Youkai Gundan no Chousen (Japan)
   title:  Gegege no Kitarou 2 - Youkai Gundan no Chousen (Japan)
@@ -3018,6 +7200,49 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: d9d6d4343ab20d777d91e9e19098e19f6d2ff04ca03deaa59fe54c79f30625fb
+  name:   Geimos (Japan)
+  title:  Geimos (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 4fcd559442c95e41e7e406eeab6953b51d444587c3ed3fd96d387201ca83b3cc
+  name:   Gekitotsu Yonku Battle (Japan)
+  title:  Gekitotsu Yonku Battle (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: c0f0fad3abcb7c284eca6bf17b263d22ea1749316d6321a8b83969bd4a7c22ee
@@ -3067,6 +7292,92 @@ game
       content: Character
 
 game
+  sha256: 36acc6ce4674043e23c337cc1c266aed55187b75c890af7c7a2ddd617993e494
+  name:   Ghostbusters (Japan)
+  title:  Ghostbusters (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 43221ae8a386e8ddf68251d5870d6fe3d696be14a5e41d9a44c36227894044d8
+  name:   Ghostbusters (USA)
+  title:  Ghostbusters (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: d17cf723ad1216b454c5b3074231e63e3ae32033aff81282a1f9cdde43fc2810
+  name:   Ghosts'n Goblins (Europe)
+  title:  Ghosts'n Goblins (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: eea66f7bcc90d1145454da487791be5926473bee4014313af12dfa0f7453ea81
+  name:   Ghosts'n Goblins (USA)
+  title:  Ghosts'n Goblins (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 1bbe4b3e20a004a4f741018e31e6ae291772b8876d6fb6f01494c9c5b0917c6c
   name:   Gimmick! (Japan)
   title:  Gimmick! (Japan)
@@ -3086,6 +7397,28 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: d9a88d6052eb4c81dbdd29cb041e24d143872924db87e9d2283c6a817acb0b1b
+  name:   Ginga no Sannin (Japan)
+  title:  Ginga no Sannin (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 7911375ab98da4ac5c628ba4dfffcba8ba4fc13a341901aed120ab967be5e26c
@@ -3130,6 +7463,69 @@ game
       content: Character
 
 game
+  sha256: d4bd5f9e2bbfafb624d67a77f4292b92bad183c9aa4728620aedf3201591f6d8
+  name:   Golf (Europe)
+  title:  Golf (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 12c99ef93f7bf1eaace749b38e5b63bca1b9885fd7680c14dfcc20c3637d6aa5
+  name:   Golf (Japan)
+  title:  Golf (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: c41555b61617e52cae950e0a94d4d655646eed4e4ce4c1d26740ddee0a9ae090
+  name:   Golf (USA)
+  title:  Golf (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: d530bfd8bae1fd38d29d776e663bcf5e774590866a5ee8a09e2c1d992e28a008
   name:   Golfkko Open (Japan)
   title:  Golfkko Open (Japan)
@@ -3151,6 +7547,27 @@ game
       content: Character
 
 game
+  sha256: 100fe2b085e3d57dc1a8f1cea44a31766e8c81c50a6083bf16687dcd1b6219f4
+  name:   Gomoku Narabe (Japan)
+  title:  Gomoku Narabe (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: f837e0807ade4bb8036d40746e2433ed66986f043fc2be722e765e45a676cd5d
   name:   Goonies (Japan)
   title:  Goonies (Japan)
@@ -3169,6 +7586,198 @@ game
     memory
       type: ROM
       size: 0x4000
+      content: Character
+
+game
+  sha256: 547412c4bcaf369ab9d3b3925f893e63a8b0f9de7c81d95c8dfe1224aa0a13d8
+  name:   Goonies 2 - Fratelli Saigo no Chousen (Japan)
+  title:  Goonies 2 - Fratelli Saigo no Chousen (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 60024e03ad1ce66866688b6238011054631364a3f98bc4855b166a6662f2cd55
+  name:   Goonies II, The (Europe)
+  title:  Goonies II, The (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 16c7de15b7dc72c567f58172bbf0cd1328d11625f6707814da030df15f95dc92
+  name:   Goonies II, The (USA)
+  title:  Goonies II, The (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: c20e08d6566d27245e7dc59d3eba5429dacc8ee2abb67be1ff722e37efb017e1
+  name:   Gorby no Pipeline Daisakusen (Japan)
+  title:  Gorby no Pipeline Daisakusen (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 15685dee8bc1c588dfa2649b7b5f715aa7b4136454ba09c046d1b17209749d76
+  name:   Gotcha! - The Sport! (USA)
+  title:  Gotcha! - The Sport! (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 3aa97b519a5191766a53ae51c28a51c17778716bc02ef58b9c82afc761e20329
+  name:   Gradius (Europe)
+  title:  Gradius (Europe)
+  region: PAL
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 2dba259ce318f16ae994fa9cb5152c6daf9ee27c433e68000318535afb17ddfc
+  name:   Gradius (Japan) (ArchiMENdes Hen)
+  title:  Gradius (Japan) (ArchiMENdes Hen)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 02f300a653509b84a4565742aeda5b76e79a2fa36ef5f9d903b2607db1586813
+  name:   Gradius (Japan)
+  title:  Gradius (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 6918d7cbb81bfcd20d95bb08bcf137c7ea80ae9f0c12b92bfdcc90a6cf9752a0
+  name:   Gradius (USA)
+  title:  Gradius (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -3221,6 +7830,116 @@ game
       content: Character
 
 game
+  sha256: f43783672e895baab707b1e10786e004e4eb452c86f26abc8977f641fdf4cccf
+  name:   Guardian Legend, The (Europe)
+  title:  Guardian Legend, The (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: d18ad8b76f9d067858dc8012ee84119c90524cdc3f4d555dd5a752a6f469fe6b
+  name:   Guardian Legend, The (USA)
+  title:  Guardian Legend, The (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: ad138bb80a1ee4eab6ead06d473a16b1ea4b4f503d61cef4a6c517fc03c8d4f1
+  name:   Guardic Gaiden (Japan)
+  title:  Guardic Gaiden (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: f82e65b91b7ce609146bc8c3975f2c1780fe965c1208695892a2be2cb281616e
+  name:   Gun.Smoke (Europe)
+  title:  Gun.Smoke (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: f39421a126f3b93caa37d6c3ed899840ddfd51b0587446ca459f72564aca1433
+  name:   Gun.Smoke (USA)
+  title:  Gun.Smoke (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 4628f32db9b826d19fe5dd8e2c45a9f70e1041f15b7b44b06dee2f01731566e8
   name:   Gumshoe (USA, Europe)
   title:  Gumshoe (USA, Europe)
@@ -3236,6 +7955,141 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: d0e7a85701615fb1c6f2441ef4d33e71fe8a95e4e5149fabfa05dca91d703662
+  name:   Gyrodine (Japan)
+  title:  Gyrodine (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 0d895a031dd38f2661ba2af4a1b3c7b9753632b1530ea28eec936cf3fda8bf54
+  name:   Gyromite ~ Gyro (World)
+  title:  Gyromite ~ Gyro (World)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: c6e275929764f7950ee85806ef5fdab9dda36e27f9f29935101bfc0916bf90a6
+  name:   Gyruss (USA)
+  title:  Gyruss (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 5c61e53dcade69a1cfac4eb4b979262bd2f70a37aa9aece6402e19870d6ac9e7
+  name:   Hana no Star Kaidou (Japan)
+  title:  Hana no Star Kaidou (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 4ccc1500ca9e95db50961ef4e825bef9ef9e10f994fd6e424693a3e8abf6f72b
+  name:   Hayauchi Super Igo (Japan)
+  title:  Hayauchi Super Igo (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: RAM
+      size: 0x800
+      content: Save
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 767b463b54486311ffb8af9262b847f17a78ebfc9a18b7761e0335fe4a0c6a09
+  name:   Hayauchi Super Igo (Japan) (Rev 1)
+  title:  Hayauchi Super Igo (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: RAM
+      size: 0x800
+      content: Save
     memory
       type: ROM
       size: 0x8000
@@ -3263,6 +8117,28 @@ game
       content: Character
 
 game
+  sha256: 13e71ecf7a022a39c0d0380ae13baea5b97fdf60c1dd68bbe8223746075937f5
+  name:   Hector '87 (Japan)
+  title:  Hector '87 (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 429c833eb61c0728b0d9335c61f4bd8d3fb19c3bf8a18564917bf75526f104af
   name:   Heisei Tensai Bakabon (Japan)
   title:  Heisei Tensai Bakabon (Japan)
@@ -3284,6 +8160,93 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 680a56e038176c7b8deca9fb910b26b097cadd58fa553ea29f3c9836c9a4e11b
+  name:   Hello Kitty no Ohanabatake (Japan)
+  title:  Hello Kitty no Ohanabatake (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 90d8dbd7ef704f6fd44b3ead9d83d56d14750f498b3c142e01752abe07394d8f
+  name:   Hello Kitty World (Japan)
+  title:  Hello Kitty World (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 72fa562dfb319bfe982a68053128126e2ed5d579ff1a36f7345bd3fe624e8e92
+  name:   Heracles no Eikou - Toujin Makyou Den (Japan)
+  title:  Heracles no Eikou - Toujin Makyou Den (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 45f0d711cb0de239be0322f899f4f8dd10eb9232d5cda1e7ed88f42e44d2556b
+  name:   Higemaru - Makai-jima - Nanatsu no Shima Daibouken (Japan)
+  title:  Higemaru - Makai-jima - Nanatsu no Shima Daibouken (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 0ba8c48be4033b02a28be9e7da664a03e3956ba381a3d45bf66e9c080df47167
@@ -3331,6 +8294,158 @@ game
       type: ROM
       size: 0x10000
       content: Character
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 40e2325eb25a77dc06b9f67b13948225a2c686dc07d75f550e8f17867f85c28c
+  name:   Hikari no Senshi Foton - The Ultimate Game on Planet Earth (Japan)
+  title:  Hikari no Senshi Foton - The Ultimate Game on Planet Earth (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0e428c95d9f4c7df1988b0c660c928c4e17e7fc998657f7101e1ebd4042e7532
+  name:   Hino Tori - Houou Hen - Gaou no Bouken (Japan)
+  title:  Hino Tori - Houou Hen - Gaou no Bouken (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 1d414ba38bbbd3495ddb988b340f265912f5bdfc3cdd7fb8b607fff404da1ad9
+  name:   Hiryuu no Ken - Ougi no Sho (Japan)
+  title:  Hiryuu no Ken - Ougi no Sho (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 8e4a04076b6a728a7e65a09737776dcb9defed7922bf0437d9a89bbe8c724b55
+  name:   Hogan's Alley (World)
+  title:  Hogan's Alley (World)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 6db66b884008281c466e3da4af668ac4a9b6e6e164efb3012d6e816f9fee57ca
+  name:   Hokuto no Ken (Japan)
+  title:  Hokuto no Ken (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: df5248feb66d118c193a6a35e633371534c650ce7741931a012c37ae49958fbf
+  name:   Hokuto no Ken 2 (Japan)
+  title:  Hokuto no Ken 2 (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 54fb22e081d95b803798fb4268ece92cf1093d1113713a3355427e97cbe62d12
+  name:   Hollywood Squares (USA)
+  title:  Hollywood Squares (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
     memory
       type: RAM
       size: 0x2000
@@ -3403,6 +8518,91 @@ game
       content: Character
 
 game
+  sha256: a7b9f64b07ad09a3a74b69db4db673c264d54f9735c0820a302cdab7fb6d851a
+  name:   Honshougi - Naitou 9 Dan Shougi Hiden (Japan)
+  title:  Honshougi - Naitou 9 Dan Shougi Hiden (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 4604ba6e93ae7846f6cb8b2e37a79187e84f3c549f3619670269592c5aaa4612
+  name:   Hoshi o Miru Hito (Japan)
+  title:  Hoshi o Miru Hito (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5029ba6d72f01a53cc7dd6e54d6618cd31c7a877bed971d4a638c68132473b8b
+  name:   Hottarman no Chitei Tanken (Japan)
+  title:  Hottarman no Chitei Tanken (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 770abf58074764db12aade941ab1a389a818b8ff94d95f4b4b4913912b1f40b5
+  name:   Hydlide (USA)
+  title:  Hydlide (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 8a18ba7a4d8708ea21ae973fa1871824c55bec30570d0808e2852760f07ce59b
   name:   Hydlide 3 - Yami kara no Houmonsha (Japan)
   title:  Hydlide 3 - Yami kara no Houmonsha (Japan)
@@ -3424,6 +8624,48 @@ game
       content: Character
 
 game
+  sha256: e1193ca695c2d515a5c862aead189dde00884284c2aab8b5196fe906a94f4560
+  name:   Hydlide Special (Japan)
+  title:  Hydlide Special (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 93214cf1c685f0459430bf6e7bb762ee175c9d9f169f2b74beb63d0cd58bbd2d
+  name:   Hyper Olympic (Japan)
+  title:  Hyper Olympic (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: c4bf5a80d8c2a941e9809338f97a86b7764e3c3101ad102bcfd76832cd72d27f
   name:   Hyper Olympic (Japan) (Genteiban!)
   title:  Hyper Olympic (Japan) (Genteiban!)
@@ -3442,6 +8684,348 @@ game
     memory
       type: ROM
       size: 0x4000
+      content: Character
+
+game
+  sha256: 919247ec81bf59b05ddbfdef089b01b095641f36cb0bc220ba260babd95cedf6
+  name:   Hyper Sports (Japan)
+  title:  Hyper Sports (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 2e88fe44e99b9a4d100770161877a5501fbec13b278217f9b9747946e77eabab
+  name:   Hyper Sports (Japan) (Rev 1)
+  title:  Hyper Sports (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 5b2b9eb0a2a1dd539eeb29a5a236265923064fa751312e93cd313e0368c90303
+  name:   Ice Climber (Japan)
+  title:  Ice Climber (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 002bb62441c1625051555109bce93ff2e2a2badb534a350b6d17ad0d7e7ef023
+  name:   Ice Climber (USA, Europe)
+  title:  Ice Climber (USA, Europe)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 76b58a0218d431c3f69d4d2b3be75b0f344165dca6584ca1415b526d0b55b528
+  name:   Ice Hockey (Europe)
+  title:  Ice Hockey (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: b59b46aaaa6b382d61b3e108d0cb83fda65932a1729800043c37f049aa0f43bf
+  name:   Ice Hockey (USA)
+  title:  Ice Hockey (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 80c088f12eb860e3603b122996890372877e382c827765df5e76294ff0a22dd5
+  name:   Ide Yousuke Meijin no Jissen Mahjong (Japan)
+  title:  Ide Yousuke Meijin no Jissen Mahjong (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 4e7134d0001653297587975162bec6d8efce886e86d48b81d31f1e6d510e596d
+  name:   Ide Yousuke Meijin no Jissen Mahjong (Japan) (Rev 1)
+  title:  Ide Yousuke Meijin no Jissen Mahjong (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: dd902f0a59e56f5f919b48ff90f5176db3374e34a35859c573f8c84b413fc372
+  name:   Igo Meikan (Japan)
+  title:  Igo Meikan (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 3d019eb29f7007e70ee91a79087e9e73402244d9830cd946d6dbde5b0c926a61
+  name:   Igo Shinan (Japan)
+  title:  Igo Shinan (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 0888da461ea7b782c1517c68bfbd893a015f62782be1c04afd1e3764d024f93d
+  name:   Ikari (Japan)
+  title:  Ikari (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 4cbf79bfda9d9e37dd113dd56ce1325282f43360c9d8a4231e2995bc49833fd5
+  name:   Ikari Warriors (Europe)
+  title:  Ikari Warriors (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 294f70829b72f3d1b6c81be92b542e96fec1a243d16dfd338a4226b97ad09732
+  name:   Ikari Warriors (USA)
+  title:  Ikari Warriors (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 3775c1184419c0786841c5b4f2694b2a15e181678f92e75fb9b71bfb5668c7b3
+  name:   Ikari Warriors (USA) (Rev 1)
+  title:  Ikari Warriors (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 3ed673cee9984ec8a9e8ca5d722f9918302eeaf533f79a6177a34359da3f5880
+  name:   Ikinari Musician (Japan)
+  title:  Ikinari Musician (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
+  sha256: 5ec016f2d2fb27c27ce8e8e9b54d22616f274b632d4f51d2fc77cea23a5efd4b
+  name:   Ikki (Japan)
+  title:  Ikki (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -3468,6 +9052,50 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: b651bc3e55b351e6f14926625ca8c9bd25bf3e8aa5dadca1afad4c29f2b4c42f
+  name:   Indiana Jones and the Last Crusade (Europe)
+  title:  Indiana Jones and the Last Crusade (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 79c03fec3f459ac6e762c27d8f08debe6589b01df21919ef69645870a16723b3
+  name:   Indiana Jones and the Last Crusade (USA)
+  title:  Indiana Jones and the Last Crusade (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 0f406a7c853b919ed880868420808b945855146db9817ebc3102f08da13fa703
@@ -3556,6 +9184,72 @@ game
   title:  Ivan 'Ironman' Stewart's Super Off Road (USA)
   region: NTSC-U
   board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 68fbdb91cb10581396836eba5ba5d5a45b44cd6124e6022e87439d5bf3683908
+  name:   Jack Nicklaus' Greatest 18 Holes of Major Championship Golf (Europe)
+  title:  Jack Nicklaus' Greatest 18 Holes of Major Championship Golf (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0516f35bf14eb5c06fba01e8545b038bd580d3bfb6bf2b1c896e33d0cd10ff59
+  name:   Jack Nicklaus' Greatest 18 Holes of Major Championship Golf (USA)
+  title:  Jack Nicklaus' Greatest 18 Holes of Major Championship Golf (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 6928e8c589d6d9cc199a7b0841877531ef53dce479e36f90ec1d9cdcbf54372d
+  name:   Jackal (USA)
+  title:  Jackal (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
     memory
       type: ROM
       size: 0x10
@@ -3660,6 +9354,49 @@ game
       type: ROM
       size: 0x40000
       content: Character
+
+game
+  sha256: 8db2cb94dc9caec681b13b66f26590e88229245fa592e5292d097e8599ee79e0
+  name:   Jaws (USA)
+  title:  Jaws (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: b844aff505c9db9fe75a45b115b65b6d3b26010eeae0a6357980a99e5e94ddf3
+  name:   Jekyll Hakase no Houma ga Toki (Japan)
+  title:  Jekyll Hakase no Houma ga Toki (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 4b744bf7205495f80cdf7c3230034ed40ef61a37ae9b716bccd8bad5af0ee166
@@ -3783,6 +9520,179 @@ game
     memory
       type: ROM
       size: 0x10000
+      content: Character
+
+game
+  sha256: 0f3071daebc6e7486c1a2fec9a88c52b6d8dab3be3a16820e935988ec9c3f4f5
+  name:   Jimmy Connors Tennis (Europe)
+  title:  Jimmy Connors Tennis (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 69cf1773c23606cdbd8b5e556f39c7c317100914779115a8c5c8b5dbf3fe0fcc
+  name:   Jimmy Connors Tennis (USA)
+  title:  Jimmy Connors Tennis (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 511e82e8271080e940c90bafcc4e39671eef73af08e6c564e42732839cca7614
+  name:   JJ (Japan)
+  title:  JJ (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 8d21e1e256f82579704d28041ac33e06e48b0defbadc5e8790ea98c41732920c
+  name:   John Elway's Quarterback (USA)
+  title:  John Elway's Quarterback (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: fefa8d2d2d01e723c58026921599310d1133771799904bb6d652bba671af7059
+  name:   Jongbou (Japan)
+  title:  Jongbou (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 2d0b789f04621e4a46c047cbcd54b1c034a258b0631b213076bc844e1543d33e
+  name:   Jordan vs Bird - One on One (USA)
+  title:  Jordan vs Bird - One on One (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: aeb18e54f24d060985247f59cf9a4ad586993b993d7b5ac7b568041ac37de2c3
+  name:   Joust (Japan)
+  title:  Joust (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 8471a6b7c7c7d6c7be0ee278778e2d25dc91462db22643395787eaaeb6e320c1
+  name:   Joust (USA)
+  title:  Joust (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
       content: Character
 
 game
@@ -3942,6 +9852,50 @@ game
       content: Character
 
 game
+  sha256: 5510a6c46506381d580c27e2c80462b0976f1a92deaa7ddc37d950f662b97e00
+  name:   Kakefu-kun no Jump Tengoku - Speed Jigoku (Japan)
+  title:  Kakefu-kun no Jump Tengoku - Speed Jigoku (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: c660d61280f9294080aa05ef25346a354e4bcaedff6feeba77159a8f4de3b814
+  name:   Kamen no Ninja - Akakage (Japan)
+  title:  Kamen no Ninja - Akakage (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 2241728a8072ccdf13c3bb913d2d16abd62bb43c71757d80a376c4f65cd060cf
   name:   Kamen Rider Club (Japan)
   title:  Kamen Rider Club (Japan)
@@ -4052,6 +10006,90 @@ game
       volatile
 
 game
+  sha256: 54c366ec62c0faec3d5619f62bad73092996a26e674f58819e9b76433cc04e15
+  name:   Karate Champ (USA)
+  title:  Karate Champ (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: d67817e44f3a421a78ce4217a0660ee375ea162f1465a28da77659dfa46f8f7c
+  name:   Karate Champ (USA) (Rev 1)
+  title:  Karate Champ (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 8aa5c70100080adf0f6d8945ea10382f3986b99d41e010c356991dfe061eaa8d
+  name:   Karate Kid, The (USA)
+  title:  Karate Kid, The (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 5f3209496275caf5eed14fdf16e4a5a1aedd4d6159faae664074e82da669e685
+  name:   Karateka (Japan)
+  title:  Karateka (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 9905d9999767b7428ba770f855e9b8904123c84fa46b9e6cc0a178fef3ad4e2c
   name:   Karnov (Japan)
   title:  Karnov (Japan)
@@ -4121,6 +10159,69 @@ game
       content: Character
 
 game
+  sha256: 7a406a58cf781b9ceb87f4266dca812a271bfe1f42aa392864e8bc404b2575e1
+  name:   Kekkyoku Nankyoku Daibouken (Japan)
+  title:  Kekkyoku Nankyoku Daibouken (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: b62b06af7acd451592c8b007d6674d88796e9d9daf990988ffbee07d48516f7a
+  name:   Kekkyoku Nankyoku Daibouken (Japan) (Rev 1)
+  title:  Kekkyoku Nankyoku Daibouken (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: bdd265d499d74578445f28eb158b642d3feec8eb95559f918d4deef260f05c06
+  name:   Kero Kero Keroppi no Daibouken (Japan)
+  title:  Kero Kero Keroppi no Daibouken (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 67123fe28cf5fbadeafc77400a0812f0135ab36706ec7d1267f84931d044e71d
   name:   Ki no Bouken - The Quest of Ki (Japan)
   title:  Ki no Bouken - The Quest of Ki (Japan)
@@ -4144,6 +10245,71 @@ game
       content: Character
 
 game
+  sha256: a2ad856850af3b2a84f3d175946300450d0e45d4e56e3224f2c88d5510a7e3df
+  name:   Kick Off (Europe)
+  title:  Kick Off (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: f85a689b4ff7a5e51703e5fabc73ca1af43e6519754c4a59c11a960baa323b47
+  name:   Kid Kool and the Quest for the Seven Wonder Herbs (USA)
+  title:  Kid Kool and the Quest for the Seven Wonder Herbs (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 247b44799bacdfd66ffe30212da2d67d5bbab877042c13050ba30ea22f933d74
+  name:   Kiddy Sun in Fantasia (Asia)
+  title:  Kiddy Sun in Fantasia (Asia)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 73982959bbf7dad73dd2e57b08ed79dbdcf7399aa87f0ca602995c366a3732bb
   name:   Kidou Senshi Z Gundam - Hot Scramble (Japan)
   title:  Kidou Senshi Z Gundam - Hot Scramble (Japan)
@@ -4162,6 +10328,27 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: a0c9c79d0258fa2990607a92e59d373efbb0874f9662f79ab543104888d1072a
+  name:   Kidou Senshi Z Gundam - Hot Scramble Final Version (Japan)
+  title:  Kidou Senshi Z Gundam - Hot Scramble Final Version (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -4211,6 +10398,155 @@ game
       content: Character
 
 game
+  sha256: 25774b054413e212c204d05dffbb10d079a5d0c51d6728465998c611a419262f
+  name:   King's Knight (Japan)
+  title:  King's Knight (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: be97bca71e1bf099ef0f6ff91aed506df7b0506433c76e5deccea7b130e3a20f
+  name:   King's Knight (USA)
+  title:  King's Knight (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 913c5eb7d4390d0f797da95cdebd45cdb0f349ddf4cffa29d471a7f462c25717
+  name:   Kings of the Beach - Professional Beach Volleyball (USA)
+  title:  Kings of the Beach - Professional Beach Volleyball (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 3d4966ad4f0b2fe818148816cb28431fad154e7a9be338f73d870eec39ba3a35
+  name:   Kinnikuman - Muscle Tag Match (Japan)
+  title:  Kinnikuman - Muscle Tag Match (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: efc2fd31182294452de0d71ea39c6133acc5dee7187766f7f96625543d9bedd5
+  name:   Kinnikuman - Muscle Tag Match (Japan) (Rev 1)
+  title:  Kinnikuman - Muscle Tag Match (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: ef63df6bcbc7e13dace53f106a247485a09409799b99c8415e934ba532cdaa53
+  name:   KlashBall (USA)
+  title:  KlashBall (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 50b667f84cae86afb67dae6f63c16faf7df9e5cbeeb7626aa5c2e961d7fb3f3f
+  name:   Konami Hyper Soccer (Europe)
+  title:  Konami Hyper Soccer (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: d13fa0e0694a8318d7a7c51c759c254415bf1b41869a4cc04d3233062f7256ae
   name:   Konami Wai Wai World (Japan)
   title:  Konami Wai Wai World (Japan)
@@ -4232,6 +10568,69 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: b5f367b20609d0ce9ec641364415ef1e02642bca34afecadd8bf2e06cce39cc2
+  name:   Kung Fu (Europe)
+  title:  Kung Fu (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 0ba5e69962f6576d3729aa967092a7e8c98d00213cd98026dee343bff67b4177
+  name:   Kung Fu (Japan, USA)
+  title:  Kung Fu (Japan, USA)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 323d330cb50e0a4cd7855a3eedb0e97a08b31d9f7c638e4fa53ab58c1263154e
+  name:   Kung-Fu Heroes (USA)
+  title:  Kung-Fu Heroes (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -4258,6 +10657,28 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 59417473c5dc7fe25eb98eeed75b457ace127579c33f878fe530d1b978f7dd0e
+  name:   Kyoro-chan Land (Japan)
+  title:  Kyoro-chan Land (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: b0e11b917f5c604e8a6ad5a196a40219e5b19b484c8972e3255c81c4df4bda31
@@ -4410,6 +10831,28 @@ game
       content: Character
 
 game
+  sha256: 22345c87243f70b06caceee575dd95cfb026a61bc24f6e0dc8cc9dd93bc961fd
+  name:   Labyrinth (Japan)
+  title:  Labyrinth (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: a45d30c949f9d0942700826e4433ebad39e08da8252ecb541cae9d495928d63f
   name:   Lagrange Point (Japan)
   title:  Lagrange Point (Japan)
@@ -4461,6 +10904,180 @@ game
       content: Character
 
 game
+  sha256: 54dd62754f48e39af39c3e8d645897af25aaba31523267bc41d4c95f2b0348d5
+  name:   Last Starfighter, The (USA)
+  title:  Last Starfighter, The (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 8dc6d6d4b49ff2aedd7859a3ecf22cb0e70e80aabb618e5a6ef5a9a1f9f2c327
+  name:   Law of the West (Japan)
+  title:  Law of the West (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 53923dcb59afac40fbfed4aa2298be156b5b9763ec43956757ec44092ba799c5
+  name:   Layla (Japan)
+  title:  Layla (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 9d83796d8feba9713fa5a1354fd9253cda5cb33ab5bc6f1c6f97d5eb90aef6c3
+  name:   Legend of Kage, The (USA)
+  title:  Legend of Kage, The (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
+  sha256: d2a585ff6febf59447f9bd9fbb387ae4985385d6f6f61a70e145a5ee69523018
+  name:   Legendary Wings (USA)
+  title:  Legendary Wings (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: dbd530e6ca07cc4b255b1b885cd5b6b2e23b8d3cac4733c3e4d96acd7d751c28
+  name:   Life Force (USA)
+  title:  Life Force (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: a35d8a6f2139cd76ef85226e6cf5c7bd26e7e39b47d49bc5c089f982701129e0
+  name:   Life Force (USA) (Rev 1)
+  title:  Life Force (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 9a1562c3d572d642d83f95b7d3102cdf5e861f494f314bcdbd6716d09c05f6d9
+  name:   Life Force - Salamander (Europe)
+  title:  Life Force - Salamander (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: cecc797ffc82c5764e89038262c00b325f44afc0d9fc4b5bef295ea227e1dd22
   name:   Lion King, The (Europe)
   title:  Lion King, The (Europe)
@@ -4473,6 +11090,114 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 24d0cb797720cdcaf8b7438b67a84b44aa3fa8faa6ad5138ed64533ae7f68c63
+  name:   Little Mermaid - Ningyo Hime (Japan)
+  title:  Little Mermaid - Ningyo Hime (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 68e98b1b8dc5da610321f92718b4b4c2b2b71b6c752ff25ca6926e26cd91c57f
+  name:   Little Mermaid, The (USA)
+  title:  Little Mermaid, The (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5d65bc6799a147486a35299ddd07060a7c858111f0219a503586e4435a43214d
+  name:   Lode Runner (Japan)
+  title:  Lode Runner (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 6c17c7bf2f7466eb43718305a0d74bd75f31b65429bc1fe406c34565e792310c
+  name:   Lode Runner (USA)
+  title:  Lode Runner (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: fbf9426155adf3b8a57b9123760c88f2c61f33fb2f6c5b21c894d5d83dd19138
+  name:   Loopz (USA)
+  title:  Loopz (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
       content: Program
     memory
       type: RAM
@@ -4502,6 +11227,112 @@ game
       content: Character
 
 game
+  sha256: bcae0c6a0295a66110ad51093513712d4435c536b3a4037f43bb9e7afbfaaf21
+  name:   Lost Word of Jenny - Ushinawareta Message (Japan)
+  title:  Lost Word of Jenny - Ushinawareta Message (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: b4b1ead035b315c307b6d2509389d3a8c105dc971187ccdc431420cc62d91752
+  name:   Lot Lot (Japan)
+  title:  Lot Lot (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 7f23e026858c726a0c11c3880cc2e467f5ea1022e237e55265341839bbd577dc
+  name:   Lunar Ball (Japan)
+  title:  Lunar Ball (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 77e4b828e1e10a58f817732630507dfbd742ea73b200689c6237b0e43d4f0923
+  name:   Lunar Pool (Europe)
+  title:  Lunar Pool (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 9cdcac614a14e0aefe34d6333bc23ef3e08986144d2dacd322835aad8ec62add
+  name:   Lunar Pool (USA)
+  title:  Lunar Pool (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 8c801e6fb86ff4174d7c02cd576a1ada260130b403d09ddc76f6aeae9792bf12
   name:   Lupin Sansei - Pandora no Isan (Japan)
   title:  Lupin Sansei - Pandora no Isan (Japan)
@@ -4522,6 +11353,90 @@ game
     memory
       type: ROM
       size: 0x10000
+      content: Character
+
+game
+  sha256: d10e4280b6ca868142061ab731aeb378c983334b89a1727a524c57c241812d13
+  name:   M.U.S.C.L.E. - Tag Team Match (USA)
+  title:  M.U.S.C.L.E. - Tag Team Match (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 58c80d2740848f741ba32b60d63ebebb155fc50dff72afb7aa993d097f45f5a3
+  name:   Mach Rider (Europe)
+  title:  Mach Rider (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: ef238662a27934d6dbe1692e822786a74a9a2c8bc58c38aa0fd5cfb3e2f1abce
+  name:   Mach Rider (Japan, USA)
+  title:  Mach Rider (Japan, USA)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 944105c6dcc57314968d53a2e0dcdfc0e2b60678a53839ba25925416a7ac0e8c
+  name:   Mach Rider (Japan, USA) (Rev 1)
+  title:  Mach Rider (Japan, USA) (Rev 1)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -4642,6 +11557,70 @@ game
       content: Save
 
 game
+  sha256: 25772946d05c3994103894ffd94d8a51cba18aa16bb01a2ddc1c09eee3bddd59
+  name:   Magmax (Japan)
+  title:  Magmax (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: daa1c7263a804920b2ebeb5b2041da0a207a49b5bcddbfdf51f02ba7e3d89092
+  name:   Magmax (USA)
+  title:  Magmax (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: b15ba5f05e0f917344965d6287108529a9a0f15161f5e1b57d11124d0c20f599
+  name:   Magnum Kikiippatsu - Empire City - 1931 (Japan)
+  title:  Magnum Kikiippatsu - Empire City - 1931 (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 9935c7ef77152a4d91e757a02f2c58b05d3635d10d1f249129ea036fb945e69e
   name:   Maharaja (Japan)
   title:  Maharaja (Japan)
@@ -4665,6 +11644,69 @@ game
       content: Character
 
 game
+  sha256: 1da827bf9047ef3c05a26f683c1eb3fe63c37a81f18a06b497ce8d4c364a357e
+  name:   Mahjong (Japan)
+  title:  Mahjong (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: ac5b4a29b301e23dc979bfabd2e714513b188dcf9c7ed4ae83ef23fed9cf20ee
+  name:   Mahjong (Japan) (Rev 1)
+  title:  Mahjong (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 0986e9e8057c476aff3726aac6b1b7698e8e6de77530f394b8be2e5b5caf9bea
+  name:   Mahjong (Japan) (Rev 2)
+  title:  Mahjong (Japan) (Rev 2)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 4ef61de405406bfa9eeaf19ed1d882444c41bb606ac78673b7ec8ee323d0e073
   name:   Major League (Japan)
   title:  Major League (Japan)
@@ -4683,6 +11725,135 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: 0fb98e5ac91a17f995ce72cfe376e75c3a31b0d4eb60529604745b5000fe6f18
+  name:   Major League Baseball (USA)
+  title:  Major League Baseball (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 6e017c8619f900c0867ee5b0b1148c8130da522912b60aa341e8f58b8199f21a
+  name:   Major League Baseball (USA) (Rev 1)
+  title:  Major League Baseball (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 92f496a1e7ed18df8a35c300f58797f8d1d46b096ff4a65da676d6efe456a5ac
+  name:   Majou Densetsu II - Daimashikyou Galious (Japan)
+  title:  Majou Densetsu II - Daimashikyou Galious (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: c75201cfacd2ebd3f6376cd84d6af27bd2b9e42cdfdaad2aeca6252f3214b53c
+  name:   Makaimura (Japan)
+  title:  Makaimura (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 906c3ba463960a086c3f2603ede0b35121babed27cda9e20a2ddef1ce0ca2eed
+  name:   Maniac Mansion (Japan)
+  title:  Maniac Mansion (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 6bc8f71a1d19cab1a1364c7e2988eaec25b2694aa29670360cab6c513f1c47ac
+  name:   Mappy (Japan)
+  title:  Mappy (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -4770,6 +11941,48 @@ game
       volatile
 
 game
+  sha256: 7e2747b4cfcdc4e64c1188da6796779d922a521c49cf0d86182b85f7a376328d
+  name:   Mario Bros. (Europe)
+  title:  Mario Bros. (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 0cc334007d3eae698cdcd034d12ec9bab2b5266e85bc703cf24ccb4e2d63b654
+  name:   Mario Bros. (World)
+  title:  Mario Bros. (World)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 4ac0926d1e4704e75e7dfc27c4d990ebdbe685002b9af1a80a385604f3cb162c
   name:   Mashou (Japan)
   title:  Mashou (Japan)
@@ -4790,6 +12003,71 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: c8e7036e8afcd95acaf3a5e0956df53beaab127a7defcc0e80d629653ff67c23
+  name:   Mega Man (Europe)
+  title:  Mega Man (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5314ad0c406161195b6bb100ee11304bab8af121bba85992be896d5cb26b109e
+  name:   Mega Man (USA)
+  title:  Mega Man (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 11321419b21821d4a30311946ed252d00080da18df7658d851375eb56b0a6dad
+  name:   Meikyuu Kumikyoku - Milon no Daibouken (Japan)
+  title:  Meikyuu Kumikyoku - Milon no Daibouken (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
 
 game
   sha256: c9a294e5ac3490c346e24db8125761fac7e8ba57df0456a6dd29d62a34dbfda7
@@ -4832,6 +12110,72 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 69a51ca8c455518da44112748f1d517a28d50b90c1389b5b68083ff086641a84
+  name:   Metal Gear (Europe)
+  title:  Metal Gear (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 126594af516d7a4731196744306a9e2804dc7b6c67f597d75bf21d8128a50e0e
+  name:   Metal Gear (Japan)
+  title:  Metal Gear (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: f6d29afbd7ddad33672852232791a396695de2e77dccb83088a8d6b139d8c9cb
+  name:   Metal Gear (USA)
+  title:  Metal Gear (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: fa44773e3c2f1a435cbe7a8e098508b92cd79ba88c71f798b76c08aa0e257316
@@ -4882,6 +12226,69 @@ game
       content: Character
 
 game
+  sha256: eb58ea4856030ae44d404439a04a452c10e647d0bf626ecdcd8497ba900dfae7
+  name:   Mickey Mouse - Fushigi no Kuni no Daibouken (Japan)
+  title:  Mickey Mouse - Fushigi no Kuni no Daibouken (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 989243c99d6e58c4fbcc6999473e48a389eba22cf1d3cb95dbe4c8b1f3ce15d7
+  name:   Mickey Mousecapade (USA)
+  title:  Mickey Mousecapade (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 089fe9275106dddffae8c8a0bc0d728d44a14bfd83a5e248940a1c978d2c44f2
+  name:   Mighty Bomb Jack (Europe)
+  title:  Mighty Bomb Jack (Europe)
+  region: PAL
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 02d86ba60b7f43f9d04131522263e7560d9ad1d4cc474b909d487cc0d470ccc3
   name:   Mighty Bomb Jack (Japan)
   title:  Mighty Bomb Jack (Japan)
@@ -4927,6 +12334,27 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: a2b4b0fd54028f1bbbdef152d8f2a172270b60162802d298accd0c698d258c3d
+  name:   Mighty Bomb Jack (USA)
+  title:  Mighty Bomb Jack (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -5014,6 +12442,69 @@ game
       content: Character
 
 game
+  sha256: bd84b27f752aa568374e1c8a6df948340a1374478b754f2ddc32e37d75b4a2b9
+  name:   Millipede (USA)
+  title:  Millipede (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 9f0842b52b30b118b478be6b40b4ce22330f25ca638a737d64b18bec171b3535
+  name:   Millipede - Kyodai Konchuu no Gyakushuu (Japan)
+  title:  Millipede - Kyodai Konchuu no Gyakushuu (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 6eea421f6c0738ff3abfd6e059e91c3409eedd2150093d3e01d49dfaad4dbf80
+  name:   Milon's Secret Castle (USA)
+  title:  Milon's Secret Castle (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: abe5fabba427d3247b31236aba26a2669c8b79733b97b1a14ac9370eee09018b
   name:   Mindseeker (Japan)
   title:  Mindseeker (Japan)
@@ -5058,6 +12549,70 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: b17f5b18caffefdffa39d74978d03178892e03a0c66ff3ef98de4af7a33079d9
+  name:   Minna no Taabou no Nakayoshi Daisakusen (Japan)
+  title:  Minna no Taabou no Nakayoshi Daisakusen (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: d7cdc97d76ddcade456271bae2779a03bdb2346143e3ccf2521dc80ce8c05907
+  name:   Minna no Taabou no Nakayoshi Daisakusen (Japan) (Rev 1)
+  title:  Minna no Taabou no Nakayoshi Daisakusen (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: ea0dc5279f149922e48799f45fe41284286c1d251145648b7317e3db9bcc20ed
+  name:   Miracle Ropit's - 2100 Nen no Daibouken (Japan)
+  title:  Miracle Ropit's - 2100 Nen no Daibouken (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 96772d6ffccf3e0ca66c1dd59c7f03b7749ef94169e949ae0bcf8bdc9aa49aa8
@@ -5146,6 +12701,27 @@ game
       content: Character
 
 game
+  sha256: b940678f703671fc66df60c16a1b1c41e164b87c3affb45ffb48e79c10e2170e
+  name:   Moai-kun (Japan)
+  title:  Moai-kun (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 14868615d1ca04bf91cfa4ab5a9c55aef090cc957f786f9b337247047b7b179e
   name:   Moe Pro! '90 - Kandou Hen (Japan)
   title:  Moe Pro! '90 - Kandou Hen (Japan)
@@ -5186,6 +12762,28 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: f0a6b6514fcb30b305f567d6a7be40f8ebd8bea6f9571567d61c27723b9a429c
+  name:   Moero TwinBee - Cinnamon Hakase o Sukue! (Japan)
+  title:  Moero TwinBee - Cinnamon Hakase o Sukue! (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 4ba739e8e46e9c2c9086fe001e2733f9cffba9002422b85185a87a2041c32b73
@@ -5377,6 +12975,28 @@ game
       content: Character
 
 game
+  sha256: da757d6273d75e183b99f900609eef9422a000cc8ee52eace014380c58c84eaf
+  name:   Momotarou Dentetsu (Japan)
+  title:  Momotarou Dentetsu (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: f2aef1a9ade54330ff821083fda7e03c7a5f93d77f4da359069d84f98ab1f852
   name:   Money Game, The (Japan)
   title:  Money Game, The (Japan)
@@ -5400,6 +13020,49 @@ game
       type: ROM
       size: 0x8000
       content: Character
+
+game
+  sha256: 9f04b8e867aa85692d6985761b3a04d8cfe714854c8d95dd327c854cc2073279
+  name:   Monster Truck Rally (USA)
+  title:  Monster Truck Rally (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 3badc64007c9f5bea7873b1704ec415ceac9ef02fd2a41b755c43208368b53f2
+  name:   Mottomo Abunai Deka (Japan)
+  title:  Mottomo Abunai Deka (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 97ff1ac9e6061ba5fb02b4626abf3521f84ee1542fa8093d617ede08dbb17cdc
@@ -5448,6 +13111,112 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: f7cc35a736ffd7804056b92ab92bfef02ded95d999ac126b680e87b573f18182
+  name:   Ms. Pac-Man (USA)
+  title:  Ms. Pac-Man (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: e2edbc7e4e1245327de6b42eaf77561122befd49356afab754ba47a74e2c4442
+  name:   Mugen Senshi Valis (Japan)
+  title:  Mugen Senshi Valis (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 75f9462a27848319be7461e39c6df990ede740f28317299add964508cc48c14d
+  name:   Musashi no Ken - Tadaima Shugyou Chuu (Japan)
+  title:  Musashi no Ken - Tadaima Shugyou Chuu (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 61cb18d11771cffa08f79fd6973f634c8351703a2fe0f79858171d72a5a46582
+  name:   Mystery Quest (USA)
+  title:  Mystery Quest (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 68943c9e55fc9df846ae0a20decbe142fe516c9e8ba7b4d2c4f7b6aee0fc0fd7
+  name:   Nagagutsu o Haita Neko - Sekai Isshuu 80 Nichi Daibouken (Japan)
+  title:  Nagagutsu o Haita Neko - Sekai Isshuu 80 Nichi Daibouken (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -5537,6 +13306,28 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 3c72fc75173dd53a7e9bf851889ed9bfe77bb51bbbf97f820aae169598a84e46
+  name:   Nangoku Shirei!! - Spy vs Spy (Japan)
+  title:  Nangoku Shirei!! - Spy vs Spy (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: cb6cc5ceddb82e92fc36b8948588d19556706b3f89810395613ab21c0954aad9
@@ -5660,6 +13451,28 @@ game
       volatile
 
 game
+  sha256: 4ab6b5f4d6ce39fff0ef5a3d89e0884f44491fbd7d9028bd1f02a266c2698197
+  name:   Nekketsu Kouha Kunio-kun (Japan)
+  title:  Nekketsu Kouha Kunio-kun (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 4b382baa70cbc52977fd766f49a3c7c9a3239f0d9581cd961b8b26700c53247d
   name:   NES Play Action Football (USA)
   title:  NES Play Action Football (USA)
@@ -5681,6 +13494,28 @@ game
       content: Character
 
 game
+  sha256: aa0f7f60a6cff1464375ccfda4ba3ca38ddb1ee44cdefee012873c0be9f06728
+  name:   NFL (USA)
+  title:  NFL (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 58be6a811ee3370882160115253b610581e8b4af7228669eb3fbd56e7a13117c
   name:   Nightmare on Elm Street, A (USA)
   title:  Nightmare on Elm Street, A (USA)
@@ -5699,6 +13534,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 9150e08b57839fe6a82e4397463968bfb251214ea78f095f67e277e58c1f1203
+  name:   Ninja Hattori-kun - Ninja wa Syugyou de Gozaru no Maki (Japan)
+  title:  Ninja Hattori-kun - Ninja wa Syugyou de Gozaru no Maki (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
 
 game
   sha256: 648cf7ac553517573cc9b3955ab50566a91974b2348154910bfa53ef15d55b56
@@ -5743,6 +13599,91 @@ game
       content: Character
 
 game
+  sha256: 622c62d48aa244fb2427ce8d0cf45e5fc57d94ad82e47a3b5b45a0dd643c9cd7
+  name:   Ninja Kid (USA)
+  title:  Ninja Kid (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 80ad15c09c9794f52f1f35ea9bccddcdfdedaba56edc78bc1e7e0c3ef093c3a0
+  name:   Ninja-kun - Ashura no Shou (Japan)
+  title:  Ninja-kun - Ashura no Shou (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 25f785b01cc7b8480e37c1ddf39b3a72bd0322e88b2ea987e545723bfa47a3f7
+  name:   Ninja-kun - Majou no Bouken (Japan)
+  title:  Ninja-kun - Majou no Bouken (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: a6b2d5da7ce8d3c8d0abbd1317104c69e9ce5698e7256f53845c811db6cf94e6
+  name:   Ninja-kun - Majou no Bouken (Japan) (Rev 1)
+  title:  Ninja-kun - Majou no Bouken (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 98433ab0b15d19d23c544c2237988abf4a489914e63e18efc28fe2d92ae8c84a
   name:   Nishimura Kyoutarou Mystery - Blue Train Satsujin Jiken (Japan)
   title:  Nishimura Kyoutarou Mystery - Blue Train Satsujin Jiken (Japan)
@@ -5761,6 +13702,48 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: e506900cde4b49a1d234c8508f4fee3ad7c5f9b3fa710c49597395994dcbabb7
+  name:   Nuts & Milk (Japan)
+  title:  Nuts & Milk (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 7ab0e0a0724067bc4efeab2cbd8c4f3d127e59c30302b055a7c0b6cefb0f3d32
+  name:   Obake no Q Tarou - Wanwan Panic (Japan)
+  title:  Obake no Q Tarou - Wanwan Panic (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -5806,6 +13789,27 @@ game
       size: 0x8000
       content: Character
       volatile
+
+game
+  sha256: b2b21a434840d24af89546ae2b2576111b6c37526452d3ff312182f71a02a6e3
+  name:   Onyanko Town (Japan)
+  title:  Onyanko Town (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
 
 game
   sha256: adf95de2cdff7b606ceedf5908679ef9bb8ffeec37d3d1dad3446ef85ca17026
@@ -5877,6 +13881,324 @@ game
       content: Character
 
 game
+  sha256: 4a2c4a082e0b735e678ee5393c43da91f895ceb8e2067bdde8f2e7221d4e205c
+  name:   Othello (USA)
+  title:  Othello (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 7d5961b36952c439f6243d6202bafbe0cd5f6fdae54a9c2e1f98039c4ee4eee7
+  name:   Outlanders (Japan)
+  title:  Outlanders (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 15a2652861a1fb58c526a0d6fb1fcd24943bd1213cd54f87d01c96a83718e396
+  name:   Pac-Land (Japan)
+  title:  Pac-Land (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 41f63f0506bc1871285b24273a71058f5a4ace0ba36b93cc575b04375ae26896
+  name:   Pac-Man (Europe)
+  title:  Pac-Man (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 30e1b191069992208841cde9b83afe710f6e1d61fceed9ebb6f554cab81afe78
+  name:   Pac-Man (Japan)
+  title:  Pac-Man (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 1e0214b8b3baaea618abd379123733080fdb8b14e4ea230a1199c5f3405f6eb8
+  name:   Pac-Man (Japan) (Rev A)
+  title:  Pac-Man (Japan) (Rev A)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 92f4696149066cbcf53b2d9d06f58a6d6cba3e99e9f4cee7424e8ea7f6c27a68
+  name:   Pac-Man (Japan) (Rev B)
+  title:  Pac-Man (Japan) (Rev B)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: fa12a61eb787bf8346a81e5b6eaede75238a1735db24a6f4df51ac3a6b499f18
+  name:   Pac-Man (USA)
+  title:  Pac-Man (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 1e60a181e1f89f2249a3e0d44a7765c2cdd9e0446f1671c63bf2c6f6df562d4c
+  name:   Pac-Man (USA)
+  title:  Pac-Man (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: be59fd441e2509b67359cd02cadfa825ced0ec7fda8edb9c101d90fc7a793e61
+  name:   Pachicom (Japan)
+  title:  Pachicom (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 9a633d860e35ec810d9197b3bf3d99f0ee2c200a340a8be17b67752a3eb74a28
+  name:   Paperboy (Europe)
+  title:  Paperboy (Europe)
+  region: PAL
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: adbc7681f60f5fe30df83354c246d9f6c231afdf5e006b5e494f97dc588371c3
+  name:   Paperboy (Japan)
+  title:  Paperboy (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: f1c9c4723190d6be5f1f683ad5fd8cc123abd70d42f486c175a25f1237db6199
+  name:   Paperboy (USA)
+  title:  Paperboy (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 9f491efae651ea239372dfe403da1f03a6c4b91a527ebfc249e7443cb5638c73
+  name:   Paperboy 2 (Europe)
+  title:  Paperboy 2 (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: dec09033f68850bd25cf3e8bf0e05a44970301c4aaac2cbc27b8f9e96392b409
+  name:   Paperboy 2 (USA)
+  title:  Paperboy 2 (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 035383efbc5131942ba7df721ba406fd57c08a9ff87e3aa6e6f3d272bda86c44
   name:   Paris-Dakar Rally Special (Japan)
   title:  Paris-Dakar Rally Special (Japan)
@@ -5926,6 +14248,48 @@ game
       content: Character
 
 game
+  sha256: 687080cc1ba2d5f65aec071e7754094ca52b6333e5d79c16ac2091c8162880aa
+  name:   Peepar Time (Japan)
+  title:  Peepar Time (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
+  sha256: ba4f362b1d332a389d7c786e09cf4c35d48791550b1c63e52ce133bd4e647c04
+  name:   Penguin-kun Wars (Japan)
+  title:  Penguin-kun Wars (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 6d2887d978262401f315836411537a208272cba7721f598308d92983f1f5731a
   name:   Perman (Japan)
   title:  Perman (Japan)
@@ -5966,6 +14330,28 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 82d6e2fb7b67b576b75647e26080d2668040eceb5efc14203c5a751a147f359f
+  name:   Phantom Air Mission (Europe)
+  title:  Phantom Air Mission (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 1067b39e520810e55300a4ec1c94f4dddee17e899090af30cf5d626058dbe531
@@ -6020,6 +14406,48 @@ game
       volatile
 
 game
+  sha256: 74f2f752762cf5186ad491422ba1afc925b9eab1ebf729061b998c6ac522e921
+  name:   Pinball (Europe)
+  title:  Pinball (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 910ba4505b46a99b3779d84fd22ba8b18f3a649b0c1a11706c4609d06ce0bc18
+  name:   Pinball (Japan, USA)
+  title:  Pinball (Japan, USA)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: b7daa24069d54f56fb71e7659b4ad40a6e9f4695f73e7a0d0e56d5c80e2e6474
   name:   Pinball Quest (Japan)
   title:  Pinball Quest (Japan)
@@ -6038,6 +14466,27 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: a57f873ccb2c8842e9ef1a8380c87026a8ef0c6649f1cc02ce0743fae61ea120
+  name:   Pipe Dream (USA)
+  title:  Pipe Dream (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -6083,6 +14532,31 @@ game
       content: Character
 
 game
+  sha256: caeb38b9d8c02e01ad2905f17ff40b7b01b524540bc891dacdefa5f2b3294072
+  name:   Playbox BASIC (Japan)
+  title:  Playbox BASIC (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: RAM
+      size: 0x800
+      content: Save
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 6eabf52d9e7250d74a8b2186dc0da2ae89771c207dcb5d905e0328b24c8984c4
   name:   Pocket Zaurus - Juu Ouken no Nazo (Japan)
   title:  Pocket Zaurus - Juu Ouken no Nazo (Japan)
@@ -6099,6 +14573,111 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: 5a4381356dbac58d49d0bb4d16866c9d05629f90cb70d9925394498348de6610
+  name:   Pooyan (Japan)
+  title:  Pooyan (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 70c307aa0b1a4ce11259bf861e9a3260ea56743d4987d3a82e500687212e1cc0
+  name:   Popeye (Japan)
+  title:  Popeye (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 97f56ee3bcb0542996401a65c63a0e91c1c9c71da07f0619975e910946f9540d
+  name:   Popeye (World)
+  title:  Popeye (World)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: e20c619fec4c7aeb244710a3b89040f85b0aaa4cea52b5f7fede63d11db00cea
+  name:   Popeye no Eigo Asobi (Japan)
+  title:  Popeye no Eigo Asobi (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: f9434e80c4153283c96a4aac99d40319de9b0d4836520003c16bb70a5d53a3d7
+  name:   Portopia Renzoku Satsujin Jiken (Japan)
+  title:  Portopia Renzoku Satsujin Jiken (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -6123,6 +14702,137 @@ game
       content: Character
 
 game
+  sha256: 4ea88cc3edaf7e1e1bbb1fd39b468c6e8440fd5912766f79fb5c05ce9e7cd28b
+  name:   Power Soccer (Japan)
+  title:  Power Soccer (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 78369193c891ca76c49eb5921fbee269a4f7beef8bee2bf57c866ef83eb67813
+  name:   Prince of Persia (Europe)
+  title:  Prince of Persia (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: a17c60e62bdc47b524cec1c207531cfa44e554a693ecd38841024ee2c37493f9
+  name:   Prince of Persia (France)
+  title:  Prince of Persia (France)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: d6ea51ad16b9e9e5b1e91c923c384e020294cda74afe589f922d2b35dfb47826
+  name:   Prince of Persia (Germany)
+  title:  Prince of Persia (Germany)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5b2f25fc2a628f1279216736c9ab9da90cd039dd743d17fae40d218dd6e8e1ff
+  name:   Prince of Persia (Spain)
+  title:  Prince of Persia (Spain)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 7b0899bfde9661d1af5c2d88c46a8a70f1623729bf52db654fb40cda4554820b
+  name:   Prince of Persia (USA)
+  title:  Prince of Persia (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 3910ae7495a71e6a55f70ed31eb345d28d6e9d524fe88679719d831f8f2553ce
   name:   Pro Sport Hockey (USA)
   title:  Pro Sport Hockey (USA)
@@ -6142,6 +14852,94 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 32ee7a7f8b827018a9d7d4031430003ea716172d537b9b90e286e333a8ba7345
+  name:   Pro Wres (Japan)
+  title:  Pro Wres (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 260613379b87c76f6e82efc22d6b26fd9e4d5435fa6ab363b42850d67722faee
+  name:   Pro Wrestling (Europe)
+  title:  Pro Wrestling (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 96dafa1208bda2eaa601d6855d86cf670556018c2859805cae51a88f83e66e9e
+  name:   Pro Wrestling (USA)
+  title:  Pro Wrestling (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: e144020f37416f80f1a0da47aa9b3fbda338c61fcd175e8b2dc98df181e24b85
+  name:   Pro Wrestling (USA) (Rev 1)
+  title:  Pro Wrestling (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 6d37214ca4c4fa53d0dc0dd0c3a287667c3e2618c5f0cbcc41e5436d3b31379b
@@ -6213,6 +15011,28 @@ game
       content: Character
 
 game
+  sha256: 85ad3d397ee03f2e49312c60decdbc0a5d097c5f96fedcb8a2ab1382e61a242c
+  name:   Probotector (Europe)
+  title:  Probotector (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 17f4b9a5c8175c2f6650d451e7d96f9ddd5b5dabfe87f8f8d6a84adcb1439bec
   name:   Punch-Out!! (Europe)
   title:  Punch-Out!! (Europe)
@@ -6276,6 +15096,113 @@ game
       content: Character
 
 game
+  sha256: 691ef0807cacd7032c52ff65ab1718c28be45c7220afcc13f20c645dfb40d4ed
+  name:   Puss 'n Boots - Pero's Great Adventure (USA)
+  title:  Puss 'n Boots - Pero's Great Adventure (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 36d12a8f8e434b960cfb3a955c00d4211dc7304da59308f660c00f9c5af7949b
+  name:   Puyo Puyo (Japan)
+  title:  Puyo Puyo (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: ebb52e4ba3a2eb16ad1cd8a7f81cfe1f5cece8358976577cd0ea2d26325d720d
+  name:   Puzznic (Europe)
+  title:  Puzznic (Europe)
+  region: PAL
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 1fe9e3c25a17c97c53ea7975c42210e4684939698e1a4dbc831461451b41287e
+  name:   Puzznic (Japan)
+  title:  Puzznic (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 0cf2fc17a59a0932ce43e6b2e9ea4e2570f03139784b5c9df429a499e734b92e
+  name:   Puzznic (USA)
+  title:  Puzznic (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 1a8cafde15dd16dee6c651ff8ab8bbf5b977d1b7047cb84d913c0aab02727ef7
   name:   Pyokotan no Daimeiro (Japan)
   title:  Pyokotan no Daimeiro (Japan)
@@ -6294,6 +15221,48 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: 5fa346174b6b5a9dc2b5fe113ef8d8ac013a32b26dde6d5dfc9ed631d5e9af25
+  name:   Q-bert (USA)
+  title:  Q-bert (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 7a7b7147a9a25d7ae6dd28ecc1d0bb0d437aa318656ab0da0457362980db5e07
+  name:   Quarth (Japan)
+  title:  Quarth (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -6473,6 +15442,245 @@ game
       volatile
 
 game
+  sha256: ca69d694d684be2148efa08d587eafe7038d9ff5d84a3b202cdc48a52cc0a7af
+  name:   Raid on Bungeling Bay (Japan)
+  title:  Raid on Bungeling Bay (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: aed1ce116e4efdfaba6164b380bac846feeada1f4825faf60974203d6cbaec30
+  name:   Raid on Bungeling Bay (Japan) (Rev 1)
+  title:  Raid on Bungeling Bay (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: b7b5fdf2b31c4b8c5340f93f166fb56aecf598f7c43a24b4334502bb81065143
+  name:   Raid on Bungeling Bay (USA)
+  title:  Raid on Bungeling Bay (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 0a3f0c3795700df26b436f091df252e915ed4d31a99ac904945fc9d130d43a39
+  name:   Rainbow Islands (USA)
+  title:  Rainbow Islands (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: fbc2b2907a9cda3f34f2086495edb50605605919b9c37572149fb639b4c77302
+  name:   Rainbow Islands - The Story of Bubble Bobble 2 (Japan)
+  title:  Rainbow Islands - The Story of Bubble Bobble 2 (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 9866b51b16b503aa515967929060eb100ae4cbd851229a3125ecf3ee7c88346e
+  name:   Rally Bike (USA)
+  title:  Rally Bike (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 80ec0b8e93e715218cc9e8400a214775ff9abd59e87554a9df90d8059bc464bc
+  name:   Rambo (Japan)
+  title:  Rambo (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 94e0d73bfaa7dca6d117d8d6f92637ace17816bb37807152baa8978396fe8d46
+  name:   Rambo (USA)
+  title:  Rambo (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 2596cf1e1a9b09dac24aeffea708807173ec81fa7093b2a729f1539aec3b5764
+  name:   Rambo (USA) (Rev 1)
+  title:  Rambo (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 013065f9b30be7c592a303181d5d7a49c370c001ac50140c9bf25f6198682ff0
+  name:   Rampart (Japan)
+  title:  Rampart (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: b4856061c9310015101c461aef744e9dcf3b158bd13d5d9cb4a76d3ca18a6864
+  name:   Renegade (USA)
+  title:  Renegade (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: f17df83a3e714c9f839dcd428d31a0b8b3cdb5fe1a78f24f43f158cb379720c1
   name:   Ring King (USA)
   title:  Ring King (USA)
@@ -6494,6 +15702,136 @@ game
       type: ROM
       size: 0x10000
       content: Character
+
+game
+  sha256: 317094f03513a26a89dd8e5edd21b8bcbaacafe06d05c1415c914536cbf96f29
+  name:   Road Fighter (Europe)
+  title:  Road Fighter (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 086c63f105b1ad2215b03a4323d1c6ec064a454e42ef96cb2a4eafe9ae38c039
+  name:   Road Fighter (Japan)
+  title:  Road Fighter (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: a878c510eec26bd2f54bf499625020d5af818d36ea58867d3311449a195cd7d2
+  name:   Robo Warrior (Europe)
+  title:  Robo Warrior (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5431ed49f22ee8188871be088da433c26b1ddeac972ef4b8f89df4eacd5e42c2
+  name:   Robo Warrior (USA)
+  title:  Robo Warrior (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 05117c775581eb63f7686f58c24f1c9da0fa0669eede1e7bad12eed40e58935e
+  name:   Rockman (Japan)
+  title:  Rockman (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 9fdbaa2877363948b466a6e3e11a1bce02d2a6490cb90808be4d788fe4630eba
+  name:   Rodland (Europe)
+  title:  Rodland (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 03bb4abbbab7bc91844dd65b808d1281ae22f9e4460479b27dd9d9b186b40647
@@ -6542,6 +15880,27 @@ game
       content: Character
 
 game
+  sha256: 20a1b17e15dd9c78d8223fc12cdb283cc1a2adcb11c8f2be980164c0f67aae04
+  name:   Route-16 Turbo (Japan)
+  title:  Route-16 Turbo (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: ff5d21cadd406e368a622f940a272efcfc441c08aa736cf3a82fddd6e7d8a097
   name:   RPG Jinsei Game (Japan)
   title:  RPG Jinsei Game (Japan)
@@ -6567,6 +15926,116 @@ game
       content: Character
 
 game
+  sha256: ef4b6d3a4debf44f953dbdac8c297e184fff465ed858d41c5fa319a149d18069
+  name:   Rush'n Attack (Europe)
+  title:  Rush'n Attack (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: fade44d9c76173afe098fbe02d859735e06b2c509fd80da08b1cc85bfc01a556
+  name:   Rush'n Attack (USA)
+  title:  Rush'n Attack (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: f26d7d09e47ef337089926d687d022bb7d90fa6670e41febfed092e63a6a42ea
+  name:   Rygar (Europe)
+  title:  Rygar (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: e3a7e0b559b18e8e2fd6f2bf0fdadbf9094be63a01bac50e5505413e1d7697a4
+  name:   Rygar (USA)
+  title:  Rygar (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 9bef1813dbcfa003b3b1978a66a8da3ff59c93dd74f1332801515aa4b633c51e
+  name:   Rygar (USA) (Rev 1)
+  title:  Rygar (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 4d6e58f232dc1a592583889f858eac230b8e8921e715276e580073ab2dd18546
   name:   Saint Seiya - Ougon Densetsu (Japan)
   title:  Saint Seiya - Ougon Densetsu (Japan)
@@ -6584,6 +16053,28 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 38a3b43973302ebac3f9aac8159fbc704af12bd7bb17d742f2e5c5747e9139a6
+  name:   Saiyuuki World (Japan)
+  title:  Saiyuuki World (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 840723003ce183494e9aa5081462f085db2b3846b4680976b32bff0fae0d3968
@@ -6729,6 +16220,69 @@ game
       content: Character
 
 game
+  sha256: 96b7fec4e525834e6d6e2418a68120f8be9e94511a2f26a8b3d5abd6b918c565
+  name:   Sanrio Carnival (Japan)
+  title:  Sanrio Carnival (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: abc8b0ae5328f9b006420e0dd3055a7a1bb9f3a5829603a07543545d31ce4f2f
+  name:   Sanrio Carnival 2 (Japan)
+  title:  Sanrio Carnival 2 (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: ec7b47d8aad0396a0f25405db5ca714ac654f954060889dced3ce305a65ba06b
+  name:   Sanrio Cup - Pon Pon Volley (Japan)
+  title:  Sanrio Cup - Pon Pon Volley (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: a5e173f9b25b9024807108afb59ca89fa3704cddb97ac2543f41bc4a6c02f4bd
   name:   Sansuu 1 Nen - Keisan Game (Japan)
   title:  Sansuu 1 Nen - Keisan Game (Japan)
@@ -6798,6 +16352,48 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: 11684b7947abc1f030809bb729730b35100845b8e36b78c148d49e3fd7c08232
+  name:   Sansuu 4 Nen - Keisan Game (Japan)
+  title:  Sansuu 4 Nen - Keisan Game (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 0f6bb3f4ecccf84fff0d367f3aeffac208ea60415f399ebe4969ed30c689f08d
+  name:   Sansuu 5 & 6 Nen - Keisan Game (Japan)
+  title:  Sansuu 5 & 6 Nen - Keisan Game (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -6926,6 +16522,71 @@ game
       content: Character
 
 game
+  sha256: 90d3ed80060e24dbfccc4dd51a1c9d3690d3dd5dcebbe026ee520b0f32321ef4
+  name:   Section-Z (Europe)
+  title:  Section-Z (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: a98e48a26c104375ae45e5c1bc4eb7b2a446e0e9ffa7ed3923c3cf5eec9a549a
+  name:   Section-Z (USA)
+  title:  Section-Z (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: e977cf914bfeff3ca29445a81c592bb5dba171c5fe32d80d2b3641c6664756fc
+  name:   Seicross (Japan)
+  title:  Seicross (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 269c410730fde0184a39f3063fbccb06c2488ffb7b2638738b106fae8a2f0acb
   name:   Seicross (Japan) (Rev 1)
   title:  Seicross (Japan) (Rev 1)
@@ -6948,6 +16609,70 @@ game
       type: ROM
       size: 0x2000
       content: Character
+
+game
+  sha256: afc7ce7262cc03039481b9338a94db35a1f4e9e54ee3dd34f979a7921d4a5e29
+  name:   Seicross (USA)
+  title:  Seicross (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 3aa9676dac5954b577cd497ba8afd370169004f3015370e939ceb711042d66f4
+  name:   Seikima II - Akuma no Gyakushuu! (Japan)
+  title:  Seikima II - Akuma no Gyakushuu! (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 1c5c7ef0ad07700bc7d6c63dad5b9f01cd49b8ff1361762cd2165afe29853289
+  name:   Seirei Gari (Japan)
+  title:  Seirei Gari (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: dbc22a40e8a79c5ccf1d6e5126c9b10bb3d9b3e708fe5316c298c3d03dbc7977
@@ -6994,6 +16719,71 @@ game
       volatile
 
 game
+  sha256: 648af94337e6afc95178e10307d1b809bef5a20ae473e2eba1f2d5ccf5f1d968
+  name:   Shanghai II (Japan)
+  title:  Shanghai II (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: b271bf2ee7677b3ef5458c072a9e7e7dd58e37e9776d541fddee728088bb15fa
+  name:   Sherlock Holmes - Hakushaku Reijou Yuukai Jiken (Japan)
+  title:  Sherlock Holmes - Hakushaku Reijou Yuukai Jiken (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: d345e0891826cbf448f82976264a58f0d68e36fb815c502adf31aa5b513e6591
+  name:   Shin Jinrui - The New Type (Japan)
+  title:  Shin Jinrui - The New Type (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 52b9b0d7137c458b2dc3a96e693af96ce044feedcdc1edf736c728a25e2fe4d8
   name:   Shin Moero!! Pro Yakyuu (Japan)
   title:  Shin Moero!! Pro Yakyuu (Japan)
@@ -7013,6 +16803,71 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 6c705f7980a08b7a7a5d74ddfd175155492168248f65c7d9e3cef1a6b14a2886
+  name:   Shooting Range (USA)
+  title:  Shooting Range (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 67acaac29ab36a8a807bcd8fec0249fead88229c0193830de21cc5dccb0aa5f2
+  name:   Shufflepuck Cafe (Japan)
+  title:  Shufflepuck Cafe (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 4d4f7e50603e181a59e4c99434c20babbb7887da327595393dc798b2a5072894
+  name:   Side Pocket (Europe)
+  title:  Side Pocket (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: df38854a6c9e86244f8160f43aa2d650736f6c54183d2cc54a22eb2285cc5316
@@ -7038,6 +16893,159 @@ game
       content: Character
 
 game
+  sha256: 648f68ae58f3420096e052a68255d8e453ae1fc09a4214adbeaa66ff841aaa33
+  name:   Side Pocket (USA)
+  title:  Side Pocket (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: c0c09e8de8b00289b9cc7c35b3a07013d6cba84afc0a7c25a11e2af7b11d1335
+  name:   Silent Service (Europe)
+  title:  Silent Service (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 37a5cfb1aacd9bb42746f20923441b5f613971d4dc99de68c216b10a8d7bcbfc
+  name:   Silent Service (USA)
+  title:  Silent Service (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: c387805a48a897fc7b76c445738a46bc6ef366edf05cc8536e8f5c3d8d0bfe87
+  name:   Silent Service (USA) (Rev 1)
+  title:  Silent Service (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 9831d03afe8e5a7e10c6a84843500030c92cad203eaa6ba5a4da16fd96b1e7fb
+  name:   Skate or Die (Europe)
+  title:  Skate or Die (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: fe4043430276177b739137ee7ed8e6cb75e751732a3f796ce03708d3ef1755e8
+  name:   Skate or Die (USA)
+  title:  Skate or Die (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0ca5eb65ba6ada839279fb172ab15f5196573b7aa4f056e82ab44b05581fd534
+  name:   Sky Destroyer (Japan)
+  title:  Sky Destroyer (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 4fbd928f06fbc4ea537cdae7f6a906053df7cd80c35b5cfeac9dfb9d3033efb8
   name:   Sky Kid (Japan)
   title:  Sky Kid (Japan)
@@ -7058,6 +17066,112 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 19d9d3691b62763b30582a33695728a354b2cdef1f2475d86807813597a66b5d
+  name:   Slalom (Europe)
+  title:  Slalom (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: f7f6d714c7758f679db8f0c7869ef19353fdcc49c267494bb41bfefda0f152d6
+  name:   Slalom (USA)
+  title:  Slalom (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 8df9c1a7a3806873db908604bb99749673241ccd58e1b32a6d7bf2fafc97d9d4
+  name:   Smurfs, The (Europe)
+  title:  Smurfs, The (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 8d701bb3b3b714245182ebf5f889fbaa5a43eb04e2e070c33f7e1903656ef442
+  name:   Soccer (Europe)
+  title:  Soccer (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 6a0c8be0f6445d9d777080955c7aa8fbff7497633b878a36c8139ec13dabfb8b
+  name:   Soccer (Japan, USA)
+  title:  Soccer (Japan, USA)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -7099,6 +17213,69 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: b020181cbc376000de7f9218775d9493fc445d10fb2592cb4b8f42b4ba415c2b
+  name:   Solomon no Kagi (Japan)
+  title:  Solomon no Kagi (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 3ce8d763c2919911e769b71ff79e0551a56f0b6fd9c8eb0d16b1601a01574415
+  name:   Solomon's Key (Europe)
+  title:  Solomon's Key (Europe)
+  region: PAL
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 842478f0d9f01c6c547672a7e4dc4a33ed2c900f92e4b318f4d5941ba548b355
+  name:   Solomon's Key (USA)
+  title:  Solomon's Key (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
 
 game
   sha256: 5848c7e2009e2263184cd95fe060ff52d0554e6b1277666a76098cb7eaa673b9
@@ -7161,6 +17338,69 @@ game
       volatile
 
 game
+  sha256: bf8cbcdde56f63990128d73d3b01ba962b5e4f43fc3861173057a614cb4eb797
+  name:   Son Son (Japan)
+  title:  Son Son (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: cce92c9404d5dd48680b0b505acbbbce279a4f09606167f0aacfb6da991aac4c
+  name:   Space Hunter (Japan)
+  title:  Space Hunter (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 69569bebb916fcd78f904abd28aa4ed69fde0467c050c539c5359409305ca4ea
+  name:   Space Invaders (Japan)
+  title:  Space Invaders (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 82d59a71189043d8a3e690b41a339c27cbc5e1343466fcc02f8cb66d9f6757f5
   name:   Space Shadow (Japan)
   title:  Space Shadow (Japan)
@@ -7179,6 +17419,27 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: edd831c533811a0a8357629a0c17916d73acf3f74e012ca38b8c129df87130d6
+  name:   Spartan X (Japan)
+  title:  Spartan X (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -7203,6 +17464,70 @@ game
       content: Character
 
 game
+  sha256: 020a1d484c71329d7447bc1a448b172cafb5de11f2977c890dba2c86779b7dce
+  name:   Spelunker (Japan)
+  title:  Spelunker (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 6f58c6fb427cf18b4c28f07909db642abac09fac2d7ae7dc9c99f1cd79263d95
+  name:   Spelunker (USA)
+  title:  Spelunker (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: f633d8aabcde25bbcd0e99e651c042739da6ae24118393604f958ce22b753603
+  name:   Spelunker II - Yuusha e no Chousen (Japan)
+  title:  Spelunker II - Yuusha e no Chousen (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 387d82471ca5f54e70b3c4d445ae5c692640d99c47b30a6bf67f5a17b6236c85
   name:   Splatterhouse - Wanpaku Graffiti (Japan)
   title:  Splatterhouse - Wanpaku Graffiti (Japan)
@@ -7221,6 +17546,48 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: 17da401495807145c9d4db275d429b7fe94be45dde00edc40aca885911cfd138
+  name:   Spy Hunter (USA)
+  title:  Spy Hunter (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 3f53c4ca4eac76bab217efac999888f085e79cf03df11b82ef2adf08f8048e3d
+  name:   Spy vs Spy (Europe)
+  title:  Spy vs Spy (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -7248,6 +17615,343 @@ game
       content: Character
 
 game
+  sha256: 91c61066a9b6b5ed169449b175190d75d38834e07da263f637af05801bc2f5ae
+  name:   Spy vs Spy (USA)
+  title:  Spy vs Spy (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: bfff1ff3abb61d092ffaf0abf767bbb9b4f6368c0b37b153312c1ec0760d24c1
+  name:   Sqoon (Japan)
+  title:  Sqoon (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 5ce04293c4397ac5216459978b6f5f107d0e29dc6a138f8f6f4bfd3616db1172
+  name:   Sqoon (Japan) (Rev A)
+  title:  Sqoon (Japan) (Rev A)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 687963e7fd12834543da99c60a533fcdfedacd27f8a67c0c9c4007c1263a79b3
+  name:   Sqoon (USA)
+  title:  Sqoon (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: af7a31a57dd701f57b964667549240943c76bdd2a2044ad99dfeba47883f1b9b
+  name:   Stack-Up ~ Block (World)
+  title:  Stack-Up ~ Block (World)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 12857fc73079fc96c9092c54be89034a748ad798386604a8483316cbe0be4d22
+  name:   Stadium Events (Europe)
+  title:  Stadium Events (Europe)
+  region: PAL
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: ef55073037f94c42189971d04499231b60cddb7de8bc1c9a4c8f376383ad42b6
+  name:   Stadium Events (USA)
+  title:  Stadium Events (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: b0e3b04d1281c6bf2fc0c17e3bc30ef18a5118345498470ce17d3d993f9470ae
+  name:   Star Force (Europe)
+  title:  Star Force (Europe)
+  region: PAL
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: bb8b8e21cf716ad12106040d81766284647fdacddff2cdd5b3b3c9ff60fd18c4
+  name:   Star Force (Japan)
+  title:  Star Force (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 581851e22e8d499ada19e621c93571fba279fe9c8446ed2ee566b16128f13874
+  name:   Star Force (USA)
+  title:  Star Force (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 835bf5aa513e1a8a3ce2bebd5bcf3ba7c1a1d20b5d781a83c5fa810c51f1ca39
+  name:   Star Gate (Japan)
+  title:  Star Gate (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 9c957a63eeac9383082f5984ec95746e087b8c93a0425974763698dd32f48319
+  name:   Star Luster (Japan)
+  title:  Star Luster (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 94cc3363cb4dfa049e3609bc6f7c14f8374d13dda8ea1b89dd0161fdbb052ba1
+  name:   Star Soldier (Japan)
+  title:  Star Soldier (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 025abe5ae4e1610fac2507296184f64173fd960adfc79d456001adec29c546a5
+  name:   Star Soldier (USA)
+  title:  Star Soldier (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 8271542561a71830886e88ac74e6eda309440920b3607e950d5f2cd1a7edd5ca
+  name:   Star Trek - The Next Generation (USA)
+  title:  Star Trek - The Next Generation (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: c4c139d2c349a513d4ccc724daee3fd37099c3c0d2742fad777a0edbe3d042ce
+  name:   Star Voyager (USA)
+  title:  Star Voyager (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 6b42e1b3fba910280016616a24050d3aec19d32480c4b5863c3f3734d44681bc
   name:   Star Wars (Japan)
   title:  Star Wars (Japan)
@@ -7267,6 +17971,137 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 7b7ccdcda705c2c3215c646b479c5d5868b72f3cd3eff97291d608756e5f3230
+  name:   Starship Hector (USA)
+  title:  Starship Hector (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 2ce85b82b427de187b59b62d33081497acfa2010ef38660b157f8eb008336e6e
+  name:   Stick Hunter - Exciting Ice Hockey (Japan)
+  title:  Stick Hunter - Exciting Ice Hockey (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5ca7cb3c4168bb021a67b50fa071afe7679f4e79c5c46e229fbe7b88004bf51a
+  name:   Stinger (USA)
+  title:  Stinger (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 8b11fa216f87b5924205719eac1bd2709ba0489813a4d4c202a32fd42689e761
+  name:   Sukeban Deka III (Japan)
+  title:  Sukeban Deka III (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: a387a17294bb440eb821fa096bfe476f772c7f9f79c5fb251f6b0a50bdeda53d
+  name:   Super Arabian (Japan)
+  title:  Super Arabian (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 92aa617d6254a7aa8fdc915770e813b9922100e374fd44f40bf5752f6069c7a7
+  name:   Super Cars (USA)
+  title:  Super Cars (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: ecdd3a46ab46c0b6c344c86290db53d0fe5a27beb685c93c49049a8d18971d78
@@ -7289,6 +18124,91 @@ game
     memory
       type: ROM
       size: 0x4000
+      content: Character
+
+game
+  sha256: c9fc6a3492149101027a2e3edb000cb9cb5eafdcce298b40cd6f582a52d6839c
+  name:   Super Dyna'mix Badminton (Japan)
+  title:  Super Dyna'mix Badminton (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
+  sha256: 20de11cda85d7e4b35b94bdc6863e328288c6bdd653254b5240e4b4b46acf9a5
+  name:   Super Glove Ball (USA)
+  title:  Super Glove Ball (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 6b3189414053f975bcac33eb51a1e9991e0d06f42abead7919969417cc26e2ad
+  name:   Super Mario Bros. (Europe)
+  title:  Super Mario Bros. (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: fcb6a0ef3a20c19b356005fbb21dc8009563b1cb5a9aaebc8e9386b4a8c5912e
+  name:   Super Mario Bros. (World)
+  title:  Super Mario Bros. (World)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -7334,6 +18254,114 @@ game
       content: Character
 
 game
+  sha256: 8328258d8fa07be57584fb908d5e28f8f8b8a11e022c0184ce31932d4e32d8ef
+  name:   Super Mogura Tataki!! - Pokkun Mogurar (Japan)
+  title:  Super Mogura Tataki!! - Pokkun Mogurar (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: a0f36181520adf90c8d426a8767c12e363709caaff897188e408ba4701e6ee21
+  name:   Super Pitfall (Japan)
+  title:  Super Pitfall (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: fe019a7da7fb7ecd2e6478bde546e6c5d6bba185d53e5c8692522ed8fdd617a2
+  name:   Super Pitfall (USA)
+  title:  Super Pitfall (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: da11b89307b7cf1b0394b7e5459e76b3979bccd322cdc39bf5135c83038aad50
+  name:   Super Star Force (Japan)
+  title:  Super Star Force (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 54112120e3a5d0a17ce235036a9fac7117eba2b9585d66f37a646456a56fc25c
+  name:   Super Team Games (USA)
+  title:  Super Team Games (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 301d41b370e56cf3c57f22f760da55cb0dc726acf0a2b45182abe5e9dbe186a2
   name:   Super Xevious - Gump no Nazo (Japan)
   title:  Super Xevious - Gump no Nazo (Japan)
@@ -7354,6 +18382,157 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 9a084f0002013774c0d563ef59d1e46e29618d6ef1c1c48a17c368c86fc7662a
+  name:   SWAT - Special Weapons and Tactics (Japan)
+  title:  SWAT - Special Weapons and Tactics (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: bf33855bad9665b51da856413d2a4a8ab0c67178c50ea735a5325ebea8499cba
+  name:   Swords and Serpents (Europe)
+  title:  Swords and Serpents (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 94cb4ace77bd8f1d53fda5ca26a1298d49c9f75e023ec5f2aa97fc0f8d1e5309
+  name:   Swords and Serpents (France)
+  title:  Swords and Serpents (France)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: cdd148ebf43ed8918b4cd5d03e685fe0f38b434a59ffb38f0d9ceb2ee7ca9d89
+  name:   Swords and Serpents (USA)
+  title:  Swords and Serpents (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: fb6298bb3519faaee26f75e6e071ab109398f06ab381bbb9f3edf299cd694292
+  name:   Tag Team Pro-Wrestling (Japan)
+  title:  Tag Team Pro-Wrestling (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 96820abeeeb030bc2c740cebecd5837935071f1240534727f3818ff4f0e08ba9
+  name:   Tag Team Pro-Wrestling Special (Japan)
+  title:  Tag Team Pro-Wrestling Special (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: b002d1ebee16a5fd2bcae480df8ccc7b8dc7a6f96a80f5fac8b76e078e4f42f0
+  name:   Tag Team Wrestling (USA)
+  title:  Tag Team Wrestling (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -7382,6 +18561,27 @@ game
       content: Character
 
 game
+  sha256: 1e6d5548a54a0db31a13e05b604afafd8f9402b47079d708e7bf2cf8582e2ac5
+  name:   Takahashi Meijin no Bouken-jima (Japan)
+  title:  Takahashi Meijin no Bouken-jima (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: ad34a5b9519724119c9def06f8b8c5be5454c4f99f13aade6d1fd5aefad76ddd
   name:   Takahashi Meijin no Bugutte Honey (Japan)
   title:  Takahashi Meijin no Bugutte Honey (Japan)
@@ -7403,6 +18603,50 @@ game
       content: Character
 
 game
+  sha256: 022eb504c4138481ddcd7de302ef4ba843c33d5342484b4958507fa452fc1abe
+  name:   Takeda Shingen (Japan)
+  title:  Takeda Shingen (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 4395aa5fe84897f2ed47c4d55c5faf4a9ee5bcb5f79bb842ea1db31450c53062
+  name:   Takeshi no Chousenjou (Japan)
+  title:  Takeshi no Chousenjou (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 819a989fd3a7190136b07a4a3c7ee484c23c4d34dd8b91435c40c3c1009a214c
   name:   Takeshi no Sengoku Fuuunji (Japan)
   title:  Takeshi no Sengoku Fuuunji (Japan)
@@ -7421,6 +18665,49 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: 934e9cec9876f61a4a1eff4905c0b05efe8a3f41f104c04b002f06b392c5dfdd
+  name:   Tantei Jinguuji Saburou - Toki no Sugiyuku Mama ni (Japan)
+  title:  Tantei Jinguuji Saburou - Toki no Sugiyuku Mama ni (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: efb93dcae29f1ff85b58ccb9450c23d528073a019493d88a9abcabe4ca9aca4f
+  name:   Tatakae! Chou Robot Seimeitai Transformers - Convoy no Nazo (Japan)
+  title:  Tatakae! Chou Robot Seimeitai Transformers - Convoy no Nazo (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -7447,6 +18734,50 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: a181a1e8c9e39fa8b354f9855630b1c967353dd8416008ffc78a3151a88a4402
+  name:   Tatakai no Banka (Japan)
+  title:  Tatakai no Banka (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 17d44e6aeaccb710a25c41192284c48efb4608f80431c4e10719baa1dbe6bec4
+  name:   Tatakai no Banka (Japan) (Rev 1)
+  title:  Tatakai no Banka (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 6fff1bfc89bb2f3c160b88736990c764920b0c44107b265f642a50324ca3adfb
@@ -7539,6 +18870,48 @@ game
       content: Character
 
 game
+  sha256: 1e68343fe73ee8b117b0323c061d6b4abe9dfb7592d56b263b737d2d03b9f807
+  name:   Tennis (Europe)
+  title:  Tennis (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 8da7129bba8c61a5ba1cd7ce02932ea4cefbb12db75c517c14d96819fc57f299
+  name:   Tennis (Japan, USA)
+  title:  Tennis (Japan, USA)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 7735cce529485771897277685d4e5b7a6d11de52076cac80f600b7776ff5cc66
   name:   Terao no Dosukoi Oozumou (Japan)
   title:  Terao no Dosukoi Oozumou (Japan)
@@ -7557,6 +18930,134 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: e12265b8fb7fa3f162d946577dff6e1c9ffb5b7f5e3f8effad468363a7ba3f4a
+  name:   Terra Cresta (Japan)
+  title:  Terra Cresta (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 667bcf3ca1ebcf6f71fccd412ced546f4aba3b8cd2fc30d173cf6d3b4c15846a
+  name:   Terra Cresta (USA)
+  title:  Terra Cresta (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 85ebbaa069cf14ee45ed88710f30a19eb34ed39b185c830a37888a3bd7ae8a4f
+  name:   Tetris (Japan)
+  title:  Tetris (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
+  sha256: e720782a38dd0bf3821579518ea11b9a3735fb1e03dbd748931d7d2484bf8bbe
+  name:   Tetris (Japan) (Rev 1)
+  title:  Tetris (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
+  sha256: 2b3e28d08308558521c69806c51e6cd27ff6bf446346d89c8a06f444d158b46e
+  name:   Tetris (Japan) (Rev 2)
+  title:  Tetris (Japan) (Rev 2)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
+  sha256: dc195079cb8f3d552c4ae247e6971e193e8867e0164573ebf159a21114964c4d
+  name:   Tetsudou Ou - Famicom Boardgame (Japan)
+  title:  Tetsudou Ou - Famicom Boardgame (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -7581,6 +19082,27 @@ game
       content: Character
 
 game
+  sha256: 18d41a2dc65d8afce295eaf29c391539a69d7cfe6dd32503713ae13d4495a545
+  name:   Thexder (Japan)
+  title:  Thexder (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: e3be0290f198fceed633b037d9201aa4b95460617551b3a9fb5bb212b153a2d4
   name:   Thunder & Lightning (USA)
   title:  Thunder & Lightning (USA)
@@ -7595,6 +19117,112 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: c56af43761cb601a068cdc88c2fc36f715921dbae9a8a9d8c10479146c47ccb9
+  name:   Thundercade (USA)
+  title:  Thundercade (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: ad4abf18ea9cf3dcb1dd639cbb2a056615e1dc01bef5a42adb4ce0ccf281dc5d
+  name:   Tiger-Heli (Europe)
+  title:  Tiger-Heli (Europe)
+  region: PAL
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: e484887f613e0b4afd4ca093c33b2ae6f76b00513cd723e5d9d1cabacbbfca78
+  name:   Tiger-Heli (Europe) (Rev 1)
+  title:  Tiger-Heli (Europe) (Rev 1)
+  region: PAL
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 6c3ba5f57241f9ffd635765fb17c3acc3d4e205b11647ffff255d5ab7017b3f3
+  name:   Tiger-Heli (Japan)
+  title:  Tiger-Heli (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 403fe1c4454dc1e23fb272c88f70ba30dd5e860ab48ecff59420a09fc84e9a2d
+  name:   Tiger-Heli (USA)
+  title:  Tiger-Heli (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
       content: Program
     memory
       type: ROM
@@ -7627,6 +19255,50 @@ game
   title:  Time Lord (USA)
   region: NTSC-U
   board:  HVC-AMROM
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: efe733206c5ca178ed34a3e8e951f9b33704b92c9191e059255b8f5bb93e5313
+  name:   Times of Lore (Japan)
+  title:  Times of Lore (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: d0807dad4f79c978007a78ab8d0042a46a6ac19c0be1ddd4f394f6039eabba4d
+  name:   Times of Lore (USA)
+  title:  Times of Lore (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
     memory
       type: ROM
       size: 0x10
@@ -7689,6 +19361,137 @@ game
       content: Character
 
 game
+  sha256: 42a1650ef80f707f2b3f97084c2f2a4881dbe5d9c7ca874d7fa5a67d6e1416b2
+  name:   Toki no Tabibito - Time Stranger (Japan)
+  title:  Toki no Tabibito - Time Stranger (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: e79df83c7939dc1ffab0d6d07b20fac959aedf3a98db73ef6bb654f1e92d7d0a
+  name:   Tokoro-san no Mamoru mo Semeru mo (Japan)
+  title:  Tokoro-san no Mamoru mo Semeru mo (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 33bd093a1b2d015dcd39b27d8cfebd5a9d013b634182867cd137df5c9e5831d4
+  name:   Top Gun (Europe)
+  title:  Top Gun (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: bb1889cc2f3e4c601da79faf138a58ca6d0f711ee6ecb77c44d716945fd12480
+  name:   Top Gun (Japan)
+  title:  Top Gun (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: aa43f3138d4f731e5e8df530dbf8fc1f6f45303b84589f7a0715e392887f3dff
+  name:   Top Gun (USA)
+  title:  Top Gun (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: e788ae1dff1b868795395e19357525b93ddd52ac86f6a505d14eac5fa323b023
+  name:   Top Gun (USA) (Rev 1)
+  title:  Top Gun (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 5094752e3f001c1eeff60116cf64fd35a090e14bf95ef5f563afc41d59fc3445
   name:   Top Striker (Japan)
   title:  Top Striker (Japan)
@@ -7708,6 +19511,72 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: fb51c732840267b6f5d03f3fcbb6643771b56772bc52fa2d094dd20ac4b3e176
+  name:   Total Recall (Europe)
+  title:  Total Recall (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 45067f85328eabb3b8cb2bceec72192bfa8d73494521660f171b9ed6d151fdea
+  name:   Total Recall (USA)
+  title:  Total Recall (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: d0666f8f75dbe4a2adc7e90de4bb17c64a722d7672ee148acc123902784b799c
+  name:   Totsuzen! Macchoman (Japan)
+  title:  Totsuzen! Macchoman (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 4fcadd486cdd108ffd1ebc6585658c86e89626dc86815b41bc28424a67e7d133
@@ -7731,6 +19600,200 @@ game
       content: Character
 
 game
+  sha256: f3955370fe7ecc99afc27cdccf3482f75f06e0f431e42823c95982bb553ad6b9
+  name:   Town & Country Surf Designs - Wood & Water Rage (USA)
+  title:  Town & Country Surf Designs - Wood & Water Rage (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: a2812d80b3057aac9753f48247a7a46b29bea0b9aec04ca4c327180085c25b58
+  name:   Track & Field (USA)
+  title:  Track & Field (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 277b2f8f14744cac1f3ba01131e6ed2528b978476bd75bcfe91df7bec9738df6
+  name:   Track & Field in Barcelona (Europe)
+  title:  Track & Field in Barcelona (Europe)
+  region: PAL
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 22777840d24500827a96c83c74846f3298cd5f0db67a532161e94967896d831a
+  name:   Trog! (Europe)
+  title:  Trog! (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 6b2004f30e7de67dfb86db7446f2204695a3a9b9b367bacf401dbf14bb1a74f2
+  name:   Trog! (USA)
+  title:  Trog! (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 8b9ddd4dd917c700a22a919a7112109e929e1802edbebe14a807dfce84414393
+  name:   Trojan (Europe)
+  title:  Trojan (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: a5ae39359aa5b16961a98a7aaeeb278787382d5282ee80b5b3a2de954283ebb7
+  name:   Trojan (USA)
+  title:  Trojan (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: fcccf437e952aa44784961899ca17d6f6116e088cca7e5cab910bcd9054b8fa4
+  name:   Tsuppari Oozumou (Japan)
+  title:  Tsuppari Oozumou (Japan)
+  region: NTSC-J
+  board:  HVC-CNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 7de2ef8418ededae391764b92e199f4a6b250da563dc2a0a053d7a707bb89764
+  name:   Tsuri Kichi Sanpei - Blue Marlin Hen (Japan)
+  title:  Tsuri Kichi Sanpei - Blue Marlin Hen (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: e532491e590505b49f65c771e938c0f1a0d7ccbe6b3fb2cbf42693db39d878d9
   name:   Tsuru Pika Hagemaru - Mezase! Tsuru Seko no Akashi (Japan)
   title:  Tsuru Pika Hagemaru - Mezase! Tsuru Seko no Akashi (Japan)
@@ -7750,6 +19813,50 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: c36279e07bf68392c55ca8be762b52915ecd891c004df0b5a4f7e28e8bf011c7
+  name:   Twin Eagle (Japan)
+  title:  Twin Eagle (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 8eb6aa7818f1cac84af0f91350b167f2884dba45073c9f00510f47d0a38e4192
+  name:   Twin Eagle (USA)
+  title:  Twin Eagle (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 4b9c46714fa085d61ad1177b72bdaa9428d104a171eb6335a03bf06ad9782389
@@ -7813,6 +19920,49 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: c7ad19e926809adc47c0b44c852e19be7a95e7235ee58cb753e68d7cdee9c89c
+  name:   Uncanny X-Men, The (USA)
+  title:  Uncanny X-Men, The (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 7255ab27932f7c07fa61c230a51342b0441ea9b24ba094ae3129ec7453de2449
+  name:   Urban Champion (World)
+  title:  Urban Champion (World)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 
 game
@@ -7903,6 +20053,48 @@ game
       volatile
 
 game
+  sha256: 9a6a05ac119878195ff9c0f6f552957ce6971cc60ae3ea8edbf0b4ba9af5f799
+  name:   Volguard II (Japan)
+  title:  Volguard II (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 2e312fc327c1e569eccf14eee5a00c41f676c1492035d99af0873681da0f034d
+  name:   Volleyball (USA, Europe)
+  title:  Volleyball (USA, Europe)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: 2737968efa4bdb5576a6ad36e08712ba76a752a0f88b741bf72a463b451a9dfe
   name:   Wagyan Land (Japan)
   title:  Wagyan Land (Japan)
@@ -7990,6 +20182,93 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 60667bc0ed1c0c6355f59b5716c678954c5f3915064bdbfbb8e0195f2643eda8
+  name:   Wall Street Kid (USA)
+  title:  Wall Street Kid (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5cee4ecc3b020dad2a7dfa91794ff22774bda9a29f79c52a004b888725e488be
+  name:   Wanpaku Duck Yume Bouken (Japan)
+  title:  Wanpaku Duck Yume Bouken (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5b36ae6243ddb4a1ba717123db41981a96b89175928b00d63df3fa4cede83d70
+  name:   Warpman (Japan)
+  title:  Warpman (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 7ecff2d3e6d341717ebcb60aabbfb2becdfbeec2cb7e315b560b62ee7ae5199a
+  name:   Wayne Gretzky Hockey (USA)
+  title:  Wayne Gretzky Hockey (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 88691067f122467f2dae85e40b927013b91fe848f88d694616ed2f26ab1f3f4d
@@ -8112,6 +20391,92 @@ game
       volatile
 
 game
+  sha256: 62aec65696ecf24a487b7cdd19bad5cbd19f4229a89a7888634d468c67da378a
+  name:   Wild Gunman (Japan, USA)
+  title:  Wild Gunman (Japan, USA)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: adff304553b64384f86f6c2b63571f43972b9d087f92359a1b9b93b54d523542
+  name:   Wild Gunman (World)
+  title:  Wild Gunman (World)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 554c74ff0b7ce3c1a0c5f96458d5587930879258b8b08a8813097513b52356b0
+  name:   Winter Games (USA) (Rev 1)
+  title:  Winter Games (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 515dd3fdb7c6ba287c87cdfce67a05babceb83bac7dd5ccf0b01b68d853dd311
+  name:   Wit's (Japan)
+  title:  Wit's (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: a870c1add0839708b2524b5ca4ae64547001c13bbd664a51f998656936dd1075
   name:   Wizards & Warriors (Europe)
   title:  Wizards & Warriors (Europe)
@@ -8212,6 +20577,70 @@ game
       volatile
 
 game
+  sha256: 8acf6c84584a91cae8127735a2d5df520cca5ee6e05f1e57854c9e1615999207
+  name:   Woody Poko (Japan)
+  title:  Woody Poko (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 6c74bcb9ac50428266cfc4d13892b6e93c6936ba569bf3f0f2068e45a9b675fc
+  name:   World Class Track Meet (USA)
+  title:  World Class Track Meet (USA)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: ac766a8d99bfd8e95c02b9a9c68279c72ba5b3307b78edc67b52781ed185fa89
+  name:   World Class Track Meet (USA) (Rev 1)
+  title:  World Class Track Meet (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-CNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 6449c6d072fd1df14a346fbd17c11f76d7470185041b1181c36770ce11ae71e6
   name:   World Games (USA)
   title:  World Games (USA)
@@ -8230,6 +20659,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: f1eb29dd1c7b2b29f4932df853f32a7560bbfe64997281aa79f61ba9f131fb17
+  name:   Wrecking Crew (World)
+  title:  Wrecking Crew (World)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
 
 game
   sha256: 306599be84494284eb8132aaceb7fc8e23ad0f9b410825b6271ebdbd8b4ed7c2
@@ -8270,6 +20720,198 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: cc6cdf219593f99897c2fa2cea50dca3cd6a4b5d6bfd5d8f3f144b6f49e324ec
+  name:   WWF Wrestlemania Challenge (Europe)
+  title:  WWF Wrestlemania Challenge (Europe)
+  region: PAL
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: f371437fafe83d9b5c7c4c92105dd9c9039bf3f597fe6997152faeb1cc2a02b8
+  name:   WWF Wrestlemania Challenge (Japan)
+  title:  WWF Wrestlemania Challenge (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 89df74e7b275929c91a64580c5b1733bee26bcaf3a923dcca9fffdda835b2964
+  name:   WWF Wrestlemania Challenge (USA)
+  title:  WWF Wrestlemania Challenge (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 60e66e87098e68d466f554597cc81a05533e5e1d3b83b47de32995bc0d71660a
+  name:   Xevious (Europe)
+  title:  Xevious (Europe)
+  region: PAL
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 777345bbde222e06d5dee48f1b02197f5965c57c3e8972142975f0a4eac0c9f5
+  name:   Xevious (Japan)
+  title:  Xevious (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 78b4525668842d06dc347b1146cb51dc9bb4a9d268c3c141e09c15fd01a1556b
+  name:   Xevious (Japan) (Rev 1)
+  title:  Xevious (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 9112f5b30c8a8d0dbd967973e84357860b5f0cf37ab3511b39128b5d37fa86ff
+  name:   Xevious - The Avenger (USA)
+  title:  Xevious - The Avenger (USA)
+  region: NTSC-U
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: dbe10104fc90c36ff7c95424cb192dfd9619fb7c1238bbae8da87e0bc9cc5a4e
+  name:   Yie Ar Kung-Fu (Japan)
+  title:  Yie Ar Kung-Fu (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 0624c93899a588232f9193db0d560291b15636727813a4cd6c3dab8b7f74badb
+  name:   Yie Ar Kung-Fu (Japan) (Rev 1)
+  title:  Yie Ar Kung-Fu (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
 
 game
   sha256: 703411cb92283840c096d7e1e422582ecda18bd9b27604a253cb0b0702383043
@@ -8314,6 +20956,28 @@ game
       content: Character
 
 game
+  sha256: 64d643098a4d271937aa72b2f5849c71001a9bd080522c359e5ff71b27cb9b6b
+  name:   Yousei Monogatari - Rod Land (Japan)
+  title:  Yousei Monogatari - Rod Land (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: ec1d85479d72847d3adbd76e2e79221143e6c9324d5647be2c4a11aa87123f75
   name:   Ys III - Wanderers from Ys (Japan)
   title:  Ys III - Wanderers from Ys (Japan)
@@ -8336,5 +21000,113 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: bdc9dfed1b03db470a1453da0252b3e9fcd0869d02a48622476ddaa350e53374
+  name:   Zanac (USA)
+  title:  Zanac (USA)
+  region: NTSC-U
+  board:  HVC-UNROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 3d0bed52417af501590258079607f54af656a231f750d35d9d5587a2a928511f
+  name:   Zippy Race (Japan)
+  title:  Zippy Race (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
+  sha256: 6f5190caa0ef0a6e815ac044fbbba970a6aea4ef4899ddc46047dad08aedc984
+  name:   Zoids - Chuuou Tairiku no Tatakai (Japan)
+  title:  Zoids - Chuuou Tairiku no Tatakai (Japan)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 4b1c550d0aa7200b1c15667de4c149a2d1c461dc62be2e053e5064e21e3d9fda
+  name:   Zoids - Chuuou Tairiku no Tatakai (Japan) (Rev 1)
+  title:  Zoids - Chuuou Tairiku no Tatakai (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-UNROM
+    mirror
+      mode: vertical
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 061d1c3865ad62ae883bb30b9f0071e8f7aa572f15f61bfb91b3a755eeeb5eb0
+  name:   Zunou Senkan Galg (Japan)
+  title:  Zunou Senkan Galg (Japan)
+  region: NTSC-J
+  board:  HVC-NROM
+    mirror
+      mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x2000
       content: Character
 

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -31,7 +31,7 @@ auto Famicom::load(string location) -> bool {
   pak->setAttribute("board", document["game/board"].string());
   pak->setAttribute("mirror", document["game/board/mirror/mode"].string());
   pak->setAttribute("chip", document["game/board/chip/type"].string());
-  pak->setAttribute("chip/key", document["game/board/chip/key"].string());
+  pak->setAttribute("chip/key", document["game/board/chip/key"].natural());
   pak->setAttribute("pinout/a0", document["game/board/chip/pinout/a0"].natural());
   pak->setAttribute("pinout/a1", document["game/board/chip/pinout/a1"].natural());
   pak->append("manifest.bml", manifest);


### PR DESCRIPTION
Added bus conflicts to Famicom CNROM boards, as seen on real hardware.

This fixes the following games:
- Cybernoid - The Fighting Machine (USA) * corrupted graphics

Games on CNROM are programmed in a way that makes bus conflicts irrelevant, but "Cybernoid" actually relies on that behavior.

Also in this pr Famicom database is updated with NROM (mapper 0), UXROM (mapper 2) and CNROM (mapper 3) entries.