### PR TITLE
recompiler: support additional host architectures (e.g. ARM64)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+----------------------------------------------------------------------
 ares
 
 Copyright (c) 2004-2021 ares team, Near et al
@@ -13,3 +14,33 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+----------------------------------------------------------------------
+
+----------------------------------------------------------------------
+Stack-less Just-In-Time compiler
+
+Copyright Zoltan Herczeg (hzmester@freemail.hu). All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER(S) OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+----------------------------------------------------------------------

--- a/ares/ares/ares.hpp
+++ b/ares/ares/ares.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <libco/libco.h>
+#include <sljit.h>
 
 #include <nall/platform.hpp>
 #include <nall/adaptive-array.hpp>

--- a/ares/component/processor/sh2/cached.cpp
+++ b/ares/component/processor/sh2/cached.cpp
@@ -40,9 +40,9 @@ auto SH2::Recompiler::emit(u32 address) -> Block* {
   while(true) {
     u16 instruction = self.readWord(address);
     bool branched = emitInstruction(instruction);
-    mov(rax, mem64(&self.CCR));
+    mov(rax, mem64(&self.regs.CCR));
     inc(rax);
-    mov(mem64(&self.CCR), rax);
+    mov(mem64(&self.regs.CCR), rax);
     call(&SH2::instructionEpilogue, &self);
     address += 2;
     if(hasBranched || (address & 0xfe) == 0) break;  //block boundary

--- a/ares/component/processor/sh2/instruction.cpp
+++ b/ares/component/processor/sh2/instruction.cpp
@@ -45,7 +45,7 @@ auto SH2::instruction() -> void {
   }
 }
 
-auto SH2::instructionEpilogue() -> bool {
+auto SH2::instructionEpilogue() -> s32 {
   switch(PPM) {
   case Branch::Step: PC = PC + 2; return 0;
   case Branch::Slot: PC = PC + 2; PPM = Branch::Take; return 0;

--- a/ares/component/processor/sh2/sh2.cpp
+++ b/ares/component/processor/sh2/sh2.cpp
@@ -3,14 +3,26 @@
 
 namespace ares {
 
-#define SP R[15]
+#define SP   R[15]
+#define R    regs.R
+#define PC   regs.PC
+#define PR   regs.PR
+#define GBR  regs.GBR
+#define VBR  regs.VBR
+#define MAC  regs.MAC
+#define MACL regs.MACL
+#define MACH regs.MACH
+#define CCR  regs.CCR
+#define SR   regs.SR
+#define PPC  regs.PPC
+#define PPM  regs.PPM
+#define ET   regs.ET
+#define ID   regs.ID
 
 #include "sh7604/sh7604.cpp"
 #include "exceptions.cpp"
 #include "instruction.cpp"
 #include "instructions.cpp"
-//#include "cached.cpp"
-#include "recompiler.cpp"
 #include "serialization.cpp"
 #include "disassembler.cpp"
 
@@ -52,5 +64,24 @@ auto SH2::power(bool reset) -> void {
     recompiler.reset();
   }
 }
+
+#undef SP
+#undef R
+#undef PC
+#undef PR
+#undef GBR
+#undef VBR
+#undef MAC
+#undef MACL
+#undef MACH
+#undef CCR
+#undef SR
+#undef PPC
+#undef PPM
+#undef ET
+#undef ID
+
+//#include "cached.cpp"
+#include "recompiler.cpp"
 
 }

--- a/ares/component/processor/sh2/sh2.hpp
+++ b/ares/component/processor/sh2/sh2.hpp
@@ -16,7 +16,7 @@ struct SH2 {
   virtual auto busWriteLong(u32 address, u32 data) -> void = 0;
 
   auto inDelaySlot() const -> bool {
-    return PPM != Branch::Step;
+    return regs.PPM != Branch::Step;
   }
 
   //sh2.cpp
@@ -220,21 +220,23 @@ struct SH2 {
     u32 M;
   };
 
-  u32 R[16];  //general purpose registers
-  u32 PC;     //program counter
-  u32 PR;     //procedure register
-  u32 GBR;    //global base register
-  u32 VBR;    //vector base register
-  union {
-    u64 MAC;  //multiply-and-accumulate register
-    struct { u32 order_msb2(MACH, MACL); };
-  };
-  u32 CCR;    //clock counter register
-  S32 SR;     //status register
-  u32 PPC;    //program counter for delay slots
-  u32 PPM;    //delay slot mode
-  u32 ET;     //exception triggered flag
-  u32 ID;     //interrupts disabled flag
+  struct Registers {
+    u32 R[16];  //general purpose registers
+    u32 PC;     //program counter
+    u32 PR;     //procedure register
+    u32 GBR;    //global base register
+    u32 VBR;    //vector base register
+    union {
+      u64 MAC;  //multiply-and-accumulate register
+      struct { u32 order_msb2(MACH, MACL); };
+    };
+    u32 CCR;    //clock counter register
+    S32 SR;     //status register
+    u32 PPC;    //program counter for delay slots
+    u32 PPM;    //delay slot mode
+    u32 ET;     //exception triggered flag
+    u32 ID;     //interrupts disabled flag
+  } regs;
 
   enum : u32 {
     ResetCold       = 1 << 0,
@@ -251,7 +253,7 @@ struct SH2 {
 
     struct Block {
       auto execute(SH2& self) -> void {
-        ((void (*)(u32*, SH2*))code)(&self.R[0], &self);
+        ((void (*)(u32*, SH2*))code)(&self.regs.R[0], &self);
       }
 
       u8* code;

--- a/ares/md/m32x/debugger.cpp
+++ b/ares/md/m32x/debugger.cpp
@@ -17,7 +17,7 @@ auto M32X::SH7604::Debugger::load(Node::Object parent) -> void {
 }
 
 auto M32X::SH7604::Debugger::instruction() -> void {
-  if(tracer.instruction->enabled() && tracer.instruction->address(self->PC - 4)) {
+  if(tracer.instruction->enabled() && tracer.instruction->address(self->regs.PC - 4)) {
     tracer.instruction->notify(self->disassembleInstruction(), self->disassembleContext());
   }
 }

--- a/ares/md/m32x/sh7604.cpp
+++ b/ares/md/m32x/sh7604.cpp
@@ -14,27 +14,27 @@ auto M32X::SH7604::unload() -> void {
 }
 
 auto M32X::SH7604::main() -> void {
-  if(!SH2::inDelaySlot() && !SH2::ID) {
+  if(!SH2::inDelaySlot() && !regs.ID) {
     if(irq.vres.active && irq.vres.enable) {
       debugger.interrupt("VRES");
       irq.vres.active = 0;
-      return ET = 1, interrupt(14, 71);
+      return regs.ET = 1, interrupt(14, 71);
     }
-    if(irq.vint.active && irq.vint.enable && SR.I < 12) {
+    if(irq.vint.active && irq.vint.enable && regs.SR.I < 12) {
       debugger.interrupt("VINT");
-      return ET = 1, interrupt(12, 70);
+      return regs.ET = 1, interrupt(12, 70);
     }
-    if(irq.hint.active && irq.hint.enable && SR.I < 10) {
+    if(irq.hint.active && irq.hint.enable && regs.SR.I < 10) {
       debugger.interrupt("HINT");
-      return ET = 1, interrupt(10, 69);
+      return regs.ET = 1, interrupt(10, 69);
     }
-    if(irq.cmd.active && irq.cmd.enable && SR.I < 8) {
+    if(irq.cmd.active && irq.cmd.enable && regs.SR.I < 8) {
       debugger.interrupt("CMD");
-      return ET = 1, interrupt(8, 68);
+      return regs.ET = 1, interrupt(8, 68);
     }
-    if(irq.pwm.active && irq.pwm.enable && SR.I < 6) {
+    if(irq.pwm.active && irq.pwm.enable && regs.SR.I < 6) {
       debugger.interrupt("PWM");
-      return ET = 1, interrupt(6, 67);
+      return regs.ET = 1, interrupt(6, 67);
     }
   }
 

--- a/ares/n64/GNUmakefile
+++ b/ares/n64/GNUmakefile
@@ -34,8 +34,10 @@ $(object.path)/ares-n64-cpu.o:        $(ares.path)/n64/cpu/cpu.cpp
 $(object.path)/ares-n64-rdp.o:        $(ares.path)/n64/rdp/rdp.cpp
 $(object.path)/ares-n64-rsp.o:        $(ares.path)/n64/rsp/rsp.cpp
 
-flags   += -msse4.2
-options += -msse4.2
+ifeq ($(arch),amd64)
+  flags   += -msse4.2
+  options += -msse4.2
+endif
 
 ifeq ($(vulkan),true)
   ares.objects += ares-n64-vulkan

--- a/ares/n64/accuracy.hpp
+++ b/ares/n64/accuracy.hpp
@@ -15,7 +15,7 @@ struct Accuracy {
     static constexpr bool Recompiler = !Interpreter;
 
     //VU instructions
-    static constexpr bool SISD = 0 | Reference;
+    static constexpr bool SISD = 0 | Reference | !Architecture::amd64;
     static constexpr bool SIMD = !SISD;
   };
 

--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -91,7 +91,7 @@ auto CPU::instruction() -> void {
   }
 }
 
-auto CPU::instructionEpilogue() -> bool {
+auto CPU::instructionEpilogue() -> s32 {
   if constexpr(Accuracy::CPU::Recompiler) {
     icache.step(ipu.pc);  //simulates timings without performing actual icache loads
   }

--- a/ares/n64/n64.hpp
+++ b/ares/n64/n64.hpp
@@ -6,8 +6,10 @@
 #include <nall/recompiler/amd64/amd64.hpp>
 #include <component/processor/sm5k/sm5k.hpp>
 
+#if defined(ARCHITECTURE_AMD64)
 #include <nmmintrin.h>
 using v128 = __m128i;
+#endif
 
 #if defined(VULKAN)
   #include <n64/vulkan/vulkan.hpp>

--- a/ares/n64/n64.hpp
+++ b/ares/n64/n64.hpp
@@ -3,7 +3,7 @@
 
 #include <ares/ares.hpp>
 #include <nall/hashset.hpp>
-#include <nall/recompiler/amd64/amd64.hpp>
+#include <nall/recompiler/generic/generic.hpp>
 #include <component/processor/sm5k/sm5k.hpp>
 
 #if defined(ARCHITECTURE_AMD64)

--- a/ares/n64/rsp/interpreter-vpu.cpp
+++ b/ares/n64/rsp/interpreter-vpu.cpp
@@ -36,6 +36,7 @@ auto RSP::r128::operator()(u32 index) const -> r128 {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     static const __m128i shuffle[16] = {
       //vector
       _mm_set_epi8(15,14,13,12,11,10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0),  //01234567
@@ -60,6 +61,7 @@ auto RSP::r128::operator()(u32 index) const -> r128 {
     };
     //todo: benchmark to see if testing for cases 0&1 to return value directly is faster
     return {uint128_t(_mm_shuffle_epi8(v128, shuffle[index]))};
+#endif
   }
 }
 
@@ -103,8 +105,10 @@ auto RSP::CFC2(r32& rt, u8 rd) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     static const v128 reverse = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
     rt.u32 = s16(_mm_movemask_epi8(_mm_shuffle_epi8(_mm_packs_epi16(hi, lo), reverse)));
+#endif
   }
 }
 
@@ -126,9 +130,11 @@ auto RSP::CTC2(cr32& rt, u8 rd) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     static const v128 mask = _mm_set_epi16(0x0101, 0x0202, 0x0404, 0x0808, 0x1010, 0x2020, 0x4040, 0x8080);
     lo->v128 = _mm_cmpeq_epi8(_mm_and_si128(_mm_shuffle_epi8(r128{~rt.u32 >> 0}, zero), mask), zero);
     hi->v128 = _mm_cmpeq_epi8(_mm_and_si128(_mm_shuffle_epi8(r128{~rt.u32 >> 8}, zero), mask), zero);
+#endif
   }
 }
 
@@ -388,6 +394,7 @@ auto RSP::VABS(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vs0, slt;
     vs0  = _mm_cmpeq_epi16(vs, zero);
     slt  = _mm_srai_epi16(vs, 15);
@@ -395,6 +402,7 @@ auto RSP::VABS(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     vd   = _mm_xor_si128(vd, slt);
     ACCL = _mm_sub_epi16(vd, slt);
     vd   = _mm_subs_epi16(vd, slt);
+#endif
   }
 }
 
@@ -411,6 +419,7 @@ auto RSP::VADD(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), sum, min, max;
     sum  = _mm_add_epi16(vs, vte);
     ACCL = _mm_sub_epi16(sum, VCOL);
@@ -420,6 +429,7 @@ auto RSP::VADD(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     vd   = _mm_adds_epi16(min, max);
     VCOL = zero;
     VCOH = zero;
+#endif
   }
 }
 
@@ -436,6 +446,7 @@ auto RSP::VADDC(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), sum;
     sum  = _mm_adds_epu16(vs, vte);
     ACCL = _mm_add_epi16(vs, vte);
@@ -443,6 +454,7 @@ auto RSP::VADDC(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     VCOL = _mm_cmpeq_epi16(VCOL, zero);
     VCOH = zero;
     vd   = ACCL;
+#endif
   }
 }
 
@@ -456,8 +468,10 @@ auto RSP::VAND(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     ACCL = _mm_and_si128(vs, vt(e));
     vd   = ACCL;
+#endif
   }
 }
 
@@ -487,6 +501,7 @@ auto RSP::VCH(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), nvt, diff, diff0, vtn, dlez, dgez, mask;
     VCOL  = _mm_xor_si128(vs, vte);
     VCOL  = _mm_cmplt_epi16(VCOL, zero);
@@ -507,6 +522,7 @@ auto RSP::VCH(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     mask  = _mm_blendv_epi8(VCCH, VCCL, VCOL);
     ACCL  = _mm_blendv_epi8(vs, nvt, mask);
     vd    = ACCL;
+#endif
   }
 }
 
@@ -537,6 +553,7 @@ auto RSP::VCL(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), nvt, diff, ncarry, nvce, diff0, lec1, lec2, leeq, geeq, le, ge, mask;
     nvt    = _mm_xor_si128(vte, VCOL);
     nvt    = _mm_sub_epi16(nvt, VCOL);
@@ -564,6 +581,7 @@ auto RSP::VCL(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     VCOL   = zero;
     VCE    = zero;
     vd     = ACCL;
+#endif
   }
 }
 
@@ -586,6 +604,7 @@ auto RSP::VCR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), sign, dlez, dgez, nvt, mask;
     sign = _mm_xor_si128(vs, vte);
     sign = _mm_srai_epi16(sign, 15);
@@ -602,6 +621,7 @@ auto RSP::VCR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     VCOL = zero;
     VCOH = zero;
     VCE  = zero;
+#endif
   }
 }
 
@@ -619,6 +639,7 @@ auto RSP::VEQ(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), eq;
     eq   = _mm_cmpeq_epi16(vs, vte);
     VCCL = _mm_andnot_si128(VCOH, eq);
@@ -627,6 +648,7 @@ auto RSP::VEQ(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     VCOH = zero;
     VCOL = zero;
     vd   = ACCL;
+#endif
   }
 }
 
@@ -644,6 +666,7 @@ auto RSP::VGE(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), eq, gt, es;
     eq   = _mm_cmpeq_epi16(vs, vte);
     gt   = _mm_cmpgt_epi16(vs, vte);
@@ -655,6 +678,7 @@ auto RSP::VGE(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     VCOH = zero;
     VCOL = zero;
     vd   = ACCL;
+#endif
   }
 }
 
@@ -672,6 +696,7 @@ auto RSP::VLT(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), eq, lt;
     eq   = _mm_cmpeq_epi16(vs, vte);
     lt   = _mm_cmplt_epi16(vs, vte);
@@ -683,6 +708,7 @@ auto RSP::VLT(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     VCOH = zero;
     VCOL = zero;
     vd   = ACCL;
+#endif
   }
 }
 
@@ -702,6 +728,7 @@ auto RSP::VMACF(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), lo, md, hi, carry, omask;
     lo    = _mm_mullo_epi16(vs, vte);
     hi    = _mm_mulhi_epi16(vs, vte);
@@ -737,6 +764,7 @@ auto RSP::VMACF(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
       md    = _mm_andnot_si128(hmask, md);
       vd    = _mm_or_si128(omask, md);
     }
+#endif
   }
 }
 
@@ -764,6 +792,7 @@ auto RSP::VMADH(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), lo, hi, omask;
     lo    = _mm_mullo_epi16(vs, vte);
     hi    = _mm_mulhi_epi16(vs, vte);
@@ -776,6 +805,7 @@ auto RSP::VMADH(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     lo    = _mm_unpacklo_epi16(ACCM, ACCH);
     hi    = _mm_unpackhi_epi16(ACCM, ACCH);
     vd    = _mm_packs_epi32(lo, hi);
+#endif
   }
 }
 
@@ -789,6 +819,7 @@ auto RSP::VMADL(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), hi, omask, nhi, nmd, shi, smd, cmask, cval;
     hi    = _mm_mulhi_epu16(vs, vte);
     omask = _mm_adds_epu16(ACCL, hi);
@@ -808,6 +839,7 @@ auto RSP::VMADL(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     cmask = _mm_and_si128(smd, shi);
     cval  = _mm_cmpeq_epi16(nhi, zero);
     vd    = _mm_blendv_epi8(cval, ACCL, cmask);
+#endif
   }
 }
 
@@ -821,6 +853,7 @@ auto RSP::VMADM(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), lo, hi, sign, vta, omask;
     lo    = _mm_mullo_epi16(vs, vte);
     hi    = _mm_mulhi_epu16(vs, vte);
@@ -842,6 +875,7 @@ auto RSP::VMADM(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     lo    = _mm_unpacklo_epi16(ACCM, ACCH);
     hi    = _mm_unpackhi_epi16(ACCM, ACCH);
     vd    = _mm_packs_epi32(lo, hi);
+#endif
   }
 }
 
@@ -855,6 +889,7 @@ auto RSP::VMADN(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), lo, hi, sign, vsa, omask, nhi, nmd, shi, smd, cmask, cval;
     lo    = _mm_mullo_epi16(vs, vte);
     hi    = _mm_mulhi_epu16(vs, vte);
@@ -880,6 +915,7 @@ auto RSP::VMADN(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     cmask = _mm_and_si128(smd, shi);
     cval  = _mm_cmpeq_epi16(nhi, zero);
     vd    = _mm_blendv_epi8(cval, ACCL, cmask);
+#endif
   }
 }
 
@@ -906,10 +942,12 @@ auto RSP::VMRG(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     ACCL = _mm_blendv_epi8(vt(e), vs, VCCL);
     VCOH = zero;
     VCOL = zero;
     vd   = ACCL;
+#endif
   }
 }
 
@@ -923,6 +961,7 @@ auto RSP::VMUDH(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), lo, hi;
     ACCL = zero;
     ACCM = _mm_mullo_epi16(vs, vte);
@@ -930,6 +969,7 @@ auto RSP::VMUDH(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     lo   = _mm_unpacklo_epi16(ACCM, ACCH);
     hi   = _mm_unpackhi_epi16(ACCM, ACCH);
     vd   = _mm_packs_epi32(lo, hi);
+#endif
   }
 }
 
@@ -943,10 +983,12 @@ auto RSP::VMUDL(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     ACCL = _mm_mulhi_epu16(vs, vt(e));
     ACCM = zero;
     ACCH = zero;
     vd   = ACCL;
+#endif
   }
 }
 
@@ -960,6 +1002,7 @@ auto RSP::VMUDM(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), sign, vta;
     ACCL = _mm_mullo_epi16(vs, vte);
     ACCM = _mm_mulhi_epu16(vs, vte);
@@ -968,6 +1011,7 @@ auto RSP::VMUDM(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     ACCM = _mm_sub_epi16(ACCM, vta);
     ACCH = _mm_srai_epi16(ACCM, 15);
     vd   = ACCM;
+#endif
   }
 }
 
@@ -981,6 +1025,7 @@ auto RSP::VMUDN(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), sign, vsa;
     ACCL = _mm_mullo_epi16(vs, vte);
     ACCM = _mm_mulhi_epu16(vs, vte);
@@ -989,6 +1034,7 @@ auto RSP::VMUDN(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     ACCM = _mm_sub_epi16(ACCM, vsa);
     ACCH = _mm_srai_epi16(ACCM, 15);
     vd   = ACCL;
+#endif
   }
 }
 
@@ -1008,6 +1054,7 @@ auto RSP::VMULF(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), lo, hi, round, sign1, sign2, neq, eq, neg;
     lo    = _mm_mullo_epi16(vs, vte);
     round = _mm_cmpeq_epi16(zero, zero);
@@ -1031,6 +1078,7 @@ auto RSP::VMULF(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
       hi   = _mm_or_si128(ACCM, neg);
       vd   = _mm_andnot_si128(ACCH, hi);
     }
+#endif
   }
 }
 
@@ -1056,9 +1104,11 @@ auto RSP::VNAND(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     ACCL = _mm_and_si128(vs, vt(e));
     ACCL = _mm_xor_si128(ACCL, invert);
     vd   = ACCL;
+#endif
   }
 }
 
@@ -1076,6 +1126,7 @@ auto RSP::VNE(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), eq, ne;
     eq   = _mm_cmpeq_epi16(vs, vte);
     ne   = _mm_cmpeq_epi16(eq, zero);
@@ -1086,6 +1137,7 @@ auto RSP::VNE(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     VCOH = zero;
     VCOL = zero;
     vd   = ACCL;
+#endif
   }
 }
 
@@ -1102,9 +1154,11 @@ auto RSP::VNOR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     ACCL = _mm_or_si128(vs, vt(e));
     ACCL = _mm_xor_si128(ACCL, invert);
     vd   = ACCL;
+#endif
   }
 }
 
@@ -1118,9 +1172,11 @@ auto RSP::VNXOR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     ACCL = _mm_xor_si128(vs, vt(e));
     ACCL = _mm_xor_si128(ACCL, invert);
     vd   = ACCL;
+#endif
   }
 }
 
@@ -1134,8 +1190,10 @@ auto RSP::VOR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     ACCL = _mm_or_si128(vs, vt(e));
     vd   = ACCL;
+#endif
   }
 }
 
@@ -1243,6 +1301,7 @@ auto RSP::VSUB(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), udiff, sdiff, ov;
     udiff = _mm_sub_epi16(vte, VCOL);
     sdiff = _mm_subs_epi16(vte, VCOL);
@@ -1252,6 +1311,7 @@ auto RSP::VSUB(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     vd    = _mm_adds_epi16(vd, ov);
     VCOL  = zero;
     VCOH  = zero;
+#endif
   }
 }
 
@@ -1268,6 +1328,7 @@ auto RSP::VSUBC(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     r128 vte = vt(e), equal, udiff, diff0;
     udiff = _mm_subs_epu16(vs, vte);
     equal = _mm_cmpeq_epi16(vs, vte);
@@ -1276,6 +1337,7 @@ auto RSP::VSUBC(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
     VCOL  = _mm_andnot_si128(equal, diff0);
     ACCL  = _mm_sub_epi16(vs, vte);
     vd    = ACCL;
+#endif
   }
 }
 
@@ -1289,8 +1351,10 @@ auto RSP::VXOR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 
   if constexpr(Accuracy::RSP::SIMD) {
+#if defined(ARCHITECTURE_AMD64)
     ACCL = _mm_xor_si128(vs, vt(e));
     vd   = ACCL;
+#endif
   }
 }
 

--- a/ares/n64/rsp/interpreter-vpu.cpp
+++ b/ares/n64/rsp/interpreter-vpu.cpp
@@ -138,12 +138,14 @@ auto RSP::CTC2(cr32& rt, u8 rd) -> void {
   }
 }
 
-auto RSP::LBV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::LBV(r128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm;
   vt.byte(e) = dmem.read<Byte>(address);
 }
 
-auto RSP::LDV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::LDV(r128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 8;
   auto start = e;
   auto end = start + 8;
@@ -152,7 +154,8 @@ auto RSP::LDV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::LFV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::LFV(r128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 16;
   auto start = e >> 1;
   auto end = start + 4;
@@ -162,14 +165,16 @@ auto RSP::LFV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::LHV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::LHV(r128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 16;
   for(u32 offset = 0; offset < 8; offset++) {
     vt.element(offset) = dmem.read<Byte>(address + (16 - e + offset * 2 & 15)) << 7;
   }
 }
 
-auto RSP::LLV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::LLV(r128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 4;
   auto start = e;
   auto end = start + 4;
@@ -178,14 +183,16 @@ auto RSP::LLV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::LPV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::LPV(r128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 8;
   for(u32 offset = 0; offset < 8; offset++) {
     vt.element(offset) = dmem.read<Byte>(address + (16 - e + offset & 15)) << 8;
   }
 }
 
-auto RSP::LQV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::LQV(r128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 16;
   auto start = e;
   auto end = 16 - (address & 15);
@@ -194,7 +201,8 @@ auto RSP::LQV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::LRV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::LRV(r128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 16;
   auto index = e;
   auto start = 16 - ((address & 15) - index);
@@ -204,7 +212,8 @@ auto RSP::LRV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::LSV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::LSV(r128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 2;
   auto start = e;
   auto end = start + 2;
@@ -213,7 +222,8 @@ auto RSP::LSV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::LTV(u8 vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::LTV(u8 vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 16;
   auto start = vt;
   auto end = min(32, start + 8);
@@ -225,14 +235,16 @@ auto RSP::LTV(u8 vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::LUV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::LUV(r128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 8;
   for(u32 offset = 0; offset < 8; offset++) {
     vt.element(offset) = dmem.read<Byte>(address + (16 - e + offset & 15)) << 7;
   }
 }
 
-auto RSP::LWV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::LWV(r128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 16;
   auto start = 16 - e;
   auto end = e + 16;
@@ -242,23 +254,27 @@ auto RSP::LWV(r128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::MFC2(r32& rt, cr128& vs, u8 e) -> void {
+template<u8 e>
+auto RSP::MFC2(r32& rt, cr128& vs) -> void {
   auto hi = vs.byte(e + 0 & 15);
   auto lo = vs.byte(e + 1 & 15);
   rt.u32 = s16(hi << 8 | lo << 0);
 }
 
-auto RSP::MTC2(cr32& rt, r128& vs, u8 e) -> void {
+template<u8 e>
+auto RSP::MTC2(cr32& rt, r128& vs) -> void {
   vs.byte(e + 0 & 15) = rt.u32 >> 8;
   vs.byte(e + 1 & 15) = rt.u32 >> 0;
 }
 
-auto RSP::SBV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::SBV(cr128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm;
   dmem.write<Byte>(address, vt.byte(e));
 }
 
-auto RSP::SDV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::SDV(cr128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 8;
   auto start = e;
   auto end = start + 8;
@@ -267,7 +283,8 @@ auto RSP::SDV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::SFV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::SFV(cr128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 16;
   auto start = e >> 1;
   auto end = start + 4;
@@ -279,7 +296,8 @@ auto RSP::SFV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::SHV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::SHV(cr128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 16;
   for(u32 offset = 0; offset < 8; offset++) {
     auto byte = e + offset * 2;
@@ -289,7 +307,8 @@ auto RSP::SHV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::SLV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::SLV(cr128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 4;
   auto start = e;
   auto end = start + 4;
@@ -298,7 +317,8 @@ auto RSP::SLV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::SPV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::SPV(cr128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 8;
   auto start = e;
   auto end = start + 8;
@@ -311,7 +331,8 @@ auto RSP::SPV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::SQV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::SQV(cr128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 16;
   auto start = e;
   auto end = start + (16 - (address & 15));
@@ -320,7 +341,8 @@ auto RSP::SQV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::SRV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::SRV(cr128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 16;
   auto start = e;
   auto end = start + (address & 15);
@@ -331,7 +353,8 @@ auto RSP::SRV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::SSV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::SSV(cr128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 2;
   auto start = e;
   auto end = start + 2;
@@ -340,7 +363,8 @@ auto RSP::SSV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::STV(u8 vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::STV(u8 vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 16;
   auto start = vt;
   auto end = min(32, start + 8);
@@ -353,7 +377,8 @@ auto RSP::STV(u8 vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::SUV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::SUV(cr128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 8;
   auto start = e;
   auto end = start + 8;
@@ -366,7 +391,8 @@ auto RSP::SUV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::SWV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
+template<u8 e>
+auto RSP::SWV(cr128& vt, cr32& rs, s8 imm) -> void {
   auto address = rs.u32 + imm * 16;
   auto start = e;
   auto end = start + 16;
@@ -377,7 +403,8 @@ auto RSP::SWV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void {
   }
 }
 
-auto RSP::VABS(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VABS(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     r128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -406,7 +433,8 @@ auto RSP::VABS(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VADD(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VADD(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -433,7 +461,8 @@ auto RSP::VADD(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VADDC(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VADDC(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -458,7 +487,8 @@ auto RSP::VADDC(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VAND(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VAND(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     r128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -475,7 +505,8 @@ auto RSP::VAND(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VCH(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VCH(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -526,7 +557,8 @@ auto RSP::VCH(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VCL(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VCL(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -585,7 +617,8 @@ auto RSP::VCL(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VCR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VCR(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -625,7 +658,8 @@ auto RSP::VCR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VEQ(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VEQ(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -652,7 +686,8 @@ auto RSP::VEQ(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VGE(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VGE(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -682,7 +717,8 @@ auto RSP::VGE(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VLT(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VLT(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -712,8 +748,8 @@ auto RSP::VLT(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-template<bool U>
-auto RSP::VMACF(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<bool U, u8 e>
+auto RSP::VMACF(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -780,7 +816,8 @@ auto RSP::VMACQ(r128& vd) -> void {
   }
 }
 
-auto RSP::VMADH(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VMADH(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -809,7 +846,8 @@ auto RSP::VMADH(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VMADL(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VMADL(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -843,7 +881,8 @@ auto RSP::VMADL(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VMADM(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VMADM(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -879,7 +918,8 @@ auto RSP::VMADM(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VMADN(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VMADN(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -919,7 +959,9 @@ auto RSP::VMADN(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VMOV(r128& vd, u8 de, cr128& vt, u8 e) -> void {
+template<u8 E>
+auto RSP::VMOV(r128& vd, u8 de, cr128& vt) -> void {
+  u8 e = E;
   switch(e) {
   case 0x0 ... 0x1: e = e & 0b000 | de & 0b111; break;  //hardware glitch
   case 0x2 ... 0x3: e = e & 0b001 | de & 0b110; break;  //hardware glitch
@@ -930,7 +972,8 @@ auto RSP::VMOV(r128& vd, u8 de, cr128& vt, u8 e) -> void {
   ACCL = vt(e);
 }
 
-auto RSP::VMRG(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VMRG(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -951,7 +994,8 @@ auto RSP::VMRG(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VMUDH(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VMUDH(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -973,7 +1017,8 @@ auto RSP::VMUDH(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VMUDL(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VMUDL(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -992,7 +1037,8 @@ auto RSP::VMUDL(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VMUDM(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VMUDM(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -1015,7 +1061,8 @@ auto RSP::VMUDM(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VMUDN(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VMUDN(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -1038,8 +1085,8 @@ auto RSP::VMUDN(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-template<bool U>
-auto RSP::VMULF(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<bool U, u8 e>
+auto RSP::VMULF(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -1082,7 +1129,8 @@ auto RSP::VMULF(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VMULQ(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VMULQ(r128& vd, cr128& vs, cr128& vt) -> void {
   cr128 vte = vt(e);
   for(u32 n : range(8)) {
     s32 product = (s16)vs.element(n) * (s16)vte.element(n);
@@ -1094,7 +1142,8 @@ auto RSP::VMULQ(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VNAND(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VNAND(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -1112,7 +1161,8 @@ auto RSP::VNAND(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VNE(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VNE(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -1144,7 +1194,8 @@ auto RSP::VNE(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
 auto RSP::VNOP() -> void {
 }
 
-auto RSP::VNOR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VNOR(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -1162,7 +1213,8 @@ auto RSP::VNOR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VNXOR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VNXOR(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -1180,7 +1232,8 @@ auto RSP::VNXOR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VOR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VOR(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -1197,8 +1250,8 @@ auto RSP::VOR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-template<bool L>
-auto RSP::VRCP(r128& vd, u8 de, cr128& vt, u8 e) -> void {
+template<bool L, u8 e>
+auto RSP::VRCP(r128& vd, u8 de, cr128& vt) -> void {
   s32 result = 0;
   s32 input = L && DIVDP ? DIVIN << 16 | vt.element(e & 7) : s16(vt.element(e & 7));
   s32 mask = input >> 31;
@@ -1221,15 +1274,16 @@ auto RSP::VRCP(r128& vd, u8 de, cr128& vt, u8 e) -> void {
   vd.element(de) = result;
 }
 
-auto RSP::VRCPH(r128& vd, u8 de, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VRCPH(r128& vd, u8 de, cr128& vt) -> void {
   ACCL  = vt(e);
   DIVDP = 1;
   DIVIN = vt.element(e & 7);
   vd.element(de) = DIVOUT;
 }
 
-template<bool D>
-auto RSP::VRND(r128& vd, u8 vs, cr128& vt, u8 e) -> void {
+template<bool D, u8 e>
+auto RSP::VRND(r128& vd, u8 vs, cr128& vt) -> void {
   cr128 vte = vt(e);
   for(u32 n : range(8)) {
     s32 product = (s16)vte.element(n);
@@ -1248,8 +1302,8 @@ auto RSP::VRND(r128& vd, u8 vs, cr128& vt, u8 e) -> void {
   }
 }
 
-template<bool L>
-auto RSP::VRSQ(r128& vd, u8 de, cr128& vt, u8 e) -> void {
+template<bool L, u8 e>
+auto RSP::VRSQ(r128& vd, u8 de, cr128& vt) -> void {
   s32 result = 0;
   s32 input = L && DIVDP ? DIVIN << 16 | vt.element(e & 7) : s16(vt.element(e & 7));
   s32 mask = input >> 31;
@@ -1272,14 +1326,16 @@ auto RSP::VRSQ(r128& vd, u8 de, cr128& vt, u8 e) -> void {
   vd.element(de) = result;
 }
 
-auto RSP::VRSQH(r128& vd, u8 de, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VRSQH(r128& vd, u8 de, cr128& vt) -> void {
   ACCL  = vt(e);
   DIVDP = 1;
   DIVIN = vt.element(e & 7);
   vd.element(de) = DIVOUT;
 }
 
-auto RSP::VSAR(r128& vd, cr128& vs, u8 e) -> void {
+template<u8 e>
+auto RSP::VSAR(r128& vd, cr128& vs) -> void {
   switch(e) {
   case 0x8: vd = ACCH; break;
   case 0x9: vd = ACCM; break;
@@ -1288,7 +1344,8 @@ auto RSP::VSAR(r128& vd, cr128& vs, u8 e) -> void {
   }
 }
 
-auto RSP::VSUB(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VSUB(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -1315,7 +1372,8 @@ auto RSP::VSUB(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VSUBC(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VSUBC(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {
@@ -1341,7 +1399,8 @@ auto RSP::VSUBC(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
   }
 }
 
-auto RSP::VXOR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void {
+template<u8 e>
+auto RSP::VXOR(r128& vd, cr128& vs, cr128& vt) -> void {
   if constexpr(Accuracy::RSP::SISD) {
     cr128 vte = vt(e);
     for(u32 n : range(8)) {

--- a/ares/n64/rsp/interpreter.cpp
+++ b/ares/n64/rsp/interpreter.cpp
@@ -9,6 +9,25 @@
 #define jp(id, name, ...) case id: return decoder##name(__VA_ARGS__)
 #define op(id, name, ...) case id: return name(__VA_ARGS__)
 #define br(id, name, ...) case id: return name(__VA_ARGS__)
+#define vu(id, name, ...) case id: \
+  switch(E) { \
+  case 0x0: return name<0x0>(__VA_ARGS__); \
+  case 0x1: return name<0x1>(__VA_ARGS__); \
+  case 0x2: return name<0x2>(__VA_ARGS__); \
+  case 0x3: return name<0x3>(__VA_ARGS__); \
+  case 0x4: return name<0x4>(__VA_ARGS__); \
+  case 0x5: return name<0x5>(__VA_ARGS__); \
+  case 0x6: return name<0x6>(__VA_ARGS__); \
+  case 0x7: return name<0x7>(__VA_ARGS__); \
+  case 0x8: return name<0x8>(__VA_ARGS__); \
+  case 0x9: return name<0x9>(__VA_ARGS__); \
+  case 0xa: return name<0xa>(__VA_ARGS__); \
+  case 0xb: return name<0xb>(__VA_ARGS__); \
+  case 0xc: return name<0xc>(__VA_ARGS__); \
+  case 0xd: return name<0xd>(__VA_ARGS__); \
+  case 0xe: return name<0xe>(__VA_ARGS__); \
+  case 0xf: return name<0xf>(__VA_ARGS__); \
+  }
 
 #define SA     (OP >>  6 & 31)
 #define RDn    (OP >> 11 & 31)
@@ -220,11 +239,11 @@ auto RSP::decoderSCC() -> void {
 auto RSP::decoderVU() -> void {
   #define E (OP >> 7 & 15)
   switch(OP >> 21 & 0x1f) {
-  op(0x00, MFC2, RT, VS, E);
+  vu(0x00, MFC2, RT, VS);
   op(0x01, INVALID);  //DMFC2
   op(0x02, CFC2, RT, RDn);
   op(0x03, INVALID);
-  op(0x04, MTC2, RT, VS, E);
+  vu(0x04, MTC2, RT, VS);
   op(0x05, INVALID);  //DMTC2
   op(0x06, CTC2, RT, RDn);
   op(0x07, INVALID);
@@ -242,28 +261,28 @@ auto RSP::decoderVU() -> void {
   #define E  (OP >> 21 & 15)
   #define DE (OP >> 11 &  7)
   switch(OP & 0x3f) {
-  op(0x00, VMULF<0>, VD, VS, VT, E);
-  op(0x01, VMULF<1>, VD, VS, VT, E);
-  op(0x02, VRND<1>, VD, VSn, VT, E);
-  op(0x03, VMULQ, VD, VS, VT, E);
-  op(0x04, VMUDL, VD, VS, VT, E);
-  op(0x05, VMUDM, VD, VS, VT, E);
-  op(0x06, VMUDN, VD, VS, VT, E);
-  op(0x07, VMUDH, VD, VS, VT, E);
-  op(0x08, VMACF<0>, VD, VS, VT, E);
-  op(0x09, VMACF<1>, VD, VS, VT, E);
-  op(0x0a, VRND<0>, VD, VSn, VT, E);
+  vu(0x00, VMULF, VD, VS, VT);
+  vu(0x01, VMULU, VD, VS, VT);
+  vu(0x02, VRNDP, VD, VSn, VT);
+  vu(0x03, VMULQ, VD, VS, VT);
+  vu(0x04, VMUDL, VD, VS, VT);
+  vu(0x05, VMUDM, VD, VS, VT);
+  vu(0x06, VMUDN, VD, VS, VT);
+  vu(0x07, VMUDH, VD, VS, VT);
+  vu(0x08, VMACF, VD, VS, VT);
+  vu(0x09, VMACU, VD, VS, VT);
+  vu(0x0a, VRNDN, VD, VSn, VT);
   op(0x0b, VMACQ, VD);
-  op(0x0c, VMADL, VD, VS, VT, E);
-  op(0x0d, VMADM, VD, VS, VT, E);
-  op(0x0e, VMADN, VD, VS, VT, E);
-  op(0x0f, VMADH, VD, VS, VT, E);
-  op(0x10, VADD, VD, VS, VT, E);
-  op(0x11, VSUB, VD, VS, VT, E);
+  vu(0x0c, VMADL, VD, VS, VT);
+  vu(0x0d, VMADM, VD, VS, VT);
+  vu(0x0e, VMADN, VD, VS, VT);
+  vu(0x0f, VMADH, VD, VS, VT);
+  vu(0x10, VADD, VD, VS, VT);
+  vu(0x11, VSUB, VD, VS, VT);
   op(0x12, INVALID);
-  op(0x13, VABS, VD, VS, VT, E);
-  op(0x14, VADDC, VD, VS, VT, E);
-  op(0x15, VSUBC, VD, VS, VT, E);
+  vu(0x13, VABS, VD, VS, VT);
+  vu(0x14, VADDC, VD, VS, VT);
+  vu(0x15, VSUBC, VD, VS, VT);
   op(0x16, INVALID);
   op(0x17, INVALID);
   op(0x18, INVALID);
@@ -271,32 +290,32 @@ auto RSP::decoderVU() -> void {
   op(0x1a, INVALID);
   op(0x1b, INVALID);
   op(0x1c, INVALID);
-  op(0x1d, VSAR, VD, VS, E);
+  vu(0x1d, VSAR, VD, VS);
   op(0x1e, INVALID);
   op(0x1f, INVALID);
-  op(0x20, VLT, VD, VS, VT, E);
-  op(0x21, VEQ, VD, VS, VT, E);
-  op(0x22, VNE, VD, VS, VT, E);
-  op(0x23, VGE, VD, VS, VT, E);
-  op(0x24, VCL, VD, VS, VT, E);
-  op(0x25, VCH, VD, VS, VT, E);
-  op(0x26, VCR, VD, VS, VT, E);
-  op(0x27, VMRG, VD, VS, VT, E);
-  op(0x28, VAND, VD, VS, VT, E);
-  op(0x29, VNAND, VD, VS, VT, E);
-  op(0x2a, VOR, VD, VS, VT, E);
-  op(0x2b, VNOR, VD, VS, VT, E);
-  op(0x2c, VXOR, VD, VS, VT, E);
-  op(0x2d, VNXOR, VD, VS, VT, E);
+  vu(0x20, VLT, VD, VS, VT);
+  vu(0x21, VEQ, VD, VS, VT);
+  vu(0x22, VNE, VD, VS, VT);
+  vu(0x23, VGE, VD, VS, VT);
+  vu(0x24, VCL, VD, VS, VT);
+  vu(0x25, VCH, VD, VS, VT);
+  vu(0x26, VCR, VD, VS, VT);
+  vu(0x27, VMRG, VD, VS, VT);
+  vu(0x28, VAND, VD, VS, VT);
+  vu(0x29, VNAND, VD, VS, VT);
+  vu(0x2a, VOR, VD, VS, VT);
+  vu(0x2b, VNOR, VD, VS, VT);
+  vu(0x2c, VXOR, VD, VS, VT);
+  vu(0x2d, VNXOR, VD, VS, VT);
   op(0x2e, INVALID);
   op(0x2f, INVALID);
-  op(0x30, VRCP<0>, VD, DE, VT, E);
-  op(0x31, VRCP<1>, VD, DE, VT, E);
-  op(0x32, VRCPH, VD, DE, VT, E);
-  op(0x33, VMOV, VD, DE, VT, E);
-  op(0x34, VRSQ<0>, VD, DE, VT, E);
-  op(0x35, VRSQ<1>, VD, DE, VT, E);
-  op(0x36, VRSQH, VD, DE, VT, E);
+  vu(0x30, VRCP, VD, DE, VT);
+  vu(0x31, VRCPL, VD, DE, VT);
+  vu(0x32, VRCPH, VD, DE, VT);
+  vu(0x33, VMOV, VD, DE, VT);
+  vu(0x34, VRSQ, VD, DE, VT);
+  vu(0x35, VRSQL, VD, DE, VT);
+  vu(0x36, VRSQH, VD, DE, VT);
   op(0x37, VNOP);
   op(0x38, INVALID);
   op(0x39, INVALID);
@@ -315,18 +334,18 @@ auto RSP::decoderLWC2() -> void {
   #define E     (OP >> 7 & 15)
   #define IMMi7 i7(OP)
   switch(OP >> 11 & 0x1f) {
-  op(0x00, LBV, VT, E, RS, IMMi7);
-  op(0x01, LSV, VT, E, RS, IMMi7);
-  op(0x02, LLV, VT, E, RS, IMMi7);
-  op(0x03, LDV, VT, E, RS, IMMi7);
-  op(0x04, LQV, VT, E, RS, IMMi7);
-  op(0x05, LRV, VT, E, RS, IMMi7);
-  op(0x06, LPV, VT, E, RS, IMMi7);
-  op(0x07, LUV, VT, E, RS, IMMi7);
-  op(0x08, LHV, VT, E, RS, IMMi7);
-  op(0x09, LFV, VT, E, RS, IMMi7);
-//op(0x0a, LWV, VT, E, RS, IMMi7);  //not present on N64 RSP
-  op(0x0b, LTV, VTn, E, RS, IMMi7);
+  vu(0x00, LBV, VT, RS, IMMi7);
+  vu(0x01, LSV, VT, RS, IMMi7);
+  vu(0x02, LLV, VT, RS, IMMi7);
+  vu(0x03, LDV, VT, RS, IMMi7);
+  vu(0x04, LQV, VT, RS, IMMi7);
+  vu(0x05, LRV, VT, RS, IMMi7);
+  vu(0x06, LPV, VT, RS, IMMi7);
+  vu(0x07, LUV, VT, RS, IMMi7);
+  vu(0x08, LHV, VT, RS, IMMi7);
+  vu(0x09, LFV, VT, RS, IMMi7);
+//vu(0x0a, LWV, VT, RS, IMMi7);  //not present on N64 RSP
+  vu(0x0b, LTV, VTn, RS, IMMi7);
   }
   #undef E
   #undef IMMi7
@@ -336,18 +355,18 @@ auto RSP::decoderSWC2() -> void {
   #define E     (OP >> 7 & 15)
   #define IMMi7 i7(OP)
   switch(OP >> 11 & 0x1f) {
-  op(0x00, SBV, VT, E, RS, IMMi7);
-  op(0x01, SSV, VT, E, RS, IMMi7);
-  op(0x02, SLV, VT, E, RS, IMMi7);
-  op(0x03, SDV, VT, E, RS, IMMi7);
-  op(0x04, SQV, VT, E, RS, IMMi7);
-  op(0x05, SRV, VT, E, RS, IMMi7);
-  op(0x06, SPV, VT, E, RS, IMMi7);
-  op(0x07, SUV, VT, E, RS, IMMi7);
-  op(0x08, SHV, VT, E, RS, IMMi7);
-  op(0x09, SFV, VT, E, RS, IMMi7);
-  op(0x0a, SWV, VT, E, RS, IMMi7);
-  op(0x0b, STV, VTn, E, RS, IMMi7);
+  vu(0x00, SBV, VT, RS, IMMi7);
+  vu(0x01, SSV, VT, RS, IMMi7);
+  vu(0x02, SLV, VT, RS, IMMi7);
+  vu(0x03, SDV, VT, RS, IMMi7);
+  vu(0x04, SQV, VT, RS, IMMi7);
+  vu(0x05, SRV, VT, RS, IMMi7);
+  vu(0x06, SPV, VT, RS, IMMi7);
+  vu(0x07, SUV, VT, RS, IMMi7);
+  vu(0x08, SHV, VT, RS, IMMi7);
+  vu(0x09, SFV, VT, RS, IMMi7);
+  vu(0x0a, SWV, VT, RS, IMMi7);
+  vu(0x0b, STV, VTn, RS, IMMi7);
   }
   #undef E
   #undef IMMi7

--- a/ares/n64/rsp/recompiler.cpp
+++ b/ares/n64/rsp/recompiler.cpp
@@ -96,6 +96,25 @@ auto RSP::Recompiler::emit(u32 address) -> Block* {
 #define i16 s16(instruction)
 #define n16 u16(instruction)
 #define n26 u32(instruction & 0x03ff'ffff)
+#define callvu(name) \
+  switch(E) { \
+  case 0x0: call(name<0x0>); break; \
+  case 0x1: call(name<0x1>); break; \
+  case 0x2: call(name<0x2>); break; \
+  case 0x3: call(name<0x3>); break; \
+  case 0x4: call(name<0x4>); break; \
+  case 0x5: call(name<0x5>); break; \
+  case 0x6: call(name<0x6>); break; \
+  case 0x7: call(name<0x7>); break; \
+  case 0x8: call(name<0x8>); break; \
+  case 0x9: call(name<0x9>); break; \
+  case 0xa: call(name<0xa>); break; \
+  case 0xb: call(name<0xb>); break; \
+  case 0xc: call(name<0xc>); break; \
+  case 0xd: call(name<0xd>); break; \
+  case 0xe: call(name<0xe>); break; \
+  case 0xf: call(name<0xf>); break; \
+  }
 
 auto RSP::Recompiler::emitEXECUTE(u32 instruction) -> bool {
   switch(instruction >> 26) {
@@ -628,8 +647,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
   case 0x00: {
     lea(ra1, Rt);
     lea(ra2, Vs);
-    mov(ra3d, imm32(E));
-    call(&RSP::MFC2);
+    callvu(&RSP::MFC2);
     return 0;
   }
 
@@ -655,8 +673,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
   case 0x04: {
     lea(ra1, Rt);
     lea(ra2, Vs);
-    mov(ra3d, imm32(E));
-    call(&RSP::MTC2);
+    callvu(&RSP::MTC2);
     return 0;
   }
 
@@ -690,8 +707,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VMULF<0>);
+    callvu(&RSP::VMULF);
     return 0;
   }
 
@@ -700,8 +716,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VMULF<1>);
+    callvu(&RSP::VMULU);
     return 0;
   }
 
@@ -710,8 +725,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     mov(ra2d, imm32(Vsn));
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VRND<1>);
+    callvu(&RSP::VRNDP);
     return 0;
   }
 
@@ -720,8 +734,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VMULQ);
+    callvu(&RSP::VMULQ);
     return 0;
   }
 
@@ -730,8 +743,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VMUDL);
+    callvu(&RSP::VMUDL);
     return 0;
   }
 
@@ -740,8 +752,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VMUDM);
+    callvu(&RSP::VMUDM);
     return 0;
   }
 
@@ -750,8 +761,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VMUDN);
+    callvu(&RSP::VMUDN);
     return 0;
   }
 
@@ -760,8 +770,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VMUDH);
+    callvu(&RSP::VMUDH);
     return 0;
   }
 
@@ -770,8 +779,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VMACF<0>);
+    callvu(&RSP::VMACF);
     return 0;
   }
 
@@ -780,8 +788,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VMACF<1>);
+    callvu(&RSP::VMACU);
     return 0;
   }
 
@@ -790,8 +797,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     mov(ra2d, imm32(Vsn));
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VRND<0>);
+    callvu(&RSP::VRNDN);
     return 0;
   }
 
@@ -807,8 +813,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VMADL);
+    callvu(&RSP::VMADL);
     return 0;
   }
 
@@ -817,8 +822,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VMADM);
+    callvu(&RSP::VMADM);
     return 0;
   }
 
@@ -827,8 +831,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VMADN);
+    callvu(&RSP::VMADN);
     return 0;
   }
 
@@ -837,8 +840,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VMADH);
+    callvu(&RSP::VMADH);
     return 0;
   }
 
@@ -847,8 +849,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VADD);
+    callvu(&RSP::VADD);
     return 0;
   }
 
@@ -857,8 +858,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VSUB);
+    callvu(&RSP::VSUB);
     return 0;
   }
 
@@ -872,8 +872,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VABS);
+    callvu(&RSP::VABS);
     return 0;
   }
 
@@ -882,8 +881,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VADDC);
+    callvu(&RSP::VADDC);
     return 0;
   }
 
@@ -892,8 +890,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VSUBC);
+    callvu(&RSP::VSUBC);
     return 0;
   }
 
@@ -906,8 +903,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
   case 0x1d: {
     lea(ra1, Vd);
     lea(ra2, Vs);
-    mov(ra3d, imm32(E));
-    call(&RSP::VSAR);
+    callvu(&RSP::VSAR);
     return 0;
   }
 
@@ -921,8 +917,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VLT);
+    callvu(&RSP::VLT);
     return 0;
   }
 
@@ -931,8 +926,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VEQ);
+    callvu(&RSP::VEQ);
     return 0;
   }
 
@@ -941,8 +935,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VNE);
+    callvu(&RSP::VNE);
     return 0;
   }
 
@@ -951,8 +944,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VGE);
+    callvu(&RSP::VGE);
     return 0;
   }
 
@@ -961,8 +953,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VCL);
+    callvu(&RSP::VCL);
     return 0;
   }
 
@@ -971,8 +962,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VCH);
+    callvu(&RSP::VCH);
     return 0;
   }
 
@@ -981,8 +971,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VCR);
+    callvu(&RSP::VCR);
     return 0;
   }
 
@@ -991,8 +980,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VMRG);
+    callvu(&RSP::VMRG);
     return 0;
   }
 
@@ -1001,8 +989,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VAND);
+    callvu(&RSP::VAND);
     return 0;
   }
 
@@ -1011,8 +998,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VNAND);
+    callvu(&RSP::VNAND);
     return 0;
   }
 
@@ -1021,8 +1007,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VOR);
+    callvu(&RSP::VOR);
     return 0;
   }
 
@@ -1031,8 +1016,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VNOR);
+    callvu(&RSP::VNOR);
     return 0;
   }
 
@@ -1041,8 +1025,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VXOR);
+    callvu(&RSP::VXOR);
     return 0;
   }
 
@@ -1051,8 +1034,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     lea(ra2, Vs);
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VNXOR);
+    callvu(&RSP::VNXOR);
     return 0;
   }
 
@@ -1066,8 +1048,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     mov(ra2d, imm32(DE));
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VRCP<0>);
+    callvu(&RSP::VRCP);
     return 0;
   }
 
@@ -1076,8 +1057,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     mov(ra2d, imm32(DE));
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VRCP<1>);
+    callvu(&RSP::VRCPL);
     return 0;
   }
 
@@ -1086,8 +1066,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     mov(ra2d, imm32(DE));
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VRCPH);
+    callvu(&RSP::VRCPH);
     return 0;
   }
 
@@ -1096,8 +1075,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     mov(ra2d, imm32(DE));
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VMOV);
+    callvu(&RSP::VMOV);
     return 0;
   }
 
@@ -1106,8 +1084,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     mov(ra2d, imm32(DE));
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VRSQ<0>);
+    callvu(&RSP::VRSQ);
     return 0;
   }
 
@@ -1116,8 +1093,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     mov(ra2d, imm32(DE));
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VRSQ<1>);
+    callvu(&RSP::VRSQL);
     return 0;
   }
 
@@ -1126,8 +1102,7 @@ auto RSP::Recompiler::emitVU(u32 instruction) -> bool {
     lea(ra1, Vd);
     mov(ra2d, imm32(DE));
     lea(ra3, Vt);
-    mov(ra4d, imm32(E));
-    call(&RSP::VRSQH);
+    callvu(&RSP::VRSQH);
     return 0;
   }
 
@@ -1156,100 +1131,90 @@ auto RSP::Recompiler::emitLWC2(u32 instruction) -> bool {
   //LBV Vt(e),Rs,i7
   case 0x00: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::LBV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::LBV);
     return 0;
   }
 
   //LSV Vt(e),Rs,i7
   case 0x01: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::LSV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::LSV);
     return 0;
   }
 
   //LLV Vt(e),Rs,i7
   case 0x02: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::LLV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::LLV);
     return 0;
   }
 
   //LDV Vt(e),Rs,i7
   case 0x03: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::LDV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::LDV);
     return 0;
   }
 
   //LQV Vt(e),Rs,i7
   case 0x04: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::LQV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::LQV);
     return 0;
   }
 
   //LRV Vt(e),Rs,i7
   case 0x05: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::LRV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::LRV);
     return 0;
   }
 
   //LPV Vt(e),Rs,i7
   case 0x06: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::LPV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::LPV);
     return 0;
   }
 
   //LUV Vt(e),Rs,i7
   case 0x07: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::LUV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::LUV);
     return 0;
   }
 
   //LHV Vt(e),Rs,i7
   case 0x08: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::LHV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::LHV);
     return 0;
   }
 
   //LFV Vt(e),Rs,i7
   case 0x09: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::LFV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::LFV);
     return 0;
   }
 
@@ -1261,10 +1226,9 @@ auto RSP::Recompiler::emitLWC2(u32 instruction) -> bool {
   //LTV Vt(e),Rs,i7
   case 0x0b: {
     mov(ra1d, imm32(Vtn));
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::LTV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::LTV);
     return 0;
   }
 
@@ -1288,120 +1252,108 @@ auto RSP::Recompiler::emitSWC2(u32 instruction) -> bool {
   //SBV Vt(e),Rs,i7
   case 0x00: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::SBV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::SBV);
     return 0;
   }
 
   //SSV Vt(e),Rs,i7
   case 0x01: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::SSV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::SSV);
     return 0;
   }
 
   //SLV Vt(e),Rs,i7
   case 0x02: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::SLV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::SLV);
     return 0;
   }
 
   //SDV Vt(e),Rs,i7
   case 0x03: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::SDV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::SDV);
     return 0;
   }
 
   //SQV Vt(e),Rs,i7
   case 0x04: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::SQV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::SQV);
     return 0;
   }
 
   //SRV Vt(e),Rs,i7
   case 0x05: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::SRV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::SRV);
     return 0;
   }
 
   //SPV Vt(e),Rs,i7
   case 0x06: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::SPV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::SPV);
     return 0;
   }
 
   //SUV Vt(e),Rs,i7
   case 0x07: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::SUV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::SUV);
     return 0;
   }
 
   //SHV Vt(e),Rs,i7
   case 0x08: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::SHV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::SHV);
     return 0;
   }
 
   //SFV Vt(e),Rs,i7
   case 0x09: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::SFV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::SFV);
     return 0;
   }
 
   //SWV Vt(e),Rs,i7
   case 0x0a: {
     lea(ra1, Vt);
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::SWV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::SWV);
     return 0;
   }
 
   //STV Vt(e),Rs,i7
   case 0x0b: {
     mov(ra1d, imm32(Vtn));
-    mov(ra2d, imm32(E));
-    lea(ra3, Rs);
-    mov(ra4d, imm32(i7));
-    call(&RSP::STV);
+    lea(ra2, Rs);
+    mov(ra3d, imm32(i7));
+    callvu(&RSP::STV);
     return 0;
   }
 
@@ -1433,6 +1385,7 @@ auto RSP::Recompiler::emitSWC2(u32 instruction) -> bool {
 #undef i16
 #undef n16
 #undef n26
+#undef callvu
 
 template<typename V, typename... P>
 auto RSP::Recompiler::call(V (RSP::*function)(P...)) -> void {

--- a/ares/n64/rsp/rsp.cpp
+++ b/ares/n64/rsp/rsp.cpp
@@ -53,7 +53,7 @@ auto RSP::instruction() -> void {
   }
 }
 
-auto RSP::instructionEpilogue() -> bool {
+auto RSP::instructionEpilogue() -> s32 {
   if constexpr(Accuracy::RSP::Recompiler) {
     step(3);
   }

--- a/ares/n64/rsp/rsp.hpp
+++ b/ares/n64/rsp/rsp.hpp
@@ -178,10 +178,12 @@ struct RSP : Thread, Memory::IO<RSP> {
   //vpu.cpp: Vector Processing Unit
   union r128 {
     struct { uint128_t u128; };
+#if defined(ARCHITECTURE_AMD64)
     struct {   __m128i v128; };
 
     operator __m128i() const { return v128; }
     auto operator=(__m128i value) { v128 = value; }
+#endif
 
     auto byte(u32 index) -> uint8_t& { return ((uint8_t*)&u128)[15 - index]; }
     auto byte(u32 index) const -> uint8_t { return ((uint8_t*)&u128)[15 - index]; }

--- a/ares/n64/rsp/rsp.hpp
+++ b/ares/n64/rsp/rsp.hpp
@@ -229,76 +229,86 @@ struct RSP : Thread, Memory::IO<RSP> {
 
   auto CFC2(r32& rt, u8 rd) -> void;
   auto CTC2(cr32& rt, u8 rd) -> void;
-  auto LBV(r128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto LDV(r128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto LFV(r128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto LHV(r128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto LLV(r128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto LPV(r128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto LQV(r128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto LRV(r128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto LSV(r128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto LTV(u8 vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto LUV(r128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto LWV(r128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto MFC2(r32& rt, cr128& vs, u8 e) -> void;
-  auto MTC2(cr32& rt, r128& vs, u8 e) -> void;
-  auto SBV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto SDV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto SFV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto SHV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto SLV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto SPV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto SQV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto SRV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto SSV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto STV(u8 vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto SUV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto SWV(cr128& vt, u8 e, cr32& rs, s8 imm) -> void;
-  auto VABS(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VADD(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VADDC(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VAND(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VCH(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VCL(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VCR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VEQ(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VGE(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VLT(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  template<bool U>
-  auto VMACF(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
+  template<u8 e> auto LBV(r128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto LDV(r128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto LFV(r128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto LHV(r128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto LLV(r128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto LPV(r128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto LQV(r128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto LRV(r128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto LSV(r128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto LTV(u8 vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto LUV(r128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto LWV(r128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto MFC2(r32& rt, cr128& vs) -> void;
+  template<u8 e> auto MTC2(cr32& rt, r128& vs) -> void;
+  template<u8 e> auto SBV(cr128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto SDV(cr128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto SFV(cr128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto SHV(cr128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto SLV(cr128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto SPV(cr128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto SQV(cr128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto SRV(cr128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto SSV(cr128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto STV(u8 vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto SUV(cr128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto SWV(cr128& vt, cr32& rs, s8 imm) -> void;
+  template<u8 e> auto VABS(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VADD(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VADDC(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VAND(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VCH(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VCL(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VCR(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VEQ(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VGE(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VLT(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<bool U, u8 e>
+  auto VMACF(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VMACF(r128& vd, cr128& vs, cr128& vt) -> void { VMACF<0, e>(vd, vs, vt); }
+  template<u8 e> auto VMACU(r128& vd, cr128& vs, cr128& vt) -> void { VMACF<1, e>(vd, vs, vt); }
   auto VMACQ(r128& vd) -> void;
-  auto VMADH(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VMADL(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VMADM(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VMADN(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VMOV(r128& vd, u8 de, cr128& vt, u8 e) -> void;
-  auto VMRG(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VMUDH(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VMUDL(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VMUDM(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VMUDN(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  template<bool U>
-  auto VMULF(r128& rd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VMULQ(r128& rd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VNAND(r128& rd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VNE(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
+  template<u8 e> auto VMADH(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VMADL(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VMADM(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VMADN(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VMOV(r128& vd, u8 de, cr128& vt) -> void;
+  template<u8 e> auto VMRG(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VMUDH(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VMUDL(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VMUDM(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VMUDN(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<bool U, u8 e>
+  auto VMULF(r128& rd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VMULF(r128& rd, cr128& vs, cr128& vt) -> void { VMULF<0, e>(rd, vs, vt); }
+  template<u8 e> auto VMULU(r128& rd, cr128& vs, cr128& vt) -> void { VMULF<1, e>(rd, vs, vt); }
+  template<u8 e> auto VMULQ(r128& rd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VNAND(r128& rd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VNE(r128& vd, cr128& vs, cr128& vt) -> void;
   auto VNOP() -> void;
-  auto VNOR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VNXOR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VOR(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  template<bool L>
-  auto VRCP(r128& vd, u8 de, cr128& vt, u8 e) -> void;
-  auto VRCPH(r128& vd, u8 de, cr128& vt, u8 e) -> void;
-  template<bool D>
-  auto VRND(r128& vd, u8 vs, cr128& vt, u8 e) -> void;
-  template<bool L>
-  auto VRSQ(r128& vd, u8 de, cr128& vt, u8 e) -> void;
-  auto VRSQH(r128& vd, u8 de, cr128& vt, u8 e) -> void;
-  auto VSAR(r128& vd, cr128& vs, u8 e) -> void;
-  auto VSUB(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VSUBC(r128& vd, cr128& vs, cr128& vt, u8 e) -> void;
-  auto VXOR(r128& rd, cr128& vs, cr128& vt, u8 e) -> void;
+  template<u8 e> auto VNOR(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VNXOR(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VOR(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<bool L, u8 e>
+  auto VRCP(r128& vd, u8 de, cr128& vt) -> void;
+  template<u8 e> auto VRCP(r128& vd, u8 de, cr128& vt) -> void { VRCP<0, e>(vd, de, vt); }
+  template<u8 e> auto VRCPL(r128& vd, u8 de, cr128& vt) -> void { VRCP<1, e>(vd, de, vt); }
+  template<u8 e> auto VRCPH(r128& vd, u8 de, cr128& vt) -> void;
+  template<bool D, u8 e>
+  auto VRND(r128& vd, u8 vs, cr128& vt) -> void;
+  template<u8 e> auto VRNDN(r128& vd, u8 vs, cr128& vt) -> void { VRND<0, e>(vd, vs, vt); }
+  template<u8 e> auto VRNDP(r128& vd, u8 vs, cr128& vt) -> void { VRND<1, e>(vd, vs, vt); }
+  template<bool L, u8 e>
+  auto VRSQ(r128& vd, u8 de, cr128& vt) -> void;
+  template<u8 e> auto VRSQ(r128& vd, u8 de, cr128& vt) -> void { VRSQ<0, e>(vd, de, vt); }
+  template<u8 e> auto VRSQL(r128& vd, u8 de, cr128& vt) -> void { VRSQ<1, e>(vd, de, vt); }
+  template<u8 e> auto VRSQH(r128& vd, u8 de, cr128& vt) -> void;
+  template<u8 e> auto VSAR(r128& vd, cr128& vs) -> void;
+  template<u8 e> auto VSUB(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VSUBC(r128& vd, cr128& vs, cr128& vt) -> void;
+  template<u8 e> auto VXOR(r128& rd, cr128& vs, cr128& vt) -> void;
 
 //unserialized:
   u16 reciprocals[512];

--- a/ares/ps1/cpu/cpu.cpp
+++ b/ares/ps1/cpu/cpu.cpp
@@ -89,7 +89,7 @@ auto CPU::instruction() -> void {
   }
 }
 
-auto CPU::instructionEpilogue() -> bool {
+auto CPU::instructionEpilogue() -> s32 {
   if constexpr(Accuracy::CPU::Recompiler) {
     icache.step(ipu.pc);  //simulates timings without performing actual icache loads
   }

--- a/ares/ps1/cpu/interpreter-gte.cpp
+++ b/ares/ps1/cpu/interpreter-gte.cpp
@@ -614,6 +614,13 @@ auto CPU::MVMVA(bool lm, u8 tv, u8 mv, u8 mm, u8 sf) -> void {
   epilogue();
 }
 
+auto CPU::MVMVA_(bool lm, u8 MmMvTv, u8 sf) -> void {
+  u8 tv = MmMvTv >> 0 & 3;
+  u8 mv = MmMvTv >> 2 & 3;
+  u8 mm = MmMvTv >> 4 & 3;
+  MVMVA(lm, tv, mv, mm, sf);
+}
+
 //meta-instruction
 template<u32 m>
 auto CPU::NC(const v16& vector) -> void {

--- a/ares/ps1/ps1.hpp
+++ b/ares/ps1/ps1.hpp
@@ -3,7 +3,7 @@
 
 #include <ares/ares.hpp>
 #include <nall/hashset.hpp>
-#include <nall/recompiler/amd64/amd64.hpp>
+#include <nall/recompiler/generic/generic.hpp>
 #include <component/processor/m68hc05/m68hc05.hpp>
 
 namespace ares::PlayStation {

--- a/desktop-ui/GNUmakefile
+++ b/desktop-ui/GNUmakefile
@@ -12,13 +12,14 @@ include $(nall.path)/GNUmakefile
 ifeq ($(platform),windows)
  #vulkan := $(if $(shell if exist ..\ares\n64\vulkan\parallel-rdp) echo 1),true,false)
   vulkan := $(if $(shell test -e ../ares/n64/vulkan/parallel-rdp && echo 1),true,false)
-  local := false
 else ifeq ($(platform),linux)
   vulkan := $(if $(shell test -e ../ares/n64/vulkan/parallel-rdp && echo 1),true,false)
 endif
 
 ifeq ($(local),true)
-  flags += -march=native
+  ifeq ($(arch),amd64)
+    flags += -march=native
+  endif
 endif
 
 libco.path := ../libco

--- a/desktop-ui/GNUmakefile
+++ b/desktop-ui/GNUmakefile
@@ -4,7 +4,7 @@ threaded := true
 openmp := false
 vulkan := false
 local := true
-flags += -I. -I.. -I../ares -DMIA_LIBRARY
+flags += -I. -I.. -I../ares -I../thirdparty -DMIA_LIBRARY
 
 nall.path := ../nall
 include $(nall.path)/GNUmakefile
@@ -24,6 +24,10 @@ endif
 
 libco.path := ../libco
 include $(libco.path)/GNUmakefile
+
+thirdparty.path := ../thirdparty
+sljit.path := $(thirdparty.path)/sljit/sljit_src
+include $(thirdparty.path)/GNUmakefile
 
 ruby.path := ../ruby
 include $(ruby.path)/GNUmakefile
@@ -62,12 +66,13 @@ $(object.path)/desktop-ui-presentation.o: $(desktop-ui.path)/presentation/presen
 $(object.path)/desktop-ui-settings.o: $(desktop-ui.path)/settings/settings.cpp
 $(object.path)/desktop-ui-tools.o: $(desktop-ui.path)/tools/tools.cpp
 
-all.objects := $(libco.objects) $(ruby.objects) $(hiro.objects) $(ares.objects) $(mia.objects) $(desktop-ui.objects)
-all.options := $(libco.options) $(ruby.options) $(hiro.options) $(ares.options) $(mia.options) $(desktop-ui.options) $(options)
+all.objects := $(libco.objects) $(sljit.objects) $(ruby.objects) $(hiro.objects) $(ares.objects) $(mia.objects) $(desktop-ui.objects)
+all.options := $(libco.options) $(sljit.options) $(ruby.options) $(hiro.options) $(ares.options) $(mia.options) $(desktop-ui.options) $(options)
 
 all: $(all.objects)
 	$(info Linking $(output.path)/$(name) ...)
 	+@$(compiler) -o $(output.path)/$(name) $(all.objects) $(all.options)
+	cp ../LICENSE $(output.path)/LICENSE.txt
 ifeq ($(platform),macos)
 # Apply workaround for buggy linker in Xcode < 11.4.1
 	@$(compiler) -o $(output.path)/macos-fix-jit macos-fix-jit.cpp

--- a/mia/GNUmakefile
+++ b/mia/GNUmakefile
@@ -2,7 +2,7 @@ name := mia
 build := optimized
 threaded := true
 local := true
-flags += -I. -I.. -I../ares
+flags += -I. -I.. -I../ares -I../thirdparty
 
 nall.path := ../nall
 include $(nall.path)/GNUmakefile

--- a/mia/GNUmakefile
+++ b/mia/GNUmakefile
@@ -4,10 +4,6 @@ threaded := true
 local := true
 flags += -I. -I.. -I../ares
 
-ifeq ($(local),true)
-  flags += -march=native
-endif
-
 nall.path := ../nall
 include $(nall.path)/GNUmakefile
 

--- a/mia/program/home.cpp
+++ b/mia/program/home.cpp
@@ -1,6 +1,6 @@
 Home::Home(View* parent) : Panel(parent, Size{~0, ~0}) {
   setCollapsible().setVisible(false);
-  image icon{Resource::Ares::Icon};
+  image icon{Resource::Ares::Icon1x};
   icon.shrink();
   for(u32 y : range(icon.height())) {
     auto data = icon.data() + y * icon.pitch();

--- a/mia/program/program.cpp
+++ b/mia/program/program.cpp
@@ -27,7 +27,7 @@ ProgramWindow::ProgramWindow() {
 
   helpMenu.setText("Help");
   aboutAction.setIcon(Icon::Prompt::Question).setText("About ...").onActivate([&] {
-    image logo{Resource::Ares::Logo};
+    image logo{Resource::Ares::Logo1x};
     logo.shrink();
     AboutDialog()
     .setName({ares::Name, "/mia"})

--- a/nall/recompiler/generic/constants.hpp
+++ b/nall/recompiler/generic/constants.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+//{
+  enum set_flags {
+    set_z = SLJIT_SET_Z,
+    set_ult = SLJIT_SET_LESS,
+    set_uge = SLJIT_SET_GREATER_EQUAL,
+    set_ugt = SLJIT_SET_GREATER,
+    set_ule = SLJIT_SET_LESS_EQUAL,
+    set_slt = SLJIT_SET_SIG_LESS,
+    set_sge = SLJIT_SET_SIG_GREATER_EQUAL,
+    set_sgt = SLJIT_SET_SIG_GREATER,
+    set_sle = SLJIT_SET_SIG_LESS_EQUAL,
+    set_o = SLJIT_SET_OVERFLOW,
+    set_c = SLJIT_SET_CARRY,
+  };
+
+  enum flags {
+    flag_eq = SLJIT_EQUAL,
+    flag_z = flag_eq,
+    flag_ne = SLJIT_NOT_EQUAL,
+    flag_nz = flag_ne,
+    flag_ult = SLJIT_LESS,
+    flag_uge = SLJIT_GREATER_EQUAL,
+    flag_ugt = SLJIT_GREATER,
+    flag_ule = SLJIT_LESS_EQUAL,
+    flag_slt = SLJIT_SIG_LESS,
+    flag_sge = SLJIT_SIG_GREATER_EQUAL,
+    flag_sgt = SLJIT_SIG_GREATER,
+    flag_sle = SLJIT_SIG_LESS_EQUAL,
+    flag_o = SLJIT_OVERFLOW,
+    flag_no = SLJIT_NOT_OVERFLOW,
+  };
+
+  struct op_base {
+    op_base(sljit_s32 f, sljit_sw s) : fst(f), snd(s) {}
+    sljit_s32 fst;
+    sljit_sw snd;
+  };
+
+  struct imm : public op_base {
+    explicit imm(sljit_sw immediate) : op_base(SLJIT_IMM, immediate) {}
+  };
+
+  struct reg : public op_base {
+    explicit reg(sljit_s32 index) : op_base(SLJIT_R(index), 0) {}
+  };
+
+  struct sreg : public op_base {
+    explicit sreg(sljit_s32 index) : op_base(SLJIT_S(index), 0) {}
+  };
+
+  struct mem : public op_base {
+    mem(sreg base, sljit_sw offset) : op_base(SLJIT_MEM1(base.fst), offset) {}
+  };
+
+  struct unused : public op_base {
+    unused() : op_base(SLJIT_UNUSED, 0) {}
+  };
+//};

--- a/nall/recompiler/generic/encoder-calls.hpp
+++ b/nall/recompiler/generic/encoder-calls.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+//{
+  struct imm64 {
+    explicit imm64(u64 data) : data(data) {}
+    template<typename T> explicit imm64(T* pointer) : data((u64)pointer) {}
+    template<typename C, typename R, typename... P> explicit imm64(auto (C::*function)(P...) -> R) {
+      union force_cast_ub {
+        auto (C::*function)(P...) -> R;
+        u64 pointer;
+      } cast{function};
+      data = cast.pointer;
+    }
+    template<typename C, typename R, typename... P> explicit imm64(auto (C::*function)(P...) const -> R) {
+      union force_cast_ub {
+        auto (C::*function)(P...) const -> R;
+        u64 pointer;
+      } cast{function};
+      data = cast.pointer;
+    }
+    u64 data;
+  };
+
+  template<typename C, typename V, typename... P>
+  alwaysinline auto call(V (C::*function)(P...)) {
+    static_assert(sizeof...(P) <= 3);
+    sljit_s32 type = SLJIT_ARG1(SW);
+    if constexpr(sizeof...(P) >= 1) type |= SLJIT_ARG2(SW);
+    if constexpr(sizeof...(P) >= 2) type |= SLJIT_ARG3(SW);
+    if constexpr(sizeof...(P) >= 3) type |= SLJIT_ARG4(SW);
+    if constexpr(!std::is_void_v<V>) type |= SLJIT_RET(SW);
+    sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R0, 0, SLJIT_S0, 0);
+    sljit_emit_icall(compiler, SLJIT_CALL, type, SLJIT_IMM, SLJIT_FUNC_OFFSET(imm64{function}.data));
+  }
+
+  template<typename C, typename R, typename... P>
+  alwaysinline auto call(auto (C::*function)(P...) -> R, C* object) {
+    sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R0, 0, SLJIT_IMM, imm64{object}.data);
+    sljit_s32 type = SLJIT_ARG1(SW);
+    if constexpr(!std::is_void_v<R>) type |= SLJIT_RET(SW);
+    sljit_emit_icall(compiler, SLJIT_CALL, type, SLJIT_IMM, SLJIT_FUNC_OFFSET(imm64{function}.data));
+  }
+
+  template<typename C, typename R, typename... P, typename P0>
+  alwaysinline auto call(auto (C::*function)(P...) -> R, C* object, P0 p0) {
+    sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R0, 0, SLJIT_IMM, imm64{object}.data);
+    sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R1, 0, SLJIT_IMM, imm64{p0}.data);
+    sljit_s32 type = SLJIT_ARG1(SW) | SLJIT_ARG2(SW);
+    if constexpr(!std::is_void_v<R>) type |= SLJIT_RET(SW);
+    sljit_emit_icall(compiler, SLJIT_CALL, type, SLJIT_IMM, SLJIT_FUNC_OFFSET(imm64{function}.data));
+  }
+
+  template<typename C, typename R, typename... P, typename P0, typename P1>
+  alwaysinline auto call(auto (C::*function)(P...) -> R, C* object, P0 p0, P1 p1) {
+    sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R0, 0, SLJIT_IMM, imm64{object}.data);
+    sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R1, 0, SLJIT_IMM, imm64{p0}.data);
+    sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R2, 0, SLJIT_IMM, imm64{p1}.data);
+    sljit_s32 type = SLJIT_ARG1(SW) | SLJIT_ARG2(SW) | SLJIT_ARG3(SW);
+    if constexpr(!std::is_void_v<R>) type |= SLJIT_RET(SW);
+    sljit_emit_icall(compiler, SLJIT_CALL, type, SLJIT_IMM, SLJIT_FUNC_OFFSET(imm64{function}.data));
+  }
+
+  template<typename C, typename R, typename... P, typename P0, typename P1, typename P2>
+  alwaysinline auto call(auto (C::*function)(P...) -> R, C* object, P0 p0, P1 p1, P2 p2) {
+    sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R0, 0, SLJIT_IMM, imm64{object}.data);
+    sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R1, 0, SLJIT_IMM, imm64{p0}.data);
+    sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R2, 0, SLJIT_IMM, imm64{p1}.data);
+    sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R3, 0, SLJIT_IMM, imm64{p2}.data);
+    sljit_s32 type = SLJIT_ARG1(SW) | SLJIT_ARG2(SW) | SLJIT_ARG3(SW) | SLJIT_ARG4(SW);
+    if constexpr(!std::is_void_v<R>) type |= SLJIT_RET(SW);
+    sljit_emit_icall(compiler, SLJIT_CALL, type, SLJIT_IMM, SLJIT_FUNC_OFFSET(imm64{function}.data));
+  }
+//};

--- a/nall/recompiler/generic/encoder-instructions.hpp
+++ b/nall/recompiler/generic/encoder-instructions.hpp
@@ -1,0 +1,156 @@
+#pragma once
+
+//{
+  //0 operand instructions
+
+  auto brk() {
+    sljit_emit_op0(compiler, SLJIT_BREAKPOINT);
+  }
+
+  //1 operand instructions
+
+#define OP1(name, op) \
+  template<typename T, typename U> \
+  auto name(T x, U y) { \
+    sljit_emit_op1(compiler, \
+                   SLJIT_##op, \
+                   x.fst, x.snd, \
+                   y.fst, y.snd); \
+  }
+
+  OP1(mov32, MOV32)
+  OP1(mov64, MOV)
+  OP1(mov32_u8, MOV32_U8)
+  OP1(mov64_u8, MOV_U8)
+  OP1(mov32_s8, MOV32_S8)
+  OP1(mov64_s8, MOV_S8)
+  OP1(mov32_u16, MOV32_U16)
+  OP1(mov64_u16, MOV_U16)
+  OP1(mov32_s16, MOV32_S16)
+  OP1(mov64_s16, MOV_S16)
+  OP1(mov64_u32, MOV_U32)
+  OP1(mov64_s32, MOV_S32)
+  OP1(not32, NOT32)
+  OP1(not64, NOT)
+  OP1(neg32, NEG32)
+  OP1(neg64, NEG)
+#undef OP1
+
+  //2 operand instructions
+
+#define OP2(name, op) \
+  template<typename T, typename U, typename V> \
+  auto name(T x, U y, V z, sljit_s32 flags = 0) { \
+    sljit_emit_op2(compiler, \
+                   SLJIT_##op | flags, \
+                   x.fst, x.snd, \
+                   y.fst, y.snd, \
+                   z.fst, z.snd); \
+  }
+
+  OP2(add32, ADD32)
+  OP2(add64, ADD)
+  OP2(addc32, ADDC32)
+  OP2(addc64, ADDC)
+  OP2(sub32, SUB32)
+  OP2(sub64, SUB)
+  OP2(subc32, SUBC32)
+  OP2(subc64, SUBC)
+  OP2(mul32, MUL32)
+  OP2(mul64, MUL)
+  OP2(and32, AND32)
+  OP2(and64, AND)
+  OP2(or32, OR32)
+  OP2(or64, OR)
+  OP2(xor32, XOR32)
+  OP2(xor64, XOR)
+  OP2(shl32, SHL32)
+  OP2(shl64, SHL)
+  OP2(lshr32, LSHR32)
+  OP2(lshr64, LSHR)
+  OP2(ashr32, ASHR32)
+  OP2(ashr64, ASHR)
+#undef OP2
+
+  //compare instructions
+
+#define OPC(name, op) \
+  template<typename T, typename U> \
+  auto name(T x, U y, sljit_s32 flags) { \
+    sljit_emit_op2(compiler, \
+                   SLJIT_##op | flags, \
+                   SLJIT_UNUSED, 0, \
+                   x.fst, x.snd, \
+                   y.fst, y.snd); \
+  }
+
+  OPC(cmp32, SUB32)
+  OPC(cmp64, SUB)
+  OPC(test32, AND32)
+  OPC(test64, AND)
+#undef OPC
+
+  template<typename T, typename U>
+  auto cmp32_jump(T x, U y, sljit_s32 flags) -> sljit_jump* {
+    return sljit_emit_cmp(compiler,
+                          SLJIT_I32_OP | flags,
+                          x.fst, x.snd,
+                          y.fst, y.snd);
+  }
+
+  //flag instructions
+
+#define OPF(name, op) \
+  template<typename T> \
+  auto name(T x, sljit_s32 flags) { \
+    sljit_emit_op_flags(compiler, \
+                        SLJIT_##op, \
+                        x.fst, x.snd, \
+                        flags); \
+  }
+
+  OPF(mov32_f, MOV32)
+  OPF(mov64_f, MOV)
+  OPF(and32_f, AND32)
+  OPF(and64_f, AND)
+  OPF(or32_f, OR32)
+  OPF(or64_f, OR)
+  OPF(xor32_f, XOR32)
+  OPF(xor64_f, XOR)
+#undef OPF
+
+  //meta instructions
+
+  auto mov32_to_c(mem m, int sign) {
+#if defined(ARCHITECTURE_AMD64)
+    cmp32(imm(0), m, set_c);
+#elif defined(ARCHITECTURE_ARM64)
+    if(sign < 0) {
+      cmp32(imm(0), m, set_c);
+    } else {
+      cmp32(m, imm(1), set_c);
+    }
+#else
+#error "Unimplemented architecture"
+#endif
+  }
+
+  auto mov32_from_c(reg r, int sign) {
+#if defined(ARCHITECTURE_AMD64)
+    mov32(r, imm(0));
+    addc32(r, r, r);
+#elif defined(ARCHITECTURE_ARM64)
+    mov32(r, imm(0));
+    addc32(r, r, r);
+    if(sign < 0) {
+      xor32(r, r, imm(1));
+    }
+#else
+#error "Unimplemented architecture"
+#endif
+  }
+
+  auto lea(reg r, sreg base, sljit_sw offset) {
+    add64(r, base, imm(offset));
+  }
+//};

--- a/nall/recompiler/generic/generic.hpp
+++ b/nall/recompiler/generic/generic.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#if defined(SLJIT)
+namespace nall::recompiler {
+  struct generic {
+    bump_allocator& allocator;
+    sljit_compiler* compiler = nullptr;
+    sljit_label* epilogue = nullptr;
+
+    generic(bump_allocator& alloc) : allocator(alloc) {}
+
+    auto beginFunction(int args) {
+      assert(args <= 3);
+      compiler = sljit_create_compiler(nullptr, &allocator);
+
+      sljit_s32 options = 0;
+      if(args >= 1) options |= SLJIT_ARG1(SW);
+      if(args >= 2) options |= SLJIT_ARG2(SW);
+      if(args >= 3) options |= SLJIT_ARG3(SW);
+      sljit_emit_enter(compiler, 0, options, 4, 3, 0, 0, 0);
+      sljit_jump* entry = sljit_emit_jump(compiler, SLJIT_JUMP);
+      epilogue = sljit_emit_label(compiler);
+      sljit_emit_return(compiler, SLJIT_UNUSED, 0, 0);
+
+      sljit_set_label(entry, sljit_emit_label(compiler));
+    }
+
+    auto endFunction() -> u8* {
+      u8* code = (u8*)sljit_generate_code(compiler);
+      sljit_free_compiler(compiler);
+      compiler = nullptr;
+      epilogue = nullptr;
+      return code;
+    }
+
+    auto testJumpEpilog() {
+      sljit_set_label(sljit_emit_cmp(compiler, SLJIT_NOT_EQUAL | SLJIT_I32_OP, SLJIT_RETURN_REG, 0, SLJIT_IMM, 0), epilogue);
+    }
+
+    auto jumpEpilog() {
+      sljit_set_label(sljit_emit_jump(compiler, SLJIT_JUMP), epilogue);
+    }
+
+    auto setLabel(sljit_jump* jump) {
+      sljit_set_label(jump, sljit_emit_label(compiler));
+    }
+
+    auto jump() -> sljit_jump* {
+      return sljit_emit_jump(compiler, SLJIT_JUMP);
+    }
+
+    auto jump(sljit_s32 flag) -> sljit_jump* {
+      return sljit_emit_jump(compiler, flag);
+    }
+
+    #include "constants.hpp"
+    #include "encoder-instructions.hpp"
+    #include "encoder-calls.hpp"
+  };
+}
+#endif

--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -1,6 +1,9 @@
 ifeq ($(ruby),)
   ifeq ($(platform),windows)
-    ruby += video.wgl video.direct3d video.directdraw video.gdi
+    ruby += video.direct3d video.directdraw video.gdi
+    ifeq ($(arch),amd64)
+      ruby += video.wgl
+    endif
     ruby += audio.wasapi audio.xaudio2 audio.directsound audio.waveout #audio.asio
     ruby += input.windows
   else ifeq ($(platform),macos)

--- a/thirdparty/GNUmakefile
+++ b/thirdparty/GNUmakefile
@@ -1,0 +1,7 @@
+sljit.objects := sljitLir sljitAllocator
+sljit.objects := $(sljit.objects:%=$(object.path)/%.o)
+
+$(object.path)/sljitLir.o: $(sljit.path)/sljitLir.c
+$(object.path)/sljitAllocator.o: $(thirdparty.path)/sljitAllocator.cpp
+
+flags += -DSLJIT_HAVE_CONFIG_PRE=1 -DSLJIT_HAVE_CONFIG_POST=1

--- a/thirdparty/sljit.h
+++ b/thirdparty/sljit.h
@@ -1,0 +1,2 @@
+#define SLJIT
+#include "sljit/sljit_src/sljitLir.h"

--- a/thirdparty/sljitAllocator.cpp
+++ b/thirdparty/sljitAllocator.cpp
@@ -1,0 +1,9 @@
+#include <sljit.h>
+
+#include <nall/platform.hpp>
+#include <nall/bump-allocator.hpp>
+
+auto sljit_nall_malloc_exec(sljit_uw size, void* exec_allocator_data) -> void* {
+  auto allocator = (nall::bump_allocator*)exec_allocator_data;
+  return allocator->acquire(size);
+}

--- a/thirdparty/sljitConfigPost.h
+++ b/thirdparty/sljitConfigPost.h
@@ -1,0 +1,10 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//custom allocator
+void* sljit_nall_malloc_exec(sljit_uw size, void* exec_allocator_data);
+
+#ifdef __cplusplus
+}
+#endif

--- a/thirdparty/sljitConfigPre.h
+++ b/thirdparty/sljitConfigPre.h
@@ -1,0 +1,11 @@
+//custom allocator
+#define SLJIT_EXECUTABLE_ALLOCATOR      0
+#define SLJIT_MALLOC_EXEC(size, data)   sljit_nall_malloc_exec((size), (data))
+#define SLJIT_FREE_EXEC(ptr, data)      0
+#define SLJIT_EXEC_OFFSET(ptr)          0
+
+//debug-only options
+#if !defined(BUILD_DEBUG)
+#define SLJIT_DEBUG     0
+#define SLJIT_VERBOSE   0
+#endif

--- a/update-subtrees.sh
+++ b/update-subtrees.sh
@@ -11,4 +11,4 @@ cd "$(dirname "$0")" || exit 1
 
 # Merge changes from the upstream parallel-rdp repository.
 git subtree pull --prefix=ares/n64/vulkan/parallel-rdp https://github.com/Themaister/parallel-rdp-standalone.git master --squash
-
+git subtree pull --prefix=thirdparty/sljit https://github.com/zherczeg/sljit.git master --squash


### PR DESCRIPTION
This PR rewrites the recompilers used in the 32x/N64/PS1 cores in terms of a generic recompiler API implemented as a thin wrapper around the SLJIT library. This enables support for different host architectures, namely ARM64. This is a very large perf win on ARM64 machines but a modest perf loss on x86_64 (on the order of ~5% at present).

ares now builds cleanly as ARM64 for Windows, Linux, and macOS, though only the Windows build was tested. The Linux/x86_64 build was tested for regressions, and the Linux/ARM64 build is expected to work, though it is untested. The macOS build is untested but should work as well as it did before on x86_64, though the recompilers are not expected to work on ARM64 until ares is updated to make use of the new macOS JIT API.

The N64 and PS1 recompilers were run against the following CPU tests on x86_64 and ARM64:
https://github.com/PeterLemon/N64
https://github.com/PeterLemon/PSX

Additionally, the SH2 recompiler was run through a test harness comparing it to the interpreter (code not included in this PR).

A few changes were broken out into separate commits to make the interesting commits easier to read:
- Fix mia build, which was broken by a prior change; required to fully validate the arm64 build fixes
- Encapsulate SH2 register state into a plain old data struct; required to take offsetof() individual registers
- Templatize RSP VPU instructions to work around SLJIT's limit of four parameters to emitted calls