### PR TITLE
recompiler: fix page protection on Apple silicon

### DIFF
--- a/ares/ares/memory/fixed-allocator.cpp
+++ b/ares/ares/memory/fixed-allocator.cpp
@@ -2,11 +2,17 @@
 
 namespace ares::Memory {
 
-alignas(4096) u8 fixedBuffer[1_GiB];
+#if defined(PLATFORM_MACOS) && defined(ARCHITECTURE_ARM64)
+//stub for unsupported platforms
+FixedAllocator::FixedAllocator() {
+}
+#else
+alignas(4096) u8 fixedBuffer[128_MiB];
 
 FixedAllocator::FixedAllocator() {
   _allocator.resize(sizeof(fixedBuffer), 0, fixedBuffer);
 }
+#endif
 
 auto FixedAllocator::get() -> bump_allocator& {
   static FixedAllocator allocator;

--- a/ares/component/processor/sh2/recompiler.cpp
+++ b/ares/component/processor/sh2/recompiler.cpp
@@ -20,6 +20,14 @@
 #define ET      Reg(ET)
 #define ID      Reg(ID)
 
+auto SH2::Recompiler::invalidate(u32 address) -> void {
+  auto pool = pools[address >> 8 & 0xffffff];
+  if(!pool) return;
+  memory::jitprotect(false);
+  pool->blocks[address >> 1 & 0x7f] = nullptr;
+  memory::jitprotect(true);
+}
+
 auto SH2::Recompiler::pool(u32 address) -> Pool* {
   auto& pool = pools[address >> 8 & 0xffffff];
   if(!pool) pool = (Pool*)allocator.acquire(sizeof(Pool));
@@ -29,13 +37,17 @@ auto SH2::Recompiler::pool(u32 address) -> Pool* {
 auto SH2::Recompiler::block(u32 address) -> Block* {
   if(auto block = pool(address)->blocks[address >> 1 & 0x7f]) return block;
   auto block = emit(address);
-  return pool(address)->blocks[address >> 1 & 0x7f] = block;
+  pool(address)->blocks[address >> 1 & 0x7f] = block;
+  memory::jitprotect(true);
+  return block;
 }
 
 auto SH2::Recompiler::emit(u32 address) -> Block* {
   if(unlikely(allocator.available() < 1_MiB)) {
     print("SH2 allocator flush\n");
+    memory::jitprotect(false);
     allocator.release(bump_allocator::zero_fill);
+    memory::jitprotect(true);
     reset();
   }
 
@@ -56,6 +68,7 @@ auto SH2::Recompiler::emit(u32 address) -> Block* {
   }
   jumpEpilog();
 
+  memory::jitprotect(false);
   block->code = endFunction();
 
   return block;

--- a/ares/component/processor/sh2/sh2.cpp
+++ b/ares/component/processor/sh2/sh2.cpp
@@ -59,8 +59,8 @@ auto SH2::power(bool reset) -> void {
   cache.power();
 
   if constexpr(Accuracy::Recompiler) {
-    auto buffer = ares::Memory::FixedAllocator::get().acquire(512_MiB);
-    recompiler.allocator.resize(512_MiB, bump_allocator::executable | bump_allocator::zero_fill, buffer);
+    auto buffer = ares::Memory::FixedAllocator::get().tryAcquire(64_MiB);
+    recompiler.allocator.resize(64_MiB, bump_allocator::executable | bump_allocator::zero_fill, buffer);
     recompiler.reset();
   }
 }

--- a/ares/component/processor/sh2/sh2.hpp
+++ b/ares/component/processor/sh2/sh2.hpp
@@ -266,10 +266,7 @@ struct SH2 {
       for(u32 index : range(1 << 24)) pools[index] = nullptr;
     }
 
-    auto invalidate(u32 address) -> void {
-      pool(address)->blocks[address >> 1 & 0x7f] = nullptr;
-    }
-
+    auto invalidate(u32 address) -> void;
     auto pool(u32 address) -> Pool*;
     auto block(u32 address) -> Block*;
     auto emit(u32 address) -> Block*;

--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -138,8 +138,8 @@ auto CPU::power(bool reset) -> void {
   context.setMode();
 
   if constexpr(Accuracy::CPU::Recompiler) {
-    auto buffer = ares::Memory::FixedAllocator::get().acquire(512_MiB);
-    recompiler.allocator.resize(512_MiB, bump_allocator::executable | bump_allocator::zero_fill, buffer);
+    auto buffer = ares::Memory::FixedAllocator::get().tryAcquire(64_MiB);
+    recompiler.allocator.resize(64_MiB, bump_allocator::executable | bump_allocator::zero_fill, buffer);
     recompiler.reset();
   }
 }

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -7,13 +7,17 @@ auto CPU::Recompiler::pool(u32 address) -> Pool* {
 auto CPU::Recompiler::block(u32 address) -> Block* {
   if(auto block = pool(address)->blocks[address >> 2 & 0x3f]) return block;
   auto block = emit(address);
-  return pool(address)->blocks[address >> 2 & 0x3f] = block;
+  pool(address)->blocks[address >> 2 & 0x3f] = block;
+  memory::jitprotect(true);
+  return block;
 }
 
 auto CPU::Recompiler::emit(u32 address) -> Block* {
   if(unlikely(allocator.available() < 1_MiB)) {
     print("CPU allocator flush\n");
+    memory::jitprotect(false);
     allocator.release(bump_allocator::zero_fill);
+    memory::jitprotect(true);
     reset();
   }
 
@@ -37,6 +41,7 @@ auto CPU::Recompiler::emit(u32 address) -> Block* {
   }
   jumpEpilog();
 
+  memory::jitprotect(false);
   block->code = endFunction();
 
 //print(hex(PC, 8L), " ", instructions, " ", size(), "\n");

--- a/ares/n64/rsp/rsp.cpp
+++ b/ares/n64/rsp/rsp.cpp
@@ -116,8 +116,8 @@ auto RSP::power(bool reset) -> void {
   }
 
   if constexpr(Accuracy::RSP::Recompiler) {
-    auto buffer = ares::Memory::FixedAllocator::get().acquire(512_MiB);
-    recompiler.allocator.resize(512_MiB, bump_allocator::executable | bump_allocator::zero_fill, buffer);
+    auto buffer = ares::Memory::FixedAllocator::get().tryAcquire(64_MiB);
+    recompiler.allocator.resize(64_MiB, bump_allocator::executable | bump_allocator::zero_fill, buffer);
     recompiler.reset();
   }
 }

--- a/ares/ps1/cpu/cpu.cpp
+++ b/ares/ps1/cpu/cpu.cpp
@@ -257,8 +257,8 @@ auto CPU::power(bool reset) -> void {
   gte.sf = 0;
 
   if constexpr(Accuracy::CPU::Recompiler) {
-    auto buffer = ares::Memory::FixedAllocator::get().acquire(512_MiB);
-    recompiler.allocator.resize(512_MiB, bump_allocator::executable | bump_allocator::zero_fill, buffer);
+    auto buffer = ares::Memory::FixedAllocator::get().tryAcquire(64_MiB);
+    recompiler.allocator.resize(64_MiB, bump_allocator::executable | bump_allocator::zero_fill, buffer);
     recompiler.reset();
   }
 }

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -166,11 +166,6 @@ ifeq ($(platform),macos)
   options += -lc++ -lobjc -mmacosx-version-min=10.9
   # allow mprotect() on dynamic recompiler code blocks
   options += -Wl,-segprot,__DATA,rwx,rw
-  ifneq ($(local),true)
-    flags   += -arch x86_64
-    options += -arch x86_64
-    arch    := amd64
-  endif
 endif
 
 # linux settings


### PR DESCRIPTION
- when dynamically allocating executable memory, use VirtualAlloc/mmap()
  for finer control over allocation flags (like MAP_JIT on macOS/arm64)
- toggle JIT memory protection around writes on macOS/arm64
- reduce recompiler code cache sizes to improve likelihood of dynamic
  allocations being close to ares image (affects branch perf)
- remove arch x86_64 override on macOS non-local builds; native arm64
  builds should now be at feature parity with x86_64
- sh2: prevent pollution of code cache with empty pools by invalidate()