### PR TITLE
fc: improve mmc3 irq behavior

### DIFF
--- a/ares/fc/cartridge/board/hvc-hkrom.cpp
+++ b/ares/fc/cartridge/board/hvc-hkrom.cpp
@@ -31,8 +31,9 @@ struct HVC_HKROM : Interface {  //MMC6
     if(!(characterAddress & 0x1000) && (address & 0x1000)) {
       if(irqDelay == 0) {
         if(irqCounter == 0) {
-          irqCounter = irqLatch;
-        } else if(--irqCounter == 0) {
+          irqCounter = irqLatch + 1;
+        }
+        if(--irqCounter == 0) {
           if(irqEnable) irqLine = 1;
         }
       }
@@ -64,6 +65,7 @@ struct HVC_HKROM : Interface {  //MMC6
   }
 
   auto writePRG(n32 address, n8 data) -> void override {
+    if(address == 0x2006 && ++characterLatch) irqTest(data << 8);
     if(address < 0x7000) return;
 
     if(address < 0x8000) {
@@ -179,6 +181,7 @@ struct HVC_HKROM : Interface {  //MMC6
     s(irqEnable);
     s(irqDelay);
     s(irqLine);
+    s(characterLatch);
     s(characterAddress);
   }
 
@@ -194,7 +197,8 @@ struct HVC_HKROM : Interface {  //MMC6
   n8  irqLatch;
   n8  irqCounter;
   n1  irqEnable;
-  n1  irqDelay;
+  n8  irqDelay;
   n1  irqLine;
+  n1  characterLatch;
   n16 characterAddress;
 };

--- a/ares/fc/cartridge/board/hvc-txrom.cpp
+++ b/ares/fc/cartridge/board/hvc-txrom.cpp
@@ -65,8 +65,9 @@ struct HVC_TxROM : Interface {  //MMC3
     if(!(characterAddress & 0x1000) && (address & 0x1000)) {
       if(irqDelay == 0) {
         if(irqCounter == 0) {
-          irqCounter = irqLatch;
-        } else if(--irqCounter == 0) {
+          irqCounter = irqLatch + 1;
+        }
+        if(--irqCounter == 0) {
           if(irqEnable) irqLine = 1;
         }
       }
@@ -95,6 +96,7 @@ struct HVC_TxROM : Interface {  //MMC3
   }
 
   auto writePRG(n32 address, n8 data) -> void override {
+    if(address == 0x2006 && ++characterLatch) irqTest(data << 8);
     if(address < 0x6000) return;
 
     if(address < 0x8000) {
@@ -235,6 +237,7 @@ struct HVC_TxROM : Interface {  //MMC3
     s(irqEnable);
     s(irqDelay);
     s(irqLine);
+    s(characterLatch);
     s(characterAddress);
   }
 
@@ -251,5 +254,6 @@ struct HVC_TxROM : Interface {  //MMC3
   n1  irqEnable;
   n8  irqDelay;
   n1  irqLine;
+  n1  characterLatch;
   n16 characterAddress;
 };

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -1,5 +1,5 @@
 database
-  revision: 2021-12-10
+  revision: 2022-01-01
 
 game
   sha256: a75af9b5972f22056d016474234b03213e5d7932fb1e81890d58bd100bb8d0d2
@@ -130,6 +130,48 @@ game
       volatile
 
 game
+  sha256: 3a3708c4bf67ff54ea95204b15adb6cac5358a4b722f45a9fa735d6ec0da3b49
+  name:   1999 - Hore, Mitakotoka! Seikimatsu (Japan)
+  title:  1999 - Hore, Mitakotoka! Seikimatsu (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 8aed01a409fd1e6f61fbe41421fe4a1da7242c7d6d6e26594bc026669d561247
+  name:   2010 Street Fighter (Japan)
+  title:  2010 Street Fighter (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: c457644ccfb93f8978326e728931800283821e531edc409fca9c0167495319c4
   name:   3-D WorldRunner (USA)
   title:  3-D WorldRunner (USA)
@@ -194,6 +236,183 @@ game
       content: Character
 
 game
+  sha256: c4b1bde698c2090646d967392052a9b3e5c911dcbc5b88b8d1b05e9324f11396
+  name:   8 Eyes (Japan)
+  title:  8 Eyes (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3493f7621d964af7a56c407718ef1d056c6c46d4e4c6b3c48364d58a1b97a06a
+  name:   8 Eyes (USA)
+  title:  8 Eyes (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 134c0575a417a986cdae33a0f9ca5eb38d269e028416752db6c6a5dc0db8ef7f
+  name:   Aa Yakyuu Jinsei Icchokusen (Japan)
+  title:  Aa Yakyuu Jinsei Icchokusen (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 35fff8fa349361f879e419d303edd371d4f2f9d7a7912421343baa694fd471e9
+  name:   Abarenbou Tengu (Japan)
+  title:  Abarenbou Tengu (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3b6055cedd2afb75ddf56f9100c9c9d393d42e18afa5e3c9b24454a0f995fe28
+  name:   Aces - Iron Eagle III (Japan)
+  title:  Aces - Iron Eagle III (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 22e92af92aed2d8d7bddb60732963642788b3ea9341592ce2c66a542a3d7ce7d
+  name:   Advanced Dungeons & Dragons - DragonStrike (USA)
+  title:  Advanced Dungeons & Dragons - DragonStrike (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 1d54a70fac4635e2dc8855296daaaa85e80be71ba1703c5859c6583b7dddeaaa
+  name:   Advanced Dungeons & Dragons - Pool of Radiance (Japan)
+  title:  Advanced Dungeons & Dragons - Pool of Radiance (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 38e5253131d264395a302d0910316f94bec00f60db616caa7a53806f08c5b5f9
+  name:   Advanced Dungeons & Dragons - Pool of Radiance (USA)
+  title:  Advanced Dungeons & Dragons - Pool of Radiance (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 53bfc94fce46a25188f84f102810406f686a7fb13fb5e4ae8f13760106acb969
   name:   Adventure Island (USA)
   title:  Adventure Island (USA)
@@ -215,6 +434,27 @@ game
       content: Character
 
 game
+  sha256: e8dc8c0441c54d09a1cfe0c112a3137bb6d709989b23e6528f8e30360e1ad910
+  name:   Adventure Island 3 (USA)
+  title:  Adventure Island 3 (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 0b16539dccc9a914ad7ca908234842dbcdb9bad3860a503421c77bc17b34cbad
   name:   Adventure Island Classic (Europe)
   title:  Adventure Island Classic (Europe)
@@ -233,6 +473,48 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 5ee479ef04d80366a75dd144cbeb47d0347ee82025d1b65dd358e1f6498c9a39
+  name:   Adventure Island II (USA)
+  title:  Adventure Island II (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9d82d83207a460258e833d430536d03c79ab8372435c614afb3c52e6b4325b68
+  name:   Adventure Island Part II, The (Europe)
+  title:  Adventure Island Part II, The (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -277,6 +559,90 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 30db64a2f6f796308dfeefbf6f0b648176cf6c982fbb5158c5408a899d6355c3
+  name:   Adventures of Lolo (Japan)
+  title:  Adventures of Lolo (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: c37934b3eda806366d24cc3205ec656d6ac30faa30cb2172bdbc17503146dcae
+  name:   Adventures of Lolo 2 (Europe)
+  title:  Adventures of Lolo 2 (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 12d3119e25f7b40a7ccc546f5d92edaad86fb0083facf6dd61db512bac45f99d
+  name:   Adventures of Lolo 2 (USA)
+  title:  Adventures of Lolo 2 (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 03db3d003eaa91e1434093ea259a82b9f2d5ed5b02404f9feba05819f69f81c4
+  name:   Adventures of Rocky and Bullwinkle and Friends, The (USA)
+  title:  Adventures of Rocky and Bullwinkle and Friends, The (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 4fb12ad1c791c7ee8d5ec824eff871d71b43b92c4e93b45ed0b60f022459b917
@@ -359,6 +725,31 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: c4c7bcbf9b9b95c3b8dd58adf5d51256cad3aec11bd609aaacae3ec2a829b286
+  name:   Akuma no Shoutaijou (Japan)
+  title:  Akuma no Shoutaijou (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -517,6 +908,48 @@ game
       volatile
 
 game
+  sha256: 3b4f4c86e074d150e4763bf696011337a8a0b82b9ba7091b8dd38e4cd5373b2c
+  name:   Alien 3 (Europe)
+  title:  Alien 3 (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d73a9a1fae7396754c19eecd6aa9e44d02c230df8efed0bafd86aa1cb0dd2a23
+  name:   Alien 3 (USA)
+  title:  Alien 3 (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 7ae9746aa5c24c9c048b842879d93cae58c1c52be2ce1c3fbc749ab7ca2210bb
   name:   Alpha Mission (Europe)
   title:  Alpha Mission (Europe)
@@ -573,6 +1006,50 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0f9eb607392b6846c99d236198cfb3517ed0c9776b43ab0f5791d612499c3aed
+  name:   America Oudan Ultra Quiz - Shijou Saidai no Tatakai (Japan)
+  title:  America Oudan Ultra Quiz - Shijou Saidai no Tatakai (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 31b2e9e9b33d1ad55a0e57dbabea517de59f12f7d58607771a1d8924c658d293
+  name:   America Oudan Ultra Quiz - Shijou Saidai no Tatakai (Japan) (Rev 1)
+  title:  America Oudan Ultra Quiz - Shijou Saidai no Tatakai (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
       content: Program
     memory
       type: RAM
@@ -811,6 +1288,27 @@ game
       content: Character
 
 game
+  sha256: 72d1d7a95724256471b00f72033821eea61a67d3fbc7167420326f75523b4970
+  name:   Asmik-kun Land (Japan)
+  title:  Asmik-kun Land (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 67e76511b467253a3a1a9caacd4febf7a97415c963ce0b4b4bc71539d6d1e528
   name:   ASO - Armored Scrum Object (Japan)
   title:  ASO - Armored Scrum Object (Japan)
@@ -854,6 +1352,27 @@ game
       volatile
 
 game
+  sha256: 20aaf9705d2cc17bac10468544afb250019f43983677b904ca88328f67aa9439
+  name:   Astro Fang - Super Machine (Japan)
+  title:  Astro Fang - Super Machine (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: e06b95487c293ec2e2d1516ee2c61f2b5b88665a609e64e3689a42934d038792
   name:   Astro Robo Sasa (Japan)
   title:  Astro Robo Sasa (Japan)
@@ -872,6 +1391,48 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: fa143a775995ba35a7bf52bbf89456e363de9811dfff5469a411da8029a01486
+  name:   Astyanax (Europe)
+  title:  Astyanax (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a08e6b53f1fa593e001719d87e2f203deb24ee1d389a8f3f339d75e9fb7c02f4
+  name:   Astyanax (USA)
+  title:  Astyanax (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -1072,6 +1633,69 @@ game
       content: Character
 
 game
+  sha256: 56382fac9104b26797de262a7c70ddd5850451d81a5008f3943d7bc492cbeb41
+  name:   Bad Dudes (USA)
+  title:  Bad Dudes (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d9899d4e4c6dd10874117b00cd4aaec7ae6b9d9c56ff60989a0acafdab3e7724
+  name:   Bad Dudes vs. Dragon Ninja (Europe)
+  title:  Bad Dudes vs. Dragon Ninja (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: cd04386d8cb372c69c7a8eaf8888408b312938a20238d502bcc1740b26497681
+  name:   Bakushou!! Ai no Gekijou (Japan)
+  title:  Bakushou!! Ai no Gekijou (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: a04479f081dedd31fb5b3f1cfb2741c1a18946cc8f71c0c0ce9488835ce37563
   name:   Bakushou!! Jinsei Gekijou (Japan)
   title:  Bakushou!! Jinsei Gekijou (Japan)
@@ -1262,6 +1886,48 @@ game
       content: Character
 
 game
+  sha256: d718f10d4ab57f7ed3891a84bdc496472a242b9c8496a3c0a0de77b45ae2fd58
+  name:   Banana Prince (Germany)
+  title:  Banana Prince (Germany)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e05f8bb27f38527c2b5bc1ac3bebdb619355d279e45d811dd5d46120e4d137a8
+  name:   Bananan Ouji no Daibouken (Japan)
+  title:  Bananan Ouji no Daibouken (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 2a92f666ce73177eff8bfe987beac3f1c26e174c5f8737a358ed2e9a6e5915d7
   name:   Bandai Golf - Challenge Pebble Beach (USA)
   title:  Bandai Golf - Challenge Pebble Beach (USA)
@@ -1350,6 +2016,98 @@ game
       content: Character
 
 game
+  sha256: a9b940cf25490195db10d8282ad14c5b3c40c6119fdc12879418dc31e0238602
+  name:   Baseball Fighter (Japan)
+  title:  Baseball Fighter (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 5f8807999205f3800e445d6265b66fa6edff0070fc38905f7284f0ad437f9f53
+  name:   Baseball Stars II (USA)
+  title:  Baseball Stars II (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 5d84d61e7e4c2b7d72a2b4599bd8cc415b71c90d1e332a83f95d96c75bc48efd
+  name:   Bases Loaded 3 (USA)
+  title:  Bases Loaded 3 (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e4aa19e0fd2800b58655eac814e1d9a9aa16d83eabd641789f8a6625591063a3
+  name:   Bases Loaded 4 (USA)
+  title:  Bases Loaded 4 (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 299075061656934b3a1610748af3eb2a1cf4008889615e0d78811507cf5f4924
   name:   Batman (Japan)
   title:  Batman (Japan)
@@ -1421,6 +2179,90 @@ game
       content: Character
 
 game
+  sha256: 18e4148f8fa49f14940bd8e69f5f37b28356193dfb6551f2d9a88117f99686af
+  name:   Batman - The Video Game (Europe)
+  title:  Batman - The Video Game (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: f28821df0114eb6cff1d7b4eadcee87713591709da1dd8b3525cf250156111f1
+  name:   Batman - The Video Game (USA)
+  title:  Batman - The Video Game (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 77392261998a259b9984bfae5bf9f78ca95940e3e757f4e0407c1894a294b462
+  name:   Batman Returns (Europe)
+  title:  Batman Returns (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 8b7363e037883aaa36d2c643c36a6f09ce49bd515f166154bd2a48e0a6468b9d
+  name:   Batman Returns (USA)
+  title:  Batman Returns (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: 97554aa222df3d12e4d877d6314f7d52b9628a9a081b8f47470d9fc0d569bee1
   name:   Batsu & Terry - Makyou no Tetsujin Race (Japan)
   title:  Batsu & Terry - Makyou no Tetsujin Race (Japan)
@@ -1443,6 +2285,32 @@ game
       volatile
 
 game
+  sha256: 9f172c637777482bca06c298b9c535a1c698359cb90465cdf3776bb659c88df5
+  name:   Battle Baseball (Japan)
+  title:  Battle Baseball (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 263b133697e368b60a6a11a82d9f0ab0fca94da1bef8c5f823d593b4f2f64e7e
   name:   Battle Fleet (Japan)
   title:  Battle Fleet (Japan)
@@ -1450,6 +2318,27 @@ game
   board:  NAMCO-163
     chip
       type: 163
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a50c0b6d93f7e20ecfd8a95abd5b7bccd4cf290901376fcf9e4053b3f964fca1
+  name:   Battle Formula (Japan)
+  title:  Battle Formula (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
     memory
       type: ROM
       size: 0x10
@@ -1627,6 +2516,27 @@ game
       volatile
 
 game
+  sha256: 3b3865e6e44f8ef749e8a9509651a6fad688b8d744fab22974a6f4cb9e7f2b0b
+  name:   Beauty and the Beast (Europe)
+  title:  Beauty and the Beast (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: b9434d2f359f6e464da36fbcf6d9eb794b7edff03b89467d1609158f13bfef52
   name:   Beetlejuice (USA)
   title:  Beetlejuice (USA)
@@ -1689,6 +2599,52 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 47483dcc82cd7aea7d598c00b1909aa438c8d0f6fb8c4320598ae4e41231b032
+  name:   Bikkuri Nekketsu Shin Kiroku! - Harukanaru Kin Medal (Japan)
+  title:  Bikkuri Nekketsu Shin Kiroku! - Harukanaru Kin Medal (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ddf58f90fa5966137e71a0f30a162bf03b3e8b1b99f4f1d16cac26d5e2cf5b35
+  name:   Bill Elliott's NASCAR Challenge (USA)
+  title:  Bill Elliott's NASCAR Challenge (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
 
 game
   sha256: eba4b3082b0a4e648ecf6453937264364adff585d5d7fe2f38782957f876ac40
@@ -1891,6 +2847,69 @@ game
       volatile
 
 game
+  sha256: 0397e887fcb64ef0d7aa71aa2c2fea68bb421c8be1dec9141b7e9c9ba7432ec4
+  name:   Blue Marlin, The (Japan)
+  title:  Blue Marlin, The (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e311f33f98a4461f9ca79e2df863323d42572234bc59321bb9fb39ca1b18d0cf
+  name:   Blue Marlin, The (USA)
+  title:  Blue Marlin, The (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4ba112646041b10db3cdb81b16f36da4dd77cf72760dd5700abbf84cdb5adc82
+  name:   Blue Shadow (Europe)
+  title:  Blue Shadow (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: b350a470e11bb4dbc175d6e6750a0f853c9fc7dd1918974233016d8a491a761e
   name:   Blues Brothers, The (Europe)
   title:  Blues Brothers, The (Europe)
@@ -1933,6 +2952,31 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 7e59dcd2576d2e83f6f628a7bb8d5f1e54fa300f7ecb9aa5e1e0f6d967be8371
+  name:   Bo Jackson Baseball (USA)
+  title:  Bo Jackson Baseball (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
 
 game
   sha256: 822da78ef1ccb37bfa68373a83f7434960de388e4b5b53661b479953a5085322
@@ -2020,6 +3064,27 @@ game
       content: Character
 
 game
+  sha256: b3d82e2818aea6caa69dcfe7d56197a7a51afe87819527880cf08876d1a988de
+  name:   Bonk's Adventure (USA)
+  title:  Bonk's Adventure (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 9f7cf8570641ea7041e20b86ceac0a9d4e55464acbd7a235007dd5bc77e61a95
   name:   Booby Kids (Japan)
   title:  Booby Kids (Japan)
@@ -2042,6 +3107,56 @@ game
       volatile
 
 game
+  sha256: f8c903339b52bd0c90cdeda872ad52132431d8b748802397df936f742ed7adce
+  name:   Bram Stoker's Dracula (Europe)
+  title:  Bram Stoker's Dracula (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a8b6829d8d1e17cc23c8815e0b0add09e26fc5a2a27ad6bba260cef926535af2
+  name:   Bram Stoker's Dracula (USA)
+  title:  Bram Stoker's Dracula (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: caab4e955514d17ff9b08251d09a52cf2fc1126788724e28c3ac3300599694c1
   name:   Bubble Bobble 2 (Japan)
   title:  Bubble Bobble 2 (Japan)
@@ -2049,6 +3164,90 @@ game
   board:  TAITO-TC0690
     chip
       type: TC0690
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 382699d54308423c9ca1a8d775798de03c66f87e3b0e63e3cc4c95725331ceaa
+  name:   Bubble Bobble Part 2 (USA)
+  title:  Bubble Bobble Part 2 (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 2aad8e7370b1edaf56a5e95a38596a4e57605e9c95adffd2ec10a14d5ddee115
+  name:   Bucky O'Hare (Europe)
+  title:  Bucky O'Hare (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: cd88bc4cf9110ec8f52e1af6c4fa0fa0e99996a264672de6ed6a4417c4730013
+  name:   Bucky O'Hare (Japan)
+  title:  Bucky O'Hare (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d02b24e4ee8e639bf77af6746d6b3a92e996c0d2298861071851e2beec0ef812
+  name:   Bucky O'Hare (USA)
+  title:  Bucky O'Hare (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
     memory
       type: ROM
       size: 0x10
@@ -2084,6 +3283,56 @@ game
       content: Character
 
 game
+  sha256: f01fe9436ca7b50953dbe5b8dd3574612df0e5df1fa9ae50d3f3b5faac818ab2
+  name:   Bugs Bunny Birthday Blowout, The (USA)
+  title:  Bugs Bunny Birthday Blowout, The (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 87bf7e1e8273cce5c0d79bccacb811a8cfc11d67e2d47c91a91a00fae97800de
+  name:   Bugs Bunny Blowout, The (Europe)
+  title:  Bugs Bunny Blowout, The (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: ba8c9990f378b941ea362858509182b2b009e5b463e9732dc0071392b6253c2b
   name:   Bump 'n' Jump (USA)
   title:  Bump 'n' Jump (USA)
@@ -2091,6 +3340,69 @@ game
   board:  HVC-CNROM
     mirror
       mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 6315db3a05e4c9301826a743cd24039e90c0c4e0e10d929032103a03b1c36d71
+  name:   Burai Fighter (Europe)
+  title:  Burai Fighter (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 24395f0c1cd3b13e6c8ad989e3664def0ec7aceccf32cad6f946c37b1e3f8c50
+  name:   Burai Fighter (Japan)
+  title:  Burai Fighter (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: abbddcb7c85a9956f94e6185aa1f30c34c45ad0db2f7f9db40066d749ffa7920
+  name:   Burai Fighter (USA)
+  title:  Burai Fighter (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
     memory
       type: ROM
       size: 0x10
@@ -2145,6 +3457,32 @@ game
       type: ROM
       size: 0x2000
       content: Character
+
+game
+  sha256: d65dfa2d50ddd88857e026d08338af66fbc7eda1478a8476d8b32f1fd0676edd
+  name:   Business Wars (Japan)
+  title:  Business Wars (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 47dfae941b3c660be476bc28f199474b6c418431e3d493da4384a6aef3cc5016
@@ -2254,6 +3592,165 @@ game
       volatile
 
 game
+  sha256: bd550faa1c235058edb6ba724360e8e39fd986354341b3859d5ad21ac12636ad
+  name:   Capcom Barcelona '92 (Japan)
+  title:  Capcom Barcelona '92 (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: cfe5824e7e019af8f719cc1f032a87a14f7bfd643122473673cdd49328b1aea7
+  name:   Capcom's Gold Medal Challenge '92 (Europe)
+  title:  Capcom's Gold Medal Challenge '92 (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4ec881462687e08433605516d28624c5d9a7f33a243c64989c957adff8e0432a
+  name:   Capcom's Gold Medal Challenge '92 (USA)
+  title:  Capcom's Gold Medal Challenge '92 (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 39d4fd454f727c6f4884c6211a5dc456ca7b21c51eac7d443a6bada3f4410e61
+  name:   Captain America and the Avengers (Australia)
+  title:  Captain America and the Avengers (Australia)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 6d694349435603c0dcd7645081b0761e109f3994b30f9d822586c991d93510d8
+  name:   Captain America and the Avengers (USA)
+  title:  Captain America and the Avengers (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: dd746f0057710cbb956bf8d1e8e76afc7685f0011b8ac6fea93964f62110544a
+  name:   Captain Planet and the Planeteers (Europe)
+  title:  Captain Planet and the Planeteers (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 41dd396fbd9b0883b4222b6fbdae09d0e3894eb015e965a0d228f21edd98ad8c
+  name:   Captain Planet and the Planeteers (USA)
+  title:  Captain Planet and the Planeteers (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 2ac39a3e3892cc4e4ec616348a9646be8c8cb8b229c9f5d8868e3a5a5c7e8397
   name:   Captain Saver (Japan)
   title:  Captain Saver (Japan)
@@ -2335,6 +3832,27 @@ game
       volatile
 
 game
+  sha256: e36f43f90501bad2cb43407922bd2ed686a8a9bd5e2be6bc1e7e4b94f02933bd
+  name:   Captain Tsubasa II - Super Striker (Japan)
+  title:  Captain Tsubasa II - Super Striker (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: f76f1779454a8a98168c2c26bc79058161cbaefb3006c8e6aa8c63d301a66f4f
   name:   Casino Kid (USA)
   title:  Casino Kid (USA)
@@ -2377,6 +3895,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 53c48010708b82f9d269651b0e1eeea733bf259349578cefcc68a75b059f68a5
+  name:   Castle Quest (Japan)
+  title:  Castle Quest (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 042679ccdf356a96e2b879630740b4582acc05007811f5e362f759e58b47a770
@@ -2553,6 +4092,27 @@ game
       volatile
 
 game
+  sha256: 52451a89296cfcb006beb6363ddc8486fcc88154338cbec778a846056c522f50
+  name:   Cat Ninden Teyandee (Japan)
+  title:  Cat Ninden Teyandee (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: b1703cd27771d1b3aef1016e5b2655dc858bb4d0f7cde00acfe3d629caa2a46f
   name:   Chack'n Pop (Japan)
   title:  Chack'n Pop (Japan)
@@ -2725,6 +4285,69 @@ game
       content: Character
 
 game
+  sha256: 9fcb84b354fdfc16235fd0087027fe7b76179eb0e73c5f0e65dee7de41967e85
+  name:   Chiki Chiki Machine Mou Race (Japan)
+  title:  Chiki Chiki Machine Mou Race (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 026e80fd80bc9af61d9d7a762a61057f50da6b5c57914855ac6f5048d949365d
+  name:   Chitei Senkuu Vazolder (Japan)
+  title:  Chitei Senkuu Vazolder (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 50a3c86e015528f43a8cba68395d4fd0b9e9a9fb203fe4c730883c1ae0b0ee8e
+  name:   Chiyonofuji no Ooichou (Japan)
+  title:  Chiyonofuji no Ooichou (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: d5aa44754e9b2bdd3c747ca49e2e52b653889fc235d7ed0ca49177942fa8e9fe
   name:   Choplifter (Japan)
   title:  Choplifter (Japan)
@@ -2806,6 +4429,27 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: cb842db5081c13a8aba0f95275bf982bdf512246730f6dc452b4eb145abed037
+  name:   Choujinrou Senki - Warwolf (Japan)
+  title:  Choujinrou Senki - Warwolf (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -2980,6 +4624,27 @@ game
       volatile
 
 game
+  sha256: 79969ab6741823e5560794489d5b20a677a1207c06265855e5d7b633e6fef29a
+  name:   Cliffhanger (USA)
+  title:  Cliffhanger (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: ed0a1a5ca7cf404116d0073e8ccd213a082d2ac50132f54f3c8621f3dbcdb248
   name:   Clu Clu Land (World)
   title:  Clu Clu Land (World)
@@ -3041,6 +4706,27 @@ game
       volatile
 
 game
+  sha256: 2be0bd6e64cf2cb47c7b4a2d6bdb5fd4ff9ed1cd5eb6eadb4d56c410c659bdc5
+  name:   Code Name - Viper (USA)
+  title:  Code Name - Viper (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: e8bb5be4ada0b98229d370dab230b02946fb08942c7d85b265a5280107722587
   name:   Color a Dinosaur (USA)
   title:  Color a Dinosaur (USA)
@@ -3061,6 +4747,31 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 6234d3d4d1e6c08bc0cf0797324e3f0f5bcf6f45c87a67e1b9d15fb3cde7e39e
+  name:   Columbus - Ougon no Yoake (Japan)
+  title:  Columbus - Ougon no Yoake (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 0512b4aa2220f74e40fe8652b758893fa87efb6c3407808f7dda0e1901017432
@@ -3105,6 +4816,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: a5b8e24589539b0b84a6ad98aee9c91eb86eff795162be38b020dc42c3e3eca7
+  name:   Conquest of the Crystal Palace (USA)
+  title:  Conquest of the Crystal Palace (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 62c9d4e0578cb1e615ce9bb2c8ebc15b1e8de4c928c5c07ba9a85c11aa36ae4d
@@ -3153,6 +4885,48 @@ game
       volatile
 
 game
+  sha256: 0c190a8a7bfb57d7887e70183560db46fb5336abf569f6a38f5452fa32f1339f
+  name:   Contra Force (USA)
+  title:  Contra Force (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 57bb6d08f802ee52a93cb871179ae908d0060dde27c6e0b1970caa65675e0c67
+  name:   Cosmic Epsilon (Japan)
+  title:  Cosmic Epsilon (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: fd8137b02b02fcc0bed2b3107a0d934ab2af13650f418d5c64f0e9913396d62f
   name:   Cosmo Genesis (Japan)
   title:  Cosmo Genesis (Japan)
@@ -3171,6 +4945,27 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 528d501320ed0276bbc542f03c7c05fb59f9eeb540cd0d39e7286b1542aa153a
+  name:   Cowboy Kid (USA)
+  title:  Cowboy Kid (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
       content: Character
 
 game
@@ -3194,6 +4989,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: fda4fd839497634df5e77b1842f88c05ffa0ac13a894c9ea288aedcd168489c3
+  name:   Crash 'n' the Boys - Street Challenge (USA)
+  title:  Crash 'n' the Boys - Street Challenge (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 3f243f6cf4b33d25d76c7cf9459e82bcd5367aa001f4c36fdf1c5728429bed0a
@@ -3267,6 +5083,98 @@ game
       content: Character
 
 game
+  sha256: db95e3c59656b79e76887dbddf6ec422fa28ce23900eb684f44cf35171ec6f05
+  name:   CrossFire (Japan)
+  title:  CrossFire (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 5ad644d368f70b61700b74a1d04778888efcbbf98d5435d79f9fcefd23ac39c2
+  name:   Crystalis (USA)
+  title:  Crystalis (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 231701f8c463184d24af04114d2e886088f1625f33374b4e3e72bf0cc6d6a9bc
+  name:   Cyber Stadium Series - Base Wars (USA)
+  title:  Cyber Stadium Series - Base Wars (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e239709320fca149b40a1f04625741dc2b6d3b9cc933d4062882ad762fa67ca7
+  name:   Cyberball (USA)
+  title:  Cyberball (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: ad1e14d08657d99c8b70f779931f62524b4beb529090b82b368925d8b642e40c
   name:   Cybernoid - The Fighting Machine (USA)
   title:  Cybernoid - The Fighting Machine (USA)
@@ -3285,6 +5193,77 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 8b625a5503004f7026364ace9ccbe8a6cf346a5d4414f2697219658cfd773baa
+  name:   Dai-2-ji Super Robot Taisen (Japan)
+  title:  Dai-2-ji Super Robot Taisen (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 8a491a21345be4e3425622f68f6b9d2252d79f1282d80b8273c7724127b7b566
+  name:   Daikaijuu Deburas (Japan)
+  title:  Daikaijuu Deburas (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 76ec20071467c73ef8466fa35a454a51b39aee9e8efcec9e01d07b9e7615c929
+  name:   Daiku no Gen-san (Japan)
+  title:  Daiku no Gen-san (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -3369,6 +5348,31 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: d5426d3c26dc11200610044e3ff84ed13d09c372460bf09134ac8b770e69d724
+  name:   Dark Lord (Japan)
+  title:  Dark Lord (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 227e789fef94eabcf24a5ec9a3944de58b183bbc7d96140269d1c908f162b853
@@ -3596,6 +5600,48 @@ game
       content: Save
 
 game
+  sha256: 9ed3fa941bf8eac7f3cc8c43c31943b29a9bbfb651c54ebed599ec792a51e5a1
+  name:   Days of Thunder (Europe)
+  title:  Days of Thunder (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 9371fab4f58fa6d6e5211950fdaff2810cccff512fc301e88af9c5b1bf586257
+  name:   Days of Thunder (USA)
+  title:  Days of Thunder (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: 2d7414a83f46370f8f76a7276357fdcd34c29c0cdb108b417da8c6c43095a90c
   name:   De-Block (Japan)
   title:  De-Block (Japan)
@@ -3614,6 +5660,27 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 3c537d58550d8b199642ecaaeef21ed921d4af854e4900e7a0f853bf31c464b2
+  name:   Dead Fox (Japan)
+  title:  Dead Fox (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -3657,6 +5724,102 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: 167bc1a0125f12d9db292053f08d37f5b29dda3e4c3cc9ae54aa4951b447d988
+  name:   Defenders of Dynatron City (USA)
+  title:  Defenders of Dynatron City (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d83697d220ee472442642e9182a8d91dd141374d7c4ab26feb1370e405b2c32d
+  name:   Deja Vu (Sweden)
+  title:  Deja Vu (Sweden)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 87850226dc6c4c52c621de305166e59f8b69de885c99de908cbf5fec606772ad
+  name:   Deja Vu (USA)
+  title:  Deja Vu (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: ed38c1143cbb451c8d4a7fca40df62bb71094b112d573ff2624be3ad07fe4d22
+  name:   Deja Vu - A Nightmare Comes True!! (Japan)
+  title:  Deja Vu - A Nightmare Comes True!! (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
       content: Character
 
 game
@@ -3980,6 +6143,48 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: 5aaa8382ec79c170472840dfd8e9d93512bdf2be09ecd6b3709a9d27658888cd
+  name:   Dirty Harry (USA)
+  title:  Dirty Harry (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 65295da1f14578b659b6613be80d0516c2a4932dc6bc33bad2cc71a3154672e7
+  name:   Doki! Doki! Yuuenchi - Crazy Land Daisakusen (Japan)
+  title:  Doki! Doki! Yuuenchi - Crazy Land Daisakusen (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -4318,6 +6523,111 @@ game
       volatile
 
 game
+  sha256: 7a7711ad95385a87f3577699fc425a83ac8d7e690ae5aa2f72ceed3feb29113b
+  name:   Double Dragon II - The Revenge (Europe)
+  title:  Double Dragon II - The Revenge (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: f329de1e2653499221dc4d14d0e8b1040fee87bda4daccf6098b316a1a024fe2
+  name:   Double Dragon II - The Revenge (USA)
+  title:  Double Dragon II - The Revenge (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c564704993cf79c94db5c2954792e99e86100586d0ef1d4bf1aefc6d008d4c0f
+  name:   Double Dragon II - The Revenge (USA) (Rev 1)
+  title:  Double Dragon II - The Revenge (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 2dab4db61dc341a2cd8b53f51dbd66ed88c10a868d64ccf837c664fa9cff3eda
+  name:   Double Dragon III - The Sacred Stones (Europe)
+  title:  Double Dragon III - The Sacred Stones (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9f5891d333ea410c9a20f952ed21ec8b35c1b4f2a6fc2408fb2510921b64660f
+  name:   Double Dragon III - The Sacred Stones (USA)
+  title:  Double Dragon III - The Sacred Stones (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 6afada48e468f951609d5178c4c4e0ae95028abbf5971affd60af3770a4ae20d
   name:   Double Dribble (Europe)
   title:  Double Dribble (Europe)
@@ -4384,6 +6694,32 @@ game
       volatile
 
 game
+  sha256: ddc08430b83061814fec929872aa6df3abc1a624888a8e3eb3fa96abb8d32e36
+  name:   Double Moon Densetsu (Japan)
+  title:  Double Moon Densetsu (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 7fd28fb7b132052ad13b9ac0b493b87dca3e0d9b12835219e730bbab0e5f6797
   name:   Dough Boy (Japan)
   title:  Dough Boy (Japan)
@@ -4402,6 +6738,73 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: 71ca865ba15da47e7002d02886ae9548ee935e2b1f8623b78c4975f3ce30cfa6
+  name:   Downtown - Nekketsu Koushinkyoku - Soreyuke Daiundoukai (Japan)
+  title:  Downtown - Nekketsu Koushinkyoku - Soreyuke Daiundoukai (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 1eb8e534ae93c67e35a53bb177725c4f93157c6e6b748482bc974abbf25ed7de
+  name:   Downtown - Nekketsu Monogatari (Japan)
+  title:  Downtown - Nekketsu Monogatari (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: fe77718e277e1f08c29b7a268de36bbdbd2d20ad697d1e452757a3b3f4b0a4d3
+  name:   Downtown Special - Kunio-kun no Jidaigeki Da yo Zenin Shuugou! (Japan)
+  title:  Downtown Special - Kunio-kun no Jidaigeki Da yo Zenin Shuugou! (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -4898,6 +7301,27 @@ game
       content: Character
 
 game
+  sha256: 901b7a9b3e8c0256bd091f845f48b0e7bd903f7456ce3dcea386cc1871fe70c1
+  name:   Dragon Spirit - The New Legend (USA)
+  title:  Dragon Spirit - The New Legend (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: e13e26aeaba4f4c247a52ebf10fedf49a00005c39bebf965b032ee0f69f764e2
   name:   Dragon Unit (Japan)
   title:  Dragon Unit (Japan)
@@ -4918,6 +7342,73 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 3779acb840dc04e39fe8cf4d13aaaad97fb6fe3af0ef866ef4f28890a553e8b4
+  name:   Dragon Wars (Japan)
+  title:  Dragon Wars (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 5efe21c5569be4e6f6564d30ed89b8a8bab8e19a3dc9d3ab11d34ccad55ec180
+  name:   Dragon's Lair (Europe)
+  title:  Dragon's Lair (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 1580e9998e02c2cc15119595f312ba4ba58668007e804b6ae493fbebdc56fee5
+  name:   Dragon's Lair (Japan)
+  title:  Dragon's Lair (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 5564e54943deddc6d290b256638c774aa379a0d33dcea3b0a4f0c4b9fc2034e3
@@ -5226,6 +7717,31 @@ game
       content: Character
 
 game
+  sha256: 1266108d927cb288a5f396e78ac097e48678375e80c0e0c09ecbce4dc03699bc
+  name:   EarthBound Beginnings (USA, Europe)
+  title:  EarthBound Beginnings (USA, Europe)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: 7951287af48ef9f2e2b375934acff99fe1543aea39d2729d2863b38ab498e231
   name:   Egypt (Japan)
   title:  Egypt (Japan)
@@ -5505,6 +8021,203 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: 47bb3a4f4ff90990bfdfb372030e769af47fb6baf7e95518389aa9e2e39f68e1
+  name:   F-1 Sensation (Japan)
+  title:  F-1 Sensation (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 69bc9f0a2f0cd50d624fafced0051056fd91816f0593719678a42c8637622426
+  name:   F-117A Stealth Fighter (USA)
+  title:  F-117A Stealth Fighter (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 8e945336a39e6737708d4e4bcc71e4bb82857061064e86e95bb8edf9d72c775c
+  name:   F-15 Strike Eagle (Europe)
+  title:  F-15 Strike Eagle (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: acb7f767d4238cd55ced929c72e4323aaf32e460127126d7479baf2f2b1ef209
+  name:   F-15 Strike Eagle (France)
+  title:  F-15 Strike Eagle (France)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: aa12ba6acaf54f1e23c7ac2c16f70aed8e2d33f410d60b3aaddedf9ff6735065
+  name:   F-15 Strike Eagle (Germany)
+  title:  F-15 Strike Eagle (Germany)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 2b5ebdeb7e5d8bc6da79c0d180d56bc1c1c41857768943fb8e3be830f4e506a3
+  name:   F-15 Strike Eagle (Italy)
+  title:  F-15 Strike Eagle (Italy)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: ba7bd3b8c30b729baf8e8eae39abc605b7fddb07ba595c245b70b4d2ddc6ea1f
+  name:   F-15 Strike Eagle (Sweden)
+  title:  F-15 Strike Eagle (Sweden)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: bf4b9f8706814e9164971a3c32535bb2ec718232cf05decda785770fa949d396
+  name:   F-15 Strike Eagle (USA)
+  title:  F-15 Strike Eagle (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 8c3409366ba15be19521fa3cdbfefe9f818c5323f2c30e9b40b5a024f9e585b4
+  name:   F1 Circus (Japan)
+  title:  F1 Circus (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -6357,6 +9070,77 @@ game
       content: Character
 
 game
+  sha256: 6e0312213594af59f3fc14826a2a7be09cdd2dae3b2e9183ac89b8a3b69e2893
+  name:   FC Genjin - Freakthoropus Computerus (Japan)
+  title:  FC Genjin - Freakthoropus Computerus (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 83a1071f8da8d297222aab992fdf23092557abd4a7fb9607eb1d4194c021089d
+  name:   Felix the Cat (Europe)
+  title:  Felix the Cat (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 884b46ad4eb5160a94c19e8954846d644be36803efc53c977e99b1342886cc6b
+  name:   Felix the Cat (USA)
+  title:  Felix the Cat (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 84b643059bf2b4fb73c19f829ae8db16dfefb2b5ec306bb77ac2c2f69c239603
   name:   Field Combat (Japan)
   title:  Field Combat (Japan)
@@ -6378,6 +9162,53 @@ game
       content: Character
 
 game
+  sha256: 179bd9c16fc5b85168fecac685045ed58f6bec5a51363babb7aaaaceb6fa0932
+  name:   Fighting Road (Japan)
+  title:  Fighting Road (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 7ff89b50156b6f5b3d78d3d2eeec8a9221d9f7b18f8350abf89b7867a205f710
+  name:   Final Fantasy III (Japan)
+  title:  Final Fantasy III (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 9f9e96423a8a322cd79676dadb7d24a27733f834a88049bda3acc98c2d2df026
   name:   Final Lap (Japan)
   title:  Final Lap (Japan)
@@ -6385,6 +9216,27 @@ game
   board:  NAMCO-163
     chip
       type: 163
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: db16f0a5cb05dfa9344e0ae459f6c44fac7c28d4a8ecd47d3418053ab16c8a62
+  name:   Fire 'n Ice (USA)
+  title:  Fire 'n Ice (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
     memory
       type: ROM
       size: 0x10
@@ -6598,6 +9450,27 @@ game
       volatile
 
 game
+  sha256: b55db945d7f35dbcac92b416a5942a99fd2e142a4d25411e7e2b4b571ca88b31
+  name:   Flintstones, The - The Rescue of Dino & Hoppy (Europe)
+  title:  Flintstones, The - The Rescue of Dino & Hoppy (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: 41fea670ccfb999d2693ff2233466c632dd379a6ac07d9789d8a1259da714383
   name:   Flintstones, The - The Rescue of Dino & Hoppy (Japan)
   title:  Flintstones, The - The Rescue of Dino & Hoppy (Japan)
@@ -6605,6 +9478,69 @@ game
   board:  TAITO-TC0690
     chip
       type: TC0690
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 3036a59bb7bf16a3b80c94750bccaa35be9ab5cd94f99d68d3979ec53cd42c03
+  name:   Flintstones, The - The Rescue of Dino & Hoppy (USA)
+  title:  Flintstones, The - The Rescue of Dino & Hoppy (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: ccdccfe13ffc97584b4df3bf4a47a67582789c72c1eb8e267e538e561a9d9cf0
+  name:   Flintstones, The - The Surprise at Dinosaur Peak (Europe)
+  title:  Flintstones, The - The Surprise at Dinosaur Peak (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 8da82a28be164453d1f8aa293fc8b02aaede397b52622a14ead331e475e5ca2f
+  name:   Flintstones, The - The Surprise at Dinosaur Peak! (USA)
+  title:  Flintstones, The - The Surprise at Dinosaur Peak! (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
     memory
       type: ROM
       size: 0x10
@@ -6747,6 +9683,31 @@ game
       content: Character
 
 game
+  sha256: c5329c9244df8cbe196e5f3a9d8fe4e696fd493e715def0096bfac90ace3a5a3
+  name:   Formula 1 Sensation (Europe)
+  title:  Formula 1 Sensation (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 7e94b4fe8c33439779bb653d007ba4678dd589636ffbc87d1535629578a64d5e
   name:   Friday the 13th (USA)
   title:  Friday the 13th (USA)
@@ -6834,6 +9795,94 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: da4a289eba41a33d9102b67c248a4562a6781dd963bb6bc2488b634c6b4ceacf
+  name:   Fushigi no Umi no Nadia (Japan)
+  title:  Fushigi no Umi no Nadia (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 8d0a934e10a53b82e9d27f545d1ca22fa78fa1378569bd86849b9a84450c7a9d
+  name:   Fuzzical Fighter (Japan)
+  title:  Fuzzical Fighter (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d077b282b751a246549e334885d83ee587d9e6178b170afcf57553ec62015c52
+  name:   G.I. Joe - A Real American Hero (USA)
+  title:  G.I. Joe - A Real American Hero (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 9e65e4d55123612c5eb05b332e48fd975a187d706a3fd44b62125e1ae48af028
+  name:   G.I. Joe - The Atlantis Factor (USA)
+  title:  G.I. Joe - The Atlantis Factor (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
 
 game
   sha256: dae646e7b91a55bb9d7fc6a7cfe4890d81ae89e68f9ccf44438dca67d83cb1de
@@ -6938,6 +9987,48 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: 07ddef2fd4e368ca9778610c32d233ead6f699cf3aa62b407f9222e1a68c5434
+  name:   Galaxy 5000 - Racing in the 51st Century (Europe)
+  title:  Galaxy 5000 - Racing in the 51st Century (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c019750cc439810de6cbf1c3a895099674df3f397744ad3149ba1b25dd55d0ab
+  name:   Galaxy 5000 - Racing in the 51st Century (USA)
+  title:  Galaxy 5000 - Racing in the 51st Century (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -7115,6 +10206,48 @@ game
       content: Character
 
 game
+  sha256: 8a53aea22a3786d7d9571613d4726d1fb945a7abc1397e7363b6814b1b2eec7b
+  name:   Gargoyle's Quest II (Europe)
+  title:  Gargoyle's Quest II (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 055fb73baaed0f3c4a31902402e7fe581d2d2cb948d3a2f5c3552050f316e6df
+  name:   Gargoyle's Quest II (USA)
+  title:  Gargoyle's Quest II (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: a2039efb5b5b8d4941c31ae0977dacccec5aaa72fe307ae36af2a454d30d9e26
   name:   Garry Kitchen's Battletank (USA)
   title:  Garry Kitchen's Battletank (USA)
@@ -7160,6 +10293,56 @@ game
       size: 0x800
       content: Character
       volatile
+
+game
+  sha256: 2dd9792645fa5db2cb4ba45dca746785d0f213e56c04e73701ab183aac31ee9c
+  name:   Gauntlet II (Europe)
+  title:  Gauntlet II (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ffa61d9f7bfb1d60662ddf246b21a8756d518292e8fdc0f58ac1c9b3fbad672d
+  name:   Gauntlet II (USA)
+  title:  Gauntlet II (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: db08af62b038452ce1acfdcf455be09e5ef85274fa98591c0c6c9547c0f547c1
@@ -7265,6 +10448,48 @@ game
     memory
       type: ROM
       size: 0x10000
+      content: Character
+
+game
+  sha256: 79d4a45d4baf80f079575237647f476c90756d3352bbd578ea803c4e1181d397
+  name:   George Foreman's KO Boxing (Europe)
+  title:  George Foreman's KO Boxing (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: cf517940496d6085563bdbbe74f4a06d2c4eca48da8eb2b35d5cfe463df35ce4
+  name:   George Foreman's KO Boxing (USA)
+  title:  George Foreman's KO Boxing (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
       content: Character
 
 game
@@ -7463,6 +10688,31 @@ game
       content: Character
 
 game
+  sha256: 7b3701a6a8968b214ec0acf4fc0e9e3089f773ebbd0426dac4f54506519f431b
+  name:   God Slayer - Haruka Tenkuu no Sonata (Japan)
+  title:  God Slayer - Haruka Tenkuu no Sonata (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: d4bd5f9e2bbfafb624d67a77f4292b92bad183c9aa4728620aedf3201591f6d8
   name:   Golf (Europe)
   title:  Golf (Europe)
@@ -7544,6 +10794,27 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: 45d62dadd79dbe0ed2cb89c310ebd7e5c8ceeee50dcb457497b458cc898a2900
+  name:   Golgo 13 - Dainishou - Icarus no Nazo (Japan)
+  title:  Golgo 13 - Dainishou - Icarus no Nazo (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -7674,6 +10945,28 @@ game
       type: ROM
       size: 0x8000
       content: Character
+
+game
+  sha256: 09ba233598f0fa3fe56e73d515888c7107ad532138b986a1a9949ed5b5e260e1
+  name:   Gorilla Man, The (Japan)
+  title:  Gorilla Man, The (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 15685dee8bc1c588dfa2649b7b5f715aa7b4136454ba09c046d1b17209749d76
@@ -7809,6 +11102,52 @@ game
       content: Character
 
 game
+  sha256: d96de4b5e924c9fb59e9ba953aa6aa2590ae466d696c2508a3752df9fe2ddb63
+  name:   Great Battle Cyber (Japan)
+  title:  Great Battle Cyber (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: c90202befdc54d32d9bf1b0a784bac26a3fabe455fe20979a99ef89405dfad6f
+  name:   Great Boxing - Rush Up (Japan)
+  title:  Great Boxing - Rush Up (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 029c4a8b572bdf3a655fb06a2e6ac67bd1c89c15d472d5078c8e77376c40102f
   name:   Gremlin 2 - Shinshu Tanjou (Japan)
   title:  Gremlin 2 - Shinshu Tanjou (Japan)
@@ -7816,6 +11155,48 @@ game
   board:  SUNSOFT-5B
     chip
       type: 5B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 8d61df0fd2b7d521a79366c700ba1e85371793a931bfba86fa63f9c6af4b3f76
+  name:   Gremlins 2 - The New Batch (Europe)
+  title:  Gremlins 2 - The New Batch (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 2b77da430b08e6a91a3453fde8ea82692415d44c3e953fdf281aa39352d5289d
+  name:   Gremlins 2 - The New Batch (USA)
+  title:  Gremlins 2 - The New Batch (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
     memory
       type: ROM
       size: 0x10
@@ -7896,6 +11277,48 @@ game
       volatile
 
 game
+  sha256: 7c948ac8b05b128691a64d936a5c6dfdb7d121e23b52fff3d86f72b04b064b47
+  name:   Gun Nac (Japan)
+  title:  Gun Nac (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d22a0c390dfc47c99226226c98158bf0ca3b4cd07dbd3d46cc50c2f1b9303c22
+  name:   Gun Nac (USA)
+  title:  Gun Nac (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: f82e65b91b7ce609146bc8c3975f2c1780fe965c1208695892a2be2cb281616e
   name:   Gun.Smoke (Europe)
   title:  Gun.Smoke (Europe)
@@ -7938,6 +11361,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 5380e1e2a10764dbaef4eb7041925386977e7e5e2a59b77ea48cafc65cc03e57
+  name:   Gun-Dec (Japan)
+  title:  Gun-Dec (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 4628f32db9b826d19fe5dd8e2c45a9f70e1041f15b7b44b06dee2f01731566e8
@@ -8024,6 +11468,27 @@ game
       content: Character
 
 game
+  sha256: bd5c7925e616da879ee63ac4ac2004af26e20ae36a494247e704d41440ac971a
+  name:   Hammerin' Harry (Europe)
+  title:  Hammerin' Harry (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 5c61e53dcade69a1cfac4eb4b979262bd2f70a37aa9aece6402e19870d6ac9e7
   name:   Hana no Star Kaidou (Japan)
   title:  Hana no Star Kaidou (Japan)
@@ -8044,6 +11509,31 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 0a91c3d7ef625b6710677174010066eea584d5bcfb5e5d2002be369c7a3c289a
+  name:   Happy Birthday Bugs (Japan)
+  title:  Happy Birthday Bugs (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 4ccc1500ca9e95db50961ef4e825bef9ef9e10f994fd6e424693a3e8abf6f72b
@@ -8093,6 +11583,48 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: a0a108a13dde28b7af63c814b44f3f9ec5d7eee686232bf840fa5b9e6ae52ae0
+  name:   Heavy Barrel (Japan)
+  title:  Heavy Barrel (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: fd3c19b0339bf2b326d8a0526216b5143f035f68dabb3b3392689c92d6c140d9
+  name:   Heavy Barrel (USA)
+  title:  Heavy Barrel (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -8367,6 +11899,52 @@ game
       volatile
 
 game
+  sha256: 384c01b71e1eed23778356753646fb518f1dfa483e0e3a3c1b7391c67cb8ec08
+  name:   Hiryuu no Ken III - 5 Nin no Dragon (Japan)
+  title:  Hiryuu no Ken III - 5 Nin no Dragon (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d0e1bf484da0590204ae6183a8fc484e344a03177c600cfe7c717afb0d0e6e46
+  name:   Hissatsu Shigoto Nin (Japan)
+  title:  Hissatsu Shigoto Nin (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 8e4a04076b6a728a7e65a09737776dcb9defed7922bf0437d9a89bbe8c724b55
   name:   Hogan's Alley (World)
   title:  Hogan's Alley (World)
@@ -8472,6 +12050,98 @@ game
       content: Character
 
 game
+  sha256: 67e2212831c0757f920c1221827c9eb2d5b17d67d0654c20395ba3a6aa682973
+  name:   Home Alone (USA)
+  title:  Home Alone (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e719d718810963450325a3c754c181526ab2f2552c19134a42229918eb6a08ed
+  name:   Home Alone (USA) (Rev 1)
+  title:  Home Alone (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 19b2cfe2c5f5806f1c2a1256d88626b73b6c1b041898a0b6f7f56af60fbcfb46
+  name:   Home Alone 2 - Lost in New York (Europe)
+  title:  Home Alone 2 - Lost in New York (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3f761f529d40cf42aed60fabc0e60ecfecf528f4165948e6157b552e3bbb4f89
+  name:   Home Alone 2 - Lost in New York (USA)
+  title:  Home Alone 2 - Lost in New York (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 1d7d435fe2aa494f5752a3098d1d627b99f91b0c5ded99038f36e80c22d6a162
   name:   Honoo no Toukyuuji - Dodge Danpei (Japan)
   title:  Honoo no Toukyuuji - Dodge Danpei (Japan)
@@ -8539,6 +12209,31 @@ game
       content: Character
 
 game
+  sha256: 5cfc1c6d83afd59de8b359e6dbbfc866dc64436dbd46efd336ccc869ef48e2da
+  name:   Hoshi no Kirby - Yume no Izumi no Monogatari (Japan)
+  title:  Hoshi no Kirby - Yume no Izumi no Monogatari (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: 4604ba6e93ae7846f6cb8b2e37a79187e84f3c549f3619670269592c5aaa4612
   name:   Hoshi o Miru Hito (Japan)
   title:  Hoshi o Miru Hito (Japan)
@@ -8579,6 +12274,69 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 0f7e5351ea2b5b8891f1ff561ac8a1c09eb51cdcae752c2501073798e560543a
+  name:   Hunt for Red October, The (Europe)
+  title:  Hunt for Red October, The (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9a5181302b447c6614318802dd01aa3e822b373bf77bcc159a2a3229fbea20ce
+  name:   Hunt for Red October, The (USA)
+  title:  Hunt for Red October, The (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: bafe68d5e6bbebb0d71432d09bed0a482215d4534778a76d471150a3bdd01b08
+  name:   Hunt for Red October, The (USA) (Rev 1)
+  title:  Hunt for Red October, The (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -8987,6 +12745,27 @@ game
       volatile
 
 game
+  sha256: 0101fe2707200edec891b81a1091f7f28a74bcfad27951a35bd280bef0c48021
+  name:   Ike Ike! Nekketsu Hockey-bu - Subette Koronde Dairantou (Japan)
+  title:  Ike Ike! Nekketsu Hockey-bu - Subette Koronde Dairantou (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 3ed673cee9984ec8a9e8ca5d722f9918302eeaf533f79a6177a34359da3f5880
   name:   Ikinari Musician (Japan)
   title:  Ikinari Musician (Japan)
@@ -9054,6 +12833,94 @@ game
       content: Character
 
 game
+  sha256: 7032a94d140339f9d6603accc9fed2846f5bbb781659cdff869d4b5f137d4e4a
+  name:   Image Fight (USA)
+  title:  Image Fight (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 8bc6a252778c2909a97b3fff185c5ff2a1786afe5e8237098f15fe3eaf23adab
+  name:   Immortal, The (USA)
+  title:  Immortal, The (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 8e73489823c229296e122667df8eebe5de1b19d78bc3efeb38d89a269cde11e4
+  name:   Incredible Crash Dummies, The (Europe)
+  title:  Incredible Crash Dummies, The (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: c42fc592821b474b486ae32d1d63e8938f1735a6d45db026f7b78b2ec51427ac
+  name:   Incredible Crash Dummies, The (USA)
+  title:  Incredible Crash Dummies, The (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: b651bc3e55b351e6f14926625ca8c9bd25bf3e8aa5dadca1afad4c29f2b4c42f
   name:   Indiana Jones and the Last Crusade (Europe)
   title:  Indiana Jones and the Last Crusade (Europe)
@@ -9096,6 +12963,69 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 8125d69b66dd7784246156bb669542924f1c2b7f53b8d325ffcbaa74746d14ff
+  name:   Indiana Jones and the Temple of Doom (USA)
+  title:  Indiana Jones and the Temple of Doom (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
+  sha256: 884765e5df86042211191f7e7e4653255425e3da70a9dec6f4a9336c07b5f258
+  name:   Indiana Jones and the Temple of Doom (USA) (Rev 1)
+  title:  Indiana Jones and the Temple of Doom (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
+  sha256: 0bb401bbd0cae2758b2bd355cd3cac3cc26a01950859c830b3b122bd379f2463
+  name:   Infiltrator (USA)
+  title:  Infiltrator (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 0f406a7c853b919ed880868420808b945855146db9817ebc3102f08da13fa703
@@ -9159,6 +13089,48 @@ game
       volatile
 
 game
+  sha256: 401e5d3afb4d623308458e2c6c594fd38faa8cd9e5276d39b4052e996f937216
+  name:   Isolated Warrior (Europe)
+  title:  Isolated Warrior (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 81311ff2507c6522172b203534f91f99749f465c8b765ac584f0e851a8bf96b2
+  name:   Isolated Warrior (USA)
+  title:  Isolated Warrior (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: cc7b41335ca8c0f3fb399e3647d5489effcdf804a5f45509e5f0f684b9edd947
   name:   Ivan 'Ironman' Stewart's Super Off Road (Europe)
   title:  Ivan 'Ironman' Stewart's Super Off Road (Europe)
@@ -9197,6 +13169,56 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 35fa6794c655a23563bd4e265ed55901c42f49a45c1c41ed18511815bcf2301a
+  name:   J.League Fighting Soccer - The King of Ace Strikers (Japan)
+  title:  J.League Fighting Soccer - The King of Ace Strikers (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c1e3ff90951979e708278d5ba285b431e591435c3e660ff5db6096c335bfdb7e
+  name:   J.League Winning Goal (Japan)
+  title:  J.League Winning Goal (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 68fbdb91cb10581396836eba5ba5d5a45b44cd6124e6022e87439d5bf3683908
@@ -9265,6 +13287,69 @@ game
       volatile
 
 game
+  sha256: 129bc703b45625f7fbb9708bf766798551013e7c52c8a246b5705362756e55c2
+  name:   Jackie Chan (Japan)
+  title:  Jackie Chan (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 48d4a3fe3084d24f50a38f2ce44f22a98fef9aa61ba568b089c78c97ed6c2958
+  name:   Jackie Chan's Action Kung Fu (Europe)
+  title:  Jackie Chan's Action Kung Fu (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 628d6696c7ac84c3ae5ab86d04b28b2fd1742076ca9478fdd5708e3bbb9f13c1
+  name:   Jackie Chan's Action Kung Fu (USA)
+  title:  Jackie Chan's Action Kung Fu (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: ea770788f68e4bb089e4205807931d64b83175a0106e7563d0a6d3ebac369991
   name:   Jajamaru Gekimaden - Maboroshi no Kinmajou (Japan)
   title:  Jajamaru Gekimaden - Maboroshi no Kinmajou (Japan)
@@ -9329,6 +13414,48 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: a5930b2ec038de9463ee4f763f35f76e3708bc883c38c4933001d899e4006afa
+  name:   James Bond Jr (Europe)
+  title:  James Bond Jr (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e0d4463066d9985d51f80f8a51b1b9c5945e481ef19df48056d7648337d59095
+  name:   James Bond Jr (USA)
+  title:  James Bond Jr (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -9479,6 +13606,27 @@ game
       volatile
 
 game
+  sha256: 2a796f3a927ff9ad02b784abfabf54c892620edcda4a38163e976f57523f9b73
+  name:   Jetsons, The - Cogswell's Caper (Europe)
+  title:  Jetsons, The - Cogswell's Caper (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: 740de2e292b8ba92ee87c2cac51ccdfa6a2e5bfe230078f3e02fd3f4f83af34d
   name:   Jetsons, The - Cogswell's Caper (Japan)
   title:  Jetsons, The - Cogswell's Caper (Japan)
@@ -9497,6 +13645,48 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: c9a3c9873a859fcbb5b7442b3decfdcab3a1457e028ae444b050a377fc92afa2
+  name:   Jetsons, The - Cogswell's Caper (USA)
+  title:  Jetsons, The - Cogswell's Caper (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 3e63a5b2f749dc8bf07bbdc316df69a83b74ef7056b170a2b3ddd17a29299f15
+  name:   Jigoku Gokuraku Maru (Japan)
+  title:  Jigoku Gokuraku Maru (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -9587,6 +13777,48 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 509f04b745d11b8d83afb42f084179a6f2ebc87f647927432a647f0e7ee51bb5
+  name:   Joe & Mac (USA)
+  title:  Joe & Mac (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b4e846b4bfc4b16d9ed060c306be7fef2635d0a6a1383154c9d3c1252e6e325c
+  name:   Joe & Mac - Caveman Ninja (Europe)
+  title:  Joe & Mac - Caveman Ninja (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 8d21e1e256f82579704d28041ac33e06e48b0defbadc5e8790ea98c41732920c
@@ -9696,6 +13928,207 @@ game
       content: Character
 
 game
+  sha256: f9a27ccbde3f382e3cd8d90d34383429407d1d257ce5fd403f6f887225a37db2
+  name:   Joy Mech Fight (Japan)
+  title:  Joy Mech Fight (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 6d01dabdbcfe136bf63a265d154532223792cefe795cc043a30b03cb61d54e2c
+  name:   JuJu Densetsu (Japan)
+  title:  JuJu Densetsu (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: a48913e95ad8164f1d1e5e74ac6dd464d89a1f966e79bcbb2d20afbeb81dc5e3
+  name:   Jumpin' Kid - Jack to Mame no Ki Monogatari (Japan)
+  title:  Jumpin' Kid - Jack to Mame no Ki Monogatari (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e440fd2a007e33d8e62e0fdd8630375262e5ed697aa46de491aa3a5d4a6e3b33
+  name:   Jungle Book, The (Europe)
+  title:  Jungle Book, The (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e5bcb8838f567f485c6f872e9695d2e3ef676f4bcda1c32d51d56008efb96e7a
+  name:   Jungle Book, The (USA)
+  title:  Jungle Book, The (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 2a5a74615e8746ae4af86f29a5d9e36a5be663a9d0d57377e709e3a38709fe14
+  name:   Jurassic Park (Europe)
+  title:  Jurassic Park (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 49fe0c49cd0a2841ae9c8ae5aa19f710d187ee6931a1e531d3bff19772ca4af0
+  name:   Jurassic Park (USA)
+  title:  Jurassic Park (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 5c93122c03f9b3aac24ff491f6ece110a5d3536e14e42ab31b6a3197de211391
+  name:   Juuouki (Japan)
+  title:  Juuouki (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4232dc535467b513a3c7a5e6feaf4d8209e48ca8bf377631f0917d4fa930df13
+  name:   Juuryoku Soukou Metal Storm (Japan)
+  title:  Juuryoku Soukou Metal Storm (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: 670d4bb81befa1957b47a712d0234dd5169ee03a41b0700b28615a73ef211ce3
   name:   Juvei Quest (Japan)
   title:  Juvei Quest (Japan)
@@ -9746,6 +14179,48 @@ game
       content: Character
 
 game
+  sha256: 0512f45807021062d84d88c051c7a52432ee4140abc46acea61ddfb1b2c83025
+  name:   Kabuki - Quantum Fighter (Europe)
+  title:  Kabuki - Quantum Fighter (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 2ae0a99b457a6d00ff0b241aa08f98d40c5c5ed45e634a7ed934b386bbd17a12
+  name:   Kabuki - Quantum Fighter (USA)
+  title:  Kabuki - Quantum Fighter (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 722035257431bbc43bbc612ccf36f5c8346c4f7073b298dcf6d46d95866f860a
   name:   Kage no Densetsu (Japan)
   title:  Kage no Densetsu (Japan)
@@ -9764,6 +14239,31 @@ game
     memory
       type: ROM
       size: 0x4000
+      content: Character
+
+game
+  sha256: 300cc2d78f74aca0262e64c85b2774345619603f4d86e4bad53c9d712be5e940
+  name:   Kagerou Densetsu (Japan)
+  title:  Kagerou Densetsu (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -9917,6 +14417,31 @@ game
       content: Character
 
 game
+  sha256: 1cb2dd4589233bc9a43b2799d99fab3d25f1f627f5ab7d350a71eb943fd4b61f
+  name:   Kamen Rider SD - Granshocker no Yabou (Japan)
+  title:  Kamen Rider SD - Granshocker no Yabou (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 683514860ec52aaab636ffcdef33c442270c85000190dfd4956cfb8f224ea7a3
   name:   Kanshakudama Nage Kantarou no Toukaidou Gojuusan Tsugi (Japan)
   title:  Kanshakudama Nage Kantarou no Toukaidou Gojuusan Tsugi (Japan)
@@ -9935,6 +14460,31 @@ game
     memory
       type: ROM
       size: 0x4000
+      content: Character
+
+game
+  sha256: 3f2285471f1ea078002e31cd55f6092f679b3a7cc86dccb1326883501f4f0289
+  name:   Karakuri Kengou Den Musashi Lord - Karakuribito Hashiru (Japan)
+  title:  Karakuri Kengou Den Musashi Lord - Karakuribito Hashiru (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -10159,6 +14709,48 @@ game
       content: Character
 
 game
+  sha256: 5e0be3637c32515abc5a2913551e5a5ace5b7d9f39f0a2e7ec09dee6dcd6f362
+  name:   Kawa no Nushi Tsuri (Japan)
+  title:  Kawa no Nushi Tsuri (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 735f1fbd5cffcf89403eeb36b5e65b5554d73e7451b5698298f4b58bda4971b2
+  name:   Keiba Simulation - Honmei (Japan)
+  title:  Keiba Simulation - Honmei (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 7a406a58cf781b9ceb87f4266dca812a271bfe1f42aa392864e8bc404b2575e1
   name:   Kekkyoku Nankyoku Daibouken (Japan)
   title:  Kekkyoku Nankyoku Daibouken (Japan)
@@ -10265,6 +14857,94 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 07f95dc4c71df089ef8b3ec3785720626e95871ff39b380c8a7eda6dea065edf
+  name:   Kickle Cubicle (Europe)
+  title:  Kickle Cubicle (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4a9544bb41869e88ec0610a799b5ce9c7d89bf9a48198923ea7ba22f385ea349
+  name:   Kickle Cubicle (USA)
+  title:  Kickle Cubicle (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 23bf669afb3125d72f352848628e201607b4cece974cce86f2558a1812056ece
+  name:   KickMaster (USA)
+  title:  KickMaster (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a11eec5762a029c95a5d496c0671b73e663225be50a5b1e89f16f380637b6665
+  name:   Kid Klown in Night Mayor World (USA)
+  title:  Kid Klown in Night Mayor World (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: f85a689b4ff7a5e51703e5fabc73ca1af43e6519754c4a59c11a960baa323b47
@@ -10440,6 +15120,31 @@ game
       content: Character
 
 game
+  sha256: 997ddca52ac724481ad5daafbc4e61547a541d673214eac579a8de746b26978d
+  name:   King's Quest V (USA)
+  title:  King's Quest V (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: 913c5eb7d4390d0f797da95cdebd45cdb0f349ddf4cffa29d471a7f462c25717
   name:   Kings of the Beach - Professional Beach Volleyball (USA)
   title:  Kings of the Beach - Professional Beach Volleyball (USA)
@@ -10503,6 +15208,177 @@ game
       content: Character
 
 game
+  sha256: 24fca0fe86464c807ab5d58a2d56155a3fa1994e9bd78d119e3f8f84c8aee785
+  name:   Kirby's Adventure (Canada)
+  title:  Kirby's Adventure (Canada)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: c6f3d15f8c9b60aff995e7e2559db82a5659a3fc9cf9cb6aa9da0e695e5030f3
+  name:   Kirby's Adventure (Europe)
+  title:  Kirby's Adventure (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: b9124d9991574d190b8661f11140c5ce319ba050d26609fcf4c0f6349f7602bf
+  name:   Kirby's Adventure (France)
+  title:  Kirby's Adventure (France)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: e57cded0299931b2e2b6dca0be1f251d0f66c7566a49c38a426085afaa175d68
+  name:   Kirby's Adventure (Germany)
+  title:  Kirby's Adventure (Germany)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: a6b81fec11c24a33fd763db5c28005e760a1614e70c1bb5ccde0bd4242431000
+  name:   Kirby's Adventure (USA)
+  title:  Kirby's Adventure (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 1250a80faf865aa5ee5585ad7639e5ef2b3fa541554effda5fad2cc5dc2acef5
+  name:   Kirby's Adventure (USA) (Rev 1)
+  title:  Kirby's Adventure (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 9caa01a2b81ce1f98b17520aee09d415da7192382c1e47316998b6c1be6168eb
+  name:   Kiwi Kraze - A Bird-Brained Adventure! (USA)
+  title:  Kiwi Kraze - A Bird-Brained Adventure! (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: ef63df6bcbc7e13dace53f106a247485a09409799b99c8415e934ba532cdaa53
   name:   KlashBall (USA)
   title:  KlashBall (USA)
@@ -10523,6 +15399,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 4d88be60082c66213c0f32c91aaa6588d87225a15c708916de74fa5ee9b205e2
+  name:   Klax (Japan)
+  title:  Klax (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
 
 game
   sha256: 50b667f84cae86afb67dae6f63c16faf7df9e5cbeeb7626aa5c2e961d7fb3f3f
@@ -10564,6 +15461,94 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4f6245828d6140c2e5c4748873b5049879fb54136d4744af3f9988eaaed2d4b1
+  name:   Kouryuu Densetsu Villgust Gaiden (Japan)
+  title:  Kouryuu Densetsu Villgust Gaiden (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: e5673075301b0c84137d24aff0ffbfa0565d33c960968d9843d7bc57f1107417
+  name:   Krion Conquest, The (USA)
+  title:  Krion Conquest, The (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d026272c9235c687938da38c7039e63c068d1c1f6ae3c3f9a3907e4377e63db3
+  name:   Krusty's Fun House (Europe)
+  title:  Krusty's Fun House (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 5f981ab1988614a96fd029c6fe3f103465dbf3219265bd8274bf8cd537adee34
+  name:   Krusty's Fun House (USA)
+  title:  Krusty's Fun House (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
       content: Program
     memory
       type: ROM
@@ -10634,6 +15619,52 @@ game
       content: Character
 
 game
+  sha256: 25a072266db7fac3898cea51bfbd2659da4d2929a36d9480f07a3a360d0fa8ae
+  name:   Kunio-kun no Nekketsu Soccer League (Japan)
+  title:  Kunio-kun no Nekketsu Soccer League (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ed382f0b60a194ca7fc0aea8fc0a14109f4958a03cf7e1164be99019d2fff6c6
+  name:   Kurogane Hiroshi no Yosou Daisuki! - Kachiuma Densetsu (Japan)
+  title:  Kurogane Hiroshi no Yosou Daisuki! - Kachiuma Densetsu (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 3b3419873ea0d53d6fd18ed9b58c4c77fc111e2971ed7f3715bd114dc6d24d84
   name:   Kyonshiizu 2 (Japan)
   title:  Kyonshiizu 2 (Japan)
@@ -10681,6 +15712,27 @@ game
       volatile
 
 game
+  sha256: dfb2b494064be60370b825126a85dd934144de7152140ca816f80a8d04447d36
+  name:   Kyoto Hana no Misshitsu Satsujin Jiken (Japan)
+  title:  Kyoto Hana no Misshitsu Satsujin Jiken (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: b0e11b917f5c604e8a6ad5a196a40219e5b19b484c8972e3255c81c4df4bda31
   name:   Kyoto Ryuu no Tera Satsujin Jiken (Japan)
   title:  Kyoto Ryuu no Tera Satsujin Jiken (Japan)
@@ -10700,6 +15752,27 @@ game
       type: RAM
       size: 0x80
       content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: f370f2d35cec2bd02cc464eddf5612eb3f000295bfa486da383e3a67c1eaf33b
+  name:   Kyouryuu Sentai Zyuranger (Japan)
+  title:  Kyouryuu Sentai Zyuranger (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
     memory
       type: ROM
       size: 0x20000
@@ -10831,6 +15904,31 @@ game
       content: Character
 
 game
+  sha256: bdf281bfce0cb073f7c8b58cf05b264c6e233f366e3ef84aaedce979f1e6eb7f
+  name:   Kyuukyoku Tiger (Japan)
+  title:  Kyuukyoku Tiger (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 22345c87243f70b06caceee575dd95cfb026a61bc24f6e0dc8cc9dd93bc961fd
   name:   Labyrinth (Japan)
   title:  Labyrinth (Japan)
@@ -10904,6 +16002,74 @@ game
       content: Character
 
 game
+  sha256: f4b7d8d31c5bbfee69c117332fa3878d04dc3b6e693d1a343d3ef2f20b10a85e
+  name:   Last Action Hero (USA)
+  title:  Last Action Hero (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 333d9de968973202f641714d746012237dc9d65fb592aac10c6146ed1f2fdaeb
+  name:   Last Armageddon (Japan)
+  title:  Last Armageddon (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: f15382be46e474c596566c5a726ae39dadfa18289722bac2da44b6493bbabfec
+  name:   Last Ninja, The (USA)
+  title:  Last Ninja, The (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 54dd62754f48e39af39c3e8d645897af25aaba31523267bc41d4c95f2b0348d5
   name:   Last Starfighter, The (USA)
   title:  Last Starfighter, The (USA)
@@ -10969,6 +16135,27 @@ game
       volatile
 
 game
+  sha256: 203dc9486ba58e65f9a4289da476dc15ff34d6fd39d355b438ae4db2d182746d
+  name:   Legacy of the Wizard (USA)
+  title:  Legacy of the Wizard (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
   sha256: 9d83796d8feba9713fa5a1354fd9253cda5cb33ab5bc6f1c6f97d5eb90aef6c3
   name:   Legend of Kage, The (USA)
   title:  Legend of Kage, The (USA)
@@ -11010,6 +16197,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 3b5627bc1ebaa7a84953d7337c7684a93beaf973f4a8b3a42b513dc1e0ab0a09
+  name:   Legends of the Diamond - The Baseball Championship Game (USA)
+  title:  Legends of the Diamond - The Baseball Championship Game (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
 
 game
   sha256: dbd530e6ca07cc4b255b1b885cd5b6b2e23b8d3cac4733c3e4d96acd7d751c28
@@ -11098,6 +16306,31 @@ game
       volatile
 
 game
+  sha256: 37095b3fad194709095a7827ddc4547b5762f0ef9fc50d9368660b1d6a3f6b64
+  name:   Little Magic (Japan)
+  title:  Little Magic (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 24d0cb797720cdcaf8b7438b67a84b44aa3fa8faa6ad5138ed64533ae7f68c63
   name:   Little Mermaid - Ningyo Hime (Japan)
   title:  Little Mermaid - Ningyo Hime (Japan)
@@ -11142,6 +16375,132 @@ game
       volatile
 
 game
+  sha256: 8fdfdeb9e0958734261bf2ed4dd483873bf11b211c71a7bc198ea06dd27a2dbf
+  name:   Little Nemo - The Dream Master (Europe)
+  title:  Little Nemo - The Dream Master (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e95d3557fa60bacabe7a0b65277cdf2f084b6f58b55784d3d631ab030def0a91
+  name:   Little Nemo - The Dream Master (USA)
+  title:  Little Nemo - The Dream Master (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9f393e5fdae7003663d96a7c9bbc7fbec7b18be690f062ffa614077103f40381
+  name:   Little Ninja Brothers (Europe)
+  title:  Little Ninja Brothers (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 50badb618accf0ca28966c05ca4ff159aa9afa2fccd7f0354b8eff6af105a8f0
+  name:   Little Ninja Brothers (USA)
+  title:  Little Ninja Brothers (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a38af0ce7fa9f83683b3db554cb6e19aaedd0a7794784b5678552738075a2541
+  name:   Little Samson (Europe)
+  title:  Little Samson (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a5165565263eaf8bdc45a8e6a615704f9bf271cd6d547d22c098c80cbaffd879
+  name:   Little Samson (USA)
+  title:  Little Samson (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 5d65bc6799a147486a35299ddd07060a7c858111f0219a503586e4435a43214d
   name:   Lode Runner (Japan)
   title:  Lode Runner (Japan)
@@ -11181,6 +16540,27 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: 622ef597b328a204fafcef55c9aef0de08489a43898a6c9adaa9d39971e06f69
+  name:   Lone Ranger, The (USA)
+  title:  Lone Ranger, The (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -11270,6 +16650,48 @@ game
       content: Character
 
 game
+  sha256: be51feb0883f8f5f3be34c8ee05737ac72c484680ee8d6f37c3a99e5b89d0fce
+  name:   Low G Man - The Low Gravity Man (Europe)
+  title:  Low G Man - The Low Gravity Man (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4fb6c5c8359dcbabcb4d05cf36192c790e68a509ef8666c20ebdb81541df3243
+  name:   Low G Man - The Low Gravity Man (USA)
+  title:  Low G Man - The Low Gravity Man (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 7f23e026858c726a0c11c3880cc2e467f5ea1022e237e55265341839bbd577dc
   name:   Lunar Ball (Japan)
   title:  Lunar Ball (Japan)
@@ -11353,6 +16775,31 @@ game
     memory
       type: ROM
       size: 0x10000
+      content: Character
+
+game
+  sha256: 52812b55986f96fa77eb24a76e795dc8d79977eec7488c7b5b84ac3b47d60366
+  name:   M.C. Kids (USA)
+  title:  M.C. Kids (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -11440,6 +16887,27 @@ game
       content: Character
 
 game
+  sha256: 80757aa85fe4001123cb839db0fc72fc7e06020ecba5c89abb049b8490fd3d0b
+  name:   Mad Max (USA)
+  title:  Mad Max (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: dc541137d79000fe3e0bdf5ce35b687a5b137c3a09160c5742599b4ff257cfae
   name:   Madoola no Tsubasa (Japan)
   title:  Madoola no Tsubasa (Japan)
@@ -11461,6 +16929,52 @@ game
       content: Character
 
 game
+  sha256: ab0a43bc7c33f0cdd8acf15c4da967ba2af56431de1a598b9767bd10e78cc8fa
+  name:   Mafat Conspiracy, The (USA)
+  title:  Mafat Conspiracy, The (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 7ce82a63388c1fdb7e8fff5b10afffbb7a072ab34e055d30150b27621fb589fb
+  name:   Magic Candle, The (Japan)
+  title:  Magic Candle, The (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 497c3015516cb6ae2f20d70b8fb1b70b8c4cfcd64e118992c438cfe7b0579f2b
   name:   Magic John (Japan)
   title:  Magic John (Japan)
@@ -11468,6 +16982,27 @@ game
   board:  JALECO-JF-24A
     chip
       type: SS88006
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: bb0dffa73425857126a4c701cd1f340428c180d7b6368a2834032bb3c620e627
+  name:   Magical Kid's Doropie (Japan)
+  title:  Magical Kid's Doropie (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
     memory
       type: ROM
       size: 0x10
@@ -11555,6 +17090,31 @@ game
       type: EEPROM
       size: 0x80
       content: Save
+
+game
+  sha256: caae56599689d4297c3be1afdc77d5bfc510d47d6e668244c308b9732eb41dea
+  name:   Magician (USA)
+  title:  Magician (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 25772946d05c3994103894ffd94d8a51cba18aa16bb01a2ddc1c09eee3bddd59
@@ -11704,6 +17264,57 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: 2a17952d972be7b36f2ffea47c1a53ca9ae0e48d5cfbe75979b2d237209b607f
+  name:   Mahjong Club Nagatachou - Sousaisen (Japan)
+  title:  Mahjong Club Nagatachou - Sousaisen (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 591ee64715eeee17d35a6c4444cfe303ba140958e191287586a79bd26066e536
+  name:   Mahjong Taisen (Japan)
+  title:  Mahjong Taisen (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -11901,6 +17512,27 @@ game
       content: Character
 
 game
+  sha256: 7d07d335a873205964299b2735c14fe06170329523341a651f275cdf3ed96f18
+  name:   Mappy-Land (USA)
+  title:  Mappy-Land (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 1be87ef4b1b6520b57bf91ea3f3b64d813a73b1f28e76df75994a964727eac62
   name:   Marble Madness (Europe)
   title:  Marble Madness (Europe)
@@ -11983,6 +17615,69 @@ game
       content: Character
 
 game
+  sha256: a4a98df2dbc6030774c9e80b3c5063c8bc84752501f4bac8ab408e887a40c5c7
+  name:   Mario is Missing! (Europe)
+  title:  Mario is Missing! (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9babea1d40007f936e3d4e1450ec7e7bfe5aff71162ffdf7ede3acae8d811962
+  name:   Mario is Missing! (USA)
+  title:  Mario is Missing! (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c9348c4e30ef0bc62c4fd119b5e38d85af493a1eb436c6c229b7a6a52af42681
+  name:   Mario's Time Machine (USA)
+  title:  Mario's Time Machine (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 4ac0926d1e4704e75e7dfc27c4d990ebdbe685002b9af1a80a385604f3cb162c
   name:   Mashou (Japan)
   title:  Mashou (Japan)
@@ -12003,6 +17698,120 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 3e30584ccff1f5d5aa55d6969925a84fa56ba9d9b8906c8920447d84772c9a0e
+  name:   Masuzoe Youichi - Asa Made Famicom (Japan)
+  title:  Masuzoe Youichi - Asa Made Famicom (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: f0f3ecc070e03bd61ebabc5de270dfc69d7bfd81b21acf0a251724059086fd52
+  name:   Matendouji (Japan)
+  title:  Matendouji (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: edd5299a1ac411c9cbbe12b3513a5f5f5621109960ca2630099c18b2b589ef89
+  name:   Max Warrior - Wakusei Kaigenrei (Japan)
+  title:  Max Warrior - Wakusei Kaigenrei (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9945da48be210eafe77464b0646c14b432248be551400a199a31f24289583e97
+  name:   McDonaldland (Europe)
+  title:  McDonaldland (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 579cdc9d8445105c327dbf4997074a8862c19f144be1d9fdf4b10e395a636857
+  name:   McDonaldland (France)
+  title:  McDonaldland (France)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: c8e7036e8afcd95acaf3a5e0956df53beaab127a7defcc0e80d629653ff67c23
@@ -12041,6 +17850,199 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: d50a9750fb8fc75c96834303c3449e871773d7b4959b48e59aac51bf554ff4b7
+  name:   Mega Man 3 (Europe)
+  title:  Mega Man 3 (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: f13146a0daa7f34847f9595d6c9ede78b93bb91ec1b71f3576927bd3f747b6c8
+  name:   Mega Man 3 (Europe) (Rev 1)
+  title:  Mega Man 3 (Europe) (Rev 1)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 5b85c1ff632c6ac34742ac87b9c8ddee9a13827caf1212ecfa1d11f1f9dece50
+  name:   Mega Man 3 (USA)
+  title:  Mega Man 3 (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: f95e08ec3f4eb3feca02923c6a2fbffbb3ffe7986c20817a2906dc68e632eab6
+  name:   Mega Man 4 (Europe)
+  title:  Mega Man 4 (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: a1fda74d03a9dd0c168b1ecae66803d78723cf7ccd85a482dedf017b97e660e8
+  name:   Mega Man 4 (USA)
+  title:  Mega Man 4 (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: ed8bc89c9cd44bf566666451779d7db2da3d9c211ff2a4824372c172b554e05b
+  name:   Mega Man 4 (USA) (Rev 1)
+  title:  Mega Man 4 (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 355a2c8fa31b39d729c395605ebacbf345f0adfea9d95d150eea3193accaf1c0
+  name:   Mega Man 5 (Europe)
+  title:  Mega Man 5 (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 4ddb728c3a007f1aa7184b60a1355cfd376cae46edc007fd48e6bcf41207cdb7
+  name:   Mega Man 5 (USA)
+  title:  Mega Man 5 (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 2037babe50fed7a13b6f6559914cb81497245c9477592e6f8da183df09a3609a
+  name:   Mega Man 6 (USA)
+  title:  Mega Man 6 (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
       content: Program
     memory
       type: RAM
@@ -12098,6 +18100,52 @@ game
   board:  BANDAI-FCG
     chip
       type: FCG
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: eb59ed12f797fbdf8916a18c8686cbeb619efba40382c39b963b6c136d237666
+  name:   Meimon! Takonishi Ouendan - Kouha 6 Nin Shuu (Japan)
+  title:  Meimon! Takonishi Ouendan - Kouha 6 Nin Shuu (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 1152961edf8d484f0e33294ae19fbcac8ab85099e6c8a59f1732c5f17b622885
+  name:   Mendel Palace (USA)
+  title:  Mendel Palace (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
     memory
       type: ROM
       size: 0x10
@@ -12178,6 +18226,52 @@ game
       volatile
 
 game
+  sha256: 96beeccaf00865a15a19bd32e0d849fd6a5ee7dfc565329809a598d35bdfdbd4
+  name:   Metal Max (Japan)
+  title:  Metal Max (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 2fbbc465fc239b483cb89582f75451b21276d97868d67f3d8d89c2269fec5e37
+  name:   Metal Storm (USA)
+  title:  Metal Storm (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: fa44773e3c2f1a435cbe7a8e098508b92cd79ba88c71f798b76c08aa0e257316
   name:   Metro-Cross (Japan)
   title:  Metro-Cross (Japan)
@@ -12226,6 +18320,27 @@ game
       content: Character
 
 game
+  sha256: 77c9100f4d3f291dd751098d3291b14e824cc367696c9167d01051041e08b5cb
+  name:   Michael Andretti's World GP (USA)
+  title:  Michael Andretti's World GP (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: eb58ea4856030ae44d404439a04a452c10e647d0bf626ecdcd8497ba900dfae7
   name:   Mickey Mouse - Fushigi no Kuni no Daibouken (Japan)
   title:  Mickey Mouse - Fushigi no Kuni no Daibouken (Japan)
@@ -12247,6 +18362,31 @@ game
       content: Character
 
 game
+  sha256: 826ace604eb7a657acedd98cd3479dbe1d3ebb087dd7a1b2ad299ab854c0d519
+  name:   Mickey Mouse III - Yume Fuusen (Japan)
+  title:  Mickey Mouse III - Yume Fuusen (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 989243c99d6e58c4fbcc6999473e48a389eba22cf1d3cb95dbe4c8b1f3ce15d7
   name:   Mickey Mousecapade (USA)
   title:  Mickey Mousecapade (USA)
@@ -12265,6 +18405,98 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: d3b0627673e6dea5c52c80a14238f2fdc6f48ff63e7a86372649c5f021151bd5
+  name:   Mickey's Adventure in Numberland (USA)
+  title:  Mickey's Adventure in Numberland (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e958d5556bdcc8731fe5efe65052de4c13f7a7899ac2996b9cadef0ec24e6c81
+  name:   Mickey's Safari in Letterland (USA)
+  title:  Mickey's Safari in Letterland (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c0dea150d9f391278f00870af8cedebc6030db9709821055cfde27c84358a038
+  name:   Might & Magic - Secret of the Inner Sanctum (USA)
+  title:  Might & Magic - Secret of the Inner Sanctum (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 25ab4da521e6933832a21270c66e5396819f1d9f30cd4aa3cde9df27b3b9758d
+  name:   Might and Magic - Book One - Secret of the Inner Sanctum (Japan)
+  title:  Might and Magic - Book One - Secret of the Inner Sanctum (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
       content: Character
 
 game
@@ -12355,6 +18587,69 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 8e7525b427b26af1c9d19b14ea20c311d8c592ffde292e204879ddba6cbbc89d
+  name:   Mighty Final Fight (Europe)
+  title:  Mighty Final Fight (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 1935d08e1dce06f5dfc6d2f4ddb78d7c2d7e7a30f11080ba711ce753ed1c8d78
+  name:   Mighty Final Fight (Japan)
+  title:  Mighty Final Fight (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ef8ccb38760604f5122e034ae0c4591362364632fe2dc2fa10f2660e15bd368f
+  name:   Mighty Final Fight (USA)
+  title:  Mighty Final Fight (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -12640,6 +18935,69 @@ game
       content: Character
 
 game
+  sha256: 2dfcedb69f92f56eaa4f6409688f85240033e8b7f2b67d39694a5dcfa967aa53
+  name:   Mission - Impossible (Europe)
+  title:  Mission - Impossible (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c6c2d8997d8dcb36085484a74b44c83ada5107d5e60ffd2f782b53470a8dff66
+  name:   Mission - Impossible (France)
+  title:  Mission - Impossible (France)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 6b04b87ab30e885974844ad693cc39ba8c87e7e650e1f9cf22a054e0a385df4e
+  name:   Mission - Impossible (USA)
+  title:  Mission - Impossible (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 3d510de6ca2e4445da5f5d33ae6ed6e5e552953d5852d365ab7a7a2d6bd1c589
   name:   Mississippi Satsujin Jiken (Japan)
   title:  Mississippi Satsujin Jiken (Japan)
@@ -12687,6 +19045,27 @@ game
   title:  Mito Koumon - Sekai Manyuu Ki (Japan)
   region: NTSC-J
   board:  SUNSOFT-3
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 0bd6257a4566c57c582421bfbf8e81a5491a94e13f4e7a9378c3332c70884532
+  name:   Mitsume ga Tooru (Japan)
+  title:  Mitsume ga Tooru (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
     memory
       type: ROM
       size: 0x10
@@ -12997,6 +19376,32 @@ game
       volatile
 
 game
+  sha256: 70d7f12da456528ace91efcf13b4f83696d6508a1f37e7727a52b1abd727db53
+  name:   Momotarou Densetsu Gaiden (Japan)
+  title:  Momotarou Densetsu Gaiden (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: f2aef1a9ade54330ff821083fda7e03c7a5f93d77f4da359069d84f98ab1f852
   name:   Money Game, The (Japan)
   title:  Money Game, The (Japan)
@@ -13022,6 +19427,48 @@ game
       content: Character
 
 game
+  sha256: 38c3225b6b37292b1869743ecb5859e21c7cac8feca14fea5462b93782304088
+  name:   Monster in My Pocket (Europe)
+  title:  Monster in My Pocket (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 08615e9e339bd2df713cdb15f6426895ba643fbd8f383758f7f5c06ebf7ac10b
+  name:   Monster in My Pocket (USA)
+  title:  Monster in My Pocket (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 9f04b8e867aa85692d6985761b3a04d8cfe714854c8d95dd327c854cc2073279
   name:   Monster Truck Rally (USA)
   title:  Monster Truck Rally (USA)
@@ -13040,6 +19487,52 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: ce493dcb4ba133d9a31e234a4c446a365bcf98c5f99c13968f1e1c777747ac29
+  name:   Moon Crystal (Japan)
+  title:  Moon Crystal (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: aa0fe1b0b1e0c3a0a01695f1914fbb5e92649db33b74a9bdcb51be1481221f49
+  name:   Mother (Japan)
+  title:  Mother (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -13157,6 +19650,27 @@ game
       volatile
 
 game
+  sha256: 3ab2b17abf9502cc04c8f150a55154db9acf7f26d3d98dfc8e2575d8e84be682
+  name:   Murder Club - Honkaku Mystery Adventure (Japan)
+  title:  Murder Club - Honkaku Mystery Adventure (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 75f9462a27848319be7461e39c6df990ede740f28317299add964508cc48c14d
   name:   Musashi no Ken - Tadaima Shugyou Chuu (Japan)
   title:  Musashi no Ken - Tadaima Shugyou Chuu (Japan)
@@ -13175,6 +19689,31 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 64f88455de17afc1b8efc63abe496700dd49132458d35ea335e99349b2c0e1da
+  name:   My Life My Love - Boku no Yume - Watashi no Negai (Japan)
+  title:  My Life My Love - Boku no Yume - Watashi no Negai (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
       content: Character
 
 game
@@ -13217,6 +19756,73 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 3b238b68680d94870a12c39c0c6fdc7b6a8df29dc768dbc9447daa163c98bcbb
+  name:   Nakajima Satoru - F-1 Hero (Japan)
+  title:  Nakajima Satoru - F-1 Hero (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 694c4d25335c5ca038e2eb2df1419f49c5753906c0e88fbae3adb0f421206ae9
+  name:   Nakajima Satoru Kanshuu - F-1 Hero 2 (Japan)
+  title:  Nakajima Satoru Kanshuu - F-1 Hero 2 (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3b78e734e7d4de182c7b4c79b52374831e7d69f24994f03a23ea1670e2ea662f
+  name:   Nakayoshi to Issho (Japan)
+  title:  Nakayoshi to Issho (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
       content: Character
 
 game
@@ -13451,6 +20057,27 @@ game
       volatile
 
 game
+  sha256: 3c419e3ecf328c03364afbcf5bd15bf0029a525db9e8f74379ae1cce4062b3c3
+  name:   Nekketsu Kakutou Densetsu (Japan)
+  title:  Nekketsu Kakutou Densetsu (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 4ab6b5f4d6ce39fff0ef5a3d89e0884f44491fbd7d9028bd1f02a266c2698197
   name:   Nekketsu Kouha Kunio-kun (Japan)
   title:  Nekketsu Kouha Kunio-kun (Japan)
@@ -13473,11 +20100,95 @@ game
       volatile
 
 game
+  sha256: 558897a4e2083b95bd77d230e1f2cf932800a01b0ba246f1d84c3aa64b236f21
+  name:   Nekketsu Koukou Dodgeball-bu - Soccer Hen (Japan)
+  title:  Nekketsu Koukou Dodgeball-bu - Soccer Hen (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c6bf12acde78d03efde7a1335b217c6895b112e5785951267d49ed2c00fd5307
+  name:   Nekketsu! Street Basket - Ganbare Dunk Heroes (Japan)
+  title:  Nekketsu! Street Basket - Ganbare Dunk Heroes (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 4b382baa70cbc52977fd766f49a3c7c9a3239f0d9581cd961b8b26700c53247d
   name:   NES Play Action Football (USA)
   title:  NES Play Action Football (USA)
   region: NTSC-U
   board:  HVC-TLSROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ee09897e76e4d3418d5e757135a9e7df1e9a6b30fb558fcce8906b827a81d31b
+  name:   New York Nyankies (Japan)
+  title:  New York Nyankies (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 996986c13ac4fbf561664f5ae57bbf1b9a76ab6d046b5c0cc139652c4f683a88
+  name:   NewZealand Story, The (Europe)
+  title:  NewZealand Story, The (Europe)
+  region: PAL
+  board:  HVC-TLROM
     chip
       type: MMC3B
     memory
@@ -13516,6 +20227,31 @@ game
       volatile
 
 game
+  sha256: 31fcb3e03ebb208e4fe3421342ec1e04216a22539fe6d6c29fc6124f4673e499
+  name:   Nichibutsu Mahjong III - Mahjong G Men (Japan)
+  title:  Nichibutsu Mahjong III - Mahjong G Men (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 58be6a811ee3370882160115253b610581e8b4af7228669eb3fbd56e7a13117c
   name:   Nightmare on Elm Street, A (USA)
   title:  Nightmare on Elm Street, A (USA)
@@ -13534,6 +20270,138 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 02caaf66cc43a4c5a8d54252fca7bcb929dad91c71f127eabe37f29ef9199105
+  name:   Nightshade (USA)
+  title:  Nightshade (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 590e508b47eb6d6c0088dffd83fe2436edd0d75e74faba7a9da2008770fb1986
+  name:   Niji no Silk Road (Japan)
+  title:  Niji no Silk Road (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b1c2ae757c5ec76f488893f130f0f7f1aacf36a25467b9012ca3a11ab52204ce
+  name:   Ninja Crusaders (USA)
+  title:  Ninja Crusaders (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 824d9e981c27ceaa684c08b12991db67212f241e9f90516279b8ed031af744c1
+  name:   Ninja Crusaders - Ryuuga (Japan)
+  title:  Ninja Crusaders - Ryuuga (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 21c51dc47a458a7de66544533d56eb9a69de0190d012b1645699e816d2cb5008
+  name:   Ninja Gaiden II - The Dark Sword of Chaos (USA)
+  title:  Ninja Gaiden II - The Dark Sword of Chaos (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ba5968f14a02f1adf8a6144fcf9c4acde80bce8a3e01bae54b555f258540dd4b
+  name:   Ninja Gaiden III - The Ancient Ship of Doom (USA)
+  title:  Ninja Gaiden III - The Ancient Ship of Doom (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 9150e08b57839fe6a82e4397463968bfb251214ea78f095f67e277e58c1f1203
@@ -13620,6 +20488,48 @@ game
       content: Character
 
 game
+  sha256: 7f049259c061b81607ab7271f72d930bc679f45cb80a97187de90dae6c56f40a
+  name:   Ninja Ryuuken Den II - Ankoku no Jashin Ken (Japan)
+  title:  Ninja Ryuuken Den II - Ankoku no Jashin Ken (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: eee5b3ecddf478cb2cf2a539e42d92ff584948234c431db77e5d0ad250fc50cd
+  name:   Ninja Ryuuken Den III - Yomi no Hakobune (Japan)
+  title:  Ninja Ryuuken Den III - Yomi no Hakobune (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 80ad15c09c9794f52f1f35ea9bccddcdfdedaba56edc78bc1e7e0c3ef093c3a0
   name:   Ninja-kun - Ashura no Shou (Japan)
   title:  Ninja-kun - Ashura no Shou (Japan)
@@ -13684,6 +20594,111 @@ game
       content: Character
 
 game
+  sha256: 747481f0854295542936fa29f9c520033b2da8608c680202d36fff4badb681a0
+  name:   Nintendo World Cup (Europe)
+  title:  Nintendo World Cup (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 5e2f8f838edfba925973ddbdc9f4b70050bd132efcb62e173021c63de14fee5d
+  name:   Nintendo World Cup (Europe) (Rev 1)
+  title:  Nintendo World Cup (Europe) (Rev 1)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 40772bc90ce8b60494de60f76dbb53a4b094281eb2a30773644c491718a10dda
+  name:   Nintendo World Cup (Europe) (Rev 2)
+  title:  Nintendo World Cup (Europe) (Rev 2)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b0e4d88db0b21db4a84e3c21d51898c686e9031dc138b2939877ecad20dd2350
+  name:   Nintendo World Cup (USA)
+  title:  Nintendo World Cup (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: bdc810a7fc8fcce3b463024d64baea4bb9ec0b98fd63790277d854b36745f198
+  name:   Nintendo World Cup (USA) (Rev 1)
+  title:  Nintendo World Cup (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 98433ab0b15d19d23c544c2237988abf4a489914e63e18efc28fe2d92ae8c84a
   name:   Nishimura Kyoutarou Mystery - Blue Train Satsujin Jiken (Japan)
   title:  Nishimura Kyoutarou Mystery - Blue Train Satsujin Jiken (Japan)
@@ -13702,6 +20717,127 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: 40bd40b76f7c68063f73bca4200017f9e656066195c823f3b32fa56fbb7e5857
+  name:   Nishimura Kyoutarou Mystery - Super Express Satsujin Jiken (Japan)
+  title:  Nishimura Kyoutarou Mystery - Super Express Satsujin Jiken (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 6157c99fe7a214025c65fd3649e4afe9cd2d38c333e65af028b935e49fbeb500
+  name:   Noah's Ark (Europe)
+  title:  Noah's Ark (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4288e508734836e6ddd123dfae39a7a388abdd0afdc9d885ed597ee58a62fc61
+  name:   North & South (Europe)
+  title:  North & South (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 278e591b87352adff7cdcf9a7d056561e54e8dc400c55dbfd0ca9bbaf439435b
+  name:   North & South - Wakuwaku Nanboku Sensou (Japan)
+  title:  North & South - Wakuwaku Nanboku Sensou (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 55c2d10ae1b034b39533f780f6205f736735df1954c0eca6d147cfc13a224f82
+  name:   North and South (USA)
+  title:  North and South (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -13833,6 +20969,31 @@ game
       content: Character
 
 game
+  sha256: 6d310d9f2249932c7187130ebd696c42ff05f678c3086ac727ee6a27fdad4f43
+  name:   Otaku no Seiza - An Adventure in the Otaku Galaxy (Japan)
+  title:  Otaku no Seiza - An Adventure in the Otaku Galaxy (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 8b7bfbd2e0d636ff1683d08119c39f468f20074233b8c82c18b22956a4a9dd03
   name:   Othello (Japan)
   title:  Othello (Japan)
@@ -13922,6 +21083,56 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: d50327afa539f4a5ccfd6e10f685326eb0f01915ccf305f752deae2bf17385a6
+  name:   Over Horizon (Europe)
+  title:  Over Horizon (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c1784656aeb221c68ca443a8917d5d96a253a02ff071449acfd87b6d293ad336
+  name:   Over Horizon (Japan)
+  title:  Over Horizon (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 15a2652861a1fb58c526a0d6fb1fcd24943bd1213cd54f87d01c96a83718e396
@@ -14071,6 +21282,48 @@ game
       content: Character
 
 game
+  sha256: 4f07d0a54e13454ec22c22f7b4d0b05fde839be2586031fd3e8157afb7439e77
+  name:   Pachi-Slot Adventure 2 - Sorotta-kun no Pachi-Slot Tanteidan (Japan)
+  title:  Pachi-Slot Adventure 2 - Sorotta-kun no Pachi-Slot Tanteidan (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 5941960bedb49f728acfecd744001cd44f2a28790ed2e3daf696e5d500f89d75
+  name:   Pachi-Slot Adventure 3 - Bitaoshii 7 Kenzan! (Japan)
+  title:  Pachi-Slot Adventure 3 - Bitaoshii 7 Kenzan! (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: be59fd441e2509b67359cd02cadfa825ced0ec7fda8edb9c101d90fc7a793e61
   name:   Pachicom (Japan)
   title:  Pachicom (Japan)
@@ -14089,6 +21342,170 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: d04a6f539c0a4ae50e4fade3c1016004304ea1d9ad516f5e5d59554a3d0e10ee
+  name:   Pachio-kun 3 (Japan)
+  title:  Pachio-kun 3 (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c8959626b4b263648fe3f9765a49178c008c8ccbcb2e6c8f68e01c854fef1950
+  name:   Pachio-kun 3 (Japan) (Rev 1)
+  title:  Pachio-kun 3 (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ed50b58aec4edd3b5ee1d2c2b2ef17c96821aa16ea699ea0e0ec027465e0cb54
+  name:   Pachio-kun 4 (Japan)
+  title:  Pachio-kun 4 (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: ab2f34b76622d483a5ff59d0babdb80f9e976bfc38d3decc3b9bc6ecc74f012a
+  name:   Pachio-kun 5 (Japan)
+  title:  Pachio-kun 5 (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9ec97184b5106e40acce1054a480db00affb898058d07314ee4015d4953c2389
+  name:   Pajama Hero - Nemo (Japan)
+  title:  Pajama Hero - Nemo (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: fd4b617c3aea2f486a117564311ed4ff841e1bb48bec53aff4fb3dfc566d7f48
+  name:   Panic Restaurant (Europe)
+  title:  Panic Restaurant (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 6c47c73eb510fb0f71eeb2a3f5cca7c25eca8678ffe060aa17df6534dbd10ef1
+  name:   Panic Restaurant (USA)
+  title:  Panic Restaurant (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -14199,6 +21616,48 @@ game
       volatile
 
 game
+  sha256: 150cccc4797e89e33dd77bdd7d07d183e60ddce15af0d51a640ef26bd2141ad6
+  name:   Parallel World (Japan)
+  title:  Parallel World (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 49b9102ebcc8ee381bd00c41675348cc21074141f7806bf6a1a8f43ee65afe98
+  name:   Parasol Henbee (Japan)
+  title:  Parasol Henbee (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 035383efbc5131942ba7df721ba406fd57c08a9ff87e3aa6e6f3d272bda86c44
   name:   Paris-Dakar Rally Special (Japan)
   title:  Paris-Dakar Rally Special (Japan)
@@ -14217,6 +21676,31 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: f0d89b53126513e1df56b46bae3a43b4a4b87543d48974c9087ba94737249801
+  name:   Parodius (Europe)
+  title:  Parodius (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -14266,6 +21750,31 @@ game
     memory
       type: ROM
       size: 0x4000
+      content: Character
+
+game
+  sha256: d6bbf2d829f966792adc47d52237270890bbed417f4ca70d6ba717fda8a0ac88
+  name:   Pennant League, The - Home Run Nighter '90 (Japan)
+  title:  Pennant League, The - Home Run Nighter '90 (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -14681,6 +22190,69 @@ game
       content: Character
 
 game
+  sha256: f09858288e057b86b055f4fb51ce0f7bf446ecf43467f0ea990096b89ad9a750
+  name:   Power Blade (Europe)
+  title:  Power Blade (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4986c3862a04fcf5b22df58b1182ec2ad636e6083714ac7c069adc1639023ebf
+  name:   Power Blade (USA)
+  title:  Power Blade (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 6c462c3fa07aab70759376fe6b59e9c91e808f79fae2960f869bafc9cf20dca2
+  name:   Power Blade 2 (USA)
+  title:  Power Blade 2 (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 1f5a86488d8bbc8fbc09fdb91a33fa2530ed124949a7001576e7c631f87bd9df
   name:   Power Blazer (Japan)
   title:  Power Blazer (Japan)
@@ -14699,6 +22271,27 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: ae360d56679f179109ca7d07ad8b4da644ad53a39ffe1d47c8db00648af4bdb0
+  name:   Power Punch II (USA)
+  title:  Power Punch II (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
       content: Character
 
 game
@@ -15033,6 +22626,53 @@ game
       volatile
 
 game
+  sha256: 13bc26c9eed04f301cef812ebaf2a6e989aff164692f24002957659b0c946b3c
+  name:   Probotector II - Return of the Evil Forces (Europe)
+  title:  Probotector II - Return of the Evil Forces (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a831af59a90850a79b62678169f9e32c513b7c25184295222aa85c2574b8f136
+  name:   Project Q (Japan)
+  title:  Project Q (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 17f4b9a5c8175c2f6650d451e7d96f9ddd5b5dabfe87f8f8d6a84adcb1439bec
   name:   Punch-Out!! (Europe)
   title:  Punch-Out!! (Europe)
@@ -15082,6 +22722,27 @@ game
   board:  HVC-PNROM
     chip
       type: MMC2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ea81de1a6d901d8d1ad229a6d8d88edcc8e1aeeae6146aa4cd01eb0310eb44d5
+  name:   Punisher, The (USA)
+  title:  Punisher, The (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
     memory
       type: ROM
       size: 0x10
@@ -15416,6 +23077,27 @@ game
       content: Character
 
 game
+  sha256: 0c0a9e908ea61b304052f02515c8bcdfdaa77954d67a88c1215c6416406c7f9e
+  name:   Rackets & Rivals (Europe)
+  title:  Rackets & Rivals (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: bcc8a24ab99f85933ff2cd0787daab6093710ef04f95b4c7bec842961ee0e3ad
   name:   Rad Racer II (USA)
   title:  Rad Racer II (USA)
@@ -15440,6 +23122,31 @@ game
       size: 0x800
       content: Character
       volatile
+
+game
+  sha256: 879ada5f1aa0282d81f9f13e91de53e181ed1030242029fcce002dfb8847c0c9
+  name:   Radia Senki - Reimei Hen (Japan)
+  title:  Radia Senki - Reimei Hen (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: ca69d694d684be2148efa08d587eafe7038d9ff5d84a3b202cdc48a52cc0a7af
@@ -15637,6 +23344,48 @@ game
       volatile
 
 game
+  sha256: bbe150f50bd11f5aa4e3edab47541261c58ab9899b6d9329450b3c77df172823
+  name:   Rampage (USA)
+  title:  Rampage (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
+  sha256: d65f5d02dd7c2a37f4026dc8416d41aa86732eeef998b803c924e576ceca4c52
+  name:   Rampart (Europe)
+  title:  Rampart (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 013065f9b30be7c592a303181d5d7a49c370c001ac50140c9bf25f6198682ff0
   name:   Rampart (Japan)
   title:  Rampart (Japan)
@@ -15657,6 +23406,69 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 85e29454e42aecf1fc91a677774150184e3a7ac8da9e2b9566421cff0cc3f7b9
+  name:   Rampart (USA)
+  title:  Rampart (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 09b1bb056b41577173d6944ddfbbd7b59120d5e5d765a98d65d8e499df9ffd16
+  name:   Red Arremer II (Japan)
+  title:  Red Arremer II (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 501e921616931e4796c44b1e80c7112c881eb1e9a3190d0e6a3b4b199ee368e3
+  name:   Ren & Stimpy Show, The - Buckeroo$! (USA)
+  title:  Ren & Stimpy Show, The - Buckeroo$! (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: b4856061c9310015101c461aef744e9dcf3b158bd13d5d9cb4a76d3ca18a6864
@@ -15701,6 +23513,27 @@ game
     memory
       type: ROM
       size: 0x10000
+      content: Character
+
+game
+  sha256: 54cdc8b6fab804339c44601663585c8e7a8b01ef35b49754eb13a767b57c7d07
+  name:   River City Ransom (USA)
+  title:  River City Ransom (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -15790,6 +23623,153 @@ game
       volatile
 
 game
+  sha256: 100c394264b40c17f635a6356c884135558bf2aee1a7f60c9ce43441e48a06cb
+  name:   Robocco Wars (Japan)
+  title:  Robocco Wars (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 39181c7c830bad1b064de5c5cec0f7a200ca29462e707522e7c49a48d0adab60
+  name:   RoboCop (Europe)
+  title:  RoboCop (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 35b1d43323baf3e1cc1ef48cc82bf0bac32e5c25c33ebaa10c0856c7c23efa29
+  name:   RoboCop (Japan)
+  title:  RoboCop (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d04b445ac57cccb3a31a3bf83d002dc9a9765f15313e96f67be077b6114d2411
+  name:   RoboCop (USA)
+  title:  RoboCop (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 2bd31df34f925d030ceceb944c1ac973ccf892358de75c35fd77d61372d23a3b
+  name:   Rock 'n' Ball (USA)
+  title:  Rock 'n' Ball (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
+  sha256: 74d27ae70cb936c2434310da32c7d612d7b90099274bdf5ed19388cee2bc4fc1
+  name:   Rockin' Kats (Europe)
+  title:  Rockin' Kats (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 683c49e4ea3f4b179065deccecd3e4a86a4e355e13924872571e7b7c79205d0c
+  name:   Rockin' Kats (USA)
+  title:  Rockin' Kats (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 05117c775581eb63f7686f58c24f1c9da0fa0669eede1e7bad12eed40e58935e
   name:   Rockman (Japan)
   title:  Rockman (Japan)
@@ -15804,6 +23784,114 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 93bfebd7e32b7ef8264e2c45e477a8ef3bb27c02a82359cbe51d0557e9cf77be
+  name:   Rockman 3 - Dr. Wily no Saigo! (Japan)
+  title:  Rockman 3 - Dr. Wily no Saigo! (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 808f921e3109f41bfac924d2d1acb6a32d98b081a8ca98758a32706f680ba5b7
+  name:   Rockman 4 - Aratanaru Yabou!! (Japan)
+  title:  Rockman 4 - Aratanaru Yabou!! (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5afc837e325b1bc0fa11645472cea43bb4bbc7f0239cd817c75966091c90a3c3
+  name:   Rockman 4 - Aratanaru Yabou!! (Japan) (Rev 1)
+  title:  Rockman 4 - Aratanaru Yabou!! (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0df7ec4d77df70094179b0a43af3f143775fd3cea4ef599b41b9e5bdab8cc1bc
+  name:   Rockman 5 - Blues no Wana! (Japan)
+  title:  Rockman 5 - Blues no Wana! (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: fc749d3c9d80797506164b9add954729a5ebcb84972449177f5be09821261e99
+  name:   Rockman 6 - Shijou Saidai no Tatakai!! (Japan)
+  title:  Rockman 6 - Shijou Saidai no Tatakai!! (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
       content: Program
     memory
       type: RAM
@@ -15834,6 +23922,48 @@ game
       volatile
 
 game
+  sha256: 1a35607e218d68106367e7b87735aa9f10bf330c3a71f607a21de2d7fc763ef8
+  name:   Roger Clemens' MVP Baseball (USA)
+  title:  Roger Clemens' MVP Baseball (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 7060b12fcb5f02d2d38325fe005f203aa93de1aad8140d01bc818a48f99ac0a5
+  name:   Roger Clemens' MVP Baseball (USA) (Rev 1)
+  title:  Roger Clemens' MVP Baseball (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: 03bb4abbbab7bc91844dd65b808d1281ae22f9e4460479b27dd9d9b186b40647
   name:   Rokudenashi Blues (Japan)
   title:  Rokudenashi Blues (Japan)
@@ -15859,6 +23989,69 @@ game
       content: Save
 
 game
+  sha256: 942c802c34627c969c49dae94fb8b48c7b1e873a65803caad559324e2a54b4c8
+  name:   Rollerblade Racer (USA)
+  title:  Rollerblade Racer (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e7cc118c5b0c2038a6478d4458bc411c4113806706a865a07983c2da1118bc50
+  name:   Rollergames (Europe)
+  title:  Rollergames (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 7ddc56bf2b8d8f3f980837bbc48284fd7241e111a9f51599c6e358518d3469dc
+  name:   Rollergames (USA)
+  title:  Rollergames (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: ed8c07ac72403ef5d131e9e5eb9b90578b40a1fec0b2925bab9ce06aa308477a
   name:   Rolling Thunder (Japan)
   title:  Rolling Thunder (Japan)
@@ -15874,6 +24067,56 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 7212ee85b8e2a76c62cacd326a2731082b563b2b25f6881c65a5c1826c889157
+  name:   Roundball - 2-on-2 Challenge (Europe)
+  title:  Roundball - 2-on-2 Challenge (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 644291444ae16a02a128c613fa4e10559a45e4740e3614fb57b73b8c736bdbef
+  name:   Roundball - 2-on-2 Challenge (USA)
+  title:  Roundball - 2-on-2 Challenge (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: ROM
       size: 0x20000
@@ -16147,6 +24390,31 @@ game
       volatile
 
 game
+  sha256: 95bdd6994cfd556e2ffc3147f608ac0b1890ca570be5c519b8a7d1cc6aa413b0
+  name:   Samsara Naga (Japan)
+  title:  Samsara Naga (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 6a258031a63ea324b02d865ef7860bde15bd0b29be1071311c45d87a2f1d56f2
   name:   Sangokushi - Chuugen no Hasha (Japan)
   title:  Sangokushi - Chuugen no Hasha (Japan)
@@ -16397,6 +24665,127 @@ game
       content: Character
 
 game
+  sha256: 4b0ea8c15d7c5abce2def31f8e7c10f06a91f32444a9f5fae62a26c0d0ec1f58
+  name:   SD Battle Oozumou - Heisei Hero Basho (Japan)
+  title:  SD Battle Oozumou - Heisei Hero Basho (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e63211bd331c58a82308a7a372712aea687146de2ecd7d5353ce717067f97271
+  name:   SD Gundam - Gachapon Senshi 2 - Capsule Senki (Japan)
+  title:  SD Gundam - Gachapon Senshi 2 - Capsule Senki (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4eb1d8e59ee96d0c6390a5b01ffbdbe45f6612c463e45983f1879925124b3337
+  name:   SD Gundam - Gachapon Senshi 3 - Eiyuu Senki (Japan)
+  title:  SD Gundam - Gachapon Senshi 3 - Eiyuu Senki (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: fed44d486dfeb330e391f98d58598083280411b76913da59500a0f31bcfe72aa
+  name:   SD Gundam - Gachapon Senshi 4 - NewType Story (Japan)
+  title:  SD Gundam - Gachapon Senshi 4 - NewType Story (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 74176b92850a2b8931109036aff5c0b25d7bbc5127e0047eeda7255ae55e5017
+  name:   SD Gundam - Gachapon Senshi 5 - Battle of Universal Century (Japan)
+  title:  SD Gundam - Gachapon Senshi 5 - Battle of Universal Century (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: cd6e7fb18348488f256d08d8c02802dea3980cdb5b46bd0ea200324b913c1a07
   name:   SD Gundam Gaiden - Knight Gundam Monogatari (Japan)
   title:  SD Gundam Gaiden - Knight Gundam Monogatari (Japan)
@@ -16497,6 +24886,27 @@ game
       content: Save
 
 game
+  sha256: aecdb15fd435d8c8bcf8c4f29db4b5c9b83db54268913044161553c89676c5e1
+  name:   SD Hero Soukessen - Taose! Aku no Gundan (Japan)
+  title:  SD Hero Soukessen - Taose! Aku no Gundan (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 2d3d6f009b1f81640867a5b5102c10e4d26c8ad6280c30e43d65dcd1acce9fb3
   name:   SD Keiji - Blader (Japan)
   title:  SD Keiji - Blader (Japan)
@@ -16504,6 +24914,31 @@ game
   board:  TAITO-X1-017
     chip
       type: X1-017
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: dc61b34ed42aee038a4c292465f4025b8a9b54dd50aecc737c8793e443f29a58
+  name:   SD Sengoku Bushou Retsuden (Japan)
+  title:  SD Sengoku Bushou Retsuden (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
     memory
       type: ROM
       size: 0x10
@@ -16653,6 +25088,27 @@ game
       content: Character
 
 game
+  sha256: 5483658872ee75b6324cd631045241f14c76084d93799cf51495a9a2039a3800
+  name:   Seirei Densetsu Lickle (Japan)
+  title:  Seirei Densetsu Lickle (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 1c5c7ef0ad07700bc7d6c63dad5b9f01cd49b8ff1361762cd2165afe29853289
   name:   Seirei Gari (Japan)
   title:  Seirei Gari (Japan)
@@ -16675,6 +25131,31 @@ game
       volatile
 
 game
+  sha256: c31c548eca551aa14857761c3de04b99c1f2a159037dc28f64dd9adf30580a7d
+  name:   Seiryaku Simulation - Inbou no Wakusei - Shancara (Japan)
+  title:  Seiryaku Simulation - Inbou no Wakusei - Shancara (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: dbc22a40e8a79c5ccf1d6e5126c9b10bb3d9b3e708fe5316c298c3d03dbc7977
   name:   Senjou no Ookami (Japan)
   title:  Senjou no Ookami (Japan)
@@ -16695,6 +25176,223 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: daa4d4cd609da751e2380186fbf6dbc7062e549297286d4304b9ddb421a4a278
+  name:   Shadow Brain (Japan)
+  title:  Shadow Brain (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 2395a8a102bfc403bb2c474f77035483792ec15bce37695c9f2d96d62bc8fe10
+  name:   Shadow of the Ninja (USA)
+  title:  Shadow of the Ninja (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e6df2e9c0ba3882d9dbb59192c138d88845b5e8dc8c5b4e441a5a31e40c9c4a2
+  name:   Shadow Warriors II - Ninja Gaiden II (Europe)
+  title:  Shadow Warriors II - Ninja Gaiden II (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9008fc9267c7680eb944d864d966dcc8a0ed3229a8505368e9a5e2ce28655fc7
+  name:   Shadowgate (Europe)
+  title:  Shadowgate (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3cc697860fb3c5eb75a0b886f7a9ca96aeefeaf8bff844973fdbc6e90b7fcc5a
+  name:   Shadowgate (France)
+  title:  Shadowgate (France)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ff9da7517a3aaf03bd1bd40765a0e05e8183bae8b1d2bc32f8c422d524f3c411
+  name:   Shadowgate (Germany)
+  title:  Shadowgate (Germany)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e1204b70ebdd726d6565639463b71046b1e79ca6b9613ce0fe07fd7b5bbaf84f
+  name:   Shadowgate (Japan)
+  title:  Shadowgate (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c7c9f8b12231254b5ab3f39687a1d623720a2bdd43631e379a7438515f18ba58
+  name:   Shadowgate (Sweden)
+  title:  Shadowgate (Sweden)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: fbc69cdaf7c1419906d8cf2a74ab70d11520b2f3877387b8fd70460b6e6dd542
+  name:   Shadowgate (USA)
+  title:  Shadowgate (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: f7271a7030e2f5298f3931f08c84fdbe1dad3108aaf1259a766f05b80b12910a
@@ -16739,6 +25437,48 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 953f28b27154246a06aedbe6697ff84c9283d827af178099b911906f6ed77680
+  name:   Shatterhand (Europe)
+  title:  Shatterhand (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c3f361c4a1441101d6a3eb42f5776073c712198e7ed45d6ab5350816ea15aee4
+  name:   Shatterhand (USA)
+  title:  Shatterhand (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: b271bf2ee7677b3ef5458c072a9e7e7dd58e37e9776d541fddee728088bb15fa
@@ -16824,6 +25564,109 @@ game
       type: ROM
       size: 0x8000
       content: Character
+
+game
+  sha256: e7395fa3133a8b02e1b521139ad9ef6e0c7108a103922a7849aa2ec4e119f74a
+  name:   Shougi Meikan '92 (Japan)
+  title:  Shougi Meikan '92 (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 71938f6b0fa1fd6b2bc4588866653815843b042589996c43f6e294749c2b91b2
+  name:   Shougi Meikan '93 (Japan)
+  title:  Shougi Meikan '93 (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: fa7718c5bd0ad2ad7ef63c276b9ceacee11aed5a193874e3eab4c4ae5a125e8d
+  name:   Shounen Ashibe - Nepal Daibouken no Maki (Japan)
+  title:  Shounen Ashibe - Nepal Daibouken no Maki (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: f60be8c279f4b90507ce7e5a7ef26c894483a9e26685dbbd745031d2eeb97c50
+  name:   Shuffle Fight (Japan)
+  title:  Shuffle Fight (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 67acaac29ab36a8a807bcd8fec0249fead88229c0193830de21cc5dccb0aa5f2
@@ -16981,6 +25824,140 @@ game
       volatile
 
 game
+  sha256: 35d90ce12b0d0b9e8d954c92e5dbb20773d0c4bdb23a121e231c1d3a0e21c62c
+  name:   Silva Saga (Japan)
+  title:  Silva Saga (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 718dce0398dba4f8968969fe3e078f55ea0a5b3cff91895fd9ac0225fe4c437e
+  name:   Silver Surfer (USA)
+  title:  Silver Surfer (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 4d574a43c52f30b1210c4c039915a3f32183460e7a0fe089d4aecaaded73af5a
+  name:   Simpsons, The - Bart vs. the World (Europe)
+  title:  Simpsons, The - Bart vs. the World (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 678565338a9efa2d9d4bd399b314b62864d486a4e9f4c314bf11ae5a240cdab8
+  name:   Simpsons, The - Bart vs. the World (USA)
+  title:  Simpsons, The - Bart vs. the World (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 49861c7126846f1a86fdd6595c73f5f91d5323193c8a97674969ca3d78f19e6f
+  name:   Simpsons, The - Bartman Meets Radioactive Man (Europe)
+  title:  Simpsons, The - Bartman Meets Radioactive Man (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ce1fd1fcf89d2d6334cc3d96101c7b995ff4959257ed04df92f0afad711d08da
+  name:   Simpsons, The - Bartman Meets Radioactive Man (USA)
+  title:  Simpsons, The - Bartman Meets Radioactive Man (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 9831d03afe8e5a7e10c6a84843500030c92cad203eaa6ba5a4da16fd96b1e7fb
   name:   Skate or Die (Europe)
   title:  Skate or Die (Europe)
@@ -17111,6 +26088,48 @@ game
       content: Character
 
 game
+  sha256: 75517b9688e97f8f2eb0b72ff401cb7f710f8469c18723dfb38802fa6e230c93
+  name:   Smash T.V. (Europe)
+  title:  Smash T.V. (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 6dde1137253e7e41972dd04e09dc736efee82cc7f41f8deac8d0dcb111301616
+  name:   Smash T.V. (USA)
+  title:  Smash T.V. (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 8df9c1a7a3806873db908604bb99749673241ccd58e1b32a6d7bf2fafc97d9d4
   name:   Smurfs, The (Europe)
   title:  Smurfs, The (Europe)
@@ -17236,6 +26255,31 @@ game
       content: Character
 
 game
+  sha256: 3f59bd2d0534682201f4ccd20f1b8aed64532854e3aefee0465e38961b0b4c0b
+  name:   Solomon no Kagi 2 - Coolmintou Kyuushutsu Sakusen (Japan)
+  title:  Solomon no Kagi 2 - Coolmintou Kyuushutsu Sakusen (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 3ce8d763c2919911e769b71ff79e0551a56f0b6fd9c8eb0d16b1601a01574415
   name:   Solomon's Key (Europe)
   title:  Solomon's Key (Europe)
@@ -17275,6 +26319,27 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 41621c00ed0effc7bf3ec1541415720c8fb492df49797973ba8df94a5750d201
+  name:   Solomon's Key 2 (Europe)
+  title:  Solomon's Key 2 (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -17356,6 +26421,69 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: e05ca235fa846c1ff3eef6b636742f90d29bfb7d0df02914afb4faba8e7745fb
+  name:   Soreike! Anpanman - Minna de Hiking Game! (Japan)
+  title:  Soreike! Anpanman - Minna de Hiking Game! (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: acaad4e43a6c2cc38823e9430e748088eee47288b929bf44d3e61b0968df2abd
+  name:   Sou Setsu Ryuu II - The Revenge (Japan)
+  title:  Sou Setsu Ryuu II - The Revenge (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: bb4cc5b39dca9f665b1873993bc363d7687e087eb7ed19d4ee20e2479ac3323f
+  name:   Sou Setsu Ryuu III - The Rosetta Stone (Japan)
+  title:  Sou Setsu Ryuu III - The Rosetta Stone (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -17526,6 +26654,48 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: ed96032f4a044f0b9b60638c219c2ea1c0545b91f0332f19dc561264de002379
+  name:   Spider-Man - Return of the Sinister Six (Europe)
+  title:  Spider-Man - Return of the Sinister Six (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 1104d574711a103745aed2407997275e1ac43fd4d5c7ff96bde0af5bfa014c2d
+  name:   Spider-Man - Return of the Sinister Six (USA)
+  title:  Spider-Man - Return of the Sinister Six (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
 
 game
   sha256: 387d82471ca5f54e70b3c4d445ae5c692640d99c47b30a6bf67f5a17b6236c85
@@ -17762,6 +26932,27 @@ game
       content: Character
 
 game
+  sha256: d9a666f7b122bff2db329d346e20d9708ad58471ea80fbd032aa4600e86ad8f1
+  name:   Stanley - The Search for Dr. Livingston (USA)
+  title:  Stanley - The Search for Dr. Livingston (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: b0e3b04d1281c6bf2fc0c17e3bc30ef18a5118345498470ce17d3d993f9470ae
   name:   Star Force (Europe)
   title:  Star Force (Europe)
@@ -17909,6 +27100,48 @@ game
       content: Character
 
 game
+  sha256: 4bba077105f0e4834394067e477d7fe07495b916f2a63623b66110c298f3978b
+  name:   Star Trek - 25th Anniversary (Germany)
+  title:  Star Trek - 25th Anniversary (Germany)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: a3d132f118c0d95590579c6d6b89b6bbe448a93aab93b3a29490f985b821a42c
+  name:   Star Trek - 25th Anniversary (USA)
+  title:  Star Trek - 25th Anniversary (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: 8271542561a71830886e88ac74e6eda309440920b3607e950d5f2cd1a7edd5ca
   name:   Star Trek - The Next Generation (USA)
   title:  Star Trek - The Next Generation (USA)
@@ -17952,6 +27185,56 @@ game
       content: Character
 
 game
+  sha256: 563c7691583ef2904cdc6afab9618978d9c4c4c0e05e0f2ae2c2b388f277f268
+  name:   Star Wars (Europe)
+  title:  Star Wars (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: aff3e2f76facf9f66729ff4f20a728e386501180d6fc6606adcda625b40218ab
+  name:   Star Wars (Japan)
+  title:  Star Wars (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 6b42e1b3fba910280016616a24050d3aec19d32480c4b5863c3f3734d44681bc
   name:   Star Wars (Japan)
   title:  Star Wars (Japan)
@@ -17970,6 +27253,94 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: b9116f11828e39d3e201c878a874f0d88fa0eae9dece0469bf94a7e9c8616775
+  name:   Star Wars (USA)
+  title:  Star Wars (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 61c2efe4587d7b531652b66397ea0baa143f6a601ff8642d8f674622af2b629c
+  name:   Star Wars - The Empire Strikes Back (Europe)
+  title:  Star Wars - The Empire Strikes Back (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: b20b66b3ff212627482c093196c0af135b6b83ab5fc7a73bfea83bd7d9ecbabc
+  name:   Star Wars - The Empire Strikes Back (Japan)
+  title:  Star Wars - The Empire Strikes Back (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 01b1bc93f72286a10ac62869ebe1bf2493ca24b3386e01447b0ccac50acdee94
+  name:   Star Wars - The Empire Strikes Back (USA)
+  title:  Star Wars - The Empire Strikes Back (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
       content: Character
 
 game
@@ -18089,6 +27460,73 @@ game
       volatile
 
 game
+  sha256: 885cfd4396e0ade5f3abbbdb5055bc48ef166f86207db631bac83c51c0844f08
+  name:   Street Fighter 2010 - The Final Fight (USA)
+  title:  Street Fighter 2010 - The Final Fight (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 899e1ee8caee735f6c5df3cb2ec8921d470f8426cc5c0edfd18c131f6b18aa42
+  name:   Street Gangs (Europe)
+  title:  Street Gangs (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9d83b65b3c86957e16f35c6cb58f54ebd2203ec5b6b06943da7149a9d3a58517
+  name:   Sugoro Quest - Dice no Senshitachi (Japan)
+  title:  Sugoro Quest - Dice no Senshitachi (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 8b11fa216f87b5924205719eac1bd2709ba0489813a4d4c202a32fd42689e761
   name:   Sukeban Deka III (Japan)
   title:  Sukeban Deka III (Japan)
@@ -18111,6 +27549,27 @@ game
       volatile
 
 game
+  sha256: 86174a611f526c54e1b08fc102d0867e9f8d3edb564dfad845a12414216459ea
+  name:   Summer Carnival '92 - Recca (Japan)
+  title:  Summer Carnival '92 - Recca (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: a387a17294bb440eb821fa096bfe476f772c7f9f79c5fb251f6b0a50bdeda53d
   name:   Super Arabian (Japan)
   title:  Super Arabian (Japan)
@@ -18129,6 +27588,27 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: 3edd803db1cc88155720625ed8f3e362a5e3c660e7faf3285bbe3a2c6571511c
+  name:   Super C (USA)
+  title:  Super C (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -18174,6 +27654,48 @@ game
     memory
       type: ROM
       size: 0x4000
+      content: Character
+
+game
+  sha256: 289a34391920c29d9903c75bc303031fa0558c7ed20ec6307712bf8811f1b28b
+  name:   Super Chinese 2 - Dragon Kid (Japan)
+  title:  Super Chinese 2 - Dragon Kid (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ef5222c1332c9d24919acf29517fb027edb811f2b7313ee58f9079a29e99900d
+  name:   Super Contra (Japan)
+  title:  Super Contra (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -18304,6 +27826,231 @@ game
       content: Character
 
 game
+  sha256: bbaed03936b187f165f197973561b924307f802912578631c03fd28f3a45f245
+  name:   Super Mario Bros. 2 (Europe)
+  title:  Super Mario Bros. 2 (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: cba920f9394733c82253685d7783f26a3033ba58a94623e9abf7892329b969b9
+  name:   Super Mario Bros. 2 (USA)
+  title:  Super Mario Bros. 2 (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 728d0ca6751b0c039fc3e34f2e7f27a870afcab30f5e270244ac40979c5f69ca
+  name:   Super Mario Bros. 2 (USA) (Rev 1)
+  title:  Super Mario Bros. 2 (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a4e8ea06ca01664ff995194a6f5de29a967ddf1e479156fde18fac0a557ae48b
+  name:   Super Mario Bros. 3 (Europe)
+  title:  Super Mario Bros. 3 (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 1c74200e996b37b1315818de6b6dd2d2a7b8a17fb06b6967158235d703424ebe
+  name:   Super Mario Bros. 3 (Japan)
+  title:  Super Mario Bros. 3 (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 7fa8e9125baa2590019db90f1446d501a27e520b2593e87dff71e74906bfbad2
+  name:   Super Mario Bros. 3 (Japan) (Rev 1)
+  title:  Super Mario Bros. 3 (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d77d17d34af24871d7ce1160ccd3330555835c8e940b7100e095ac38973d927a
+  name:   Super Mario Bros. 3 (USA)
+  title:  Super Mario Bros. 3 (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 959fdd32c71735d6fb2bd16a646d39f4ee65623273dd035e6a968e991bd13ef8
+  name:   Super Mario Bros. 3 (USA) (Rev 1)
+  title:  Super Mario Bros. 3 (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 77a65e9091193b776fc1006686ba2769a8f4a825e6e913b2a00cb722a471c1f3
+  name:   Super Mario USA (Japan)
+  title:  Super Mario USA (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 8328258d8fa07be57584fb908d5e28f8f8b8a11e022c0184ce31932d4e32d8ef
   name:   Super Mogura Tataki!! - Pokkun Mogurar (Japan)
   title:  Super Mogura Tataki!! - Pokkun Mogurar (Japan)
@@ -18369,6 +28116,111 @@ game
       volatile
 
 game
+  sha256: 9d87f205aca5fd31d27130dc7595a73d3a5fbbb2030dd3b4fe1ea0eb5b340104
+  name:   Super Spike V'Ball (Europe)
+  title:  Super Spike V'Ball (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3387595598af933fb852a07e554a9b3c3dba7ba331ad4ec94eb8e3ccbe564f3b
+  name:   Super Spike V'Ball (USA)
+  title:  Super Spike V'Ball (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 08888c3c97b9cb1c3bd07341b7c20a07bb595a1ec7cefef716709e0ee4e9855a
+  name:   Super Sprint (Japan)
+  title:  Super Sprint (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
+  sha256: 7fd8937c6313e57739efa066b8e27597763afa2ff1bdf8ed285d77a89edc9b07
+  name:   Super Spy Hunter (Europe)
+  title:  Super Spy Hunter (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 7806ee6afcdf88ef6364da23af8b28f359ef7d850fe55224e188b8a01d5ade67
+  name:   Super Spy Hunter (USA)
+  title:  Super Spy Hunter (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: da11b89307b7cf1b0394b7e5459e76b3979bccd322cdc39bf5135c83038aad50
   name:   Super Star Force (Japan)
   title:  Super Star Force (Japan)
@@ -18412,6 +28264,31 @@ game
       content: Character
 
 game
+  sha256: 639d5b9dad2f4eae48559dadc708d396f50f898a5912631c0a3c1715a5eab729
+  name:   Super Turrican (Europe)
+  title:  Super Turrican (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 301d41b370e56cf3c57f22f760da55cb0dc726acf0a2b45182abe5e9dbe186a2
   name:   Super Xevious - Gump no Nazo (Japan)
   title:  Super Xevious - Gump no Nazo (Japan)
@@ -18435,6 +28312,27 @@ game
       content: Character
 
 game
+  sha256: 208f0fdb48f469153e7e62188e1478dcb2af86a8d4bd36b8a35d4510bd158da6
+  name:   Superstar Pro Wrestling (Japan)
+  title:  Superstar Pro Wrestling (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 9a084f0002013774c0d563ef59d1e46e29618d6ef1c1c48a17c368c86fc7662a
   name:   SWAT - Special Weapons and Tactics (Japan)
   title:  SWAT - Special Weapons and Tactics (Japan)
@@ -18455,6 +28353,69 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: c83cc9e467c565e925e3371aa0c73d81b51bf3fd2cb2ea6ac927f5c64086b3ed
+  name:   Sword Master (Europe)
+  title:  Sword Master (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b882c48c8307ea759f7d49d48b11354c63d1f4f4472a8c36dd61bfb7508820c8
+  name:   Sword Master (Japan)
+  title:  Sword Master (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 553d6db3959c8ae3e3cfa598a33c57756b06653ce434fddd0de92bafb460cb05
+  name:   Sword Master (USA)
+  title:  Sword Master (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: bf33855bad9665b51da856413d2a4a8ab0c67178c50ea735a5325ebea8499cba
@@ -18586,6 +28547,48 @@ game
       content: Character
 
 game
+  sha256: fb73dc4f79bf263b251104c2018443bad87777a248f5619f11fe6caec1e06eac
+  name:   Taito Basketball (Japan)
+  title:  Taito Basketball (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9583caa45626da3899b725fad3fcf345acbecd77eae6b77dbb065343c995ff1d
+  name:   Taito Chase H.Q. (Japan)
+  title:  Taito Chase H.Q. (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 054097cbfccd8ec2d343c0adc134d69f2b6b9067f880ec51464696e0581326c0
   name:   Taito Grand Prix - Eikou e no License (Japan)
   title:  Taito Grand Prix - Eikou e no License (Japan)
@@ -18611,6 +28614,27 @@ game
       content: Character
 
 game
+  sha256: 3163244a32165495831c3f89b770b86cc85a386c4db7df20dbb0f051f100cfe5
+  name:   Taiyou no Yuusha - Fighbird (Japan)
+  title:  Taiyou no Yuusha - Fighbird (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 1e6d5548a54a0db31a13e05b604afafd8f9402b47079d708e7bf2cf8582e2ac5
   name:   Takahashi Meijin no Bouken-jima (Japan)
   title:  Takahashi Meijin no Bouken-jima (Japan)
@@ -18629,6 +28653,69 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: e31511ebbea6e664490660eca241d91d3fc427945386570e8f124e7272a2b72d
+  name:   Takahashi Meijin no Bouken-jima II (Japan)
+  title:  Takahashi Meijin no Bouken-jima II (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c6ef86ee14ec274fd00cec39fd669f24fdc3b7348747bb13bc7425029ea73c56
+  name:   Takahashi Meijin no Bouken-jima III (Japan)
+  title:  Takahashi Meijin no Bouken-jima III (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 65d11519c8bc1435a994e4f71362dbc734ca808ac3048b66e87c5a80475e3f5e
+  name:   Takahashi Meijin no Bouken-jima IV (Japan)
+  title:  Takahashi Meijin no Bouken-jima IV (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -18830,6 +28917,215 @@ game
       volatile
 
 game
+  sha256: ebc23cffd93a5c8d83c9f49b5ba3c8da3903f24395dbfd2269a6798e47307e59
+  name:   Tecmo NBA Basketball (USA)
+  title:  Tecmo NBA Basketball (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 54d809b38573248ff73e104505a57f71f8b4356c8a7983a363c2ee242f878205
+  name:   Tecmo NBA Basketball (USA)
+  title:  Tecmo NBA Basketball (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 0b3afd6b8e4fc12f63a81b6dfd8ebd434f40f5f7b026d28edb76d7fdff7ff6c4
+  name:   Tecmo NBA Basketball (USA) (Rev 1)
+  title:  Tecmo NBA Basketball (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 14cdf8c78722210ccb9e772cafa210f56ceacd60cc8f0f2852993affec68479a
+  name:   Tecmo Super Bowl (Japan)
+  title:  Tecmo Super Bowl (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: cd5ad84e6bba35c19098c6f9783b568e4f1218582a12ec0513e5fafbdabb0303
+  name:   Tecmo Super Bowl (USA)
+  title:  Tecmo Super Bowl (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b6adca3680ba28efd41b2216cfcb9af66ed175e4359f0fbd5eda90e6cb6380e8
+  name:   Tecmo World Cup Soccer (Europe)
+  title:  Tecmo World Cup Soccer (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
+  sha256: 1de336db632787ec0c42dfcca2030d77cbe4fbd928ded83d44d7a0df1e16a6fb
+  name:   Tecmo World Cup Soccer (Japan)
+  title:  Tecmo World Cup Soccer (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
+  sha256: a3936ff5a5ffdb961399121413817ac66df72a4571eab8df88ac3693f4784d35
+  name:   Teenage Mutant Hero Turtles - Tournament Fighters (Europe)
+  title:  Teenage Mutant Hero Turtles - Tournament Fighters (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: abdb196091b7fea5e75f7e652f65b99ad7f85ea01cb9e3c4c9fa22a2734039f7
+  name:   Teenage Mutant Hero Turtles II - The Arcade Game (Europe)
+  title:  Teenage Mutant Hero Turtles II - The Arcade Game (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: 6fff1bfc89bb2f3c160b88736990c764920b0c44107b265f642a50324ca3adfb
   name:   Teenage Mutant Ninja Turtles (Japan)
   title:  Teenage Mutant Ninja Turtles (Japan)
@@ -18851,6 +29147,27 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: 10e2091a1c5e3ff3f636944fb274cd61db09dc25d0c14868710675cf1f86fd0b
+  name:   Teenage Mutant Ninja Turtles - Tournament Fighters (USA)
+  title:  Teenage Mutant Ninja Turtles - Tournament Fighters (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -18876,6 +29193,121 @@ game
       type: ROM
       size: 0x40000
       content: Character
+
+game
+  sha256: 4b4e554027e8ad5777726ce30a7072eb83e0c3b73880e19dd3690fc45437d313
+  name:   Teenage Mutant Ninja Turtles II - The Arcade Game (Australia)
+  title:  Teenage Mutant Ninja Turtles II - The Arcade Game (Australia)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 368d7ea3a066d4dc937473ca6cfc3e0d79d928b2308fff5ddd6ff199c7da153d
+  name:   Teenage Mutant Ninja Turtles II - The Arcade Game (USA)
+  title:  Teenage Mutant Ninja Turtles II - The Arcade Game (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 9f671090ffd2bb1dc95b9d413c3627f7aa0d576435eeb5b868fa7ca9c29c1190
+  name:   Teenage Mutant Ninja Turtles III - The Manhattan Project (USA)
+  title:  Teenage Mutant Ninja Turtles III - The Manhattan Project (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: aa60762c71e508d3b6cd6ac5aace8eaade986fb2a7434a4772bdcce516a75e48
+  name:   Tenchi o Kurau II - Shokatsu Koumei Den (Japan)
+  title:  Tenchi o Kurau II - Shokatsu Koumei Den (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: affec8b63660c25dde2a7d51e79f6abcfa5dd15993de8e83fe59cf6ee2203982
+  name:   Tenchi o Kurau II - Shokatsu Koumei Den (Japan) (Rev 1)
+  title:  Tenchi o Kurau II - Shokatsu Koumei Den (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 3ad469c7d183db6a9d9829802fc43a95d90aefd83ec8193d8d2da4aca36063c5
@@ -18983,6 +29415,90 @@ game
       content: Character
 
 game
+  sha256: e87a1a51580e5cdcdf2e79110d6316acba063b2be72b84269eca94bc39080e7a
+  name:   Terminator 2 (Japan)
+  title:  Terminator 2 (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c2654579b442723580a5716d3191d7f3aee898d20b32640fca66a31d70e8b656
+  name:   Terminator 2 - Judgment Day (Europe)
+  title:  Terminator 2 - Judgment Day (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 6f66d14e5f17ca244444e74538afe31f8abda8376b5b0205afaeb86075407c45
+  name:   Terminator 2 - Judgment Day (USA)
+  title:  Terminator 2 - Judgment Day (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: dd89b8e08738243d20740194ef814b011df138d820844ee4e53d3a6e536b1c83
+  name:   Terminator, The (USA, Europe)
+  title:  Terminator, The (USA, Europe)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: e12265b8fb7fa3f162d946577dff6e1c9ffb5b7f5e3f8effad468363a7ba3f4a
   name:   Terra Cresta (Japan)
   title:  Terra Cresta (Japan)
@@ -19025,6 +29541,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 022752eeba0930ab726a1e25db2a960a763d214d3b753d142d2b1a6525115e11
+  name:   Tetrastar - The Fighter (Japan)
+  title:  Tetrastar - The Fighter (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
 
 game
   sha256: 85ebbaa069cf14ee45ed88710f30a19eb34ed39b185c830a37888a3bd7ae8a4f
@@ -19087,6 +29624,81 @@ game
     memory
       type: ROM
       size: 0x4000
+      content: Character
+
+game
+  sha256: ca32162f32998a8d4462efdae21b05e9c66b177fa0b9218b57b803100cf4ee4a
+  name:   Tetris 2 (Europe)
+  title:  Tetris 2 (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: dd77dc88d380807990f55d0b1b55c151f78c480a0a0895e91d6edfb945ad71d7
+  name:   Tetris 2 (USA)
+  title:  Tetris 2 (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b75b92628e3b489a035797d2f42b39290504d01da3a01fb1bd2142e5da23a202
+  name:   Tetris Flash (Japan)
+  title:  Tetris Flash (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -19320,6 +29932,27 @@ game
       volatile
 
 game
+  sha256: fd623ab2382d91b9b2fbed34087ac6768b9d408ec0565d0206c7c2a118ef1533
+  name:   Time Zone (Japan)
+  title:  Time Zone (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: efe733206c5ca178ed34a3e8e951f9b33704b92c9191e059255b8f5bb93e5313
   name:   Times of Lore (Japan)
   title:  Times of Lore (Japan)
@@ -19364,6 +29997,27 @@ game
       volatile
 
 game
+  sha256: 8a28ea134e48bd54ec0ba17cd089553d23cc4346fd28f600c42f2806acd5b16f
+  name:   Tiny Toon Adventures (Europe)
+  title:  Tiny Toon Adventures (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 4b80a1db42ecde039f01c52a74146887f9dfc2ad54fe3706bcdf625ec3e2de97
   name:   Tiny Toon Adventures (Japan)
   title:  Tiny Toon Adventures (Japan)
@@ -19374,6 +30028,27 @@ game
       pinout
         a0: 2
         a1: 3
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c47a01c9b32642ad3145316804e64b0475a20863e42e81d17c664d03dcdde3c5
+  name:   Tiny Toon Adventures (USA)
+  title:  Tiny Toon Adventures (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
     memory
       type: ROM
       size: 0x10
@@ -19411,6 +30086,182 @@ game
       content: Character
 
 game
+  sha256: ea98c7eedd31b350bb57aa35b4fd8ae0e63712a6e93c8f79cb4ac79b1561b578
+  name:   Tiny Toon Adventures 2 - Trouble in Wackyland (Europe)
+  title:  Tiny Toon Adventures 2 - Trouble in Wackyland (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d4a94fd07859485fc2aac73d627933b70e1977c93b744ec3d71b66d4365ab7f7
+  name:   Tiny Toon Adventures 2 - Trouble in Wackyland (USA)
+  title:  Tiny Toon Adventures 2 - Trouble in Wackyland (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d752396622c697fab7e938edc6e27a5e7a9e78d717a8a9ce95737e8d0626cd7e
+  name:   Tiny Toon Adventures Cartoon Workshop (Europe)
+  title:  Tiny Toon Adventures Cartoon Workshop (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4a991ac38eb235b6b10df85073bc4439817483de8cefe871711f7d226b515fa5
+  name:   Tiny Toon Adventures Cartoon Workshop (USA)
+  title:  Tiny Toon Adventures Cartoon Workshop (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 5ca3263ed824f1ce1a09bff7c0729d758784b15ccf5f3aea7512209dd7b3c4e7
+  name:   TM Network - Live in Power Bowl (Japan)
+  title:  TM Network - Live in Power Bowl (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 0781e6d4724a2dfea183635b862c78da02df9242befebe5ac55e17c84e6ff4a3
+  name:   To the Earth (Europe)
+  title:  To the Earth (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 44569cef71a0b859bd0390e0155b19077ddef4a684f6fba6569a5f918910d4a2
+  name:   To the Earth (USA)
+  title:  To the Earth (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: e580f51b06217b102e56ec98fff7c4ebad5b925fa3a28042d67433cffa8c5cdc
+  name:   Toki (USA)
+  title:  Toki (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: 42a1650ef80f707f2b3f97084c2f2a4881dbe5d9c7ca874d7fa5a67d6e1416b2
   name:   Toki no Tabibito - Time Stranger (Japan)
   title:  Toki no Tabibito - Time Stranger (Japan)
@@ -19433,6 +30284,27 @@ game
       volatile
 
 game
+  sha256: 9c77cec4f5a14d23409c3c6596cfdda9ff95e9ab58cb9054cc1157055d055340
+  name:   Tokkyuu Shirei Solbrain (Japan)
+  title:  Tokkyuu Shirei Solbrain (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: e79df83c7939dc1ffab0d6d07b20fac959aedf3a98db73ef6bb654f1e92d7d0a
   name:   Tokoro-san no Mamoru mo Semeru mo (Japan)
   title:  Tokoro-san no Mamoru mo Semeru mo (Japan)
@@ -19451,6 +30323,90 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: b922d432752f63061768814d8040733e51dbd98f996371b0ad547ce00f26707a
+  name:   Tom & Jerry (Japan)
+  title:  Tom & Jerry (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 720f4598dc42067c07390ed060ef0454e8f546d1f838d29dafd1a73dac3b54ee
+  name:   Tom & Jerry - The Ultimate Game of Cat and Mouse! (Europe)
+  title:  Tom & Jerry - The Ultimate Game of Cat and Mouse! (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b49e3b3c2a307e9c24715ea5863d6c80b805f9566eb1f468a4c701cf54605a5a
+  name:   Tom & Jerry - The Ultimate Game of Cat and Mouse! (USA)
+  title:  Tom & Jerry - The Ultimate Game of Cat and Mouse! (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9cbc7b1cb42e18ab3cf8cc32b75f17211e0410e8008d0e97ec0af724ef94fa71
+  name:   Tom Sawyer no Bouken (Japan)
+  title:  Tom Sawyer no Bouken (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -19542,6 +30498,69 @@ game
       volatile
 
 game
+  sha256: bc7be1cd154cfe9b99e8f28cccd8d3c9e86a540230303f910f63c9062694be56
+  name:   Top Gun - Dual Fighters (Japan)
+  title:  Top Gun - Dual Fighters (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3dd6f25e3a9eba2624b68f83949df0eda2afbb20c0e2007341e03d957ebc43b8
+  name:   Top Gun - The Second Mission (Europe)
+  title:  Top Gun - The Second Mission (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 55375474cdebdb05eeec27494761b686a7df63b8f874516004f1739760665c87
+  name:   Top Gun - The Second Mission (USA)
+  title:  Top Gun - The Second Mission (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 5094752e3f001c1eeff60116cf64fd35a090e14bf95ef5f563afc41d59fc3445
   name:   Top Striker (Japan)
   title:  Top Striker (Japan)
@@ -19607,6 +30626,48 @@ game
       volatile
 
 game
+  sha256: 31374c4db4d3fdcb01abd55c69bded267b235f116cee474aadb0677b8231be4b
+  name:   Totally Rad (Europe)
+  title:  Totally Rad (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 0bd29c5b583570e195e05a4272e69b74257db1f4ff928d59c8eb1022bad871ce
+  name:   Totally Rad (USA)
+  title:  Totally Rad (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: d0666f8f75dbe4a2adc7e90de4bb17c64a722d7672ee148acc123902784b799c
   name:   Totsuzen! Macchoman (Japan)
   title:  Totsuzen! Macchoman (Japan)
@@ -19650,6 +30711,27 @@ game
       content: Character
 
 game
+  sha256: cfa1cc0f40cf139b1ba61794838d52c029b40ea12194b4248178d8ae59c69b7a
+  name:   Town & Country Surf Designs - Thrilla's Surfari (USA)
+  title:  Town & Country Surf Designs - Thrilla's Surfari (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: f3955370fe7ecc99afc27cdccf3482f75f06e0f431e42823c95982bb553ad6b9
   name:   Town & Country Surf Designs - Wood & Water Rage (USA)
   title:  Town & Country Surf Designs - Wood & Water Rage (USA)
@@ -19668,6 +30750,27 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: c3fec0650f1709911432e8953a6075cb5883601a209323ba0744cb19d82b7f80
+  name:   Toxic Crusaders (USA)
+  title:  Toxic Crusaders (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -19801,6 +30904,27 @@ game
       volatile
 
 game
+  sha256: 5699da9924f31e0f1b7d5cacd05111786881b7a87da38a99aee092fc855ab353
+  name:   Trolls in Crazyland, The (Europe)
+  title:  Trolls in Crazyland, The (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: fcccf437e952aa44784961899ca17d6f6116e088cca7e5cab910bcd9054b8fa4
   name:   Tsuppari Oozumou (Japan)
   title:  Tsuppari Oozumou (Japan)
@@ -19851,6 +30975,27 @@ game
   board:  JALECO-JF-24A
     chip
       type: SS88006
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e2b26560d326cc626736efa2addf1c66f5af77913968fcf5cde738188c4a0132
+  name:   Twin Cobra (USA)
+  title:  Twin Cobra (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
     memory
       type: ROM
       size: 0x10
@@ -19954,6 +31099,27 @@ game
       content: Character
 
 game
+  sha256: f0735a53381292228e845794fc2c235a77f2a20fe5c329dc21eb57cfd89357f0
+  name:   U.S. Championship V'Ball (Japan)
+  title:  U.S. Championship V'Ball (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 407e54848ad9991399f0383118f138d3a0532bb03bb488ed856deb7f2eb4efbf
   name:   Uchuusen Cosmo Carrier (Japan)
   title:  Uchuusen Cosmo Carrier (Japan)
@@ -19967,6 +31133,157 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ef818c90f326383d13087b6e0131bf36563d76c3c1a3c13821c79368e377cf8d
+  name:   Ufouria - The Saga (Europe)
+  title:  Ufouria - The Saga (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 5fc575035c9d7cf5e43feb3c020b11be635adb7e8e951e33f04012d4a0017bf4
+  name:   Ultimate Air Combat (Europe)
+  title:  Ultimate Air Combat (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 8dda0b6bcb5d66fd6983f71f9257225ce053822cbb5edda5d072feeddec9358e
+  name:   Ultimate Air Combat (USA)
+  title:  Ultimate Air Combat (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: bd6797920755a1dc159bee32bf5555651fc8ce077a36ac7469c7dac02d0db21f
+  name:   Ultimate Basketball (USA)
+  title:  Ultimate Basketball (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ee958fe6a0d6b5d026b7c9a09c11d58a0bad3e8a671cff44ca7a81671864fcdf
+  name:   Ultraman Club - Kaijuu Daikessen!! (Japan)
+  title:  Ultraman Club - Kaijuu Daikessen!! (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 70db192e7f71f6dc21f970f92b8812ded7d36dd25ad71d5b79703652874c1276
+  name:   Ultraman Club 2 - Kaettekita Ultraman Club (Japan)
+  title:  Ultraman Club 2 - Kaettekita Ultraman Club (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9e467abd5a39a8684177aa34fc2227202fb0fbceec804804b6650a1862fc1e5f
+  name:   Ultraman Club 3 - Matamata Shutsugeki!! Ultra Kyoudai (Japan)
+  title:  Ultraman Club 3 - Matamata Shutsugeki!! Ultra Kyoudai (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: ROM
       size: 0x20000
@@ -19993,6 +31310,31 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 955abe39d0a45dab909510d24af99b4e71fe7cc24e3784bbfb9d02ed16ed2ef2
+  name:   Uninvited (USA)
+  title:  Uninvited (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 7255ab27932f7c07fa61c230a51342b0441ea9b24ba094ae3129ec7453de2449
@@ -20058,6 +31400,52 @@ game
       content: Character
 
 game
+  sha256: 1e26c1bd7c9a597d69c0ecfcae3aac8a70871d5c691989df17d9960ed7414c17
+  name:   Ushio to Tora - Shinen no Taiyou (Japan)
+  title:  Ushio to Tora - Shinen no Taiyou (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 3e63da4c45b1e8dd7b9d3076476c73510e860e58edc344520ca3aa58595f0765
+  name:   Utsurun Desu - Kawauso Hawaii e Iku (Japan)
+  title:  Utsurun Desu - Kawauso Hawaii e Iku (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 8374e40b94d13047e6304a4b2d4057f0ef29103bd9fae0f31feafe50889cde76
   name:   Valkyrie no Bouken - Toki no Kagi Densetsu (Japan)
   title:  Valkyrie no Bouken - Toki no Kagi Densetsu (Japan)
@@ -20078,6 +31466,27 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 433f6bcbd59a9d5916d2209ddeacd39d24810c1ed21a33366171b4991fc7e844
+  name:   Vice - Project Doom (USA)
+  title:  Vice - Project Doom (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -20142,6 +31551,27 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: 8589b1dc55e04d23e56e864f1b001c6eecf18b7dcb7a0c4a9c4a40cbcc451601
+  name:   Wacky Races (USA)
+  title:  Wacky Races (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -20278,6 +31708,102 @@ game
       volatile
 
 game
+  sha256: 728d4f17c698bb030eb1f62fd53c73f318632b2743929bd2f2e43d20b287a326
+  name:   Wanpaku Kokkun no Gourmet World (Japan)
+  title:  Wanpaku Kokkun no Gourmet World (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c6097d923df166818c3f25a7a25995d3ceddbca246770bec26554d7a920854b8
+  name:   Wario no Mori (Japan)
+  title:  Wario no Mori (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 9fe815d8fd175ef9ef03fb010638f2b6b7aa9d11d5a40eda2476450918543e6f
+  name:   Wario's Woods (Europe)
+  title:  Wario's Woods (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: c12771e8155b030eff0081bfabd98e57a162d6592899f29dd16f141f0e6e08a3
+  name:   Wario's Woods (USA)
+  title:  Wario's Woods (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: 5b36ae6243ddb4a1ba717123db41981a96b89175928b00d63df3fa4cede83d70
   name:   Warpman (Japan)
   title:  Warpman (Japan)
@@ -20319,6 +31845,111 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 059409954035963f1f13029dfa25468100a8e6a90d9388c4a225f235ade97a45
+  name:   Wayne's World (USA)
+  title:  Wayne's World (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a00db4c89bfd12704c53768b62b4f09d57d28891093447d81a0678b059629e59
+  name:   WCW World Championship Wrestling (USA)
+  title:  WCW World Championship Wrestling (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9b14a16063d357d4af79d5edd4a1b7ed8e4d8e3444854721a8adbe752ccf2e18
+  name:   Werewolf - The Last Warrior (Europe)
+  title:  Werewolf - The Last Warrior (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ab6f1bbcda6f0c0bbe1450b5f2ab2b21a5e01ec39143a455701862965cdbd7b4
+  name:   Werewolf - The Last Warrior (USA)
+  title:  Werewolf - The Last Warrior (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a0fc4dbbfb001a6f0752303d997bef9815f874d3544a7dba3ae9a73048ed0ae4
+  name:   Western Kids (Japan)
+  title:  Western Kids (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
 
 game
   sha256: 88691067f122467f2dae85e40b927013b91fe848f88d694616ed2f26ab1f3f4d
@@ -20421,6 +32052,56 @@ game
       volatile
 
 game
+  sha256: 768867bd0dc79c856277ab974f4fae1fd2bf943aeddfeb9d75ead6e8a6a8e09b
+  name:   Where in Time Is Carmen Sandiego (USA)
+  title:  Where in Time Is Carmen Sandiego (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: a66195e11e38bee9f602abd279b7c04367528380dfa5b915dce0fa6fd272c23c
+  name:   Where's Waldo (USA)
+  title:  Where's Waldo (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 700ebc3c2dd27420bbdcccb987ba60d3f0680469101353de15a1b2bd565ac701
   name:   Who Framed Roger Rabbit (USA)
   title:  Who Framed Roger Rabbit (USA)
@@ -20439,6 +32120,48 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: b9a4542417439619239cdb2cefd8c7eced2407ba2954f026c0ab1ea7d4def3d3
+  name:   Whomp 'Em (USA)
+  title:  Whomp 'Em (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9d875583dbdf80a0631ce4ffb3099064454d80568b5e9fe748a5e850f8fa0161
+  name:   Widget (USA)
+  title:  Widget (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 62aec65696ecf24a487b7cdd19bad5cbd19f4229a89a7888634d468c67da378a
@@ -20483,6 +32206,28 @@ game
       content: Character
 
 game
+  sha256: df4e1e14d4df078083f9ec0104f200ed3ad4cb69fd1792f7a70c588e9c9ce46d
+  name:   Wily & Right no Rockboard - That's Paradise (Japan)
+  title:  Wily & Right no Rockboard - That's Paradise (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 554c74ff0b7ce3c1a0c5f96458d5587930879258b8b08a8813097513b52356b0
   name:   Winter Games (USA) (Rev 1)
   title:  Winter Games (USA) (Rev 1)
@@ -20525,6 +32270,81 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: de5e01c6b46aac2cc503b1af1ab3c0251eaa3f1d04780b8cfe447d4a6805474b
+  name:   Wizardry - Knight of Diamonds - The Second Scenario (USA)
+  title:  Wizardry - Knight of Diamonds - The Second Scenario (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: de15ac43f44c8ada9cb53163222410d039a672e072dfbbfd320e29c2dfc39a7d
+  name:   Wizardry II - Llylgamyn no Isan (Japan)
+  title:  Wizardry II - Llylgamyn no Isan (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e927839f91655757b69cb2044d377e1f0c595dd24dcec3f625842481b928a211
+  name:   Wizardry III - Diamond no Kishi (Japan)
+  title:  Wizardry III - Diamond no Kishi (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: a870c1add0839708b2524b5ca4ae64547001c13bbd664a51f998656936dd1075
@@ -20627,6 +32447,27 @@ game
       volatile
 
 game
+  sha256: 2d62114f3f139e8dd01c3e6e56d83a848a236ebb0c146fac5d372ba40ae456d5
+  name:   Wolverine (USA)
+  title:  Wolverine (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 8acf6c84584a91cae8127735a2d5df520cca5ee6e05f1e57854c9e1615999207
   name:   Woody Poko (Japan)
   title:  Woody Poko (Japan)
@@ -20647,6 +32488,48 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 6accb108e62c0c47b939694796bd5c193a6f5a9ae896af74e010232937fa55d1
+  name:   World Champ (Europe)
+  title:  World Champ (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 05684e63aa981006ae73619dcd48b7c0a63f98fa6bebcab93044095a70c11678
+  name:   World Champ (USA)
+  title:  World Champ (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 6c74bcb9ac50428266cfc4d13892b6e93c6936ba569bf3f0f2068e45a9b675fc
@@ -20732,6 +32615,69 @@ game
       content: Character
 
 game
+  sha256: a0354fb9c1c29e25b8bd2bd45735e8af2263cde66b56cc2e61eb5d9295a42de1
+  name:   Wurm - Journey to the Center of the Earth! (USA)
+  title:  Wurm - Journey to the Center of the Earth! (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 65bfa31091ecc5e04f705a26128781e84a5011e3eb042c339ac1eb5d228ace7b
+  name:   WWF King of the Ring (Europe)
+  title:  WWF King of the Ring (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: e5de4656729ffa37f7f6afdccb7c207ca7b867768369cc1a2817626919bff8dc
+  name:   WWF King of the Ring (USA)
+  title:  WWF King of the Ring (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: 306599be84494284eb8132aaceb7fc8e23ad0f9b410825b6271ebdbd8b4ed7c2
   name:   WWF Wrestlemania (Europe)
   title:  WWF Wrestlemania (Europe)
@@ -20770,6 +32716,48 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: dcbb44b764eaddc61b48d62e7849713703b0535797fd4d972e5c7a38b634bc64
+  name:   WWF Wrestlemania - Steel Cage Challenge (Europe)
+  title:  WWF Wrestlemania - Steel Cage Challenge (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: b0e4bcb63416c32fc247ff8afc28915ba15906a9b02aaed77a41e8109eab91fc
+  name:   WWF Wrestlemania - Steel Cage Challenge (USA)
+  title:  WWF Wrestlemania - Steel Cage Challenge (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
 
 game
   sha256: cc6cdf219593f99897c2fa2cea50dca3cd6a4b5d6bfd5d8f3f144b6f49e324ec
@@ -20922,6 +32910,52 @@ game
       content: Character
 
 game
+  sha256: ca3be04cea2d32aaa51cc8484fda363d6afacb6bb89e03714f3eb2b74605b6fe
+  name:   Yamamura Misa Suspense Series - Kyoto Zai-Tech Satsujin Jiken (Japan)
+  title:  Yamamura Misa Suspense Series - Kyoto Zai-Tech Satsujin Jiken (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4eafd7debc4bbad5371e0a2ef8f138d70172c8a1bde6bab0b34a841bfa8a455a
+  name:   Yami no Shigotonin Kage (Japan)
+  title:  Yami no Shigotonin Kage (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: dbe10104fc90c36ff7c95424cb192dfd9619fb7c1238bbae8da87e0bc9cc5a4e
   name:   Yie Ar Kung-Fu (Japan)
   title:  Yie Ar Kung-Fu (Japan)
@@ -20961,6 +32995,69 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: bcd3abd5e767b8ce102dd0a037a85b827fd219b750edce90c431e038e9287ff1
+  name:   Yoshi no Cookie (Japan)
+  title:  Yoshi no Cookie (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
+  sha256: 1584ddcfb5915f2b601fd908c2eb6a71ac99223dc35320cfe48c6bc7ef2aa5e8
+  name:   Yoshi's Cookie (Europe)
+  title:  Yoshi's Cookie (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
+  sha256: 24b117a0830fcb91d88d9150ff89a374134a9ddebd5eedcb5df21eab580eb2c0
+  name:   Yoshi's Cookie (USA)
+  title:  Yoshi's Cookie (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
       content: Character
 
 game
@@ -21006,6 +33103,27 @@ game
       content: Character
 
 game
+  sha256: fd4884c98d9412eb362c0654c8f5475e7f24266984f11e19961495c2d642d38a
+  name:   Young Indiana Jones Chronicles, The (USA)
+  title:  Young Indiana Jones Chronicles, The (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 64d643098a4d271937aa72b2f5849c71001a9bd080522c359e5ff71b27cb9b6b
   name:   Yousei Monogatari - Rod Land (Japan)
   title:  Yousei Monogatari - Rod Land (Japan)
@@ -21026,6 +33144,31 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: c79202082042baeb3a45e747a1675c9530137f847c357c393270715efc32217e
+  name:   Ys II - Ancient Ys Vanished - The Final Chapter (Japan)
+  title:  Ys II - Ancient Ys Vanished - The Final Chapter (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: ec1d85479d72847d3adbd76e2e79221143e6c9324d5647be2c4a11aa87123f75
@@ -21053,6 +33196,27 @@ game
       content: Character
 
 game
+  sha256: a5bd6e9e073b9bc7a6a646de629676661dbec0444c58b13e8efa3c7c682d5694
+  name:   Yume Penguin Monogatari (Japan)
+  title:  Yume Penguin Monogatari (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: bdc9dfed1b03db470a1453da0252b3e9fcd0869d02a48622476ddaa350e53374
   name:   Zanac (USA)
   title:  Zanac (USA)
@@ -21073,6 +33237,48 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: ef43a3d30fee2283cd87c99ebbf67632440d4d09cbb5356637d7b2df44356cf0
+  name:   Zen - Intergalactic Ninja (Europe)
+  title:  Zen - Intergalactic Ninja (Europe)
+  region: PAL
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 939dcb88fce04f9c91e1ce49016b12e301afc4861684576ab5862eada5860db7
+  name:   Zen - Intergalactic Ninja (USA)
+  title:  Zen - Intergalactic Ninja (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 3d0bed52417af501590258079607f54af656a231f750d35d9d5587a2a928511f
@@ -21163,6 +33369,48 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: d73e3c30943e67e63c36cdc29830555b67cd2f09838c8fab3020e578464de7ea
+  name:   Zoids Mokushiroku (Japan)
+  title:  Zoids Mokushiroku (Japan)
+  region: NTSC-J
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 91eae4e0e59dadd5de7cdbe71fe57e304d741ae5107928e29e0f6ff8813151a9
+  name:   Zombie Nation (USA)
+  title:  Zombie Nation (USA)
+  region: NTSC-U
+  board:  HVC-TLROM
+    chip
+      type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 061d1c3865ad62ae883bb30b9f0071e8f7aa572f15f61bfb91b3a755eeeb5eb0

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -17995,6 +17995,56 @@ game
       volatile
 
 game
+  sha256: 7ff16ac31650db5d353a7c77349e916c71cd104b3fb8e97df3d9da35af248644
+  name:   StarTropics (Europe)
+  title:  StarTropics (Europe)
+  region: PAL
+  board:  HVC-HKROM
+    chip
+      type: MMC6
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x400
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
+  sha256: 69de2c7552fa81ca5921da0e457abf1be35f18ffbad159788a76141be59c9f6b
+  name:   StarTropics (USA)
+  title:  StarTropics (USA)
+  region: NTSC-U
+  board:  HVC-HKROM
+    chip
+      type: MMC6
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x400
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
+      content: Character
+
+game
   sha256: 2ce85b82b427de187b59b62d33081497acfa2010ef38660b157f8eb008336e6e
   name:   Stick Hunter - Exciting Ice Hockey (Japan)
   title:  Stick Hunter - Exciting Ice Hockey (Japan)
@@ -21043,6 +21093,31 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: d0850075065ecbd125a33accc952de5d012527be45aa14a1b8223a9adf1643ae
+  name:   Zoda's Revenge - StarTropics II (USA)
+  title:  Zoda's Revenge - StarTropics II (USA)
+  region: NTSC-U
+  board:  HVC-HKROM
+    chip
+      type: MMC6
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x400
+      content: Save
+    memory
+      type: ROM
+      size: 0x40000
       content: Character
 
 game

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -173,14 +173,9 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     break;
 
   case   4:
-    //MMC3
     s += "  board:  HVC-TLROM\n";
     s += "    chip type=MMC3B\n";
     prgram = 8192;
-    //MMC6
-  //s += "  board:  HVC-HKROM\n";
-  //s += "    chip type=MMC6\n";
-  //prgram = 1024;
     break;
 
   case   5:


### PR DESCRIPTION
Improvements to NES/Famicom MMC3 irq behavior and support for MMC6.

This fix the following games:
- Beauty and the Beast (Europe) * sporadic flicker issues when scrolling
- Gauntlet II (Europe/USA) * sporadic flicker issues when scrolling and eventual hang
- King's Quest V (USA) * blue intro screen has scanline issue at bottom
- Mickey's Adventure in Numberland (USA) * 1 scrambled scanline on title screen
- Star Trek - 25th Anniversary (USA) * gfx corruption between scrolling transitions
- StarTropics (Europe/USA) * hangs when starting game
- Zoda's Revenge - StarTropics II (USA) * hangs when starting game

This pr adds two changes to MMC3 irq generation:
1. When the counter is reloaded with 0 the MMC3 will generate an interrupt on each scanline. This fix issues on "Beauty and the Beast", "Gauntlet II" and "Star Trek 25th Anniversary" ("Beauty and the Beast" still has another issue, some black lines on the intro).
2. The counter can be manually clocked by writes to ppu 0x2006. This fix issues on "King's Quest V" and "Mickey's Adventure in Numberland".

The "StarTropics" games are fixed by using MMC6 for them; there were already an implementation in ares for it, but unused. Updating this implementation with the same MMC3 changes and adding the games to database made them work.

Also in this pr iNES mapper 4 games (MMC3/6) are added to database.