### PR TITLE
fc: check if ram exists on mmc3

### DIFF
--- a/ares/fc/cartridge/board/hvc-txrom.cpp
+++ b/ares/fc/cartridge/board/hvc-txrom.cpp
@@ -80,7 +80,7 @@ struct HVC_TxROM : Interface {  //MMC3
     if(address < 0x6000) return data;
 
     if(address < 0x8000) {
-      if(!ramEnable) return data;
+      if(!ramEnable || !programRAM) return data;
       return programRAM.read((n13)address);
     }
 
@@ -100,7 +100,7 @@ struct HVC_TxROM : Interface {  //MMC3
     if(address < 0x6000) return;
 
     if(address < 0x8000) {
-      if(!ramEnable || !ramWritable) return;
+      if(!ramEnable || !ramWritable || !programRAM) return;
       return programRAM.write((n13)address, data);
     }
 


### PR DESCRIPTION
Check if prg RAM exists on MMC3.

Games fixed:
- Mickey's Adventure in Numberland (USA) * crashes emulator when you try to pause ingame

It was reported that the game "Mickey's Adventure in Numberland (USA)" is now crashing ares when you try to pause ingame. This is because it's now on the database and ares is loading it now with no prg RAM. This game doesn't have RAM on board, but tries to read from it when pausing the game.