### PR TITLE
n64: fix RSP halt condition to be more accurate

### DIFF
--- a/ares/n64/rsp/interpreter-ipu.cpp
+++ b/ares/n64/rsp/interpreter-ipu.cpp
@@ -55,7 +55,6 @@ auto RSP::BREAK() -> void {
   status.halted = 1;
   status.broken = 1;
   if(status.interruptOnBreak) mi.raise(MI::IRQ::SP);
-  branch.halt();
 }
 
 auto RSP::J(u32 imm) -> void {

--- a/ares/n64/rsp/io.cpp
+++ b/ares/n64/rsp/io.cpp
@@ -170,7 +170,11 @@ auto RSP::Status::readWord(u32 address) -> u32 {
 
   if(address == 0) {
     //SP_PC_REG
-    data.bit(0,11) = self.ipu.pc;
+    if(halted) {
+      data.bit(0,11) = self.ipu.pc;
+    } else {
+      data.bit(0,11) = random();
+    }
   }
 
   if(address == 1) {
@@ -187,11 +191,8 @@ auto RSP::Status::writeWord(u32 address, u32 data_) -> void {
 
   if(address == 0) {
     //SP_PC_REG
-    if(self.branch.state == Branch::Take) {
-      self.branch.pc = data.bit(0,11) & ~3;
-    } else {
-      self.ipu.pc = data.bit(0,11) & ~3;
-    }
+    self.ipu.pc = data.bit(0,11) & ~3;
+    self.branch.reset();
   }
 
   if(address == 1) {

--- a/ares/n64/rsp/rsp.cpp
+++ b/ares/n64/rsp/rsp.cpp
@@ -61,10 +61,9 @@ auto RSP::instructionEpilogue() -> s32 {
   ipu.r[0].u32 = 0;
 
   switch(branch.state) {
-  case Branch::Step: ipu.pc += 4; return 0;
-  case Branch::Take: ipu.pc += 4; branch.delaySlot(); return 0;
+  case Branch::Step: ipu.pc += 4; return status.halted;
+  case Branch::Take: ipu.pc += 4; branch.delaySlot(); return status.halted;
   case Branch::DelaySlot: ipu.pc = branch.pc; branch.reset(); return 1;
-  case Branch::Halt: ipu.pc += 4; return 1;
   }
 
   unreachable;

--- a/ares/n64/rsp/rsp.hpp
+++ b/ares/n64/rsp/rsp.hpp
@@ -115,13 +115,12 @@ struct RSP : Thread, Memory::IO<RSP> {
   } ipu;
 
   struct Branch {
-    enum : u32 { Step, Take, DelaySlot, Halt };
+    enum : u32 { Step, Take, DelaySlot };
 
     auto inDelaySlot() const -> bool { return state == DelaySlot; }
     auto reset() -> void { state = Step; }
     auto take(u32 address) -> void { state = Take; pc = address; }
     auto delaySlot() -> void { state = DelaySlot; }
-    auto halt() -> void { state = Halt; }
 
     u64 pc = 0;
     u32 state = Step;


### PR DESCRIPTION
 * Fix usage of break opcode in a delay slot. After unhalt, the
   RSP continues execution, taking the jump if needed. So the
   branch state should not be affected by the break opcode.
 * Reading from SP_PC produces garbage (open bus?) when the RSP is
   running. This fix is unlikely to fix games but may help homebrew
   developers.
 * Writing to SP_PC resets the RSP MIPS pipeline, so any pending branch
   is canceled.
