### PR TITLE
n64: fix SRA/SRAV opcodes

### DIFF
--- a/ares/n64/cpu/interpreter-ipu.cpp
+++ b/ares/n64/cpu/interpreter-ipu.cpp
@@ -938,11 +938,11 @@ auto CPU::SLTU(r64& rd, cr64& rs, cr64& rt) -> void {
 }
 
 auto CPU::SRA(r64& rd, cr64& rt, u8 sa) -> void {
-  rd.u64 = rt.s32 >> sa;
+  rd.u64 = s32(rt.s64 >> sa);
 }
 
 auto CPU::SRAV(r64& rd, cr64& rt, cr64& rs) -> void {
-  rd.u64 = rt.s32 >> (rs.u32 & 31);
+  rd.u64 = s32(rt.s64 >> (rs.u32 & 31));
 }
 
 auto CPU::SRL(r64& rd, cr64& rt, u8 sa) -> void {

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -592,7 +592,7 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //SRA Rd,Rt,Sa
   case 0x03: {
-    ashr32(reg(0), mem(Rt32), imm(Sa));
+    ashr64(reg(0), mem(Rt), imm(Sa));
     mov64_s32(reg(0), reg(0));
     mov64(mem(Rd), reg(0));
     return 0;
@@ -626,9 +626,8 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> bool {
 
   //SRAV Rd,Rt,Rs
   case 0x07: {
-    mov32(reg(0), mem(Rt32));
     and32(reg(1), mem(Rs32), imm(31));
-    ashr32(reg(0), reg(0), reg(1));
+    ashr64(reg(0), mem(Rt), reg(1));
     mov64_s32(reg(0), reg(0));
     mov64(mem(Rd), reg(0));
     return 0;


### PR DESCRIPTION
These two opcodes were incorrectly ignoring the higher part of the
register before shifting.

Attached ROMs can be used for testing:
[sra.zip](https://github.com/ares-emulator/ares/files/7885152/sra.zip)

Origin: https://github.com/Dillonb/n64-tests/releases/tag/latest
