### PR TITLE
fc: clear oam address on each scanline and mmc1 updates

### DIFF
--- a/ares/fc/cartridge/board/hvc-sxrom.cpp
+++ b/ares/fc/cartridge/board/hvc-sxrom.cpp
@@ -136,7 +136,7 @@ struct HVC_SxROM : Interface {  //MMC1
       if(revision == Revision::SNROM) {
         if(characterBank[0].bit(4)) return data;
       }
-      if(ramDisable) return 0x00;
+      if(!programRAM || ramDisable) return 0x00;
       return programRAM.read(addressProgramRAM(address));
     }
 
@@ -152,7 +152,7 @@ struct HVC_SxROM : Interface {  //MMC1
       if(revision == Revision::SNROM) {
         if(characterBank[0].bit(4)) return;
       }
-      if(ramDisable) return;
+      if(!programRAM || ramDisable) return;
       return programRAM.write(addressProgramRAM(address), data);
     }
 

--- a/ares/fc/ppu/render.cpp
+++ b/ares/fc/ppu/render.cpp
@@ -138,6 +138,7 @@ auto PPU::renderScanline() -> void {
 
   //257-320
   for(u32 sprite : range(8)) {
+    if(enable()) io.oamAddress = 0;
     u32 nametable = loadCHR(0x2000 | (n12)io.v.address);
     step(1);
 

--- a/mia/Database/Famicom.bml
+++ b/mia/Database/Famicom.bml
@@ -1,5 +1,27 @@
 database
-  revision: 2022-01-01
+  revision: 2022-01-26
+
+game
+  sha256: 4f6fa63277b7a114a24e8d67175ff3f7b993fa5db569d8b689ec20ccf1b0c0d3
+  name:   '89 Dennou Kyuusei Uranai (Japan)
+  title:  '89 Dennou Kyuusei Uranai (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: a75af9b5972f22056d016474234b03213e5d7932fb1e81890d58bd100bb8d0d2
@@ -63,6 +85,28 @@ game
       type: ROM
       size: 0x2000
       content: Character
+
+game
+  sha256: bd578147b15c610e0ceafc7e27a87a3bf96e65af3b31aa98ae6924fc27a2d797
+  name:   100 Man Dollar Kid - Maboroshi no Teiou Hen (Japan)
+  title:  100 Man Dollar Kid - Maboroshi no Teiou Hen (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: e868400409c70876b98dad2cca87b8e9ee31877b0cccbbd8405be5c54922722a
@@ -236,6 +280,28 @@ game
       content: Character
 
 game
+  sha256: df696ce2af90b18ca2b57468bdc525afce371bb1868152eb2cbbe1d62252f617
+  name:   720 Degrees (USA)
+  title:  720 Degrees (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: c4b1bde698c2090646d967392052a9b3e5c911dcbc5b88b8d1b05e9324f11396
   name:   8 Eyes (Japan)
   title:  8 Eyes (Japan)
@@ -278,6 +344,31 @@ game
       content: Character
 
 game
+  sha256: 9040f16eb22946f3b505dc9ccd7ac7ee5c6544580cfdc3f9f71cbc07755d1fc9
+  name:   A Ressha de Ikou (Japan)
+  title:  A Ressha de Ikou (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x4000
+      content: Save
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
   sha256: 134c0575a417a986cdae33a0f9ca5eb38d269e028416752db6c6a5dc0db8ef7f
   name:   Aa Yakyuu Jinsei Icchokusen (Japan)
   title:  Aa Yakyuu Jinsei Icchokusen (Japan)
@@ -298,6 +389,48 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 7934c8620f90ace5cd357d233a7c68687efb78cca7f3f95be48f3965f9e24c9a
+  name:   Abadox (Japan)
+  title:  Abadox (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c4d4ff0bd283656c63d9a30dfc7dc6d2956744730a3641ba2c8f9f8e7204d9a1
+  name:   Abadox - The Deadly Inner War (USA)
+  title:  Abadox - The Deadly Inner War (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 35fff8fa349361f879e419d303edd371d4f2f9d7a7912421343baa694fd471e9
@@ -342,6 +475,136 @@ game
       content: Character
 
 game
+  sha256: 6da6c8ac123df0f51e6f1b2ba79cb067d3352262532604ab08cf5dd587e84006
+  name:   Action in New York (Europe)
+  title:  Action in New York (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e92938b2379008222e093d0b9674607f4483da931061946e675c8a1ed6c8254e
+  name:   Addams Family, The (Europe)
+  title:  Addams Family, The (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 005c48a5984e3b75e069ef78d736266b12f7f6b102d88d90172ba9ae480b378b
+  name:   Addams Family, The (USA)
+  title:  Addams Family, The (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d272fd3f15a3eb1f191fc488551373486f77bc7d39fad246bd4cea5eb1c91440
+  name:   Addams Family, The - Pugsley's Scavenger Hunt (Europe)
+  title:  Addams Family, The - Pugsley's Scavenger Hunt (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b3e09c94e33e0293672c1405c60fc69b2ab1564c8a4ee988e3ab6ada51484eea
+  name:   Addams Family, The - Pugsley's Scavenger Hunt (USA)
+  title:  Addams Family, The - Pugsley's Scavenger Hunt (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 314a546c20d6aa44e699c011bf04afd4f9d472d2af40d82836f76612cc606da8
+  name:   Advanced Dungeons & Dragons - Dragons of Flame (Japan)
+  title:  Advanced Dungeons & Dragons - Dragons of Flame (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 22e92af92aed2d8d7bddb60732963642788b3ea9341592ce2c66a542a3d7ce7d
   name:   Advanced Dungeons & Dragons - DragonStrike (USA)
   title:  Advanced Dungeons & Dragons - DragonStrike (USA)
@@ -361,6 +624,108 @@ game
       type: ROM
       size: 0x40000
       content: Character
+
+game
+  sha256: 0c92894d0df0d890ddc437f1557dc0d6adfb81263c25c40841a1e83cd9d21732
+  name:   Advanced Dungeons & Dragons - Heroes of the Lance (Japan)
+  title:  Advanced Dungeons & Dragons - Heroes of the Lance (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: df2609c80e818bb95983b30a3ac1435ea2332ac83e29fde469f397e1d5a2db93
+  name:   Advanced Dungeons & Dragons - Heroes of the Lance (USA)
+  title:  Advanced Dungeons & Dragons - Heroes of the Lance (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a980a897a688b8f1f70eb135355bb90cc7469f1bd18237781f6d0ae342217713
+  name:   Advanced Dungeons & Dragons - Hillsfar (Japan)
+  title:  Advanced Dungeons & Dragons - Hillsfar (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 60061c0042741f7c1e53ad8f738c27ffd9057310ff5d556662b3667e5700e751
+  name:   Advanced Dungeons & Dragons - Hillsfar (USA)
+  title:  Advanced Dungeons & Dragons - Hillsfar (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 1d54a70fac4635e2dc8855296daaaa85e80be71ba1703c5859c6583b7dddeaaa
@@ -518,6 +883,90 @@ game
       content: Character
 
 game
+  sha256: 4a4aeb204802fe00b801bf9f2d270e3def26e08fcafbbbaa9ec8bbca029550c4
+  name:   Adventures in the Magic Kingdom (Europe)
+  title:  Adventures in the Magic Kingdom (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 185e4adb2cbcb71ebf0fd3f6af767f2215f93916cd2ccf932ce5864d3953239a
+  name:   Adventures in the Magic Kingdom (USA)
+  title:  Adventures in the Magic Kingdom (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 599d9ed820218edada6f6f14fda1d0d21bad50cca28664f6604c171a72327adc
+  name:   Adventures of Bayou Billy, The (Europe)
+  title:  Adventures of Bayou Billy, The (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 0e862077f390348b8e109caa8189ff5ecdf3fac53eefc204369fae880e077d19
+  name:   Adventures of Bayou Billy, The (USA)
+  title:  Adventures of Bayou Billy, The (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 58d0f0e504b8450e7d2dfbe11948a244143bfe3065f7e78524633cce8ac73103
   name:   Adventures of Dino Riki (USA)
   title:  Adventures of Dino Riki (USA)
@@ -561,6 +1010,27 @@ game
       volatile
 
 game
+  sha256: ba954a009fbbd2b6de6f87e008e01145d842dd16b3f25625a994d58d420055bc
+  name:   Adventures of Lolo (Europe)
+  title:  Adventures of Lolo (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 30db64a2f6f796308dfeefbf6f0b648176cf6c982fbb5158c5408a899d6355c3
   name:   Adventures of Lolo (Japan)
   title:  Adventures of Lolo (Japan)
@@ -568,6 +1038,27 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: c5e47c0479f500b86995fc8d09e132f5ba3f54cfd9a2a601ea3848bb60871a20
+  name:   Adventures of Lolo (USA)
+  title:  Adventures of Lolo (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -624,6 +1115,111 @@ game
       content: Character
 
 game
+  sha256: f2fd40a1207d504d140da9df73029002572c61be86d1ebfeaabad88475c833fa
+  name:   Adventures of Lolo 3 (Europe)
+  title:  Adventures of Lolo 3 (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 24f7bb802a0ddce0648ea9f156db42b3eaf4cc6598ce852ffac9f849bf92abee
+  name:   Adventures of Lolo 3 (USA)
+  title:  Adventures of Lolo 3 (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: efa323475fa4567dbf88fc1f7dc8e072ba4ebc7de11e94e22022e7e95325c938
+  name:   Adventures of Lolo II (Japan)
+  title:  Adventures of Lolo II (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 15b52b417006aeb18a2b8bcba9d89be89980ed8e1f7e78502921e637de7d0423
+  name:   Adventures of Rad Gravity, The (Europe)
+  title:  Adventures of Rad Gravity, The (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 322d6be47ed539c3dd3c1c92398e9842c3922d7c13914b9c72752ddec377145c
+  name:   Adventures of Rad Gravity, The (USA)
+  title:  Adventures of Rad Gravity, The (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 03db3d003eaa91e1434093ea259a82b9f2d5ed5b02404f9feba05819f69f81c4
   name:   Adventures of Rocky and Bullwinkle and Friends, The (USA)
   title:  Adventures of Rocky and Bullwinkle and Friends, The (USA)
@@ -631,6 +1227,27 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 227e8a900206d0f8c67b7cb09eaee25f181085623b42bd9694dc30986d955f27
+  name:   Adventures of Tom Sawyer (USA)
+  title:  Adventures of Tom Sawyer (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -700,6 +1317,170 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0702704138e11bf3441f6bdd1ec03d59a7bf06ddb3c3a6607102f8ca394476b5
+  name:   Air Fortress (Europe)
+  title:  Air Fortress (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 616d753986be5ddf359f5d914168d972724de9fd3cbf8e8118fc4cc34d637144
+  name:   Air Fortress (Japan)
+  title:  Air Fortress (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 6d0215929f2dfeeecdeee4dd50b8aec07f279a8ab8df1dc4e877bbcad3db0d37
+  name:   Air Fortress (USA)
+  title:  Air Fortress (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: fb1059806d503225093126145fc3cad0da773bcb81ea83165f7ee2e4b9ca6fd3
+  name:   Airwolf (Europe)
+  title:  Airwolf (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 42b21cc066490b78afca98224d642507a4dbb74c1483c3d63fa85ffc883fe640
+  name:   Airwolf (Japan)
+  title:  Airwolf (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b82c1234165cd725d8e7f3e51926bceb834744eb49ad915bd3ea8b76fa465eb1
+  name:   Airwolf (USA)
+  title:  Airwolf (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 99d13c5a1d0a3c9ee1f31a8718744635a1c4b0a58cb7133e4c56203821484101
+  name:   Akagawa Jirou no Yuurei Ressha (Japan)
+  title:  Akagawa Jirou no Yuurei Ressha (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: RAM
       size: 0x2000
@@ -844,6 +1625,31 @@ game
       content: Character
 
 game
+  sha256: 4c95afeda9a92842933c174983fee954cf40d1301d32f6169f6653f1e5cdc10f
+  name:   Al Unser Jr. Turbo Racing (USA)
+  title:  Al Unser Jr. Turbo Racing (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 722096b8929442310bc268f9cfea10b26cff8a7e900197b54c73b4a8603b5d96
   name:   Aladdin (Europe)
   title:  Aladdin (Europe)
@@ -862,6 +1668,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 5cb8d03a90732d01737a401e8dc87a3d594ab2f901970f309fe551c0013ac5da
+  name:   Alex DeMeo's Race America (USA)
+  title:  Alex DeMeo's Race America (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 752eb500a872ce4dedfa419d673b738bde8342bdbe5304411b6d19607b155a5f
@@ -950,6 +1777,48 @@ game
       content: Character
 
 game
+  sha256: cd1a9bc6c9e2181668fea96db14bc67fbbf9bf1572eef2bb074e5912a0dd54c9
+  name:   Alien Syndrome (Japan)
+  title:  Alien Syndrome (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 1c811b67d3e211f95ced51f3725c36fe45562d75d0a553b66dc3fb0b10e61ff1
+  name:   All-Pro Basketball (USA)
+  title:  All-Pro Basketball (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 7ae9746aa5c24c9c048b842879d93cae58c1c52be2ce1c3fbc749ab7ca2210bb
   name:   Alpha Mission (Europe)
   title:  Alpha Mission (Europe)
@@ -1014,6 +1883,31 @@ game
       volatile
 
 game
+  sha256: dd83b05d9f77c9b8932fc99eca4ccf9d90b03e74f7ca24c1a25e93fbe340c44f
+  name:   America Daitouryou Senkyo (Japan)
+  title:  America Daitouryou Senkyo (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 0f9eb607392b6846c99d236198cfb3517ed0c9776b43ab0f5791d612499c3aed
   name:   America Oudan Ultra Quiz - Shijou Saidai no Tatakai (Japan)
   title:  America Oudan Ultra Quiz - Shijou Saidai no Tatakai (Japan)
@@ -1056,6 +1950,180 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 64c4a4b718e60a8527c28b53f7aedfce448a013f4dd80c11815ef35f7426f7a4
+  name:   American Dream (Japan)
+  title:  American Dream (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 261c7fb3ed73bc1ddcf93f3cbc2f315f7eb908c54ca137044e71492f2938d21f
+  name:   American Football - Touchdown Fever (Japan)
+  title:  American Football - Touchdown Fever (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: be12cff13a06e0b5de2dad4d431f7cf9a6aa73be45cdbd952dfd03a9d23571b6
+  name:   American Gladiators (USA)
+  title:  American Gladiators (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: fd822408e52a2330af1fe35feae429be5bd504cba2d0298213d4192cd461460a
+  name:   Ankoku Shinwa - Yamato Takeru Densetsu (Japan)
+  title:  Ankoku Shinwa - Yamato Takeru Densetsu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 9cd99bfb1e6f2ccde7b35063793a5879a2273c73e2cd6bed69c72c87b3b5f27c
+  name:   Anticipation (Europe)
+  title:  Anticipation (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 427876021e6c077479a1a1171e013f84ae951197005a317b099df3b6c2862603
+  name:   Anticipation (USA)
+  title:  Anticipation (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 1d1fdadb35660db0048f20e056d61dc80726ef9b6d08f49f1799af6b364549db
+  name:   Aoki Ookami to Shiroki Mejika - Genghis Khan (Japan)
+  title:  Aoki Ookami to Shiroki Mejika - Genghis Khan (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x4000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 222240318f1decd91556d6837260bd8821c7bab7ce6f3143438a076f1dfdd7dd
+  name:   Arabian Dream Scheherazade (Japan)
+  title:  Arabian Dream Scheherazade (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 5fe3435b99c10cd641e3f5509ec34e16559fdbd607e11b830f5a2ad572dff50f
@@ -1285,6 +2353,31 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: 0efd33e900759399ed29c36350ed146eb60396d68f67bf29baa48d4d8c77bd23
+  name:   Artelius (Japan)
+  title:  Artelius (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -1565,6 +2658,69 @@ game
       volatile
 
 game
+  sha256: 9ed6247ab3374e36f340a7841cf6b4b0f1ee2c3fce2d8d3563dd38ab38b1f65e
+  name:   Attack of the Killer Tomatoes (Europe)
+  title:  Attack of the Killer Tomatoes (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3b687bf0a8ccd23736bb7ed2e6e75f9d150318d79da22bbf7ff1dd97ab980957
+  name:   Attack of the Killer Tomatoes (USA)
+  title:  Attack of the Killer Tomatoes (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d143c472ff7bb30adc8ba90d1be1b0905ca2e37bb4a4dfc6d6297b0284cb9ef2
+  name:   Aussie Rules Footy (Australia)
+  title:  Aussie Rules Footy (Australia)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 2b4ac20082e2f45a8f8fd4922a0e995829719a523e118a9eec891c3206adf25b
   name:   B-Wings (Japan)
   title:  B-Wings (Japan)
@@ -1633,6 +2789,27 @@ game
       content: Character
 
 game
+  sha256: b265adba4a6f751f4da7b157672f324264f11fed3ca0b1e4ca703eb0b8a5ab77
+  name:   Back to the Future Part II & III (USA)
+  title:  Back to the Future Part II & III (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 56382fac9104b26797de262a7c70ddd5850451d81a5008f3943d7bc492cbeb41
   name:   Bad Dudes (USA)
   title:  Bad Dudes (USA)
@@ -1673,6 +2850,93 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 467a2e53c7af4c60809db9c2670850a6e21a98ea37c1d920dc4fcb6afcb5a104
+  name:   Bad News Baseball (USA)
+  title:  Bad News Baseball (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 98658d5c8e530994730be6f4f7f76fe09142dee90e0afca613f5d6baaf208f52
+  name:   Bad Street Brawler (USA)
+  title:  Bad Street Brawler (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 45cf72dd5af13e0c67698a1207336f75b0c970bd883d83eb73bceba6fcf87ced
+  name:   Baken Hisshou Gaku - Gate In (Japan)
+  title:  Baken Hisshou Gaku - Gate In (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 9f5d1e7737e21d7eb16820487acaeae39d67d408e26154807bbc03229ce0f4c3
+  name:   Bakushou! Star Monomane Shitennou (Japan)
+  title:  Bakushou! Star Monomane Shitennou (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: cd04386d8cb372c69c7a8eaf8888408b312938a20238d502bcc1740b26497681
@@ -1949,6 +3213,69 @@ game
       content: Character
 
 game
+  sha256: ff10c4e0639015e6b26915631e6dd701f3d7dc60080936bc00546cdb063cb5d1
+  name:   Barbie (Europe)
+  title:  Barbie (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: bb30e4f4b1f6d8ccfdbd538b6f20347ed732cd37e8ac0a8305a277cf298b3dc8
+  name:   Barbie (USA)
+  title:  Barbie (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3f8a65278efb20dfb229a473ef9bb8d8135cdc6f287ffb09281ae14194d470fe
+  name:   Barbie (USA) (Rev 1)
+  title:  Barbie (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: b5f98350a10270ed1675ac4c9abe986e54e71f9f58982526351f937857ac6c66
   name:   Barcode World (Japan)
   title:  Barcode World (Japan)
@@ -1971,6 +3298,126 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: 3c95e9b47c51e135876d0f1cbc1c1d1e8e42e0f670dfe56a7c58613a58c31ff9
+  name:   Bard's Tale II, The - The Destiny Knight (Japan)
+  title:  Bard's Tale II, The - The Destiny Knight (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: efe66fd2420f23e585cf430a5fd846fb8053bda236a69f5353749d9090f3e76b
+  name:   Bard's Tale, The (Japan)
+  title:  Bard's Tale, The (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: e88de987a5b798335644a62052101d23fe38131c20cdfe006a404493c2a9d493
+  name:   Bard's Tale, The (USA)
+  title:  Bard's Tale, The (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 524d08755c4709846e64acad0d6655112bf4ffeb903af972785fba54859b2900
+  name:   Barker Bill's Trick Shooting (Europe)
+  title:  Barker Bill's Trick Shooting (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4da0d4900b297274680826c72b3e73f9f4c5a9f63de1f4005ee102d01dc04273
+  name:   Barker Bill's Trick Shooting (USA)
+  title:  Barker Bill's Trick Shooting (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -2041,6 +3488,81 @@ game
       content: Character
 
 game
+  sha256: 8bb20791eb3f4fd2455c33f0eead4538af3372205fba70fd4c3e0867b2c34c9a
+  name:   Baseball Simulator 1.000 (USA)
+  title:  Baseball Simulator 1.000 (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 89b1b3f8dcbb1de3c5b8b86b0799ea11d7d11eac08088af7c84cd657c77dcc89
+  name:   Baseball Star - Mezase Sankanou!! (Japan)
+  title:  Baseball Star - Mezase Sankanou!! (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b035ec9e2a7fc408c19bb2ffd22dceb0483a73e5f5bf232132628c9d8657b1e8
+  name:   Baseball Stars (USA)
+  title:  Baseball Stars (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 5f8807999205f3800e445d6265b66fa6edff0070fc38905f7284f0ad437f9f53
   name:   Baseball Stars II (USA)
   title:  Baseball Stars II (USA)
@@ -2063,6 +3585,69 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: 685c94591a76510bf1bb120f81acd68e62ce37384eccc1635180ca3be742fd36
+  name:   Bases Loaded (USA)
+  title:  Bases Loaded (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
+  sha256: 3a55db2bf9f03e138c60da85a9e8ee5472aff31475ba30762b247ff362a0216a
+  name:   Bases Loaded (USA) (Rev 1)
+  title:  Bases Loaded (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
+  sha256: 85de365c6e538bc7197e9cc326203957d4d160efe7ea02e4830e3cbda5072e16
+  name:   Bases Loaded (USA) (Rev 2)
+  title:  Bases Loaded (USA) (Rev 2)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
       content: Character
 
 game
@@ -2094,6 +3679,27 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b9af9efdf490e14895e7980097a86d2f69d6396383773c221e77c6183a4ab9c8
+  name:   Bases Loaded II - Second Season (USA)
+  title:  Bases Loaded II - Second Season (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -2311,6 +3917,28 @@ game
       volatile
 
 game
+  sha256: f4d57c83d8b3af0f60179648bac57ceefc9203d217af0bbee41f7ee2afb81274
+  name:   Battle Chess (USA)
+  title:  Battle Chess (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 263b133697e368b60a6a11a82d9f0ab0fca94da1bef8c5f823d593b4f2f64e7e
   name:   Battle Fleet (Japan)
   title:  Battle Fleet (Japan)
@@ -2347,6 +3975,100 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d48ed7ee7ad1debed2ddef34b0c09bbd7678ac6afa22b0d55c835e55635492a3
+  name:   Battle of Olympus, The (Europe)
+  title:  Battle of Olympus, The (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: d095eab5376c2b7c4f1c09018c9591598831c557e0b691c01ca2480e49e60c0a
+  name:   Battle of Olympus, The (USA)
+  title:  Battle of Olympus, The (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 93a40e57bd0b80817345906d10a9aec68f36365673f1dc5fac92094603b34c14
+  name:   Battle Stadium - Senbatsu Pro Yakyuu (Japan)
+  title:  Battle Stadium - Senbatsu Pro Yakyuu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: f6d6feb272249351814da9f1874dacf9af015310e18b9c983a0b7454445e40ed
+  name:   Battle Storm (Japan)
+  title:  Battle Storm (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: ROM
       size: 0x20000
@@ -2516,6 +4238,31 @@ game
       volatile
 
 game
+  sha256: 15a684628be6928ebc639cf1f9fa2882b4018d7a0a93ef6c83a31d3ce6f7f4cf
+  name:   Be-Bop-Highschool - Koukousei Gokuraku Densetsu (Japan)
+  title:  Be-Bop-Highschool - Koukousei Gokuraku Densetsu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 3b3865e6e44f8ef749e8a9509651a6fad688b8d744fab22974a6f4cb9e7f2b0b
   name:   Beauty and the Beast (Europe)
   title:  Beauty and the Beast (Europe)
@@ -2555,6 +4302,56 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 336660870339ec7018ee195a3cdc54577a826fa0d99ebde2025290418fd23948
+  name:   Best Keiba - Derby Stallion (Japan)
+  title:  Best Keiba - Derby Stallion (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 33cc984aebbf83c346bc2673d49c1a899f1fa00c0874d8a1a33b1289caf306b6
+  name:   Best Keiba - Derby Stallion (Japan) (Rev 1)
+  title:  Best Keiba - Derby Stallion (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: ce50bd0bdc0dc2f4766128b78618bee9524b670b7d55076b1e0de5fd0da417d5
@@ -2601,6 +4398,202 @@ game
       volatile
 
 game
+  sha256: 4ad46b7d10c4a997a5bfbd5d87d4fca050d783d68455ed3e9b78f91bf1b70756
+  name:   Best Play Pro Yakyuu '90 (Japan)
+  title:  Best Play Pro Yakyuu '90 (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 14a61ae25d49342ad5740b144aba595d077a9ebf7780a53bf58fe1ffc01682e7
+  name:   Best Play Pro Yakyuu (Japan)
+  title:  Best Play Pro Yakyuu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: ec5db46b6a68b35b615728a7a782f7ea7bdd84038754cb4dde25429738e8fdcf
+  name:   Best Play Pro Yakyuu (Japan) (Rev 1)
+  title:  Best Play Pro Yakyuu (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 28a6f5ece06598e4c0ca8b1a00ef907b58440e941218cd31fd7d5a2c727bf7fa
+  name:   Best Play Pro Yakyuu II (Japan)
+  title:  Best Play Pro Yakyuu II (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 3bbe80c3d0f5f586991f3587bc56cbde6036b30f7ff8ded8845189f2628b11ff
+  name:   Best Play Pro Yakyuu Special (Japan)
+  title:  Best Play Pro Yakyuu Special (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x8000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: c309152f37710aaffc8d828415f376781abb98c941da80ebb507a48ff6e5c28a
+  name:   Best Play Pro Yakyuu Special (Japan) (Rev 1)
+  title:  Best Play Pro Yakyuu Special (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x8000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 6ac2457411dfc8518e41e2455712b4d3c1a9412760135601d6fc24dbe0fd669c
+  name:   Bigfoot (Europe)
+  title:  Bigfoot (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 32fa00d52f39b053c30061d6789944fc61c0c88c885bd8248ff5771fd2f78ae6
+  name:   Bigfoot (USA)
+  title:  Bigfoot (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 47483dcc82cd7aea7d598c00b1909aa438c8d0f6fb8c4320598ae4e41231b032
   name:   Bikkuri Nekketsu Shin Kiroku! - Harukanaru Kin Medal (Japan)
   title:  Bikkuri Nekketsu Shin Kiroku! - Harukanaru Kin Medal (Japan)
@@ -2608,6 +4601,53 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e2076224467a0b8e96d50a3393056d2b13304b41af91b5b6d06ad575aecbec64
+  name:   Bikkuriman World - Gekitou Sei Senshi (Japan)
+  title:  Bikkuriman World - Gekitou Sei Senshi (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: b183c0952994cadc1c8d6dd290730f43ecacb051d3dfe53784578635a1049455
+  name:   Bill & Ted's Excellent Video Game Adventure (USA)
+  title:  Bill & Ted's Excellent Video Game Adventure (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -2711,6 +4751,50 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 92407ccb251d18be5ff681b9dbc945322fd3b7495875de973dbb80004f26fd5c
+  name:   Bionic Commando (Europe)
+  title:  Bionic Commando (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: aeb61fd5cf5a5ed73344c46a43f8a8d539f601ff57e8f56c49bc1caea4ab3d9e
+  name:   Bionic Commando (USA)
+  title:  Bionic Commando (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: acf054b0886a2ca74a0280fc36bc1d55e9845acc29759f1893c1da4c1389f9c2
@@ -2840,6 +4924,95 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 3ee11ba127805f85ae90d3b7749ec0fc6572016ff1f03daecd19d737cba85219
+  name:   Blaster Master (Europe)
+  title:  Blaster Master (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 7a26c62a9b1605cbedf7cd5b2672aa0fc15b688b227a6cb57dbf74aa71a05f1c
+  name:   Blaster Master (USA)
+  title:  Blaster Master (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9401d98517ce10c51b7cf40d33721ec0b459c771e05b5974c20a2e27b92c33da
+  name:   Blodia Land - Puzzle Quest (Japan)
+  title:  Blodia Land - Puzzle Quest (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 48f9d3d4ac02092ac3b3d59e405e52939fc5790b0026d481613ac921ee6f2e72
+  name:   Bloody Warriors - Shan-Go no Gyakushuu (Japan)
+  title:  Bloody Warriors - Shan-Go no Gyakushuu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: RAM
       size: 0x2000
@@ -3064,6 +5237,58 @@ game
       content: Character
 
 game
+  sha256: deccf3e75b8630a90f1dc02088eabf582499402743f0d856ceae573c7561a1db
+  name:   Bomberman II (Japan)
+  title:  Bomberman II (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 83cb47fda376900e8c1d8eef5c413229fb6cacaff43201afd421c71610c20368
+  name:   Bomberman II (USA)
+  title:  Bomberman II (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: b3d82e2818aea6caa69dcfe7d56197a7a51afe87819527880cf08876d1a988de
   name:   Bonk's Adventure (USA)
   title:  Bonk's Adventure (USA)
@@ -3105,6 +5330,69 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: ade4818b09d7754236ce29bcd2512301238bc19c2267423d22cdcf8d9ddf7c59
+  name:   Boulder Dash (Europe)
+  title:  Boulder Dash (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 8d496330a56442bd74da8c28999b6cb6d5c97984c83dadae510683a092f2ff71
+  name:   Boulder Dash (Japan)
+  title:  Boulder Dash (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 0e58f270e7b116782e0822f52058eff66465df49527c6f8c6f0eca994d8cae7a
+  name:   Boulder Dash (USA)
+  title:  Boulder Dash (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
 
 game
   sha256: f8c903339b52bd0c90cdeda872ad52132431d8b748802397df936f742ed7adce
@@ -3154,6 +5442,90 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: fde81fc5af055819700842db8650077d64b853f95b3542bf12f039a6df48115d
+  name:   Break Time - The National Pool Tour (USA)
+  title:  Break Time - The National Pool Tour (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: e1487d23800aa2c29cb9da6f2bf538aa10044930ef566d087f7acf1aa649fb9e
+  name:   BreakThru (USA)
+  title:  BreakThru (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9b755a371693a0875230b482c41ad18696a13675649c9401a9df05484ebc2f9a
+  name:   Bubble Bobble (Europe)
+  title:  Bubble Bobble (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 31523322db8f94e7244f6e2d958692a412c1395fc744601d83d1e5111eff9042
+  name:   Bubble Bobble (USA)
+  title:  Bubble Bobble (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -3330,6 +5702,27 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: 7882e99e08deb1c22a3c38b17e12bd6373af503fd76e97b31699f3d19bef5aad
+  name:   Bugs Bunny Crazy Castle, The (USA)
+  title:  Bugs Bunny Crazy Castle, The (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -3709,6 +6102,28 @@ game
       content: Character
 
 game
+  sha256: c07f280bd6da38eb9c457e2ce692a01defa201b5862d5f9c36d440e3e84a5d0c
+  name:   Captain ED (Japan)
+  title:  Captain ED (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: dd746f0057710cbb956bf8d1e8e76afc7685f0011b8ac6fea93964f62110544a
   name:   Captain Planet and the Planeteers (Europe)
   title:  Captain Planet and the Planeteers (Europe)
@@ -3758,6 +6173,27 @@ game
   board:  TAITO-TC0690
     chip
       type: TC0690
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4115e6a0cd2e60c85a7838d949de494530c334929d5cd2ee389f0aa661abd76b
+  name:   Captain Silver (Japan)
+  title:  Captain Silver (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -3832,6 +6268,27 @@ game
       volatile
 
 game
+  sha256: 6d35007ff1818b63871153048e439a4638d0713b4825e612c96c0bca4a7ecbc1
+  name:   Captain Tsubasa (Japan)
+  title:  Captain Tsubasa (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: e36f43f90501bad2cb43407922bd2ed686a8a9bd5e2be6bc1e7e4b94f02933bd
   name:   Captain Tsubasa II - Super Striker (Japan)
   title:  Captain Tsubasa II - Super Striker (Japan)
@@ -3851,6 +6308,28 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 110b18ff7a981be79841a9ecb1f661a7467f97ae517f82fa8c1f84669412c9bb
+  name:   Casino Derby (Japan)
+  title:  Casino Derby (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: f76f1779454a8a98168c2c26bc79058161cbaefb3006c8e6aa8c63d301a66f4f
@@ -4092,6 +6571,48 @@ game
       volatile
 
 game
+  sha256: b85af3c666a0390262d1a6fe19b8f3e5edcfe8206d4f42082c63169987931488
+  name:   Castlevania II - Simon's Quest (Europe)
+  title:  Castlevania II - Simon's Quest (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9575ec31c1c658fd6b77ae1d69e4861ecada8570e4eebf51409941486e4b4ef4
+  name:   Castlevania II - Simon's Quest (USA)
+  title:  Castlevania II - Simon's Quest (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 52451a89296cfcb006beb6363ddc8486fcc88154338cbec778a846056c522f50
   name:   Cat Ninden Teyandee (Japan)
   title:  Cat Ninden Teyandee (Japan)
@@ -4099,6 +6620,27 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 61bab3612f96371b1aeee12bb2a0ad76810cb76a2f31ca2f5b72592189c2c636
+  name:   Caveman Games (USA)
+  title:  Caveman Games (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -4240,6 +6782,127 @@ game
       volatile
 
 game
+  sha256: a8f18eb52126cdf3d004877f8c4c315ddf15f823f13f42b0154da17db21ecddd
+  name:   Championship Rally (Europe)
+  title:  Championship Rally (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ac93d7101174432a58c095e6ddce59665b752653dd9feca7fa7517200727fac8
+  name:   Chaos World (Japan)
+  title:  Chaos World (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c51dc3bdf5c1346e740200167b44532af866c2746701d8189008cc445b72dac9
+  name:   Chessmaster, The (Europe)
+  title:  Chessmaster, The (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: b705f866955c7d19292b55a9b0f3ec0e970e3f2509c3da15708b7afd879d98ed
+  name:   Chessmaster, The (USA)
+  title:  Chessmaster, The (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 66d4beb992a646325099e0fc9cbb27fb920bc695cf96768739fc7844b0e9db12
+  name:   Chessmaster, The (USA) (Rev 1)
+  title:  Chessmaster, The (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 60a13315624ef2449c8ff2d8e45cd2537b318ee15096f63509d2eea7b7c97428
   name:   Chester Field - Ankoku Shin e no Chousen (Japan)
   title:  Chester Field - Ankoku Shin e no Chousen (Japan)
@@ -4260,6 +6923,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 89dfe6190167a791ba7f1c054084fb4d7e68074c6dc97aaa0f7b12a1581e3ea4
+  name:   Chevaliers du Zodiaque, Les - La Legende d'Or (France)
+  title:  Chevaliers du Zodiaque, Les - La Legende d'Or (France)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 59f228976854136f7988c309ad5baa68687b363df27810e28bb6959b771d5af6
@@ -4285,6 +6969,27 @@ game
       content: Character
 
 game
+  sha256: f3df1bf296609ebfefffdb37232bc99a02ea928a1a520f5c617e01da8c255049
+  name:   Chiisana Obake - Acchi Socchi Kocchi (Japan)
+  title:  Chiisana Obake - Acchi Socchi Kocchi (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 9fcb84b354fdfc16235fd0087027fe7b76179eb0e73c5f0e65dee7de41967e85
   name:   Chiki Chiki Machine Mou Race (Japan)
   title:  Chiki Chiki Machine Mou Race (Japan)
@@ -4292,6 +6997,132 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 155e21d57588c89954b0e6088676936d75e233d755cdd9ad56ae3b315e07171d
+  name:   Chip 'n Dale - Rescue Rangers (Europe)
+  title:  Chip 'n Dale - Rescue Rangers (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e84d90fefb92f2b6ab70e35bfb990978c7e384e357ec6b995c3880bff4c5b460
+  name:   Chip 'n Dale - Rescue Rangers (USA)
+  title:  Chip 'n Dale - Rescue Rangers (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 40dad8f246bbef9246367904b79d8ae9161aa5e56437b32113431c8668ed8392
+  name:   Chip 'n Dale - Rescue Rangers 2 (Europe)
+  title:  Chip 'n Dale - Rescue Rangers 2 (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: afa359b53e90781ed3810642c09f7cb22f0ba21c40142649771bfb21a897b4d3
+  name:   Chip 'n Dale - Rescue Rangers 2 (USA)
+  title:  Chip 'n Dale - Rescue Rangers 2 (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3b8101547a8a3fdb5b6b33e00be4885ec578bf3b463b1758790e53eb228cd6d7
+  name:   Chip to Dale no Daisakusen (Japan)
+  title:  Chip to Dale no Daisakusen (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: bfa4e6a7ce7fe9f1b104a2e5c2a4cd3b0519f0bbabe131750558a21f0f333b30
+  name:   Chip to Dale no Daisakusen 2 (Japan)
+  title:  Chip to Dale no Daisakusen 2 (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -4411,6 +7242,27 @@ game
       content: Character
 
 game
+  sha256: cc0e5443e5093d7c55ffc3e95700e96a2ed5cdd65e15106b7f91e9adfc4f3832
+  name:   Chou-Wakusei Senki - MetaFight (Japan)
+  title:  Chou-Wakusei Senki - MetaFight (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: ff864226752752bfa608d4e3e6e1e89bd0044fe70e8c7cda6eb8e3de449e5fd2
   name:   Choujikuu Yousai - Macross (Japan)
   title:  Choujikuu Yousai - Macross (Japan)
@@ -4432,6 +7284,52 @@ game
       content: Character
 
 game
+  sha256: 29db47b75e56eaa32397e065290fc0f98e8622101ea228ad161b8589d342d9f6
+  name:   Choujin - Ultra Baseball (Japan)
+  title:  Choujin - Ultra Baseball (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 8ff13fcd04a15d107fb996849eff21488a7be4de5fb0c5e14b7bb323560c5dd5
+  name:   Choujin Sentai Jetman (Japan)
+  title:  Choujin Sentai Jetman (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: cb842db5081c13a8aba0f95275bf982bdf512246730f6dc452b4eb145abed037
   name:   Choujinrou Senki - Warwolf (Japan)
   title:  Choujinrou Senki - Warwolf (Japan)
@@ -4439,6 +7337,27 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 68a6f5ef79892e49d647e8585655985db30a2166f397bf41f32da39ec081a94a
+  name:   Chris Evert & Ivan Lendl in Top Players' Tennis (USA)
+  title:  Chris Evert & Ivan Lendl in Top Players' Tennis (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -4474,6 +7393,27 @@ game
       content: Character
 
 game
+  sha256: 045493a19a2e4644635c37645d696f8bc40f5df1dcc35f709ce6474e75c5bf99
+  name:   Chuugoku Janshi Story - Tonfuu (Japan)
+  title:  Chuugoku Janshi Story - Tonfuu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: c8328f85580f03676d4ed875ea0a985ed77ca68ade51d880481a415f65335ca0
   name:   Chuugoku Senseijutsu (Japan)
   title:  Chuugoku Senseijutsu (Japan)
@@ -4494,6 +7434,48 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 1f8c8edf9516d2ba0bdbbdf199097a1aa21cbd8ac561097728c6a0c91bce4e22
+  name:   Chuuka Taisen (Japan)
+  title:  Chuuka Taisen (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: fa701601d39819ef26821d05350ccb793cc606191e03c06203a4274b434dfaeb
+  name:   Circus Caper (USA)
+  title:  Circus Caper (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 6f2fc666c34264b20854197391121374670710d716bea8798add7a5bf3ba7e78
@@ -4602,6 +7584,27 @@ game
       content: Character
 
 game
+  sha256: cf226f0d9486103bbaa19ee124b673d47aa2b3766334b6b7587d704c03e6649e
+  name:   Clash at Demonhead (USA)
+  title:  Clash at Demonhead (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 69d26e6e849a103c2a553e62579f159bc8fcf7a4050fee0f7f97a4a64c2f9a4b
   name:   Classic Concentration (USA)
   title:  Classic Concentration (USA)
@@ -4666,6 +7669,48 @@ game
       content: Character
 
 game
+  sha256: a147f56cc48033f4b12b1e725ca6ae5d66dc5bf8aa86e092148143485761def1
+  name:   Cobra Command (Japan)
+  title:  Cobra Command (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 711eee6690af76a59321f49c8dbfec39eef702775e6cc2a1e63553b40fa3aa5f
+  name:   Cobra Command (USA)
+  title:  Cobra Command (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: f34872482c6c1359b1b87373b620960590915e9805ac4e970666768cfc27172b
   name:   Cobra Triangle (Europe)
   title:  Cobra Triangle (Europe)
@@ -4699,6 +7744,32 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5c31fbb369ae0102799de2e5fdfa2d7c249640db917c0b6d236285641a6de931
+  name:   Cocoron (Japan)
+  title:  Cocoron (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: RAM
       size: 0x2000
@@ -4818,6 +7889,56 @@ game
       volatile
 
 game
+  sha256: 26f1cde3ded84be088509fc082fd5284aa020060bb920f9fd042c891bbc477df
+  name:   Conflict (Japan)
+  title:  Conflict (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 18ca062abee6bf3b9b4df865c2a154bee8ba5ec40c6d0520a01d0bee2250bff3
+  name:   Conflict (USA)
+  title:  Conflict (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: a5b8e24589539b0b84a6ad98aee9c91eb86eff795162be38b020dc42c3e3eca7
   name:   Conquest of the Crystal Palace (USA)
   title:  Conquest of the Crystal Palace (USA)
@@ -4906,6 +8027,48 @@ game
       content: Character
 
 game
+  sha256: 22ea833fd9466795bd2b05df96a47081ca45a26f545af1242f4c89b2d6688bdd
+  name:   Cool World (USA)
+  title:  Cool World (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 194dab0dca3020d07d0fb200c9511e0a1a0b9aa18dec34642045d708b7595e89
+  name:   Corvette ZR-1 Challenge (Europe)
+  title:  Corvette ZR-1 Challenge (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 57bb6d08f802ee52a93cb871179ae908d0060dde27c6e0b1970caa65675e0c67
   name:   Cosmic Epsilon (Japan)
   title:  Cosmic Epsilon (Japan)
@@ -4927,6 +8090,31 @@ game
       content: Character
 
 game
+  sha256: 2011249d5711ea1c9172e79513e2808eb8ab521e5985d2cdaabe87558b21c208
+  name:   Cosmic Wars (Japan)
+  title:  Cosmic Wars (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: fd8137b02b02fcc0bed2b3107a0d934ab2af13650f418d5c64f0e9913396d62f
   name:   Cosmo Genesis (Japan)
   title:  Cosmo Genesis (Japan)
@@ -4945,6 +8133,31 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 266bd4a0ef165eac3c6a823e75611f614836fe32197a5b10df19288e4728a682
+  name:   Cosmo Police Galivan (Japan)
+  title:  Cosmo Police Galivan (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -5196,6 +8409,27 @@ game
       content: Character
 
 game
+  sha256: 817ca07b9e085defb37b55212748f21bb2d3d737cfc5921afe24324a0e2e9c6c
+  name:   Cycle Race - Road Man (Japan)
+  title:  Cycle Race - Road Man (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 8b625a5503004f7026364ace9ccbe8a6cf346a5d4414f2697219658cfd773baa
   name:   Dai-2-ji Super Robot Taisen (Japan)
   title:  Dai-2-ji Super Robot Taisen (Japan)
@@ -5288,6 +8522,31 @@ game
       content: Character
 
 game
+  sha256: 8383af1981e5aa93c06cc190af21080b257b23c473e820876e32296054e516c7
+  name:   Daisenryaku (Japan)
+  title:  Daisenryaku (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: cb63bf5ee1cef6478c138a141cd244dfbeb341274be97848d98a8f0d8d0dcc2f
   name:   Daiva - Imperial of Nirsartia (Japan)
   title:  Daiva - Imperial of Nirsartia (Japan)
@@ -5308,6 +8567,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 3c4ef00443a1675e676847394796cb728eb41e7d61ae8b55621f5c3460f718c5
+  name:   Dance Aerobics (USA)
+  title:  Dance Aerobics (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
 
 game
   sha256: aa9e3be1451ad009111c587cd2adb9275b052402461f27257617baa7d7cd6767
@@ -5369,6 +8649,111 @@ game
       type: RAM
       size: 0x2000
       content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b19f2bd0c77ad5d656613c47800df5ddf05841012b621a55f1333be91eda15fe
+  name:   Darkman (Europe)
+  title:  Darkman (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9b6d967f493a565e25b51aee044354f857c5cefc41f476d4f259e7368b1fdd70
+  name:   Darkman (USA)
+  title:  Darkman (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 730d4148b8d23d50bfe10a81b73534a4b08d22823d9ab5224da343b25cf7cb0d
+  name:   Darkwing Duck (Europe)
+  title:  Darkwing Duck (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: fd3b15b71d014ca45572af17c1196bb4803fbed4601690d997031d9181370276
+  name:   Darkwing Duck (Germany)
+  title:  Darkwing Duck (Germany)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: f97f05a4f8747d81dc8adaf07df70d1f87366632ae3e93103d387043ef5ec508
+  name:   Darkwing Duck (USA)
+  title:  Darkwing Duck (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
     memory
       type: ROM
       size: 0x20000
@@ -5600,6 +8985,111 @@ game
       content: Save
 
 game
+  sha256: d647acb3911765828e363683d41a5287358f02782d2c4bc7a49920780400da04
+  name:   Datsugoku (Japan)
+  title:  Datsugoku (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 42e8e4c946675902f6db8f24c77f86c19fc286dd28661b7b680f2d125257d9d1
+  name:   David Crane's A Boy and His Blob - Trouble on Blobolonia (Europe)
+  title:  David Crane's A Boy and His Blob - Trouble on Blobolonia (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 7745f1d2a58bd9c3c53433ba9c862ddf5d032568e7dc4e326ec6317f6b6c7627
+  name:   David Crane's A Boy and His Blob - Trouble on Blobolonia (Europe) (Rev 1)
+  title:  David Crane's A Boy and His Blob - Trouble on Blobolonia (Europe) (Rev 1)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 911fb75ec1f900a5c258635fae79e56520eeb4aec35b40737c44b735eeccdc56
+  name:   David Crane's A Boy and His Blob - Trouble on Blobolonia (USA)
+  title:  David Crane's A Boy and His Blob - Trouble on Blobolonia (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 41f949cfedf7167985f779c0782ee17ee83d82e35111c5f22ee5037f54313a06
+  name:   Day Dreamin' Davey (USA)
+  title:  Day Dreamin' Davey (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 9ed3fa941bf8eac7f3cc8c43c31943b29a9bbfb651c54ebed599ec792a51e5a1
   name:   Days of Thunder (Europe)
   title:  Days of Thunder (Europe)
@@ -5706,6 +9196,58 @@ game
       volatile
 
 game
+  sha256: 72731c314296d03c52e8c61ff887979c861b452457f286f2141d23127cd6f402
+  name:   Deep Dungeon III - Yuushi e no Tabi (Japan)
+  title:  Deep Dungeon III - Yuushi e no Tabi (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: b00368628f74397907f3843f47c794b2cdd0db67138c4f125f8cbc2dd3e1e615
+  name:   Deep Dungeon IV - Kuro no Youjutsushi (Japan)
+  title:  Deep Dungeon IV - Kuro no Youjutsushi (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: bf58512dc3bc427d14a6d851445801967cd14f3d02ae236eabceeb7928a55462
   name:   Defender II (USA)
   title:  Defender II (USA)
@@ -5725,6 +9267,72 @@ game
       type: ROM
       size: 0x2000
       content: Character
+
+game
+  sha256: 50ff39aea1abb34955060ec359bf5e281c02e44e5fb42709ea1506c639212a4d
+  name:   Defender of the Crown (Europe)
+  title:  Defender of the Crown (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 1ad51084f5eabd43076bb4a2e716eda6521a7d572da6f0de495a6b9394befef3
+  name:   Defender of the Crown (France)
+  title:  Defender of the Crown (France)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 9e31d3d918a352c0c5a81c52efc364253f3fb75cc84151ee904ad078be62d8e1
+  name:   Defender of the Crown (USA)
+  title:  Defender of the Crown (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 167bc1a0125f12d9db292053f08d37f5b29dda3e4c3cc9ae54aa4951b447d988
@@ -5823,6 +9431,48 @@ game
       content: Character
 
 game
+  sha256: c408dd19ca49e55173ff2c491868f437d8100671f7b9646ee20e3204e0ba216f
+  name:   Demon Sword (USA)
+  title:  Demon Sword (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4b13643e53f2f7b43075233eebe65489d1d0a4ce3cf71a4f934178c3091930cf
+  name:   Dengeki - Big Bang! (Japan)
+  title:  Dengeki - Big Bang! (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: a18f143cce068d9df46473f968b31c65beb5246b521843b7653d5993b707d310
   name:   Densetsu no Kishi - Elrond (Japan)
   title:  Densetsu no Kishi - Elrond (Japan)
@@ -5841,6 +9491,56 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: a8a5e9398eca004bff421cf4bda9c2b76a8e4ef9cb1ea0a6ca55744cd8affac2
+  name:   Derby Stallion - Zenkoku Ban (Japan)
+  title:  Derby Stallion - Zenkoku Ban (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 281ad7bdb4f94e2303d95c6078c20295e240b80370fdceda27950966b0e09198
+  name:   Desert Commander (USA)
+  title:  Desert Commander (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 44cd6b2aa05286c37e78bd04d15793018bb0656b24260e5c76fc5cfad39f699b
@@ -5862,6 +9562,32 @@ game
       type: ROM
       size: 0x8000
       content: Character
+
+game
+  sha256: 6d082c801942ce6787b471428ab4c8a6acb3e21f3f38fa197f2aeb698d9a2d7e
+  name:   Destiny of an Emperor (USA)
+  title:  Destiny of an Emperor (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: d2140fc2e6354a9f4d0154dabac757e5559890edba4885799c1c979d8b7a8b20
@@ -5968,6 +9694,69 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: bc101ed4c663fc477f3efd1597339c68e1e51741d93265dd39588b2f86a1eaa2
+  name:   Die Hard (Europe)
+  title:  Die Hard (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: eb0796ed4e2e5cc7ca7a935cd2fa91e277a3284cd3c45941a5646ad001f0a0b9
+  name:   Die Hard (Japan)
+  title:  Die Hard (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e060fd43ef58d6e022f1fcab853a388142fd68d4bbd00dedc095992152e27976
+  name:   Die Hard (USA)
+  title:  Die Hard (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 7c8b6add50b20e4612e3043df0671e701cd2aa163e4af864913e3940feee27f2
@@ -6251,6 +10040,48 @@ game
       content: Character
 
 game
+  sha256: 61b156be788fd47a027951bc4c13f72d928dc2ff1b2f6ac55bc39b0d9e3569ed
+  name:   Donald Duck (Japan)
+  title:  Donald Duck (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3ce807f46e50c7f44c0ce17ec61b25500d885623514209beed001e99cdaa27a8
+  name:   Donald Land (Japan)
+  title:  Donald Land (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: dd108e55b60070b4c0147f7dba31844ed83065255466bfacd5038e6382483026
   name:   Donkey Kong (Japan)
   title:  Donkey Kong (Japan)
@@ -6503,6 +10334,32 @@ game
       content: Character
 
 game
+  sha256: fedf20f057ae65bea2adfc3d3271bc90a2c34729ddbdbe15578bf65b2ac7415d
+  name:   Doraemon - Giga Zombie no Gyakushuu (Japan)
+  title:  Doraemon - Giga Zombie no Gyakushuu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 56cb5897c539b6874e311a314767df85186184690f10d9982b02cb90ff606537
   name:   Double Dare (USA)
   title:  Double Dare (USA)
@@ -6521,6 +10378,69 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 8db8b4389a6510267bcb9d7a69a89c61178588fec46c771ab2b9fc253d02a2e7
+  name:   Double Dragon (Europe)
+  title:  Double Dragon (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 8f2f9ba926280edd3652745e1d04a30ecce64089fbf3f022a35b4039a2dd7b66
+  name:   Double Dragon (USA)
+  title:  Double Dragon (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 346f5d48b25cb09ef5c9ebe4ef6626e07128245e4775618b108bf9f6595f5832
+  name:   Double Dragon - Sou Setsu Ryuu (Japan)
+  title:  Double Dragon - Sou Setsu Ryuu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 7a7711ad95385a87f3577699fc425a83ac8d7e690ae5aa2f72ceed3feb29113b
@@ -6830,6 +10750,90 @@ game
       volatile
 
 game
+  sha256: 5860e217030f9da957d487b3ca59000d5f4d79bf23486bad08205c5aa4d992ea
+  name:   Dr. Jekyll and Mr. Hyde (USA)
+  title:  Dr. Jekyll and Mr. Hyde (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 9d39ca09c9fe9eb0c03ede1b506fd7297f50b985467739d1697ce809b3ab8736
+  name:   Dr. Mario (Europe)
+  title:  Dr. Mario (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 01d303a8c0ed6f374586d3a2562065b77f627e8dbf071bd919877e3b48dbdb57
+  name:   Dr. Mario (Japan, USA)
+  title:  Dr. Mario (Japan, USA)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: d2fbe8b10f762099d320016ddfd4d2961a591fe6dfaaab2efbeb77282264d06a
+  name:   Dr. Mario (Japan, USA) (Rev 1)
+  title:  Dr. Mario (Japan, USA) (Rev 1)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: d36b8989cbaf9ceafd91d15edd7b990dce6f9aede1bf9ac696ea8d288ec53d44
   name:   Dragon Ball - Daimaou Fukkatsu (Japan)
   title:  Dragon Ball - Daimaou Fukkatsu (Japan)
@@ -7125,6 +11129,48 @@ game
       content: Character
 
 game
+  sha256: cd334f77b256f212a5c139dc0fdca485ad68616d62443837c76054cf50045fae
+  name:   Dragon Fighter (Japan)
+  title:  Dragon Fighter (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: af505b8530b3303ebe0bf727730733cdbcd83ce1a19781d9487cd7cb202933c1
+  name:   Dragon Fighter (USA)
+  title:  Dragon Fighter (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 456caa33251d5b666913b193036c99d9ba78a0170d9d8606b70ab1e1b02d49f3
   name:   Dragon Ninja (Japan)
   title:  Dragon Ninja (Japan)
@@ -7224,6 +11270,110 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: ba223cc3aa7992ace45dd9c50bc8b29100e18dd77d338b5383d006af47d05ed3
+  name:   Dragon Quest III - Soshite Densetsu e... (Japan)
+  title:  Dragon Quest III - Soshite Densetsu e... (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 691fe8b7112654dbe7d87c5996037059d880f010ebf1f34decb89cedce7c4b9d
+  name:   Dragon Quest III - Soshite Densetsu e... (Japan) (Rev 1)
+  title:  Dragon Quest III - Soshite Densetsu e... (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 234f217fe0cd761d73b2ce03c686bbc3b4cba0d3054a62a1c9a724068148468e
+  name:   Dragon Quest IV - Michibikareshi Monotachi (Japan)
+  title:  Dragon Quest IV - Michibikareshi Monotachi (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 2c9786c4fc04fe476e83c0e3e06b1577dc244a6c388cd4b31c86f045ef146d12
+  name:   Dragon Quest IV - Michibikareshi Monotachi (Japan) (Rev 1)
+  title:  Dragon Quest IV - Michibikareshi Monotachi (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: RAM
       size: 0x2000
@@ -7337,6 +11487,134 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: abc5bcb459316a7d245065149ea72b5a8317f62fa6ed578569e15b670d3c0022
+  name:   Dragon Warrior (USA)
+  title:  Dragon Warrior (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
+  sha256: d968a138b19d39dad24aceb3464c7b90e8d50416297273586d3faf1f094eb35c
+  name:   Dragon Warrior (USA) (Rev 1)
+  title:  Dragon Warrior (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
+  sha256: c15ab051ff066f018cf4b0159780c58026114bb47a6376ef81c1571a39a8fe9b
+  name:   Dragon Warrior II (USA)
+  title:  Dragon Warrior II (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: f91a8bfc25bd267f5ae77bafa7fc650f77f8e50067869e99682b32d5b410644e
+  name:   Dragon Warrior III (USA)
+  title:  Dragon Warrior III (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: e49cb745370065a40aff078ae52b5de1c0db137fedcbe93b78ab18d76479deed
+  name:   Dragon Warrior IV (USA)
+  title:  Dragon Warrior IV (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: RAM
       size: 0x2000
@@ -7650,6 +11928,129 @@ game
       volatile
 
 game
+  sha256: 0451a2044e14978e8b3bb873323d52d56897a4de139154a95a6014c51e3356a6
+  name:   Dungeon & Magic - Swords of Element (Japan)
+  title:  Dungeon & Magic - Swords of Element (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 21766f06d63c1181d9d88ee8f20864b813dd466e8b7a9bde2da3291d412db24e
+  name:   Dungeon Kid (Japan)
+  title:  Dungeon Kid (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: c613c10e32b93dbc402356273d698efa14814a51b0339d6d7aacdfb639a7acd7
+  name:   Dungeon Magic - Sword of the Elements (USA)
+  title:  Dungeon Magic - Sword of the Elements (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 35ac08a055cbaa1321d84729a88d7594dba835ec6aeeef17b27aa388f75f0046
+  name:   Dusty Diamond's All-Star Softball (USA)
+  title:  Dusty Diamond's All-Star Softball (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 541abf033484be951a5d42d2f7de58400c2491fc664e7031840ad9cf1443dca3
+  name:   Dynablaster (Europe)
+  title:  Dynablaster (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 165a5cc2a460463e24b8596c9004434d7a50aab1d2bd0435c2047f618fbd1309
   name:   Dynamite Batman (Japan)
   title:  Dynamite Batman (Japan)
@@ -7717,6 +12118,27 @@ game
       content: Character
 
 game
+  sha256: 690ec2de233486d9fdb1e096ca4aa07aa6e764b0d6d6417454d0a770c875078d
+  name:   Dynowarz - The Destruction of Spondylus (USA)
+  title:  Dynowarz - The Destruction of Spondylus (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 1266108d927cb288a5f396e78ac097e48678375e80c0e0c09ecbce4dc03699bc
   name:   EarthBound Beginnings (USA, Europe)
   title:  EarthBound Beginnings (USA, Europe)
@@ -7739,6 +12161,27 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: 6bd254c630e0a8cfd5dc270415dc04927ad637e6d7c85fbca5fc174dbd95cd5f
+  name:   Eggerland - Meikyuu no Fukkatsu (Japan)
+  title:  Eggerland - Meikyuu no Fukkatsu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -7826,6 +12269,74 @@ game
       content: Character
 
 game
+  sha256: 1105e6d6e8005dba6fe35782fd8520ee3e11b753b2edef9045c6cf0fdf0e12e5
+  name:   Eliminator Boat Duel (Europe)
+  title:  Eliminator Boat Duel (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9d0396286f2c027367422b8347216a309200a21b019939f08a7c457c7c4c918d
+  name:   Eliminator Boat Duel (USA)
+  title:  Eliminator Boat Duel (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: f040abfbeaec436e3723d48ec6ce371e29584ba39cf5447bb30e8f6b66c92764
+  name:   Elite (Europe)
+  title:  Elite (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 58972627ec3840f560dfe9dd8aaa2daa1e359bb651be0f06793a75cb12e9de75
   name:   Elnark no Zaihou (Japan)
   title:  Elnark no Zaihou (Japan)
@@ -7846,6 +12357,52 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 64aab47661140fc163074df84ce58de07f42083f2c1e5a990f12d602fda554ce
+  name:   Elysion (Japan)
+  title:  Elysion (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3ac3a435b96f19c83ef0e1df628c0b9f2a226eff8f084161f80ebc37360ad195
+  name:   Emoyan no 10 Bai Pro Yakyuu (Japan)
+  title:  Emoyan no 10 Bai Pro Yakyuu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: badedff174fd32fcaad914ea72d04763b828ed4d1d883e8c902cb668ea52b92a
@@ -7989,6 +12546,27 @@ game
   board:  KONAMI-VRC-1
     chip
       type: VRC1
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: aeadf9b0b47765fe6d44766330a7c6a21221b52c0a11355d364234880c3d7958
+  name:   Exciting Rally - World Rally Championship (Japan)
+  title:  Exciting Rally - World Rally Championship (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -8242,6 +12820,52 @@ game
       content: Character
 
 game
+  sha256: ad9fe91cdc6278829ac064a09aec0ba07afd449b178d9540643e9e00f6e8feae
+  name:   Famicom Doubutsu Seitai Zukan! - Katte ni Shirokuma - Mori o Sukue no Maki! (Japan)
+  title:  Famicom Doubutsu Seitai Zukan! - Katte ni Shirokuma - Mori o Sukue no Maki! (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 525ae3ece57a489ad0b997f92107208e584fc4a0137216d87666d0f06f05f469
+  name:   Famicom Igo Nyuumon (Japan)
+  title:  Famicom Igo Nyuumon (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 342f0e5ad45d040e538e6b1c576d02c264e7982d2b440afcb4f12cedccbb11de
   name:   Famicom Jump - Eiyuu Retsuden (Japan)
   title:  Famicom Jump - Eiyuu Retsuden (Japan)
@@ -8289,6 +12913,107 @@ game
       volatile
 
 game
+  sha256: f5b61b188b98a4a8b5af090a74a6191dd4876875a39221140c582d3089366ae1
+  name:   Famicom Meijin Sen (Japan)
+  title:  Famicom Meijin Sen (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 6411bc5fe4b4ca118695dd51e9822d8e3272db57ff753c5eb7188cfc68a6928d
+  name:   Famicom Meijin Sen (Japan) (Rev 1)
+  title:  Famicom Meijin Sen (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 92c3a8dbf3d9c8fc63d056e03f2c6969ef7e7866181be2e37420937ab3970139
+  name:   Famicom Shougi - Ryuuousen (Japan)
+  title:  Famicom Shougi - Ryuuousen (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 2d9a970752b2626847527f6f3e96dcb525ea47e780462bed3e73070a75155c1b
+  name:   Famicom Top Management (Japan)
+  title:  Famicom Top Management (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 7586cdd8b742ba3c4f0ea3eefaa2f6f2215af197a5269e3de9026bcdf236e981
   name:   Famicom Wars (Japan)
   title:  Famicom Wars (Japan)
@@ -8311,6 +13036,31 @@ game
     memory
       type: ROM
       size: 0x10000
+      content: Character
+
+game
+  sha256: 8e5e6eb8e1e0b28b8c4d1d5d4b5b15ea6797b7857e98b305474362fab9c8accf
+  name:   Famicom Yakyuu Ban (Japan)
+  title:  Famicom Yakyuu Ban (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -8508,6 +13258,27 @@ game
       content: Character
 
 game
+  sha256: 0de5af54fd433bc6678cd8c62b5e6f0a0987c26d64b2081764e66263cf0c658c
+  name:   Family Feud (USA)
+  title:  Family Feud (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 4dd1ccb16d8af15d5cb029f69cf8551c5c720a69ec314bd618be892f0fc20f86
   name:   Family Jockey (Japan)
   title:  Family Jockey (Japan)
@@ -8637,6 +13408,28 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0435c73b4ea6087c1d4b876fedc15dec76902daa212a651ac49d9c0f0bf44f2e
+  name:   Family School (Japan)
+  title:  Family School (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
       content: Program
     memory
       type: RAM
@@ -9070,6 +13863,144 @@ game
       content: Character
 
 game
+  sha256: 6f23f245b9edc5af0c07fab9e12f5c0571ea0f52413e4ce6ad36e2f57ddf4097
+  name:   Faria - A World of Mystery & Danger! (USA)
+  title:  Faria - A World of Mystery & Danger! (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 84b87531a1a23498a58ab40228aa759e44da2ce42f5dd610535606b1e9c23471
+  name:   Faria - Fuuin no Tsurugi (Japan)
+  title:  Faria - Fuuin no Tsurugi (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ae48238446220cb63414ada090cd2102f9e15881a93a106953f3f8091fb59175
+  name:   Faxanadu (Europe)
+  title:  Faxanadu (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 26ec94c10291aa7a0b4e2d888abffb7a80aec5e1f1fbef75a4b69f23bd63a98a
+  name:   Faxanadu (Japan)
+  title:  Faxanadu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 52f7e7309f1f53f632912182f3a65f574c949392ab92f55c2494a7e648ef5ccb
+  name:   Faxanadu (USA)
+  title:  Faxanadu (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 58f2ba801354a8e5b32e7d1cbcc740b8dc838e7d48c3d2f3eedea36b49b1a518
+  name:   Faxanadu (USA) (Rev 1)
+  title:  Faxanadu (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 6e0312213594af59f3fc14826a2a7be09cdd2dae3b2e9183ac89b8a3b69e2893
   name:   FC Genjin - Freakthoropus Computerus (Japan)
   title:  FC Genjin - Freakthoropus Computerus (Japan)
@@ -9141,6 +14072,132 @@ game
       content: Character
 
 game
+  sha256: 6218e3dd30c1e6049ab5c59f5433fbf8ac016ea0959ff0f3c5877e38bec7ccce
+  name:   Ferrari (Japan)
+  title:  Ferrari (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 91308ebeefb21377247bb37f6395429ef081893d767bb123a325f6f0af1c120d
+  name:   Ferrari Grand Prix Challenge (Europe)
+  title:  Ferrari Grand Prix Challenge (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9bc9b891cb8da7f4e7c8c963de1a8d13a9e756b8670a817d72184690ef8c54c1
+  name:   Ferrari Grand Prix Challenge (USA)
+  title:  Ferrari Grand Prix Challenge (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 8454b8a679e41f3467ada467e538191303c5b9f075cf98ba9adbe642f3bfb37f
+  name:   Fester's Quest (Europe)
+  title:  Fester's Quest (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 2b0dd31140d340358e3945aef5b75b3c41c2412cfe0e409b28b17c36c1d25b28
+  name:   Fester's Quest (Europe) (Rev 1)
+  title:  Fester's Quest (Europe) (Rev 1)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c0c98471130cd09c82af6ead5e706c9299cc2cb4584016a5e5eb0c8897380172
+  name:   Fester's Quest (USA)
+  title:  Fester's Quest (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 84b643059bf2b4fb73c19f829ae8db16dfefb2b5ec306bb77ac2c2f69c239603
   name:   Field Combat (Japan)
   title:  Field Combat (Japan)
@@ -9159,6 +14216,27 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: 16f116053eee2d5c0be6c934c750224aaade45d4f6236b36967cdf986772e351
+  name:   Fighting Golf (Japan)
+  title:  Fighting Golf (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -9181,6 +14259,136 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 13038600940772bd8276e7de55674d9d241d9bcd56b0ba7f31537b297c0e1e13
+  name:   Final Fantasy (Japan)
+  title:  Final Fantasy (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: b0def1b810ab3d29ce7e4d7a7ab8373ce7b28ced56967c483da193ce0cad5ee2
+  name:   Final Fantasy (Japan) (Rev 1)
+  title:  Final Fantasy (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: fa456d852372173ea31b192459ba1a2026f779df67793327ba6e132476c1d034
+  name:   Final Fantasy (USA)
+  title:  Final Fantasy (USA)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: a637619a8b794ac9382723930b5be0e5a3d37991d2804b1ee637eced44b2b494
+  name:   Final Fantasy I, II (Japan)
+  title:  Final Fantasy I, II (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x8000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 60c65138a0edecee77e7fa808291d6198ef2ebd10b1fd2bc4f047298d93a4cc0
+  name:   Final Fantasy II (Japan)
+  title:  Final Fantasy II (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 7ff89b50156b6f5b3d78d3d2eeec8a9221d9f7b18f8350abf89b7867a205f710
@@ -9216,6 +14424,27 @@ game
   board:  NAMCO-163
     chip
       type: 163
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: f9914a70561f98b388399ef1ba2fa4dca0f8dff62be6e24dd7e37707e8626dcb
+  name:   Final Mission (Japan)
+  title:  Final Mission (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -9641,6 +14870,27 @@ game
       volatile
 
 game
+  sha256: 1568e77e6533087eee26f952b0f58373fc5e56c4b2139023dbfdadc0828249c8
+  name:   Flying Warriors (USA)
+  title:  Flying Warriors (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: eedcf3fae4fe66102a1bf1338a1ea3276f5aadb3c3bc5770dd1d260e2fc44bac
   name:   Formation Z (Japan)
   title:  Formation Z (Japan)
@@ -9702,6 +14952,115 @@ game
       type: RAM
       size: 0x2000
       content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 758ea7bee928136abf612ba564fab4dd4f3caa951cb685bc8e1d4533c7b0680e
+  name:   Formula One - Built to Win (USA)
+  title:  Formula One - Built to Win (USA)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3f7586512e2a9840411330f418ecd96368c2af6c9c7a06306ee375b4de3f4ed9
+  name:   Four Players' Tennis (Europe)
+  title:  Four Players' Tennis (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e9fe69c87a9ab1183ce8492843bacf868e1f8df2fd4e1441403091d13025a619
+  name:   Fox's Peter Pan & the Pirates - The Revenge of Captain Hook (USA)
+  title:  Fox's Peter Pan & the Pirates - The Revenge of Captain Hook (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
+  sha256: 682a0629d25275a95975e3822ded9fc6cfe5ce8dfb4650aeda0981bfe6a6afc0
+  name:   Frankenstein - The Monster Returns (USA)
+  title:  Frankenstein - The Monster Returns (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 995b57f7d2c68a5689549fc53645dcc44f871c8d172e15deafd7389bc3f6ee0a
+  name:   Freedom Force (USA)
+  title:  Freedom Force (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
     memory
       type: ROM
       size: 0x20000
@@ -9797,6 +15156,27 @@ game
       volatile
 
 game
+  sha256: 95c41a89bd6c08a03a139eb362b1d28f493f5add35847d311695d5847f2e46e1
+  name:   Fushigi na Blobby - Blobania no Kiki (Japan)
+  title:  Fushigi na Blobby - Blobania no Kiki (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: da4a289eba41a33d9102b67c248a4562a6781dd963bb6bc2488b634c6b4ceacf
   name:   Fushigi no Umi no Nadia (Japan)
   title:  Fushigi no Umi no Nadia (Japan)
@@ -9820,6 +15200,32 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 38505fc15302051e1a5d668e039be65e5b22a2e8abbcbc66cc6b6cc60cdb9e3a
+  name:   Future Wars - Mirai Senshi Lios (Japan)
+  title:  Future Wars - Mirai Senshi Lios (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 8d0a934e10a53b82e9d27f545d1ca22fa78fa1378569bd86849b9a84450c7a9d
@@ -10032,6 +15438,105 @@ game
       content: Character
 
 game
+  sha256: c7ac9f2c180492f3ab35875aacf715d5de7dd6ab9b03661d70a2e5dc03dd503c
+  name:   Gambler Jiko Chuushinha (Japan)
+  title:  Gambler Jiko Chuushinha (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 103efca29ac3190205c32d4f778fecc38ec9e4f289db36db1686eaf5ee887aa6
+  name:   Gambler Jiko Chuushinha 2 (Japan)
+  title:  Gambler Jiko Chuushinha 2 (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 29b8ec5522f07ed9f95dae45f141d652a829e984631a46874d011cd38e798752
+  name:   Game Designer Yousei Soft - Dezaemon (Japan)
+  title:  Game Designer Yousei Soft - Dezaemon (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x8000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: cff6cc393bb1adf3e48decc8b7cfbdf7a297c5ebcd954a7ce3799e94f7e1e762
+  name:   Game Party (Japan)
+  title:  Game Party (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 270b84c1f6fcac20f2ce66bdf702882d44fc5345cdf76ff62d7823ccda9f2cba
   name:   Ganbare Goemon 2 (Japan)
   title:  Ganbare Goemon 2 (Japan)
@@ -10199,6 +15704,27 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 5a32727b23c74b3371f7efcb0d67ce6261b7409c9a78cc9ad47a2fffb696aea3
+  name:   Garfield no Isshukan (Japan)
+  title:  Garfield no Isshukan (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
       content: Program
     memory
       type: ROM
@@ -10406,6 +15932,27 @@ game
       content: Character
 
 game
+  sha256: fb34a83075f38cbba4480c968ca628ccfb8a59af2782ae3e1c0a9031fe3a8424
+  name:   Gekikame Ninja Den (Japan)
+  title:  Gekikame Ninja Den (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 4fcd559442c95e41e7e406eeab6953b51d444587c3ed3fd96d387201ca83b3cc
   name:   Gekitotsu Yonku Battle (Japan)
   title:  Gekitotsu Yonku Battle (Japan)
@@ -10421,6 +15968,74 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 888b27eed0de29f7a8c3138ca0580caf775a87c9c90db93e97c6c2c21480d638
+  name:   Gekitou Pro Wrestling!! - Toukon Densetsu (Japan)
+  title:  Gekitou Pro Wrestling!! - Toukon Densetsu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 09b602c6c6262ddd356959e9a56b77556bf38904c6629ee48b52d350521ab8da
+  name:   Gekitou Stadium!! (Japan)
+  title:  Gekitou Stadium!! (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 2a2f75c2be5f6952428612f019a4a4efa86bc64aace21a08d8d2b9d8859c3034
+  name:   Genghis Khan (USA)
+  title:  Genghis Khan (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x4000
+      content: Save
     memory
       type: RAM
       size: 0x2000
@@ -10517,6 +16132,31 @@ game
       content: Character
 
 game
+  sha256: 1849bb687d038a43971651b13392481768ea0bc15f3d04b6898f052bbfa356e5
+  name:   Ghost Lion (USA)
+  title:  Ghost Lion (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 36acc6ce4674043e23c337cc1c266aed55187b75c890af7c7a2ddd617993e494
   name:   Ghostbusters (Japan)
   title:  Ghostbusters (Japan)
@@ -10556,6 +16196,48 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 08d05f2f3463f7a0e4f58849542f48a0ae72c2c7895a8ca4698332973c747f0e
+  name:   Ghostbusters II (Europe)
+  title:  Ghostbusters II (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 1ea36ebd81692d3a3c1db217e0df832f060c1566c69a74fac299aaeb0d8eb82f
+  name:   Ghostbusters II (USA)
+  title:  Ghostbusters II (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -10603,6 +16285,71 @@ game
       volatile
 
 game
+  sha256: 48aaef58dee3ad370546db569306e40aeecd27b88b7faef3ccd9b8b818c9ea71
+  name:   Ghoul School (USA)
+  title:  Ghoul School (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d9d9a4d97afcbfafa19a406a495f5caad2f046f673fa80a34d735c9260acd55f
+  name:   Gimmi a Break - Shijou Saikyou no Quiz Ou Ketteisen (Japan)
+  title:  Gimmi a Break - Shijou Saikyou no Quiz Ou Ketteisen (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 668a644101aa6b4e9c0c2b41f8ef6ba342ebefdb7ef2a0ce8ba0e839feb81064
+  name:   Gimmi a Break - Shijou Saikyou no Quiz Ou Ketteisen 2 (Japan)
+  title:  Gimmi a Break - Shijou Saikyou no Quiz Ou Ketteisen 2 (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 1bbe4b3e20a004a4f741018e31e6ae291772b8876d6fb6f01494c9c5b0917c6c
   name:   Gimmick! (Japan)
   title:  Gimmick! (Japan)
@@ -10618,6 +16365,31 @@ game
       type: ROM
       size: 0x40000
       content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4a3ea7606276ca3fca7595713c91d22ca0582812314600e87fc6825566850ffa
+  name:   Ginga Eiyuu Densetsu (Japan)
+  title:  Ginga Eiyuu Densetsu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: ROM
       size: 0x20000
@@ -10644,6 +16416,48 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 3f32cffa42c14c6e803cd5e8f6b41d33ac9ca24b2ab5447ce9483ae8c383b9db
+  name:   Goal! (Europe)
+  title:  Goal! (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: bf22e6aff97bb44210987f5631c1667d4fa75ef79522e8c46dbb3b0f4877896b
+  name:   Goal! (USA)
+  title:  Goal! (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 7911375ab98da4ac5c628ba4dfffcba8ba4fc13a341901aed120ab967be5e26c
@@ -10713,6 +16527,90 @@ game
       content: Character
 
 game
+  sha256: dd4868be31085ae8de737c2a2358d1e477cd446639412a1cc812e74f43ba508e
+  name:   Godzilla - Monster of Monsters! (Europe)
+  title:  Godzilla - Monster of Monsters! (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c2383e5cd8670c7107d59887026b9001f30045aa5f07be4b687b7a6bc290db1f
+  name:   Godzilla - Monster of Monsters! (USA)
+  title:  Godzilla - Monster of Monsters! (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 37b5a1c9d9bc17471d6b8ab2013f86538ed67960c7aea19dc46266c646b64710
+  name:   Godzilla 2 - War of the Monsters (USA)
+  title:  Godzilla 2 - War of the Monsters (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e02a6fee449847901d7cff63a1665b29219f7552d9ecbea944aa5653eb299f28
+  name:   Gojira (Japan)
+  title:  Gojira (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: d4bd5f9e2bbfafb624d67a77f4292b92bad183c9aa4728620aedf3201591f6d8
   name:   Golf (Europe)
   title:  Golf (Europe)
@@ -10776,6 +16674,90 @@ game
       content: Character
 
 game
+  sha256: 266a0aa3348c7a9fabe3ea9726c0eb054a29bc676022e8e60d0b3eff8e442425
+  name:   Golf '92, The (Japan)
+  title:  Golf '92, The (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c708813f8104288aaa603fa3970c0906a45c32a25dc2fcfe398a8f0f55ac4994
+  name:   Golf Club - Birdy Rush (Japan)
+  title:  Golf Club - Birdy Rush (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 6c2626487d91254f4b468e439a66ac61d97baf4b93701b2b7e23b3f0cfeaa305
+  name:   Golf Grand Slam (Japan)
+  title:  Golf Grand Slam (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: af24262bc78865b81b1a42d2842e222553fca27fb841a4eb8fbe26da7eba6163
+  name:   Golf Grand Slam (USA)
+  title:  Golf Grand Slam (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: d530bfd8bae1fd38d29d776e663bcf5e774590866a5ee8a09e2c1d992e28a008
   name:   Golfkko Open (Japan)
   title:  Golfkko Open (Japan)
@@ -10804,6 +16786,48 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3d6bf7221fc38cd5bd1a55b50a5b0f50e6cbba0f44e5236e8447876f711e74ae
+  name:   Golgo 13 - Daiisshou - Kamigami no Tasogare (Japan)
+  title:  Golgo 13 - Daiisshou - Kamigami no Tasogare (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9f559f83b9b5179137069bae0ca4b8eacf84378892b598044b88ef50681b58bb
+  name:   Golgo 13 - Top Secret Episode (USA)
+  title:  Golgo 13 - Top Secret Episode (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -10990,6 +17014,27 @@ game
       content: Character
 
 game
+  sha256: 7f0f30ab54eb3d62c65d299e3d2b9493f6ab8d7c5a8289ce8239d7b2b45757d0
+  name:   Gozonji - Yaji Kita Chin Douchuu (Japan)
+  title:  Gozonji - Yaji Kita Chin Douchuu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 3aa97b519a5191766a53ae51c28a51c17778716bc02ef58b9c82afc761e20329
   name:   Gradius (Europe)
   title:  Gradius (Europe)
@@ -11102,6 +17147,27 @@ game
       content: Character
 
 game
+  sha256: fe3d2f94dadd3b2437e45ed9a38276b8b32af9e25d484de79c3cc7bf60eef386
+  name:   Grand Master (Japan)
+  title:  Grand Master (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: d96de4b5e924c9fb59e9ba953aa6aa2590ae466d696c2508a3752df9fe2ddb63
   name:   Great Battle Cyber (Japan)
   title:  Great Battle Cyber (Japan)
@@ -11146,6 +17212,96 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: ddb68cbb2ba471df82824b1d157738260ebde39badb5945838b0627de61ffcca
+  name:   Great Deal (Japan)
+  title:  Great Deal (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: b0257dff8f9e22ceab9be2ef4c634c0627bdf21fe721345a8e7ec4463c8c48f2
+  name:   Great Tank (Japan)
+  title:  Great Tank (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 60a7d102deac7491e08b7ed5a7b96e66e09758b8411f682a4df1a7e8b49e55c5
+  name:   Great Waldo Search, The (USA)
+  title:  Great Waldo Search, The (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 978eb3b632927b65a1152fa282e8a901617da43b2fb43e0283e6dcad8125a29e
+  name:   Greg Norman's Golf Power (USA)
+  title:  Greg Norman's Golf Power (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 029c4a8b572bdf3a655fb06a2e6ac67bd1c89c15d472d5078c8e77376c40102f
@@ -11277,6 +17433,69 @@ game
       volatile
 
 game
+  sha256: f4b930ed4801897c195b4db2ca61aef151db248f5c9750621e2c1a43f63ef464
+  name:   Guerrilla War (Europe)
+  title:  Guerrilla War (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a2033c3b3d9f54b37fad8083604d37e2b2cb4ff77e0e183021141f55dfa9c4cd
+  name:   Guerrilla War (USA)
+  title:  Guerrilla War (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: dc633fbec89dc15afa3b244d3e2f991f0b43a75d505468c465d480fe67efed47
+  name:   Guevara (Japan)
+  title:  Guevara (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 7c948ac8b05b128691a64d936a5c6dfdb7d121e23b52fff3d86f72b04b064b47
   name:   Gun Nac (Japan)
   title:  Gun Nac (Japan)
@@ -11384,6 +17603,31 @@ game
       content: Character
 
 game
+  sha256: ea7d40f9a35d47ac069198a21f667dcdf0833d5353a9d2da97800d95266e376d
+  name:   Gunhed - Aratanaru Tatakai (Japan)
+  title:  Gunhed - Aratanaru Tatakai (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 4628f32db9b826d19fe5dd8e2c45a9f70e1041f15b7b44b06dee2f01731566e8
   name:   Gumshoe (USA, Europe)
   title:  Gumshoe (USA, Europe)
@@ -11468,6 +17712,27 @@ game
       content: Character
 
 game
+  sha256: ac29fd5df89bb83b95551565a1c97577f42a94afff00747218438d26e6556aa6
+  name:   Haja no Fuuin (Japan)
+  title:  Haja no Fuuin (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: bd5c7925e616da879ee63ac4ac2004af26e20ae36a494247e704d41440ac971a
   name:   Hammerin' Harry (Europe)
   title:  Hammerin' Harry (Europe)
@@ -11511,6 +17776,32 @@ game
       volatile
 
 game
+  sha256: 84c21608742d06c33a331fd6099fc2a519ed2dea1432c395301c4cf2e9d766c4
+  name:   Hanjuku Hero (Japan)
+  title:  Hanjuku Hero (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 0a91c3d7ef625b6710677174010066eea584d5bcfb5e5d2002be369c7a3c289a
   name:   Happy Birthday Bugs (Japan)
   title:  Happy Birthday Bugs (Japan)
@@ -11534,6 +17825,79 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 07bfd5bf6d3e5cea26d0a521e7d599d67a4b794c5efa66e4189877c1361aad47
+  name:   Harlem Globetrotters (USA)
+  title:  Harlem Globetrotters (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: cc19dedb3d82e1df42e7a055ae7a2a570da11218a8d99f70709ea471485b53b5
+  name:   Hatris (Japan)
+  title:  Hatris (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 3616e10dac2c7e0d217b5a742a46220444ec212d2c7a317cff9b67a7361854e3
+  name:   Hatris (USA)
+  title:  Hatris (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 4ccc1500ca9e95db50961ef4e825bef9ef9e10f994fd6e424693a3e8abf6f72b
@@ -11614,6 +17978,27 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 0a23312c8e07b9af753b25c1307f07f8061d6ac4f8427f4660382d925e7a84e2
+  name:   Heavy Shreddin' (USA)
+  title:  Heavy Shreddin' (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -11759,6 +18144,32 @@ game
       volatile
 
 game
+  sha256: 368441ce3e7433b4f31431a3e5b1095b6121f0b1a2c8a3999c1b374528a61382
+  name:   Heracles no Eikou II - Titan no Metsubou (Japan)
+  title:  Heracles no Eikou II - Titan no Metsubou (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 45f0d711cb0de239be0322f899f4f8dd10eb9232d5cda1e7ed88f42e44d2556b
   name:   Higemaru - Makai-jima - Nanatsu no Shima Daibouken (Japan)
   title:  Higemaru - Makai-jima - Nanatsu no Shima Daibouken (Japan)
@@ -11833,6 +18244,28 @@ game
       volatile
 
 game
+  sha256: e78df687929567caa9a9352e3b78cceed958a034fb90b9dc4eb5e54dc908b76c
+  name:   Highway Star (Japan)
+  title:  Highway Star (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 40e2325eb25a77dc06b9f67b13948225a2c686dc07d75f550e8f17867f85c28c
   name:   Hikari no Senshi Foton - The Ultimate Game on Planet Earth (Japan)
   title:  Hikari no Senshi Foton - The Ultimate Game on Planet Earth (Japan)
@@ -11877,6 +18310,27 @@ game
       volatile
 
 game
+  sha256: 7bc3b454f57bd1c695edce23f5c9c1202557bf0cf80a745a15f22d8334db00e2
+  name:   Hirake! Ponkikki (Japan)
+  title:  Hirake! Ponkikki (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 1d414ba38bbbd3495ddb988b340f265912f5bdfc3cdd7fb8b607fff404da1ad9
   name:   Hiryuu no Ken - Ougi no Sho (Japan)
   title:  Hiryuu no Ken - Ougi no Sho (Japan)
@@ -11899,6 +18353,27 @@ game
       volatile
 
 game
+  sha256: 5c91133fc9469352bd3ea77b61007eaa3bd0be1060680d985e6d09da69ee9a7c
+  name:   Hiryuu no Ken II - Dragon no Tsubasa (Japan)
+  title:  Hiryuu no Ken II - Dragon no Tsubasa (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 384c01b71e1eed23778356753646fb518f1dfa483e0e3a3c1b7391c67cb8ec08
   name:   Hiryuu no Ken III - 5 Nin no Dragon (Japan)
   title:  Hiryuu no Ken III - 5 Nin no Dragon (Japan)
@@ -11918,6 +18393,53 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: e96b430354032786f99c25244ef78869a76a454fa5692f2a7e80b69640345023
+  name:   Hiryuu no Ken Special - Fighting Wars (Japan)
+  title:  Hiryuu no Ken Special - Fighting Wars (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 386b4e9d1e25a428b20e4e8cdd8544f453a16c24c9a90de75d08f39c6f7971e0
+  name:   Hissatsu Doujou Yaburi (Japan)
+  title:  Hissatsu Doujou Yaburi (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: d0e1bf484da0590204ae6183a8fc484e344a03177c600cfe7c717afb0d0e6e46
@@ -11945,6 +18467,32 @@ game
       content: Character
 
 game
+  sha256: 52aea6e53c380799ac392a66eb3ce6337d704033d811b889e5589fa4ec4489f5
+  name:   Hitler no Fukkatsu - Top Secret (Japan)
+  title:  Hitler no Fukkatsu - Top Secret (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 8e4a04076b6a728a7e65a09737776dcb9defed7922bf0437d9a89bbe8c724b55
   name:   Hogan's Alley (World)
   title:  Hogan's Alley (World)
@@ -11964,6 +18512,28 @@ game
       type: ROM
       size: 0x2000
       content: Character
+
+game
+  sha256: a4ae3b7071e1dc5392af834ca751f8b3500a08daee82404c6d2e1185b876f329
+  name:   Hokkaidou Rensa Satsujin - Okhotsk ni Kiyu (Japan)
+  title:  Hokkaidou Rensa Satsujin - Okhotsk ni Kiyu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 6db66b884008281c466e3da4af668ac4a9b6e6e164efb3012d6e816f9fee57ca
@@ -12002,6 +18572,58 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: ae3a88c2519d34eff17292068ae376fae0286ff5d5c05d854af0677938590fda
+  name:   Hokuto no Ken 3 - Shin Seiki Souzou Seiken Retsuden (Japan)
+  title:  Hokuto no Ken 3 - Shin Seiki Souzou Seiken Retsuden (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 2da7ec5f8ff146159a6dd8f295eb80e30429d5841a8dd07c9bbf2ce242a77ea3
+  name:   Hokuto no Ken 4 - Shichisei Haken Den - Hokuto Shinken no Kanata e (Japan)
+  title:  Hokuto no Ken 4 - Shichisei Haken Den - Hokuto Shinken no Kanata e (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: RAM
       size: 0x2000
@@ -12209,6 +18831,111 @@ game
       content: Character
 
 game
+  sha256: 74a1e6848c341b912d17985dce1f96b5c70ca878b137995a9686441326707bf4
+  name:   Hook (Europe)
+  title:  Hook (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e486d403fa3a789995728f9e6c5200fd5239ff7548262e24a008b7449bbcaef8
+  name:   Hook (Japan)
+  title:  Hook (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: f3ff0c50c05aa5d461c293e306e553152e63564cd09e80ae0b6dcfa97b07d073
+  name:   Hook (USA)
+  title:  Hook (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: add5dfff3403e64550391c8c23267b86096a63c7a4cbfe1f5f685ebfa2eea212
+  name:   Hoops (Europe)
+  title:  Hoops (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 0a3459d0b8955bed9e9082ddad5cef63231599febfabafd59182c96174d5be1b
+  name:   Hoops (USA)
+  title:  Hoops (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 5cfc1c6d83afd59de8b359e6dbbfc866dc64436dbd46efd336ccc869ef48e2da
   name:   Hoshi no Kirby - Yume no Izumi no Monogatari (Japan)
   title:  Hoshi no Kirby - Yume no Izumi no Monogatari (Japan)
@@ -12256,6 +18983,53 @@ game
       volatile
 
 game
+  sha256: e12b5523d40031090c466b430eaf1b4f26910628382c022fa275ce278f2e399e
+  name:   Hostages - The Embassy Mission (Japan)
+  title:  Hostages - The Embassy Mission (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 01f15122080ad8765cfd9d780e2e4ebcee3a861dda5101c56ba924d7382f45de
+  name:   Hototogisu (Japan)
+  title:  Hototogisu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 5029ba6d72f01a53cc7dd6e54d6618cd31c7a877bed971d4a638c68132473b8b
   name:   Hottarman no Chitei Tanken (Japan)
   title:  Hottarman no Chitei Tanken (Japan)
@@ -12274,6 +19048,69 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: c49229945af8c84942385cca8246c8f61795419dea1d9d5b964d884f74e9d62d
+  name:   Hudson Hawk (Europe)
+  title:  Hudson Hawk (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 50102d2e91a574f45ab73c6f6c32f1b5c3a24d8109d2821f0fda55a7f5191ae2
+  name:   Hudson Hawk (Japan)
+  title:  Hudson Hawk (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3991a761116131dc412fd7cfe8e70bf414d11fa4778e9dfb049ffcc9a8586cac
+  name:   Hudson Hawk (USA)
+  title:  Hudson Hawk (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -12326,6 +19163,52 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 71d0e62b2ccd9c34f58c67e20261399cb8e175b807e39f312fad1c36aab6f0b8
+  name:   Hyakkiyagyou (Japan)
+  title:  Hyakkiyagyou (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d016f26aeb55ce0d0d44107690d833140c62333264ed7eb88e7a5fcf5553d4fe
+  name:   Hyaku no Sekai no Monogatari - The Tales on a Watery Wilderness (Japan)
+  title:  Hyaku no Sekai no Monogatari - The Tales on a Watery Wilderness (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -12400,6 +19283,27 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: f9d793e5bd2118dff866c3fd9a014963e857ac8df40b4d4bcc1abd0f9515a90a
+  name:   Hyokkori Hyoutan-jima - Nazo no Kaizokusen (Japan)
+  title:  Hyokkori Hyoutan-jima - Nazo no Kaizokusen (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -12484,6 +19388,27 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: 11a24fb4376729460990206ab410295fde65336ad82e8358135f086aa68b84ff
+  name:   I Love Softball (Japan)
+  title:  I Love Softball (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -12615,6 +19540,78 @@ game
       volatile
 
 game
+  sha256: fc04c0435b35a55ef7d236d8f2a7aa3f8807b6b6091b63c8089a5a6d0f758bea
+  name:   Ide Yousuke Meijin no Jissen Mahjong II (Japan)
+  title:  Ide Yousuke Meijin no Jissen Mahjong II (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: c14e732032e1b8de606b6ff02776426055863af844747e24eef9ec9ea731c4b8
+  name:   Idol Hakkenden (Japan)
+  title:  Idol Hakkenden (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e8870e755cd0188878c1fd9be4ae682566bf020a895b04dec9c6b38e155d4ea8
+  name:   Igo - Kyuu Roban Taikyoku (Japan)
+  title:  Igo - Kyuu Roban Taikyoku (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
   sha256: dd902f0a59e56f5f919b48ff90f5176db3374e34a35859c573f8c84b413fc372
   name:   Igo Meikan (Japan)
   title:  Igo Meikan (Japan)
@@ -12657,6 +19654,90 @@ game
       content: Character
 
 game
+  sha256: 9c09f6f57ba8a155060cadc69f746b72d19a4b6cbcdea50973f5600a0cce7e10
+  name:   Igo Shinan '91 (Japan)
+  title:  Igo Shinan '91 (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: de3365cd7d212c61ddda5a69831a33a1d6d36f5f11ab4d85322749f8250f10f2
+  name:   Igo Shinan '92 (Japan)
+  title:  Igo Shinan '92 (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 07ec7dd380ef2fd6b023ab14b66d3f8d5fbf81f728deeeb7a92e7cdf5579594b
+  name:   Igo Shinan '93 (Japan)
+  title:  Igo Shinan '93 (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 8d5add6c9979d3557f6c1ab46093863ef71a418deab46920a4cc015e31471f5d
+  name:   Igo Shinan '94 (Japan)
+  title:  Igo Shinan '94 (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 0888da461ea7b782c1517c68bfbd893a015f62782be1c04afd1e3764d024f93d
   name:   Ikari (Japan)
   title:  Ikari (Japan)
@@ -12677,6 +19758,70 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: bd3e03351e7dd1ebab9d17aca089cc4ca55e80e9630de70d241f67c6317888e5
+  name:   Ikari II - Dogosoken (Japan)
+  title:  Ikari II - Dogosoken (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: aa2735d5cba4ce26b1412987e0ea3192ac286605550fac73c08a8af74da3fe85
+  name:   Ikari III (Japan)
+  title:  Ikari III (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 181163b590a581b6d04baaedb815429a2342ded27b3fb7f2514661d1fd47c1cc
+  name:   Ikari III - The Rescue (USA)
+  title:  Ikari III - The Rescue (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 4cbf79bfda9d9e37dd113dd56ce1325282f43360c9d8a4231e2995bc49833fd5
@@ -12737,6 +19882,28 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 119f865684be58f37101b431975c827b2ad9340c0f2d3d9fc3153ee1213ee55e
+  name:   Ikari Warriors II - Victory Road (USA)
+  title:  Ikari Warriors II - Victory Road (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
       content: Program
     memory
       type: RAM
@@ -12943,6 +20110,28 @@ game
       volatile
 
 game
+  sha256: 5348f7f88695867de428b38eb6a7f724f5f97110c383567d7e4d1f5a2d8b612f
+  name:   Indiana Jones and the Last Crusade (USA)
+  title:  Indiana Jones and the Last Crusade (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 79c03fec3f459ac6e762c27d8f08debe6589b01df21919ef69645870a16723b3
   name:   Indiana Jones and the Last Crusade (USA)
   title:  Indiana Jones and the Last Crusade (USA)
@@ -13007,6 +20196,32 @@ game
       content: Character
 
 game
+  sha256: a1f5ad75b928ccb933a424290b0c9735835f08b16d2849a39b625a5bb86a99a1
+  name:   Indora no Hikari (Japan)
+  title:  Indora no Hikari (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 0bb401bbd0cae2758b2bd355cd3cac3cc26a01950859c830b3b122bd379f2463
   name:   Infiltrator (USA)
   title:  Infiltrator (USA)
@@ -13035,6 +20250,69 @@ game
   board:  TAITO-TC0190
     chip
       type: TC0190
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 41db5f5aedc539bab41e89a353732786c76ce9a753066a868e3e84da422de386
+  name:   International Cricket (Australia)
+  title:  International Cricket (Australia)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 829fd06b3cae83304394e2338951c2760730577b2cba031fd6d54f43341105c0
+  name:   Iron Tank - The Invasion of Normandy (Europe)
+  title:  Iron Tank - The Invasion of Normandy (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 6fac8ea87f7eea5e9bf7b838ff92c2fa3369908c866631340ec489beacdcbf3b
+  name:   Iron Tank - The Invasion of Normandy (USA)
+  title:  Iron Tank - The Invasion of Normandy (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -13089,6 +20367,32 @@ game
       volatile
 
 game
+  sha256: 4ad242ce01754d3445aac2d8484f906919554c20d67900b1b8343f4723e89bd3
+  name:   Isaki Shuugorou no Keiba Hisshou Gaku (Japan)
+  title:  Isaki Shuugorou no Keiba Hisshou Gaku (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 401e5d3afb4d623308458e2c6c594fd38faa8cd9e5276d39b4052e996f937216
   name:   Isolated Warrior (Europe)
   title:  Isolated Warrior (Europe)
@@ -13125,6 +20429,31 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 43b51720de41c7ace458aac1bc1e0c8ff16c14f40b82c988ca38c8af4fe3b7cc
+  name:   Itadaki Street - Watashi no Omise ni Yottette (Japan)
+  title:  Itadaki Street - Watashi no Omise ni Yottette (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: ROM
       size: 0x20000
@@ -13459,6 +20788,32 @@ game
       content: Character
 
 game
+  sha256: 4a5c84cbc801421c3d10ab2b33a386e6943af7252f17b17b707341fcd2b9fc2b
+  name:   Jangou (Japan)
+  title:  Jangou (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: e9c28ba4b940583e4a486ac5b401ac42e9aafa909d27c798f4fb3fc0045a3971
   name:   Jarinko Chie - Bakudan Musume no Shiawase Sagashi (Japan)
   title:  Jarinko Chie - Bakudan Musume no Shiawase Sagashi (Japan)
@@ -13598,6 +20953,28 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: e8453890bf0d3daf59bb5092d8f963dd2ccbfb1ac4f76fd784919d577fe3988c
+  name:   Jesus - Kyoufu no Bio Monster (Japan)
+  title:  Jesus - Kyoufu no Bio Monster (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
       content: Program
     memory
       type: RAM
@@ -13886,6 +21263,48 @@ game
       volatile
 
 game
+  sha256: 0f6294edba5e9a6ec5c6390a683f61759d20dec6cb03b0c4e9490007aa10e8be
+  name:   Journey to Silius (Europe)
+  title:  Journey to Silius (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 0417d7caec593852823b94f5520caea3745a28c9dac68e30d2c5e6f5545a9757
+  name:   Journey to Silius (USA)
+  title:  Journey to Silius (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: aeb18e54f24d060985247f59cf9a4ad586993b993d7b5ac7b568041ac37de2c3
   name:   Joust (Japan)
   title:  Joust (Japan)
@@ -13971,6 +21390,31 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: da4f1fac53d3a835acaedd5c9c08437debbb97811d63f6dc067c0c65ed3113d2
+  name:   Jumbo Ozaki no Hole in One Professional (Japan)
+  title:  Jumbo Ozaki no Hole in One Professional (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -14221,6 +21665,54 @@ game
       content: Character
 
 game
+  sha256: f8de0a3ee5bdbde0d8cdfafeb8b7120fec94c28cd30b46a6a0852d15a0b7e11c
+  name:   Kabushiki Doujou (Japan)
+  title:  Kabushiki Doujou (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: cb7692b9e6335c05c599c9117b7638e9303989af80d7fa356cfc3aee1ea25db9
+  name:   Kaettekita! Gunjin Shougi - Nanya Sore! (Japan)
+  title:  Kaettekita! Gunjin Shougi - Nanya Sore! (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 722035257431bbc43bbc612ccf36f5c8346c4f7073b298dcf6d46d95866f860a
   name:   Kage no Densetsu (Japan)
   title:  Kage no Densetsu (Japan)
@@ -14265,6 +21757,32 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: a35b5e01ce571bc6abb085db515a9e5d2244d4bb6f036d591d10012e6f4f5b4e
+  name:   Kaguya Hime Densetsu (Japan)
+  title:  Kaguya Hime Densetsu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 4d302aae428b6189c3e12261eeb42fcf1d104ab799cce71522824e1524298f46
@@ -14374,6 +21892,27 @@ game
       volatile
 
 game
+  sha256: 204b5eb443dc8f599d54e242352ba299c05015e5571f74307d78748af3d5f960
+  name:   Kame no Ongaeshi - Urashima Densetsu (Japan)
+  title:  Kame no Ongaeshi - Urashima Densetsu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: c660d61280f9294080aa05ef25346a354e4bcaedff6feeba77159a8f4de3b814
   name:   Kamen no Ninja - Akakage (Japan)
   title:  Kamen no Ninja - Akakage (Japan)
@@ -14394,6 +21933,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 1bf2acf6af87125ed3716feae74fbc87c5f85b64240c6fe443d427171ced0956
+  name:   Kamen no Ninja - Hanamaru (Japan)
+  title:  Kamen no Ninja - Hanamaru (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 2241728a8072ccdf13c3bb913d2d16abd62bb43c71757d80a376c4f65cd060cf
@@ -14814,6 +22374,48 @@ game
       content: Character
 
 game
+  sha256: 07e1b14777f8f04d4bd7c85c74a6f9e0f5c43b8c31aa7b3214e53a659fd5a2d9
+  name:   Kero Kero Keroppi no Daibouken 2 - Donuts Ike wa Oosawagi! (Japan)
+  title:  Kero Kero Keroppi no Daibouken 2 - Donuts Ike wa Oosawagi! (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 7f0305dce34fc85426e7fd58395293869554bbf94e93668b3610d4e3e3413d95
+  name:   Keroppi to Keroriinu no Splash Bomb! (Japan)
+  title:  Keroppi to Keroriinu no Splash Bomb! (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 67123fe28cf5fbadeafc77400a0812f0135ab36706ec7d1267f84931d044e71d
   name:   Ki no Bouken - The Quest of Ki (Japan)
   title:  Ki no Bouken - The Quest of Ki (Japan)
@@ -14922,6 +22524,58 @@ game
       content: Character
 
 game
+  sha256: 56f1fe3a7881b2e9d69cd33a0971b2f26247e964c3c7dd4a6019715425ff2256
+  name:   Kid Icarus (USA, Europe)
+  title:  Kid Icarus (USA, Europe)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: ee8b884dec3b2c5c0b92e4d6aee61d6ee4191ecdcd7cd4c96733bf54ecbed962
+  name:   Kid Icarus (USA, Europe) (Rev 1)
+  title:  Kid Icarus (USA, Europe) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: a11eec5762a029c95a5d496c0671b73e663225be50a5b1e89f16f380637b6665
   name:   Kid Klown in Night Mayor World (USA)
   title:  Kid Klown in Night Mayor World (USA)
@@ -14961,6 +22615,50 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 81e527e9c282f5078a3d08470ad3c032fea9a72f1559ee9d2702ea6b07fab45c
+  name:   Kid Niki - Radical Ninja (USA)
+  title:  Kid Niki - Radical Ninja (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 81a77623adf819f10548052075555998c1ec1ef5f4dc4bf6ff6b6c3fa3541c1b
+  name:   Kid Niki - Radical Ninja (USA) (Rev 1)
+  title:  Kid Niki - Radical Ninja (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
       content: Program
     memory
       type: RAM
@@ -15358,6 +23056,27 @@ game
       content: Character
 
 game
+  sha256: 2a07434449b079c8f1b6b2675a814a832419605791a7b7c38b54e6aa94f2506a
+  name:   Kiteretsu Daihyakka (Japan)
+  title:  Kiteretsu Daihyakka (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 9caa01a2b81ce1f98b17520aee09d415da7192382c1e47316998b6c1be6168eb
   name:   Kiwi Kraze - A Bird-Brained Adventure! (USA)
   title:  Kiwi Kraze - A Bird-Brained Adventure! (USA)
@@ -15422,6 +23141,69 @@ game
       content: Character
 
 game
+  sha256: 634d01fbb215f5f9240284f04ca9ba24e2d3d0aa954b7b080e817878db042a8d
+  name:   Knight Rider (Europe)
+  title:  Knight Rider (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c37ca6a568d16a0f58d639ce7b27396e4131e487e6074201322501f0e324ffa8
+  name:   Knight Rider (Japan)
+  title:  Knight Rider (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b66538543d3c4c74448e896130081c39112b14898beffbe95137a410394e5dc9
+  name:   Knight Rider (USA)
+  title:  Knight Rider (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 50b667f84cae86afb67dae6f63c16faf7df9e5cbeeb7626aa5c2e961d7fb3f3f
   name:   Konami Hyper Soccer (Europe)
   title:  Konami Hyper Soccer (Europe)
@@ -15468,6 +23250,27 @@ game
       content: Character
 
 game
+  sha256: cbd053cc942d143c5cbf26aaa307209ca8557ec7207ca6a9a07dc6537a0ac59c
+  name:   Konamic Sports in Seoul (Japan)
+  title:  Konamic Sports in Seoul (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 4f6245828d6140c2e5c4748873b5049879fb54136d4744af3f9988eaaed2d4b1
   name:   Kouryuu Densetsu Villgust Gaiden (Japan)
   title:  Kouryuu Densetsu Villgust Gaiden (Japan)
@@ -15490,6 +23293,31 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: 89203eaa54f392bfc6b90b2cc04f5e6c2d8915d661c99eb09aa877d5a474b3d4
+  name:   Koushien (Japan)
+  title:  Koushien (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -15550,6 +23378,53 @@ game
       type: ROM
       size: 0x40000
       content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: df3f107060031d15d71fa1fbff4d29d9c31ff221613707a8778c1279432145bc
+  name:   Kujaku Ou (Japan)
+  title:  Kujaku Ou (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: ed8b89dac1c063fa6b8f4b9e0bb4103ae02fb4fa333d0fad23d7d98f082c40b7
+  name:   Kujaku Ou II (Japan)
+  title:  Kujaku Ou II (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: ROM
       size: 0x20000
@@ -16135,6 +24010,48 @@ game
       volatile
 
 game
+  sha256: cfaed5512ebca1c735bf2d2cd80983ced4eb4649c99cd617b0897e7c05fba9a0
+  name:   Lee Trevino's Fighting Golf (Europe)
+  title:  Lee Trevino's Fighting Golf (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ac9d9f60f68c020c99b5bb1b91c723f16ac59091676826bced466b7ee4c97209
+  name:   Lee Trevino's Fighting Golf (USA)
+  title:  Lee Trevino's Fighting Golf (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 203dc9486ba58e65f9a4289da476dc15ff34d6fd39d355b438ae4db2d182746d
   name:   Legacy of the Wizard (USA)
   title:  Legacy of the Wizard (USA)
@@ -16177,6 +24094,131 @@ game
       content: Character
 
 game
+  sha256: c0e685382f6c44fa4ce98adbf8011860599a05bf8b37f7c53dfb41bd548b4b83
+  name:   Legend of Prince Valiant, The (Europe)
+  title:  Legend of Prince Valiant, The (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 95bc817c38bd7fa4b92efdb20bd48e3d7a9c46a4d2981f419708652e5475acaf
+  name:   Legend of Zelda, The (Europe)
+  title:  Legend of Zelda, The (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: b822db53a1cc09564044b273b4b0bae8e76527688e733f80df884dc1ffb2abfa
+  name:   Legend of Zelda, The (Europe) (Rev 1)
+  title:  Legend of Zelda, The (Europe) (Rev 1)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 085e5397a3487357c263dfa159fb0fe20a5f3ea8ef82d7af6a7e848d3b9364e8
+  name:   Legend of Zelda, The (USA)
+  title:  Legend of Zelda, The (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: ec0d4ebf6d2fcecd1d95fef7329954efe79676959bc281ea908b226459bc6dc2
+  name:   Legend of Zelda, The (USA) (Rev 1)
+  title:  Legend of Zelda, The (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: d2a585ff6febf59447f9bd9fbb387ae4985385d6f6f61a70e145a5ee69523018
   name:   Legendary Wings (USA)
   title:  Legendary Wings (USA)
@@ -16217,6 +24259,90 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: 2b3c2404cefe3a568f2159de6814b58b8d539ba33037ba02ae03aea63446ae44
+  name:   Lemmings (Europe)
+  title:  Lemmings (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 494aa7d49d3f4d66f01cac0f31a9bc7bc9626faa575a635f43e7caf19a832a48
+  name:   Lemmings (USA)
+  title:  Lemmings (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 2940c463447a87624bf7d419dc94190ee9fb51481ad1401c9b4ed2462e4ecd03
+  name:   Lethal Weapon (Europe)
+  title:  Lethal Weapon (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 97c67809c952bc25060a01dca224eedc5ed76cc770bac44452c92cd3a1d4a418
+  name:   Lethal Weapon (USA)
+  title:  Lethal Weapon (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -16304,6 +24430,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 475c35c18b5e958122473bcca52d54438e1734b1b74dc295492eba6d29927193
+  name:   Little League Baseball - Championship Series (USA)
+  title:  Little League Baseball - Championship Series (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 37095b3fad194709095a7827ddc4547b5762f0ef9fc50d9368660b1d6a3f6b64
@@ -16803,6 +24950,32 @@ game
       content: Character
 
 game
+  sha256: 345fe1e466b3e8d7a8b7f01f545808793b120ad17ed8497ddc306e205b2589a3
+  name:   M.U.L.E. (USA)
+  title:  M.U.L.E. (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: d10e4280b6ca868142061ab731aeb378c983334b89a1727a524c57c241812d13
   name:   M.U.S.C.L.E. - Tag Team Match (USA)
   title:  M.U.S.C.L.E. - Tag Team Match (USA)
@@ -16884,6 +25057,27 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: 5cb495fd9dc486d65a2197b17fd548f5201e53497dd51bdd418e3ba0d9d04bd9
+  name:   Mad City (Japan)
+  title:  Mad City (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -16975,6 +25169,48 @@ game
       content: Character
 
 game
+  sha256: 5b11ee1cb26dbf5fb958a0fdab90c979d64ee1aa15cbc9e965e754a89d16b087
+  name:   Magic Darts (Japan)
+  title:  Magic Darts (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: fe622610cd889b3513960a38775df5230caef8cee38837b0e7d0cefb8dc7f0ce
+  name:   Magic Darts (USA)
+  title:  Magic Darts (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 497c3015516cb6ae2f20d70b8fb1b70b8c4cfcd64e118992c438cfe7b0579f2b
   name:   Magic John (Japan)
   title:  Magic John (Japan)
@@ -16982,6 +25218,48 @@ game
   board:  JALECO-JF-24A
     chip
       type: SS88006
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e6e010824dad945d7112114820cac9952a1dee48cf0fcc107268fe80601c6bc9
+  name:   Magic Johnson's Fast Break (USA)
+  title:  Magic Johnson's Fast Break (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 527faba646cd9e959a4df5d015cd14ac3fae461b06655be99d47c1a754384097
+  name:   Magic of Scheherazade, The (USA)
+  title:  Magic of Scheherazade, The (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -17293,6 +25571,53 @@ game
       volatile
 
 game
+  sha256: 821bbd229ae2c6531e2831c9b27238dd72ab170744fa688ea7460deef142c608
+  name:   Mahjong RPG Dora Dora Dora (Japan)
+  title:  Mahjong RPG Dora Dora Dora (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e5c08b263bfa5867c187f9817291c487e500fd0be3b8949652674ea44e68daf3
+  name:   Mahjong Taikai (Japan)
+  title:  Mahjong Taikai (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 591ee64715eeee17d35a6c4444cfe303ba140958e191287586a79bd26066e536
   name:   Mahjong Taisen (Japan)
   title:  Mahjong Taisen (Japan)
@@ -17312,6 +25637,74 @@ game
       type: RAM
       size: 0x2000
       content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 027e54f6663a42f1a5597095d444563b85522eca05495c8d78433a5cc69b7786
+  name:   Mahou no Princess Minky Momo - Remember Dream (Japan)
+  title:  Mahou no Princess Minky Momo - Remember Dream (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: fae0b1e6aab61fde81fcc21e5c6e8bf7e2c4d0498aa36537f70cabf8f32ec386
+  name:   Maison Ikkoku (Japan)
+  title:  Maison Ikkoku (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: a232438c6419a7493a4b3fbe910d289a980e94c2ec15dad866d5af99d419c717
+  name:   Majaventure - Mahjong Senki (Japan)
+  title:  Majaventure - Mahjong Senki (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
     memory
       type: ROM
       size: 0x20000
@@ -17425,6 +25818,110 @@ game
       volatile
 
 game
+  sha256: 7ac8c7c1703b5bb8bd120343e409f61c6d7520f893a13603ba76ad2b6fffd33e
+  name:   Maniac Mansion (Europe)
+  title:  Maniac Mansion (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 9f134a041c44bf7c78c19781b1f496faa5b9920c5e7e55742594ce85591f915d
+  name:   Maniac Mansion (France)
+  title:  Maniac Mansion (France)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 28666a463b7a3bc2b1e2bab1f5e78d9a54b472667055293b312f559de804608b
+  name:   Maniac Mansion (Germany)
+  title:  Maniac Mansion (Germany)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 96b6b1922a682c0f5ab2049901478aac4271c50cba1a94544e336de1e2001929
+  name:   Maniac Mansion (Italy)
+  title:  Maniac Mansion (Italy)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 906c3ba463960a086c3f2603ede0b35121babed27cda9e20a2ddef1ce0ca2eed
   name:   Maniac Mansion (Japan)
   title:  Maniac Mansion (Japan)
@@ -17440,6 +25937,84 @@ game
       type: ROM
       size: 0x40000
       content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: f0f4f19fcd2626969082c8dc3f9b9d35116c1af412b1d436967592b06e890491
+  name:   Maniac Mansion (Spain)
+  title:  Maniac Mansion (Spain)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 309f5b39f2a8648565ff3fadd2a0d5cc9640c73f7c51525ea14b24b968c54088
+  name:   Maniac Mansion (Sweden)
+  title:  Maniac Mansion (Sweden)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 84f5377980d2fd44d71faec42f858b1e83540c2f55aba9236c3279d6dde8592a
+  name:   Maniac Mansion (USA)
+  title:  Maniac Mansion (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: RAM
       size: 0x2000
@@ -17573,6 +26148,27 @@ game
       volatile
 
 game
+  sha256: c6001b9a848385ce821f9ab5ffbb835a6286242b3956d28648b5bd5ac8905683
+  name:   Mario & Yoshi (Europe)
+  title:  Mario & Yoshi (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 7e2747b4cfcdc4e64c1188da6796779d922a521c49cf0d86182b85f7a376328d
   name:   Mario Bros. (Europe)
   title:  Mario Bros. (Europe)
@@ -17657,6 +26253,58 @@ game
       content: Character
 
 game
+  sha256: 05657999940aaa74f8a305c7263b454b1c189c217774c3b696881a73a54efa67
+  name:   Mario Open Golf (Japan)
+  title:  Mario Open Golf (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5466a034f58b05117c19d80e1017162b932e60ba5986bf5f80fefeae713d467f
+  name:   Mario Open Golf (Japan) (Rev 1)
+  title:  Mario Open Golf (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: c9348c4e30ef0bc62c4fd119b5e38d85af493a1eb436c6c229b7a6a52af42681
   name:   Mario's Time Machine (USA)
   title:  Mario's Time Machine (USA)
@@ -17676,6 +26324,53 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 7d48d09f0c5864e11255f4c117eb7427571a523faad22a99787006adfa67260a
+  name:   Marusa no Onna (Japan)
+  title:  Marusa no Onna (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c4e04727341c9d2b9bda73f49664931d4bf31ed081d17fb8d2bd0d790e0c9199
+  name:   Mashin Eiyuuden Wataru Gaiden (Japan)
+  title:  Mashin Eiyuuden Wataru Gaiden (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 4ac0926d1e4704e75e7dfc27c4d990ebdbe685002b9af1a80a385604f3cb162c
@@ -17741,6 +26436,58 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 5dde9817074d6d4996737c960324e074c82ba3e0cf65c566e5f30187d6a1592c
+  name:   Matsumoto Tooru no Kabushiki Hisshou Gaku (Japan)
+  title:  Matsumoto Tooru no Kabushiki Hisshou Gaku (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5c8cbedaa3d4bde0384a779a0616d919df91fc982f8c3ab8efa1d91d015688b0
+  name:   Matsumoto Tooru no Kabushiki Hisshou Gaku - Part II (Japan)
+  title:  Matsumoto Tooru no Kabushiki Hisshou Gaku - Part II (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: edd5299a1ac411c9cbbe12b3513a5f5f5621109960ca2630099c18b2b589ef89
@@ -17814,6 +26561,27 @@ game
       content: Character
 
 game
+  sha256: c8486cd1a35950007a3ba671a128097d780084182a854d6115ddec7dad56e806
+  name:   Mechanized Attack (USA)
+  title:  Mechanized Attack (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: c8e7036e8afcd95acaf3a5e0956df53beaab127a7defcc0e80d629653ff67c23
   name:   Mega Man (Europe)
   title:  Mega Man (Europe)
@@ -17850,6 +26618,50 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 8facf0e0d1f209ccf46af8628195919e6211214f986f986fddbd8a62cc1d3fd1
+  name:   Mega Man 2 (Europe)
+  title:  Mega Man 2 (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 1e588d435e75d80c5c0b578b4fa8d196f2cf4346c11c9a7b7e435d768828ad01
+  name:   Mega Man 2 (USA)
+  title:  Mega Man 2 (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
       content: Program
     memory
       type: RAM
@@ -18051,6 +26863,32 @@ game
       volatile
 
 game
+  sha256: 31aa0a31157abc4b34b86b66f12808d8720b34b7aefb45326eb2a0d2a081ffb7
+  name:   Meiji Ishin (Japan)
+  title:  Meiji Ishin (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 11321419b21821d4a30311946ed252d00080da18df7658d851375eb56b0a6dad
   name:   Meikyuu Kumikyoku - Milon no Daibouken (Japan)
   title:  Meikyuu Kumikyoku - Milon no Daibouken (Japan)
@@ -18069,6 +26907,27 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: c45dcaaba904dab08e747b0c1208d4fd3d1b044d253ce38f6c00711f466c4997
+  name:   Meikyuu no Tatsujin - Daimeiro (Japan)
+  title:  Meikyuu no Tatsujin - Daimeiro (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -18139,6 +26998,50 @@ game
       content: Character
 
 game
+  sha256: 6a63dde258c40501312d452d4a4736c3800f2808b410bb6e580cba5fcfa0dce7
+  name:   Meitantei Holmes - Kiri no London Satsujin Jiken (Japan)
+  title:  Meitantei Holmes - Kiri no London Satsujin Jiken (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 88e8cddf797c0f700605f0899290e936560db4a3369c286378b1eac74c165163
+  name:   Meitantei Holmes - M kara no Chousenjou (Japan)
+  title:  Meitantei Holmes - M kara no Chousenjou (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 1152961edf8d484f0e33294ae19fbcac8ab85099e6c8a59f1732c5f17b622885
   name:   Mendel Palace (USA)
   title:  Mendel Palace (USA)
@@ -18146,6 +27049,27 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 99a0f2bf5dd18442225d81f3051426821501a75b1319d33b968c2b005951b4b7
+  name:   Metal Flame - Psy Buster (Japan)
+  title:  Metal Flame - Psy Buster (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -18272,6 +27196,27 @@ game
       content: Character
 
 game
+  sha256: a00c77c3130316625403aeea9a0dbb02acf4a176740dac7b9e9a42452e574d4f
+  name:   MetalMech - Man & Machine (USA)
+  title:  MetalMech - Man & Machine (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: fa44773e3c2f1a435cbe7a8e098508b92cd79ba88c71f798b76c08aa0e257316
   name:   Metro-Cross (Japan)
   title:  Metro-Cross (Japan)
@@ -18293,6 +27238,80 @@ game
       type: ROM
       size: 0x8000
       content: Character
+
+game
+  sha256: d2cdc3e8432f104709c17c88b20ceae87780e97cf6a2e3372fd54d0a67972062
+  name:   Metroid (Europe)
+  title:  Metroid (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 649db8035018f2512ccea70aca6606c3b3a6988cd9ed43953b38dc5103dec7bb
+  name:   Metroid (USA)
+  title:  Metroid (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: bbe219918bc8ff62fdab7d8af0b52e54aa04e3d5c004908cb548cac5bc009d6b
+  name:   Mezase Pachi Pro - Pachio-kun (Japan)
+  title:  Mezase Pachi Pro - Pachio-kun (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 32c6893e0f8a14714dd2082803cfde62f8981010d23fc9cf00a5a18066d063cb
@@ -18846,6 +27865,27 @@ game
       content: Character
 
 game
+  sha256: fc73f13fb0ed636bbf97990b80eb5627c43503e9e4710eef3c77616bf4f4e5e2
+  name:   Mini-Putt (Japan)
+  title:  Mini-Putt (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: b17f5b18caffefdffa39d74978d03178892e03a0c66ff3ef98de4af7a33079d9
   name:   Minna no Taabou no Nakayoshi Daisakusen (Japan)
   title:  Minna no Taabou no Nakayoshi Daisakusen (Japan)
@@ -18885,6 +27925,81 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 0d47447410aac46d44ec79443c84bde1112e1294824cd4ae81d3c763d6e5fa64
+  name:   Miracle Piano Teaching System, The (France)
+  title:  Miracle Piano Teaching System, The (France)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
+  sha256: 737951be1b2c4754e325fa5426b225683003b958ae60f643e10deb34a159b6c9
+  name:   Miracle Piano Teaching System, The (Germany)
+  title:  Miracle Piano Teaching System, The (Germany)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
+  sha256: de66c8d971cadb53f30c049ea2e9934a45a9bf168215869f13f0e314ff870c29
+  name:   Miracle Piano Teaching System, The (USA)
+  title:  Miracle Piano Teaching System, The (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x10000
       content: Character
 
 game
@@ -19078,6 +28193,28 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: a3c28fd56bfcc582e459b9de4058dcae58859b8dc1bff48e69e6a9445ff7e66c
+  name:   Mizushima Shinji no Daikoushien (Japan)
+  title:  Mizushima Shinji no Daikoushien (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: b940678f703671fc66df60c16a1b1c41e164b87c3affb45ffb48e79c10e2170e
@@ -19354,6 +28491,49 @@ game
       content: Character
 
 game
+  sha256: 7178f3bec7ff64bab48331cff866a7aa5993760c58e0ace1f62f037e1d3bd835
+  name:   Moeru! Oniisan (Japan)
+  title:  Moeru! Oniisan (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b759ace00354ac3f28eda6a602c5c6fe4bd18ba034157f5d1f8d5178446fa204
+  name:   Momotarou Densetsu (Japan)
+  title:  Momotarou Densetsu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: da757d6273d75e183b99f900609eef9422a000cc8ee52eace014380c58c84eaf
   name:   Momotarou Dentetsu (Japan)
   title:  Momotarou Dentetsu (Japan)
@@ -19427,6 +28607,112 @@ game
       content: Character
 
 game
+  sha256: 9afa395d23c42bdb33cd672db1ab68c35d6330337c6c383fbf9db134b9658d49
+  name:   Money Game II, The - Kabutochou no Kiseki (Japan)
+  title:  Money Game II, The - Kabutochou no Kiseki (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 0d2a11eccb0bb3c6daf6718d2d0789596c87c64f8af203e7d58910a86f85428d
+  name:   Monopoly (France)
+  title:  Monopoly (France)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: fca9141064f1e7267bb2491340b2aba795f62da8ce164ec7fd014be19d35fdc4
+  name:   Monopoly (Germany)
+  title:  Monopoly (Germany)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c5745e3c25b4d4ab14cc9c29c20fc3f497586c68b2d33d10e82df7e1449573e8
+  name:   Monopoly (Japan)
+  title:  Monopoly (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: f997fe34edf1d998694aa979c81fe0063480274b4284498f230fffe694fe87ac
+  name:   Monopoly (USA)
+  title:  Monopoly (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 38c3225b6b37292b1869743ecb5859e21c7cac8feca14fea5462b93782304088
   name:   Monster in My Pocket (Europe)
   title:  Monster in My Pocket (Europe)
@@ -19455,6 +28741,53 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 91bee659dff186d3dae849f1bba0c1ab10920418c3bbce0ead2866e834d7252e
+  name:   Monster Maker - 7 Tsu no Hihou (Japan)
+  title:  Monster Maker - 7 Tsu no Hihou (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 219c94a1f0801ee255f4c8df6d7d1120bdcfd882fcaecba2c858b1e4c66d060b
+  name:   Monster Party (USA)
+  title:  Monster Party (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -19511,6 +28844,31 @@ game
       content: Character
 
 game
+  sha256: c5a375697e39f8bee9e7b952bff97db9e3c5706565564a696864328402256414
+  name:   Morita Shougi (Japan)
+  title:  Morita Shougi (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x2000
+      content: Character
+
+game
   sha256: aa0fe1b0b1e0c3a0a01695f1914fbb5e92649db33b74a9bdcb51be1481221f49
   name:   Mother (Japan)
   title:  Mother (Japan)
@@ -19530,6 +28888,48 @@ game
       type: RAM
       size: 0x2000
       content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ae28fa2905137489c1ce76a71e5259853679a575a998eeab98b9768d223d1b18
+  name:   Motocross Champion (Japan)
+  title:  Motocross Champion (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ed219a1b03be92e3ac4a2229e3e7663fd126eca6332f0564e5d3a12ec56f2142
+  name:   Motor City Patrol (USA)
+  title:  Motor City Patrol (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
     memory
       type: ROM
       size: 0x20000
@@ -19556,6 +28956,31 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 2fc7c20a4bc2445842244ad28d6eff98d247f1dbbbe8c92edf84a6d71de87e33
+  name:   Moulin Rouge Senki - Melville no Honoo (Japan)
+  title:  Moulin Rouge Senki - Melville no Honoo (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 97ff1ac9e6061ba5fb02b4626abf3521f84ee1542fa8093d617ede08dbb17cdc
@@ -19650,6 +29075,28 @@ game
       volatile
 
 game
+  sha256: 80f6f2b9cb2669e876328cf47ad94fd5288adeddaf45dee93087142ff589b6d6
+  name:   Muppet Adventure - Chaos at the Carnival (USA)
+  title:  Muppet Adventure - Chaos at the Carnival (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 3ab2b17abf9502cc04c8f150a55154db9acf7f26d3d98dfc8e2575d8e84be682
   name:   Murder Club - Honkaku Mystery Adventure (Japan)
   title:  Murder Club - Honkaku Mystery Adventure (Japan)
@@ -19665,6 +29112,31 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 893d378d96351aaf613b6080f1dea1dc9e37efeea2ebd7c0169d34c892c9053d
+  name:   Musashi no Bouken (Japan)
+  title:  Musashi no Bouken (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: ROM
       size: 0x20000
@@ -19689,6 +29161,27 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: ac2374bd4a5f7c87a7bd51e296f79800f84ea6c91a35e0c79dd9a3b2f923ef37
+  name:   Mutant Virus, The - Crisis in a Computer World (USA)
+  title:  Mutant Virus, The - Crisis in a Computer World (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -20057,6 +29550,32 @@ game
       volatile
 
 game
+  sha256: 7b391173924e1724388274ee8a674d88bf1808c71a803a86a1381ced1b482e42
+  name:   Navy Blue (Japan)
+  title:  Navy Blue (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 3c419e3ecf328c03364afbcf5bd15bf0029a525db9e8f74379ae1cce4062b3c3
   name:   Nekketsu Kakutou Densetsu (Japan)
   title:  Nekketsu Kakutou Densetsu (Japan)
@@ -20098,6 +29617,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 3aee07f35644c68301c29e6da1c9a8d9ad1fae19a52bd08303f3973d897ddc65
+  name:   Nekketsu Koukou Dodgeball-bu (Japan)
+  title:  Nekketsu Koukou Dodgeball-bu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 558897a4e2083b95bd77d230e1f2cf932800a01b0ba246f1d84c3aa64b236f21
@@ -20142,6 +29682,58 @@ game
       content: Character
 
 game
+  sha256: 8d95be64a3c1920210e930da457a193a894abe3b4aaf717c140134ee7a1847de
+  name:   NES Open Tournament Golf (Europe)
+  title:  NES Open Tournament Golf (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 55efed163edb02abc2a344aba79edc5ad873a77ed92378ad0c3e62f1e1816d3e
+  name:   NES Open Tournament Golf (USA)
+  title:  NES Open Tournament Golf (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 4b382baa70cbc52977fd766f49a3c7c9a3239f0d9581cd961b8b26700c53247d
   name:   NES Play Action Football (USA)
   title:  NES Play Action Football (USA)
@@ -20149,6 +29741,48 @@ game
   board:  HVC-TLSROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 8db5ebe26b4f5479e79d2657ce13b88bc05d14904b35aef6083083c4995962b8
+  name:   New Ghostbusters II (Europe)
+  title:  New Ghostbusters II (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a1750c1f51ddd751bf771cb0fb64ed0b46ab67c5058f28e2f59ceec10b40de3f
+  name:   New Ghostbusters II (Japan)
+  title:  New Ghostbusters II (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -20252,6 +29886,48 @@ game
       content: Character
 
 game
+  sha256: ff75884c38a7272546962ee25698c02de1d471c9ca516803292ee8d7ff4b864d
+  name:   Nigel Mansell's World Championship (Europe)
+  title:  Nigel Mansell's World Championship (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c03ffd0d5fb5439eb35f22f09df3cbd8f81f5cf3eb9b6718a4d7afb67c75c543
+  name:   Nigel Mansell's World Championship Racing (USA)
+  title:  Nigel Mansell's World Championship Racing (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 58be6a811ee3370882160115253b610581e8b4af7228669eb3fbd56e7a13117c
   name:   Nightmare on Elm Street, A (USA)
   title:  Nightmare on Elm Street, A (USA)
@@ -20293,6 +29969,32 @@ game
       content: Character
 
 game
+  sha256: dc4bd49d7cb423dad21beeb14d3b50d3a167c6b8093cb6d0145a3477f308d0a7
+  name:   Nihonichi no Mei Kantoku (Japan)
+  title:  Nihonichi no Mei Kantoku (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 590e508b47eb6d6c0088dffd83fe2436edd0d75e74faba7a9da2008770fb1986
   name:   Niji no Silk Road (Japan)
   title:  Niji no Silk Road (Japan)
@@ -20312,6 +30014,27 @@ game
       type: RAM
       size: 0x2000
       content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 5a324d7b9bb7d017319528e8e802865712ba72286402f3ac614a4032ee2f938b
+  name:   Ninja Cop Saizou (Japan)
+  title:  Ninja Cop Saizou (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
     memory
       type: ROM
       size: 0x20000
@@ -20360,6 +30083,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 6799437d4122b81c86ae35cefe5b6ae6e10e6f9a9c7b3140dd569f717ba32b3d
+  name:   Ninja Gaiden (USA)
+  title:  Ninja Gaiden (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 21c51dc47a458a7de66544533d56eb9a69de0190d012b1645699e816d2cb5008
@@ -20488,6 +30232,27 @@ game
       content: Character
 
 game
+  sha256: eedfe7bee4cac374fd453fd3c35337a2edb6187e85eac6636b0b2e3c68c7e881
+  name:   Ninja Ryuuken Den (Japan)
+  title:  Ninja Ryuuken Den (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 7f049259c061b81607ab7271f72d930bc679f45cb80a97187de90dae6c56f40a
   name:   Ninja Ryuuken Den II - Ankoku no Jashin Ken (Japan)
   title:  Ninja Ryuuken Den II - Ankoku no Jashin Ken (Japan)
@@ -20592,6 +30357,32 @@ game
       type: ROM
       size: 0x2000
       content: Character
+
+game
+  sha256: 4a08c3dee07432850adbcda4fa7c2a326bdb7e47a257ad24c695018a1a520072
+  name:   Ninjara Hoi! (Japan)
+  title:  Ninjara Hoi! (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x80000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 747481f0854295542936fa29f9c520033b2da8608c680202d36fff4badb681a0
@@ -20766,6 +30557,84 @@ game
       content: Character
 
 game
+  sha256: cdcdb39322241b3a8b4a32c4558403888b131f28b137f178622a9c85c9f3a619
+  name:   Nobunaga no Yabou - Zenkoku Ban (Japan)
+  title:  Nobunaga no Yabou - Zenkoku Ban (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x4000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: df6e092c3fc8d66edf0c8dd1c3e52ca1d891ae9b066fdeb332b7076c22a455cf
+  name:   Nobunaga no Yabou - Zenkoku Ban (Japan) (Rev 1)
+  title:  Nobunaga no Yabou - Zenkoku Ban (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x4000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 9d35bccd23f8caf0f93f953e8b6d04e7e8a27dda0ff526cfbe65b0f6dbb3f560
+  name:   Nobunaga's Ambition (USA)
+  title:  Nobunaga's Ambition (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x4000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 4288e508734836e6ddd123dfae39a7a388abdd0afdc9d885ed597ee58a62fc61
   name:   North & South (Europe)
   title:  North & South (Europe)
@@ -20883,6 +30752,31 @@ game
       content: Character
 
 game
+  sha256: 9116dfbf263a85a62586055daf45ff08e9614426a6aaa085e7c165d59f24b339
+  name:   Obocchama-kun (Japan)
+  title:  Obocchama-kun (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 6f1d8f1b3c18ce3030188a3a8e6ba0231d84699e71ce8a6e02aaeabeb34f7b89
   name:   Oeka Kids - Anpanman no Hiragana Daisuki (Japan)
   title:  Oeka Kids - Anpanman no Hiragana Daisuki (Japan)
@@ -20927,6 +30821,70 @@ game
       volatile
 
 game
+  sha256: e535f94c0767ccae463f2b38c3d07cc4b8a948a3c2ff3c175d133b665345e164
+  name:   Oishinbo - Kyuukyoku no Menu Sanbon Shoubu (Japan)
+  title:  Oishinbo - Kyuukyoku no Menu Sanbon Shoubu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 127c7dc886c3cbc3ad9bf6d5535feb85b88761234268043fb89629e1ea5c3447
+  name:   Okkotoshi Puzzle - Tonjan! (Japan)
+  title:  Okkotoshi Puzzle - Tonjan! (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 119c8c712103edcfe634e40b64ae566ef80d86fd61fc31f65f80b6f689dd8786
+  name:   Olympus no Tatakai (Japan)
+  title:  Olympus no Tatakai (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: b2b21a434840d24af89546ae2b2576111b6c37526452d3ff312182f71a02a6e3
   name:   Onyanko Town (Japan)
   title:  Onyanko Town (Japan)
@@ -20948,6 +30906,27 @@ game
       content: Character
 
 game
+  sha256: ee0ada986cee55a60e325b30ad21be61dc7360bb7b700ca949c0d0cdf5673bd3
+  name:   Operation Wolf (Europe)
+  title:  Operation Wolf (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: adf95de2cdff7b606ceedf5908679ef9bb8ffeec37d3d1dad3446ef85ca17026
   name:   Operation Wolf (Japan)
   title:  Operation Wolf (Japan)
@@ -20955,6 +30934,69 @@ game
   board:  TAITO-TC0190
     chip
       type: TC0190
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 36666e3314ee9e0a340b04ea8427aaefb6df8937425a016e78c26fb1fa77b017
+  name:   Operation Wolf (USA)
+  title:  Operation Wolf (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4d2b5339703d2300539348e3aad055fd00828afcbd9f3a97565e37725221fc0a
+  name:   Orb-3D (USA)
+  title:  Orb-3D (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 58fe9b09d7ac8d0193695bf14417afce57f8806157025c0a6071f0ed20d36a44
+  name:   Osomatsu-kun - Back to the Me no Deppa no Maki (Japan)
+  title:  Osomatsu-kun - Back to the Me no Deppa no Maki (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -21129,6 +31171,74 @@ game
       type: RAM
       size: 0x2000
       content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b3a798ab7f2f237c7bd3c3e8b36cc752d850d10a8597e43771c82dcd654d5dae
+  name:   Overlord (USA)
+  title:  Overlord (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 2f9fa6af642d4717a5ce340357dabf240ebffff4432039a6d05e03ffd415dce9
+  name:   P.O.W. - Prisoners of War (Europe)
+  title:  P.O.W. - Prisoners of War (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ae2dddda1f90b8f8e3a990a2247ab4e373f69e6599f4e63f531d3a541b54bd85
+  name:   P.O.W. - Prisoners of War (USA)
+  title:  P.O.W. - Prisoners of War (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
     memory
       type: ROM
       size: 0x20000
@@ -21345,6 +31455,70 @@ game
       content: Character
 
 game
+  sha256: 96c04c94a5427e0ba095913bc404cf61a983ad53419205b65c2cd96131023659
+  name:   Pachinko Daisakusen (Japan)
+  title:  Pachinko Daisakusen (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 5193afae23822f9c9127abacba006d97014bda5a478a4065079ef313b49d4d8b
+  name:   Pachinko Daisakusen 2 (Japan)
+  title:  Pachinko Daisakusen 2 (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 14026823dd570a8eea0126a3ced49d843668fc08c24acb9897df8b39eb68a76d
+  name:   Pachio-kun 2 (Japan)
+  title:  Pachio-kun 2 (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: d04a6f539c0a4ae50e4fade3c1016004304ea1d9ad516f5e5d59554a3d0e10ee
   name:   Pachio-kun 3 (Japan)
   title:  Pachio-kun 3 (Japan)
@@ -21464,6 +31638,69 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: b4e76cda040e26616ff72f4ef15855fdde9141381298b6221d4440ba62124d43
+  name:   Palamedes (Japan)
+  title:  Palamedes (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 270a759c64b56e72f6f3ed4a31402882539f3c1431b9fb6ddec35ba886e6b347
+  name:   Palamedes (USA)
+  title:  Palamedes (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 45ba16d7c597acf18dcf1f4f03454a6688d6e15a81380652998bc7e54a3909ba
+  name:   Palamedes II - Star Twinkle, Hoshi no Mabataki (Japan)
+  title:  Palamedes II - Star Twinkle, Hoshi no Mabataki (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -21658,6 +31895,27 @@ game
       content: Character
 
 game
+  sha256: 25ae9f90412612715a254973006f0056016a840efc8af1fbdb6fc2eb7cd5eb7c
+  name:   Parasol Stars - Rainbow Islands II (Europe)
+  title:  Parasol Stars - Rainbow Islands II (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 035383efbc5131942ba7df721ba406fd57c08a9ff87e3aa6e6f3d272bda86c44
   name:   Paris-Dakar Rally Special (Japan)
   title:  Paris-Dakar Rally Special (Japan)
@@ -21799,6 +32057,52 @@ game
       content: Character
 
 game
+  sha256: 0b8b684ff5641b3082cff4ff31d0ee341fef006187f35cb5e4380e1aa50bffc1
+  name:   Pennant League!! - Home Run Nighter (Japan)
+  title:  Pennant League!! - Home Run Nighter (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3be9e027dfd048fc1065d543ff68029a941cfc3e2d36da68933d0d2feb7cba5b
+  name:   Perfect Bowling (Japan)
+  title:  Perfect Bowling (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 6d2887d978262401f315836411537a208272cba7721f598308d92983f1f5731a
   name:   Perman (Japan)
   title:  Perman (Japan)
@@ -21861,6 +32165,49 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 1c598fe0b58811b1bedfc6f2cda05f0960b4a6e2770c8a2f73cd6da370ed2448
+  name:   Phantom Fighter (USA)
+  title:  Phantom Fighter (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: c701cffa5315b4375c0a71d2e7378137bcdeed0684f57bf7eb2fbed3b2c1b1da
+  name:   Pictionary - The Game of Video Quick Draw (USA)
+  title:  Pictionary - The Game of Video Quick Draw (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 1067b39e520810e55300a4ec1c94f4dddee17e899090af30cf5d626058dbe531
@@ -21957,6 +32304,27 @@ game
       content: Character
 
 game
+  sha256: 8d9d821dae3f6987adba4bd9e9d8c107b21ed110314e9b89fc971ffbf45b7ba9
+  name:   Pinball Quest (Australia)
+  title:  Pinball Quest (Australia)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: b7daa24069d54f56fb71e7659b4ad40a6e9f4695f73e7a0d0e56d5c80e2e6474
   name:   Pinball Quest (Japan)
   title:  Pinball Quest (Japan)
@@ -21964,6 +32332,27 @@ game
   board:  JALECO-JF-17
     mirror
       mode: horizontal
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 836a6df9f6885b2b09d9daf3cecd67a4e5f36ae0b278a32c296779f067c8694f
+  name:   Pinball Quest (USA)
+  title:  Pinball Quest (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -21999,6 +32388,81 @@ game
       content: Character
 
 game
+  sha256: 39230ad754d27ff627997de51795ec975bb9979d65c91114836fcaaf8c02e6eb
+  name:   Pirates! (Europe)
+  title:  Pirates! (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3f8195a32bfeb82ea9eab31b64411683fc40d6f1281e8006bbcff0c4c0c5246b
+  name:   Pirates! (Germany)
+  title:  Pirates! (Germany)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ae8684d9075b66658877a4e55363c974cc2f24d246af7ee9d3789f9bb08198e3
+  name:   Pirates! (USA)
+  title:  Pirates! (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 18c82e04c90a19e7148018245fffaaadc4dd92f294332a84605098ddc375b653
   name:   Pizza Pop! (Japan)
   title:  Pizza Pop! (Japan)
@@ -22027,6 +32491,48 @@ game
   board:  JALECO-JF-24A
     chip
       type: SS88006
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 61ac77e84b4aa089115a682a2e8cfaa6811ba83b567ae1f13d8b644e0c42a2bf
+  name:   Platoon (USA)
+  title:  Platoon (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ac1215af2a3315f8bbff01987f24a85e9c1fe984287c05fc21246b0a66fd5dfd
+  name:   Platoon (USA) (Rev 1)
+  title:  Platoon (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -22316,6 +32822,95 @@ game
       content: Character
 
 game
+  sha256: 8886280340c40d961f0d98096565ccd94ceab22a181d77def5841c1a49a37eeb
+  name:   Predator (Australia)
+  title:  Predator (Australia)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 31d2cd80b6a1f611dabbc8aeef67f175dbc8462f2d611a06b1d3c8c599d78519
+  name:   Predator (Japan)
+  title:  Predator (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 76cdd991b85e4a15c62275fe6b3ccd5132ee2d17e70fe4d2173b8ce5d1193ec0
+  name:   Predator (USA)
+  title:  Predator (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 26128d8d1500c93c5c8f18f48b745c001dd1eb5177e61db4f6ff81b6730053c2
+  name:   President no Sentaku (Japan)
+  title:  President no Sentaku (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 78369193c891ca76c49eb5921fbee269a4f7beef8bee2bf57c866ef83eb67813
   name:   Prince of Persia (Europe)
   title:  Prince of Persia (Europe)
@@ -22418,6 +33013,28 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 99f3ca1657ad48f9a4f128dce3e0e4efd2c4fee413a120a462055801c9581ebd
+  name:   Princess Tomato in the Salad Kingdom (USA)
+  title:  Princess Tomato in the Salad Kingdom (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
       content: Program
     memory
       type: RAM
@@ -22602,6 +33219,32 @@ game
       type: ROM
       size: 0x8000
       content: Character
+
+game
+  sha256: 5f46b427a39454cfb1c0d0aa562326212120da0bb036f4cf06a303d373389b11
+  name:   Pro Yakyuu Satsujin Jiken! (Japan)
+  title:  Pro Yakyuu Satsujin Jiken! (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 85ad3d397ee03f2e49312c60decdbc0a5d097c5f96fedcb8a2ab1382e61a242c
@@ -22801,6 +33444,27 @@ game
       volatile
 
 game
+  sha256: 04876421677718d4eeb96ffde6a189ebf7645de7c421243b403480eefcb6feff
+  name:   Puzslot (Japan)
+  title:  Puzslot (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: ebb52e4ba3a2eb16ad1cd8a7f81cfe1f5cece8358976577cd0ea2d26325d720d
   name:   Puzznic (Europe)
   title:  Puzznic (Europe)
@@ -22906,6 +33570,53 @@ game
       content: Character
 
 game
+  sha256: 745050dec23a692e1e759eb3e291f58ad7739fadb3a1308ec8d60085fefaec69
+  name:   QIX (USA)
+  title:  QIX (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 49ac4406b41c4710f72e4ac874098ae806e6b4a58073457e6c7aa3aeea1529f7
+  name:   Quarter Back Scramble (Japan)
+  title:  Quarter Back Scramble (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 7a7b7147a9a25d7ae6dd28ecc1d0bb0d437aa318656ab0da0457362980db5e07
   name:   Quarth (Japan)
   title:  Quarth (Japan)
@@ -22993,6 +33704,27 @@ game
       volatile
 
 game
+  sha256: d3c4a03d87c302a86a558965f59567363ccd305e0c79261d5b6781beb8d6d193
+  name:   R.C. Pro-Am (Europe) (Rev 1)
+  title:  R.C. Pro-Am (Europe) (Rev 1)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: aec6beb5b7e4d291a2bef75cb6dc43dc4db34f0313d26a8582ddf61b5b6a67c5
   name:   R.C. Pro-Am (USA)
   title:  R.C. Pro-Am (USA)
@@ -23011,6 +33743,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 3f9e3d3b48a897d94003df004ab4b332d749f85ea5d0e1a1b29b6d4f5634049a
+  name:   R.C. Pro-Am (USA) (Rev 1)
+  title:  R.C. Pro-Am (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
 
 game
   sha256: 282c84315ccb22895a3831b2cea301c12a54ca645429e12bf641504060ad4556
@@ -23077,6 +33830,48 @@ game
       content: Character
 
 game
+  sha256: 6a2ff9b3c4bca7385e11e172f17700ea27118f76fbe835e2741a158b78e47ce3
+  name:   Racket Attack (Europe)
+  title:  Racket Attack (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a868544e22d00eaceef502628db8757f2234ec3c5c2d5b8f632de98bc25af739
+  name:   Racket Attack (USA)
+  title:  Racket Attack (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 0c0a9e908ea61b304052f02515c8bcdfdaa77954d67a88c1215c6416406c7f9e
   name:   Rackets & Rivals (Europe)
   title:  Rackets & Rivals (Europe)
@@ -23096,6 +33891,50 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 91aa6dc4effa67515ce30497fd165bdd6e0f01ec9d708f7d91adcc3da8486cc3
+  name:   Rad Racer (Europe)
+  title:  Rad Racer (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 2e14f4481b5b762ba1ff0e7a25b07f316f7bdef0574a1704856f92823874f4e6
+  name:   Rad Racer (USA)
+  title:  Rad Racer (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: bcc8a24ab99f85933ff2cd0787daab6093710ef04f95b4c7bec842961ee0e3ad
@@ -23124,6 +33963,50 @@ game
       volatile
 
 game
+  sha256: 460852224fd3b370b97a1fae717f76dcccd6fbbcf36fc2c1b7f68f1927477974
+  name:   Radac Tailor-Made (Japan)
+  title:  Radac Tailor-Made (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 899434cc538067fa424410db4ef29b2424fbb4e9013418499354584d32f48863
+  name:   Radac Tailor-Made (Japan) (Rev 1)
+  title:  Radac Tailor-Made (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 879ada5f1aa0282d81f9f13e91de53e181ed1030242029fcce002dfb8847c0c9
   name:   Radia Senki - Reimei Hen (Japan)
   title:  Radia Senki - Reimei Hen (Japan)
@@ -23143,6 +34026,27 @@ game
       type: RAM
       size: 0x2000
       content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 5d9f7deb09c9de8725c293366c943e6fef0a505a72bb1bc92be7a7a055cde464
+  name:   Raf World (Japan)
+  title:  Raf World (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
     memory
       type: ROM
       size: 0x20000
@@ -23232,6 +34136,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 63b355e6fa76125be1bda691b375c25963df11fa4a6d46126e3298200f121eed
+  name:   Rainbow Islands - Bubble Bobble 2 (Europe)
+  title:  Rainbow Islands - Bubble Bobble 2 (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: fbc2b2907a9cda3f34f2086495edb50605605919b9c37572149fb639b4c77302
@@ -23450,6 +34375,49 @@ game
       content: Character
 
 game
+  sha256: c535be19e4b94872dd95f4483fb5a4a791fcba6f1f1fa93dbbd441b4275b27a7
+  name:   Reigen Doushi (Japan)
+  title:  Reigen Doushi (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 2f07815e80fcf807ebd13e75bfad4a83ce0f110bc29605d099b7f2db36189aed
+  name:   Remote Control (USA)
+  title:  Remote Control (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 501e921616931e4796c44b1e80c7112c881eb1e9a3190d0e6a3b4b199ee368e3
   name:   Ren & Stimpy Show, The - Buckeroo$! (USA)
   title:  Ren & Stimpy Show, The - Buckeroo$! (USA)
@@ -23493,6 +34461,48 @@ game
       volatile
 
 game
+  sha256: 41e441af5271c8cf36c68a8d61d009bb5765d326619a9d5bdf1f403bb844ae5f
+  name:   Rescue - The Embassy Mission (Europe)
+  title:  Rescue - The Embassy Mission (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 711dd795f6e24699b24097624f5c6b68ff953758f9a7016c1480607813d2400e
+  name:   Rescue - The Embassy Mission (USA)
+  title:  Rescue - The Embassy Mission (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: f17df83a3e714c9f839dcd428d31a0b8b3cdb5fe1a78f24f43f158cb379720c1
   name:   Ring King (USA)
   title:  Ring King (USA)
@@ -23514,6 +34524,28 @@ game
       type: ROM
       size: 0x10000
       content: Character
+
+game
+  sha256: fe74bf713549a1d0aa6d1a438b7bdbde859deac415014b9c81ac6edb1cd6a2f3
+  name:   Ripple Island (Japan)
+  title:  Ripple Island (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 54cdc8b6fab804339c44601663585c8e7a8b01ef35b49754eb13a767b57c7d07
@@ -23577,6 +34609,158 @@ game
       type: ROM
       size: 0x2000
       content: Character
+
+game
+  sha256: 207eaf144a13db5b021294c51913ca0b7ec98b16f04b16aa67237fd917c28733
+  name:   RoadBlasters (Europe)
+  title:  RoadBlasters (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 46361c5b4007e6ef855430934b5a205aa19c885857a7eb31072646753d06e321
+  name:   RoadBlasters (USA)
+  title:  RoadBlasters (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 029d3eb4416fd401872f94935567f09e8c653b7f2d2eab1a69457e67ee630965
+  name:   Robin Hood - Prince of Thieves (Europe)
+  title:  Robin Hood - Prince of Thieves (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: e0d2940297480701ca5bec30420f70e61f38b3fb092db03984c4bf4ec31ccf02
+  name:   Robin Hood - Prince of Thieves (Germany)
+  title:  Robin Hood - Prince of Thieves (Germany)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 516f97f88eeebb5f15e082f75e366b9b099564c27e7d71efd4b8a1960e25b17b
+  name:   Robin Hood - Prince of Thieves (Spain)
+  title:  Robin Hood - Prince of Thieves (Spain)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: bb0ed60fd8e83b56f23de16018696817cf8030b4898db6abe9dfc343e646e753
+  name:   Robin Hood - Prince of Thieves (USA)
+  title:  Robin Hood - Prince of Thieves (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 687e4129be3b8e224a9748cba9687b8c10e5feb234a727bdf2dcb8d3c8c47097
+  name:   Robin Hood - Prince of Thieves (USA) (Rev 1)
+  title:  Robin Hood - Prince of Thieves (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: a878c510eec26bd2f54bf499625020d5af818d36ea58867d3311449a195cd7d2
@@ -23707,6 +34891,132 @@ game
       content: Character
 
 game
+  sha256: 854e878219156223d5b92a8b9b6e574ce65c166e10b0ccd339e294dd59202180
+  name:   RoboCop 2 (Europe)
+  title:  RoboCop 2 (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: bc445a215af00be91f66499c96fca9635f9702d45ba42d1104e36f48ea6912cd
+  name:   RoboCop 2 (Japan)
+  title:  RoboCop 2 (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b65361b45eef137a57152dd8f64531c26e34d728e72800d1bdf8e4be9bff49e7
+  name:   RoboCop 2 (USA)
+  title:  RoboCop 2 (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 8ed3cb0046caecbefdc6c6b3ad8dae013442136f6a65c1a21b54586b0275e615
+  name:   RoboCop 2 (USA) (Rev 1)
+  title:  RoboCop 2 (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 222f426006d9f77b38b3afc4c98230ef41d5be4b7d948d00fa1c20d8cf8fdb10
+  name:   RoboCop 3 (Europe)
+  title:  RoboCop 3 (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a0f18e729a7ee6be9035e9691f4bac32c1b202afcb44100479a431055b15eee6
+  name:   RoboCop 3 (USA)
+  title:  RoboCop 3 (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 2bd31df34f925d030ceceb944c1ac973ccf892358de75c35fd77d61372d23a3b
   name:   Rock 'n' Ball (USA)
   title:  Rock 'n' Ball (USA)
@@ -23726,6 +35036,50 @@ game
       type: ROM
       size: 0x10000
       content: Character
+
+game
+  sha256: a0d60fe16b09d2018e32c277f8a297adc71acdd9e851591625b2d460e96266c8
+  name:   Rocket Ranger (USA)
+  title:  Rocket Ranger (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: e1a3d949b9bf258b4d2c92104cedd7957a311f142dc2cb32eb92ce559837377f
+  name:   Rocketeer, The (USA)
+  title:  Rocketeer, The (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 74d27ae70cb936c2434310da32c7d612d7b90099274bdf5ed19388cee2bc4fc1
@@ -23784,6 +35138,28 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0ae05be9d303da7270647f7a0725c3cb851b1b335718d8462a1f9ab69a5e0153
+  name:   Rockman 2 - Dr. Wily no Nazo (Japan)
+  title:  Rockman 2 - Dr. Wily no Nazo (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
       content: Program
     memory
       type: RAM
@@ -23989,6 +35365,69 @@ game
       content: Save
 
 game
+  sha256: 12d1fa99fad655d30b68f0354d2cbdc7d439f4d562c5689ed569989a17383238
+  name:   Rollerball (Australia)
+  title:  Rollerball (Australia)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 6ae64d9c5ce72c996f959bd86f2674abcf173f21d845aa0a7dfbc394c0df40e8
+  name:   Rollerball (Japan)
+  title:  Rollerball (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: e82f63d59b896c4cff6627bc950dd6440f832790b6b3eb3e398f25c22dfc9923
+  name:   Rollerball (USA)
+  title:  Rollerball (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 942c802c34627c969c49dae94fb8b48c7b1e873a65803caad559324e2a54b4c8
   name:   Rollerblade Racer (USA)
   title:  Rollerblade Racer (USA)
@@ -24071,6 +35510,76 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 62fa1b7ec8e926380d3060c5728a9103f7ea190ee82fc15b4a9543042921fc3f
+  name:   Romance of the Three Kingdoms (USA)
+  title:  Romance of the Three Kingdoms (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x4000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: ec422cd0e074422171288eb340f89de3e1fb29d9d3fa007ae8a3e9739138ce45
+  name:   Romancia (Japan)
+  title:  Romancia (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 08d4eeba1bc685b27093a4ea5d85ae98da0bda1ed34ff17dd3f6c9d1fe38e6c4
+  name:   Romancia (Japan) (Rev 1)
+  title:  Romancia (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 7212ee85b8e2a76c62cacd326a2731082b563b2b25f6881c65a5c1826c889157
@@ -24279,11 +35788,53 @@ game
       volatile
 
 game
+  sha256: 9579a2b5a4083420d9bc3788cae39b068c0752ac68e7b7dc1be1d748cb2b7133
+  name:   S.C.A.T. - Special Cybernetic Attack Team (USA)
+  title:  S.C.A.T. - Special Cybernetic Attack Team (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 4d6e58f232dc1a592583889f858eac230b8e8921e715276e580073ab2dd18546
   name:   Saint Seiya - Ougon Densetsu (Japan)
   title:  Saint Seiya - Ougon Densetsu (Japan)
   region: NTSC-J
   board:  BANDAI-74161A
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3ad57c83631233530bb421b14236fdba70d18f70ce46a8410ec7c2f156b559ab
+  name:   Saint Seiya - Ougon Densetsu Kanketsu Hen (Japan)
+  title:  Saint Seiya - Ougon Densetsu Kanketsu Hen (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -24362,6 +35913,28 @@ game
       content: Character
 
 game
+  sha256: 2e6e50731d31b70bef9ae8df1f1fa1305c40f760a1b88b414756e8776e6412e7
+  name:   Salad no Kuni no Tomato Hime (Japan)
+  title:  Salad no Kuni no Tomato Hime (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 9e8eb95ec2917597650131db254067ff59bc3669417563165518927357812c73
   name:   Salamander (Japan)
   title:  Salamander (Japan)
@@ -24413,6 +35986,83 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 5132359e4c3679d06d582248fae211944460c05424bafff51d0425d1d6525be4
+  name:   Sanada Juu Yuushi (Japan)
+  title:  Sanada Juu Yuushi (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 575d7d7b560a8802181eb284acd7ca8e5faaddd588d101506f02f5cb2df8b862
+  name:   Sangokushi (Japan)
+  title:  Sangokushi (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x4000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: e2699b83989b2163b66c17937be2ba21298b584abfb1135db225c38c2bbe54db
+  name:   Sangokushi (Japan) (Rev 1)
+  title:  Sangokushi (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x4000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 6a258031a63ea324b02d865ef7860bde15bd0b29be1071311c45d87a2f1d56f2
@@ -24663,6 +36313,57 @@ game
       type: ROM
       size: 0x8000
       content: Character
+
+game
+  sha256: abdb8692f84bb11ea6fe68b5b0b3495734145532b09bee0e111d16f4e274f1fd
+  name:   Satomi Hakkenden (Japan)
+  title:  Satomi Hakkenden (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 179231778fc0d155f8561f03e0eba41d2b9bea680428329e9b0c49ecf86d3d70
+  name:   Satsui no Kaisou - Soft House Renzoku Satsujin Jiken (Japan)
+  title:  Satsui no Kaisou - Soft House Renzoku Satsujin Jiken (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 4b0ea8c15d7c5abce2def31f8e7c10f06a91f32444a9f5fae62a26c0d0ec1f58
@@ -25156,6 +36857,27 @@ game
       content: Character
 
 game
+  sha256: c5b0b0c6615d24ebbb7a00f9193315a652e24795825782f2b442e202ebd1ffbb
+  name:   Sekiryuuou (Japan)
+  title:  Sekiryuuou (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: dbc22a40e8a79c5ccf1d6e5126c9b10bb3d9b3e708fe5316c298c3d03dbc7977
   name:   Senjou no Ookami (Japan)
   title:  Senjou no Ookami (Japan)
@@ -25176,6 +36898,136 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 4d9a290cc2d1d008df04d8f7eb9b66c26f6682130b95d8f0aceba93e97620544
+  name:   Sensha Senryaku - Sabaku no Kitsune (Japan)
+  title:  Sensha Senryaku - Sabaku no Kitsune (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: bf24ceb607e46f38fdca3b9008a9c5307c371f49c2a020443c2d03b8ca1be846
+  name:   Sesame Street - 123 (USA)
+  title:  Sesame Street - 123 (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: d1d15eca4bf1732e35ac14120041dc57377b8c00fa173599c098c3bd1aabcfa5
+  name:   Sesame Street - ABC & 123 (USA)
+  title:  Sesame Street - ABC & 123 (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 0d1603daf31ec66c6f7f5cf50853cf9a278d51f9dfc0412b722a9a35c462d4b3
+  name:   Sesame Street - ABC (USA)
+  title:  Sesame Street - ABC (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 63e867e7ea89b5bf5353249c635cfa1ade9e759456f2b3a2d656b23353c1297c
+  name:   Sesame Street - Big Bird's Hide & Speak (USA)
+  title:  Sesame Street - Big Bird's Hide & Speak (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c03acbd23ae90b056ed1eb01a612284e5b943aa8efaba559185b31a199b0b563
+  name:   Sesame Street - Countdown (USA)
+  title:  Sesame Street - Countdown (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: daa4d4cd609da751e2380186fbf6dbc7062e549297286d4304b9ddb421a4a278
@@ -25210,6 +37062,27 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 7755c537c70e2f9dea2564508463c5e81bf404aeae764bac92b1ec004d659b39
+  name:   Shadow Warriors - Ninja Gaiden (Europe)
+  title:  Shadow Warriors - Ninja Gaiden (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -25503,6 +37376,28 @@ game
       volatile
 
 game
+  sha256: 26693f2dd99a1c5556bc5f611c34b242bb4f8c6cae54470b73432d94388df705
+  name:   Shikinjou (Japan)
+  title:  Shikinjou (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: d345e0891826cbf448f82976264a58f0d68e36fb815c502adf31aa5b513e6591
   name:   Shin Jinrui - The New Type (Japan)
   title:  Shin Jinrui - The New Type (Japan)
@@ -25545,6 +37440,110 @@ game
       content: Character
 
 game
+  sha256: 9ba7fd325da7fc168ddb745cb1781b12fa61c64e4262869ddb7cdacd76e4b65a
+  name:   Shin Satomi Hakken-Den - Hikari to Yami no Tatakai (Japan)
+  title:  Shin Satomi Hakken-Den - Hikari to Yami no Tatakai (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 28210e19699c118f97329549d1a60049752e40b0e333b8b153729d9d674d44d3
+  name:   Shingen the Ruler (USA)
+  title:  Shingen the Ruler (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 0df6a7a16af6cffc9a54a3de1ab14225f2ce5d5a269a691f16a22d3fd42b942b
+  name:   Shinsenden (Japan)
+  title:  Shinsenden (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: d5f101d000e7413b942ef9950eebf9502ebeeafbd0ac4bcbcec9b97950bed3dc
+  name:   Shogun (Japan)
+  title:  Shogun (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 6c705f7980a08b7a7a5d74ddfd175155492168248f65c7d9e3cef1a6b14a2886
   name:   Shooting Range (USA)
   title:  Shooting Range (USA)
@@ -25559,6 +37558,27 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: ac2b69cf35ece7f0405c71f8ab5e24b02eb4e0d069d721481c5f581985fa2ee2
+  name:   Short Order + Eggsplode! (USA)
+  title:  Short Order + Eggsplode! (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
       content: Program
     memory
       type: ROM
@@ -25599,6 +37619,32 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 241aad99c38b85f77bf701d92b543cc7df8c3020889e6f530f9009b1d340f9da
+  name:   Shoukoushi Ceddie (Japan)
+  title:  Shoukoushi Ceddie (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -25824,6 +37870,27 @@ game
       volatile
 
 game
+  sha256: 28f0444e178830edf654eb72e54c7920296156524295b5a4f4418fc4d33f42fd
+  name:   Silk Worm (USA)
+  title:  Silk Worm (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 35d90ce12b0d0b9e8d954c92e5dbb20773d0c4bdb23a121e231c1d3a0e21c62c
   name:   Silva Saga (Japan)
   title:  Silva Saga (Japan)
@@ -25871,6 +37938,69 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: 636af2482a5fd29652fc347bd4bf11b70cb11ca80d5cb55a1f3256f0936bc3e1
+  name:   Simpsons, The - Bart vs. the Space Mutants (Europe)
+  title:  Simpsons, The - Bart vs. the Space Mutants (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 346fd8061a0b09c057855536012b146256bfbe386e304ef950ad93603048933c
+  name:   Simpsons, The - Bart vs. the Space Mutants (USA)
+  title:  Simpsons, The - Bart vs. the Space Mutants (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 7e8a3accbd57c9fea4f86fb9f99d9adc579bacec52fc68d547125067f8e50816
+  name:   Simpsons, The - Bart vs. the Space Mutants (USA) (Rev 1)
+  title:  Simpsons, The - Bart vs. the Space Mutants (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -26002,6 +38132,69 @@ game
       volatile
 
 game
+  sha256: 3626bb5ce3035b39d70ed5f2941b69801c1a95629609f1ebd90a5a6a9e16794f
+  name:   Skate or Die 2 - The Search for Double Trouble (USA)
+  title:  Skate or Die 2 - The Search for Double Trouble (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a49c8517f65f9bc597ccca7ff356b5e4e253cdcb377080436d992134029a9ce6
+  name:   Ski or Die (Europe)
+  title:  Ski or Die (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a29461c583ec03909c1dbc4e7d783de0aaf2f391ae8329b3d8bf06e06cfdd2fa
+  name:   Ski or Die (USA)
+  title:  Ski or Die (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 0ca5eb65ba6ada839279fb172ab15f5196573b7aa4f056e82ab44b05581fd534
   name:   Sky Destroyer (Japan)
   title:  Sky Destroyer (Japan)
@@ -26043,6 +38236,69 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 51958d12a19e7c573fab26b85fe81d57330ff6668d630c6bc95c7c563c441e93
+  name:   Sky Kid (USA)
+  title:  Sky Kid (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: f845ee19cbe21f5b463073f3716659f9c82ef6342a20879165ed21f219f6653b
+  name:   Sky Shark (USA)
+  title:  Sky Shark (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x10000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 93897372c5899b1a23d8b80cb95c166e9fe339c4eb4169ded25d66120032f1a1
+  name:   Sky Shark (USA) (Rev 1)
+  title:  Sky Shark (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -26152,6 +38408,195 @@ game
       volatile
 
 game
+  sha256: 8f061111bde949de8aae9d1738e3332b7ba60d05468b5cbb4a426eb7dce4aac0
+  name:   Snake Rattle n Roll (Europe)
+  title:  Snake Rattle n Roll (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 98691aea357072f901095e47db056a01887083fd81710d425b9171db1cd1ad1b
+  name:   Snake Rattle n Roll (USA)
+  title:  Snake Rattle n Roll (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: ee1f801543d1aa9ddaff2ec0264e6c10d6d865fe53ac71174b93aa744a033c47
+  name:   Snake's Revenge (Europe)
+  title:  Snake's Revenge (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c85ed147e6da0da5ef02c930cc52621ae38d66971a332d168bf31126a3a740ce
+  name:   Snake's Revenge (USA)
+  title:  Snake's Revenge (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: e16d48f1d703b51c36a452119e7caeb060bef1ab982f9ba3386277d1c8d23c71
+  name:   Snoopy's Silly Sports Spectacular! (USA)
+  title:  Snoopy's Silly Sports Spectacular! (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 361f0666ca3593501c56cd712ba737ef031419653e4d8899922e3293700ffd06
+  name:   Snow Bros. (Japan)
+  title:  Snow Bros. (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c00d90b99b8aeab1217c57754bc60e0b78ac232deee03088cca2fd4f521e621d
+  name:   Snow Brothers (Europe)
+  title:  Snow Brothers (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: fbd7caadaf77c2b191e74328b9b836155f8498500f7e5af44edfc0ec53b15fee
+  name:   Snow Brothers (USA)
+  title:  Snow Brothers (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 19f7cfd52c4a1ae774894c9556cf19e8f7b5e01562ff89e66db159e492d433fe
+  name:   Snowboard Challenge (Europe)
+  title:  Snowboard Challenge (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 8d701bb3b3b714245182ebf5f889fbaa5a43eb04e2e070c33f7e1903656ef442
   name:   Soccer (Europe)
   title:  Soccer (Europe)
@@ -26191,6 +38636,48 @@ game
     memory
       type: ROM
       size: 0x2000
+      content: Character
+
+game
+  sha256: b47462459841d2aae3e2b10ca85aca70a395e0ba7f1ad51a10f758bedda894fe
+  name:   Soccer League - Winner's Cup (Japan)
+  title:  Soccer League - Winner's Cup (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: f6392c19169d29250826e6ff6f19e8da9357d1176cf8e18ef87fa90797bb718e
+  name:   Softball Tengoku (Japan)
+  title:  Softball Tengoku (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -26487,6 +38974,28 @@ game
       content: Character
 
 game
+  sha256: 4bf373f6c39b719068769a2437e72cbd70f6b40a936072ce44ce072bb8ae027f
+  name:   Space Harrier (Japan)
+  title:  Space Harrier (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: cce92c9404d5dd48680b0b505acbbbce279a4f09606167f0aacfb6da991aac4c
   name:   Space Hunter (Japan)
   title:  Space Hunter (Japan)
@@ -26548,6 +39057,28 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 1c3a2806b546230c5560f7cfe229fd8aef0c14460d1c6e79bcb14ab713ae983f
+  name:   Space Shuttle Project (USA)
+  title:  Space Shuttle Project (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: edd831c533811a0a8357629a0c17916d73acf3f74e012ca38b8c129df87130d6
@@ -26719,6 +39250,58 @@ game
       content: Character
 
 game
+  sha256: c2de13ec1000a1592d413e4947e38d6cf109da71fbb9583032bbe1aab69afc48
+  name:   Spot (Japan)
+  title:  Spot (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 299910cc0ddbaa770e2af4a900d847872ab0826b501dafc565751d81be8ad6f9
+  name:   Spot - The Video Game (USA)
+  title:  Spot - The Video Game (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 17da401495807145c9d4db275d429b7fe94be45dde00edc40aca885911cfd138
   name:   Spy Hunter (USA)
   title:  Spy Hunter (USA)
@@ -26867,6 +39450,32 @@ game
       type: ROM
       size: 0x2000
       content: Character
+
+game
+  sha256: 399da727078eec3b0a53b8ce7054722d1333e6241245dfd8d6fdd3a3c5fd60b3
+  name:   Square no Tom Sawyer (Japan)
+  title:  Square no Tom Sawyer (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: af7a31a57dd701f57b964667549240943c76bdd2a2044ad99dfeba47883f1b9b
@@ -27416,6 +40025,73 @@ game
       content: Character
 
 game
+  sha256: a962be66d5b34e55e95d1f914013b97fa67490124b8ae2b3ec435b162476bb8e
+  name:   Stealth ATF (Europe)
+  title:  Stealth ATF (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 8093144834f1153e95076a76dbc720cec37a31412b422c8adf9f5bcea1b642e8
+  name:   Stealth ATF (USA)
+  title:  Stealth ATF (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 16bb97a72d5de90f2de75eac14b2278d0f2080048578b8f1c076e9662f6fbc15
+  name:   Sted - Iseki Wakusei no Yabou (Japan)
+  title:  Sted - Iseki Wakusei no Yabou (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 2ce85b82b427de187b59b62d33081497acfa2010ef38660b157f8eb008336e6e
   name:   Stick Hunter - Exciting Ice Hockey (Japan)
   title:  Stick Hunter - Exciting Ice Hockey (Japan)
@@ -27460,6 +40136,27 @@ game
       volatile
 
 game
+  sha256: d8a12772ddcb35d66a6518096c8415961cb43ceb9ffb96e5c7f83fe3a8e7f2c1
+  name:   Street Cop (USA)
+  title:  Street Cop (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 885cfd4396e0ade5f3abbbdb5055bc48ef166f86207db631bac83c51c0844f08
   name:   Street Fighter 2010 - The Final Fight (USA)
   title:  Street Fighter 2010 - The Final Fight (USA)
@@ -27500,6 +40197,28 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: d4fc5610f1355c545d1ecf21502c31a9d21a31e0d4f0043c7c8d8f199bea2a73
+  name:   Strider (USA)
+  title:  Strider (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 9d83b65b3c86957e16f35c6cb58f54ebd2203ec5b6b06943da7149a9d3a58517
@@ -27612,6 +40331,32 @@ game
       content: Character
 
 game
+  sha256: 6710a7522b7314b302a90fbb46ac63f764562f8d1bf1da496819d5f0dbc86f17
+  name:   Super Black Onyx (Japan)
+  title:  Super Black Onyx (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 92aa617d6254a7aa8fdc915770e813b9922100e374fd44f40bf5752f6069c7a7
   name:   Super Cars (USA)
   title:  Super Cars (USA)
@@ -27678,6 +40423,27 @@ game
       content: Character
 
 game
+  sha256: b2fe346e0d11b1d773a23cf7000d1de4e328dc3effbdd93a4d58cf2699849971
+  name:   Super Chinese 3 (Japan)
+  title:  Super Chinese 3 (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: ef5222c1332c9d24919acf29517fb027edb811f2b7313ee58f9079a29e99900d
   name:   Super Contra (Japan)
   title:  Super Contra (Japan)
@@ -27685,6 +40451,27 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 28ce7c337755f30a99cfbd1ad0bed56c8e43ee18b461b6dfcbbf77b7ddbcd035
+  name:   Super Dodge Ball (USA)
+  title:  Super Dodge Ball (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -27740,6 +40527,27 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: cf9b320f493edac5e62036df6510ac102bd5b40862b5d34a67f7e656b6013a0c
+  name:   Super Jeopardy! (USA)
+  title:  Super Jeopardy! (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 6b3189414053f975bcac33eb51a1e9991e0d06f42abead7919969417cc26e2ad
@@ -27823,6 +40631,48 @@ game
     memory
       type: ROM
       size: 0x4000
+      content: Character
+
+game
+  sha256: 968cf4ae63fddf6a0d379bb12add5563f468e57ddddb69e00e1379a839234f95
+  name:   Super Mario Bros. + Duck Hunt + World Class Track Meet (USA)
+  title:  Super Mario Bros. + Duck Hunt + World Class Track Meet (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
+      content: Character
+
+game
+  sha256: 26977a6c51a6f1e1af895b8863e8e7d57c5321621f29cf58ebfbf85163a999dd
+  name:   Super Mario Bros. + Duck Hunt + World Class Track Meet (USA) (Rev 1)
+  title:  Super Mario Bros. + Duck Hunt + World Class Track Meet (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x10000
       content: Character
 
 game
@@ -28072,6 +40922,54 @@ game
       content: Character
 
 game
+  sha256: f037ac14d377af44f4d4319e1784001f051b3b16211c154785a33f21fa49178b
+  name:   Super Momotarou Dentetsu (Japan)
+  title:  Super Momotarou Dentetsu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 838454772a90c486751c3d6902e18050d216195b63d0959126b89b34bb9e30b2
+  name:   Super Pinball (Japan)
+  title:  Super Pinball (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: a0f36181520adf90c8d426a8767c12e363709caaff897188e408ba4701e6ee21
   name:   Super Pitfall (Japan)
   title:  Super Pitfall (Japan)
@@ -28114,6 +41012,48 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: ae2461adebd1bd7d989e2615e7d2ab3e3d48ce389b66d3d20fab293c3e219a02
+  name:   Super Real Baseball '88 (Japan)
+  title:  Super Real Baseball '88 (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 444fac299d645addc4aa56c1318c74ba1804e45583873da5092328c0092922cd
+  name:   Super Rugby (Japan)
+  title:  Super Rugby (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 9d87f205aca5fd31d27130dc7595a73d3a5fbbb2030dd3b4fe1ea0eb5b340104
@@ -28312,6 +41252,48 @@ game
       content: Character
 
 game
+  sha256: 4efc7c95fd8fd862bd016cbef0eec81a681fcb8730c8528ba16dea96dfec9d13
+  name:   Superman (Japan)
+  title:  Superman (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9ffc36dfc772e1020a9648949aecebab687d6b386d6f02526916d1d49973a78a
+  name:   Superman (USA)
+  title:  Superman (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 208f0fdb48f469153e7e62188e1478dcb2af86a8d4bd36b8a35d4510bd158da6
   name:   Superstar Pro Wrestling (Japan)
   title:  Superstar Pro Wrestling (Japan)
@@ -28319,6 +41301,48 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 8e8d5ee4f5ba5ef0da5635c390ab3528a2ae6d55253772c2ed62e4b9924536c3
+  name:   Swamp Thing (Europe)
+  title:  Swamp Thing (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d138aba5eb5c8cf1218abc7b57ad10709041fd68b6a6c47dd30432f8b33470e9
+  name:   Swamp Thing (USA)
+  title:  Swamp Thing (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -28348,6 +41372,32 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 1dbd78445b76b3102491ff3f5cae47d21c47f674e201d75d96f1ea42499fced4
+  name:   Sweet Home (Japan)
+  title:  Sweet Home (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: RAM
       size: 0x2000
@@ -28484,6 +41534,48 @@ game
       volatile
 
 game
+  sha256: 8a98ca191a1d60fb0be8bb07feeca0c1ce621234fe8d6c4aa9b62f2e94ca016e
+  name:   Taboo - The Sixth Sense (USA)
+  title:  Taboo - The Sixth Sense (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 798888ffa76d0e527cfa9ddc58bc19a2d168df677d207108178562b0bf068291
+  name:   Taboo - The Sixth Sense (USA) (Rev 1)
+  title:  Taboo - The Sixth Sense (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: fb6298bb3519faaee26f75e6e071ab109398f06ab381bbb9f3edf299cd694292
   name:   Tag Team Pro-Wrestling (Japan)
   title:  Tag Team Pro-Wrestling (Japan)
@@ -28612,6 +41704,28 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 1dcd88f9d7fb5151e3c9ba4202db7899327087c564a70a1e80eb4cbe6f97376a
+  name:   Taiyou no Shinden (Japan)
+  title:  Taiyou no Shinden (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 3163244a32165495831c3f89b770b86cc85a386c4db7df20dbb0f051f100cfe5
@@ -28762,6 +41876,32 @@ game
       volatile
 
 game
+  sha256: 907431631d1c83c843fdd3fffd41e204a94d80290ac7a4366bf7fa6746d26ef7
+  name:   Takeda Shingen 2 (Japan)
+  title:  Takeda Shingen 2 (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 4395aa5fe84897f2ed47c4d55c5faf4a9ee5bcb5f79bb842ea1db31450c53062
   name:   Takeshi no Chousenjou (Japan)
   title:  Takeshi no Chousenjou (Japan)
@@ -28805,6 +41945,126 @@ game
       content: Character
 
 game
+  sha256: fde2566fb2def363f640df937c41040b4cbf60ed0b1d1449508be7c5bcdd9b6a
+  name:   TaleSpin (Europe)
+  title:  TaleSpin (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 6d10e95fcbf4cd1179293106d526373ea43a0c2b8531e694288b147310d617c6
+  name:   TaleSpin (USA)
+  title:  TaleSpin (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: af005dd37793a98a6c78a057c7bf8cf832547edcdd11a683de67a03237da964a
+  name:   Tamura Koushou Mahjong Seminar (Japan)
+  title:  Tamura Koushou Mahjong Seminar (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 698de5e5a9a3f70693c4e41d354a041696c82db907f624215f18258e850e1012
+  name:   Tanigawa Kouji no Shougi Shinan II (Japan)
+  title:  Tanigawa Kouji no Shougi Shinan II (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 5075b7ba11b6f0e8572263464ab49fd92e01cefe63da2576ac838d283c890c58
+  name:   Tanigawa Kouji no Shougi Shinan III (Japan)
+  title:  Tanigawa Kouji no Shougi Shinan III (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 934e9cec9876f61a4a1eff4905c0b05efe8a3f41f104c04b002f06b392c5dfdd
   name:   Tantei Jinguuji Saburou - Toki no Sugiyuku Mama ni (Japan)
   title:  Tantei Jinguuji Saburou - Toki no Sugiyuku Mama ni (Japan)
@@ -28825,6 +42085,90 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 885ad1c9587cce49326cdcdbf04d20bd2cf1761332e97da0569a69bd16a00303
+  name:   Tantei Jinguuji Saburou - Yokohamakou Renzoku Satsujin Jiken (Japan)
+  title:  Tantei Jinguuji Saburou - Yokohamakou Renzoku Satsujin Jiken (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 1aaacd13f3b4e39a1e44f898770f94234bf25472468fec96804459d97858d90f
+  name:   Tao (Japan)
+  title:  Tao (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: f6e88113b5f64cf7ffd915dd60b49e55d7015aaeb8b232c87e9855d4b9759cbd
+  name:   Target - Renegade (USA)
+  title:  Target - Renegade (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ff0953a65b12b907008b502fb19f8ac0b7e4dd5f3dc2c1071a2bf93ab47026e4
+  name:   Tashiro Masashi no Princess ga Ippai (Japan)
+  title:  Tashiro Masashi no Princess ga Ippai (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: efb93dcae29f1ff85b58ccb9450c23d528073a019493d88a9abcabe4ca9aca4f
@@ -28915,6 +42259,154 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 044015f2933671f2adb08a7d084fa76a4f77f8e273072fd1d77e6c2f23d2f986
+  name:   Tecmo Baseball (USA)
+  title:  Tecmo Baseball (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 63ef22231b5864abbef0327a899baaac27a9fcf46df3c9fcdc67b5c0de516bd7
+  name:   Tecmo Bowl (Japan)
+  title:  Tecmo Bowl (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d2b56b27912cfc03756c94df6667fdf923c8a3746fa37e4632eeb4134ef4c200
+  name:   Tecmo Bowl (USA)
+  title:  Tecmo Bowl (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d088f4b91a03dd6a618245fffb492bcda127c7faa6d880596aa5e751fdac0181
+  name:   Tecmo Bowl (USA) (Rev 1)
+  title:  Tecmo Bowl (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d7c3b161b1f12f9a4a4010f4b0c064aadeca6047d51b910b12172e075d1f9cbf
+  name:   Tecmo Cup - Football Game (Europe)
+  title:  Tecmo Cup - Football Game (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 42045f405a52c5a8e62f14bcc54caded5f26fcd724394cbf5856e501db664fc6
+  name:   Tecmo Cup - Football Game (Spain)
+  title:  Tecmo Cup - Football Game (Spain)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a334d4545d8262deafa9fa5e064d4f1f13feb5099352a192629131c45a8cddd5
+  name:   Tecmo Cup - Soccer Game (USA)
+  title:  Tecmo Cup - Soccer Game (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: ebc23cffd93a5c8d83c9f49b5ba3c8da3903f24395dbfd2269a6798e47307e59
@@ -29084,6 +42576,69 @@ game
       content: Character
 
 game
+  sha256: 4a6371257984edb05ec7bd451827189bbb3f5eff33c97edb15e05c925908c361
+  name:   Tecmo World Wrestling (Europe)
+  title:  Tecmo World Wrestling (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: daf07341c80a866333d69c7560f8402123adbb345b15185480393f0db6822b16
+  name:   Tecmo World Wrestling (USA)
+  title:  Tecmo World Wrestling (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 50f7c48f9139b942b9a84823fcb76077ec5090958514dbf392c05edcf52d449b
+  name:   Teenage Mutant Hero Turtles (Europe)
+  title:  Teenage Mutant Hero Turtles (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: a3936ff5a5ffdb961399121413817ac66df72a4571eab8df88ac3693f4784d35
   name:   Teenage Mutant Hero Turtles - Tournament Fighters (Europe)
   title:  Teenage Mutant Hero Turtles - Tournament Fighters (Europe)
@@ -29126,6 +42681,27 @@ game
       content: Character
 
 game
+  sha256: 90619e4af7991f8cab831bd3f9e7b1e4601c4bf108670a8cfb761f6e5986b4ea
+  name:   Teenage Mutant Ninja Turtles (Italy)
+  title:  Teenage Mutant Ninja Turtles (Italy)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 6fff1bfc89bb2f3c160b88736990c764920b0c44107b265f642a50324ca3adfb
   name:   Teenage Mutant Ninja Turtles (Japan)
   title:  Teenage Mutant Ninja Turtles (Japan)
@@ -29147,6 +42723,27 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: 892468d05a1097769d14e0ed4822267760d85dbfc79d83a0235878109f839dd1
+  name:   Teenage Mutant Ninja Turtles (USA)
+  title:  Teenage Mutant Ninja Turtles (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -29256,6 +42853,58 @@ game
       type: ROM
       size: 0x40000
       content: Character
+
+game
+  sha256: d12f82845f9bf7d7e2f23af95358b5e26c33fc2915bb0d19f3f7c7441d571423
+  name:   Tenchi o Kurau (Japan)
+  title:  Tenchi o Kurau (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: bb96a078c6072ed78893ec1e7b3553311efcebd0b0f9b3bd09daadaf4e97f8f5
+  name:   Tenchi o Kurau (Japan) (Rev 1)
+  title:  Tenchi o Kurau (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: aa60762c71e508d3b6cd6ac5aace8eaade986fb2a7434a4772bdcce516a75e48
@@ -29564,6 +43213,27 @@ game
       content: Character
 
 game
+  sha256: f6c64a384f7b11ab72b862a5fc237ead5c15c72102fa13b62f50408259ad4bbe
+  name:   Tetris (Europe)
+  title:  Tetris (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
   sha256: 85ebbaa069cf14ee45ed88710f30a19eb34ed39b185c830a37888a3bd7ae8a4f
   name:   Tetris (Japan)
   title:  Tetris (Japan)
@@ -29627,6 +43297,27 @@ game
       content: Character
 
 game
+  sha256: 2ae5fb18a1bf841077e3872ba05060f030ea0bfc573994b2f8fe2fb570dc7853
+  name:   Tetris (USA)
+  title:  Tetris (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+    memory
+      type: ROM
+      size: 0x4000
+      content: Character
+
+game
   sha256: ca32162f32998a8d4462efdae21b05e9c66b177fa0b9218b57b803100cf4ee4a
   name:   Tetris 2 (Europe)
   title:  Tetris 2 (Europe)
@@ -29675,6 +43366,58 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: 94ae4468aad1b317743b317b86f46be17a7626440a1a89cfe8674405bb48ce52
+  name:   Tetris 2 + Bombliss (Japan)
+  title:  Tetris 2 + Bombliss (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: f6767e55a03c80d5e1e56994969ccbc99517b0864073116f5b23b96efe8b8f35
+  name:   Tetris 2 + Bombliss (Japan) (Rev 1)
+  title:  Tetris 2 + Bombliss (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: b75b92628e3b489a035797d2f42b39290504d01da3a01fb1bd2142e5da23a202
@@ -29765,6 +43508,27 @@ game
       content: Character
 
 game
+  sha256: 700264cfa786a6bec49f5413057b30fa6ed1981fe3b75c3920db52945c1a7013
+  name:   Three Stooges, The (USA)
+  title:  Three Stooges, The (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: e3be0290f198fceed633b037d9201aa4b95460617551b3a9fb5bb212b153a2d4
   name:   Thunder & Lightning (USA)
   title:  Thunder & Lightning (USA)
@@ -29783,6 +43547,48 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 73286ea360c3a3c70b88436c51c9f5c26b232aa73947e04ef0212a4084c7e918
+  name:   Thunderbirds (Japan)
+  title:  Thunderbirds (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c0c3d7c2682dd2e0dd2122682e2ae3a9ee7aa3d095bd22a36c759c29b5d05615
+  name:   Thunderbirds (USA)
+  title:  Thunderbirds (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -30178,6 +43984,32 @@ game
       content: Character
 
 game
+  sha256: c95bf90319bd42df58fb92002476344d23b7b79dc70c20b48aa2056e8d09588c
+  name:   Titan (Japan)
+  title:  Titan (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 5ca3263ed824f1ce1a09bff7c0729d758784b15ccf5f3aea7512209dd7b3c4e7
   name:   TM Network - Live in Power Bowl (Japan)
   title:  TM Network - Live in Power Bowl (Japan)
@@ -30410,6 +44242,28 @@ game
       content: Character
 
 game
+  sha256: bffa6183b2cff7536873fdc30cdc334ce0aa89512a8909bd420b0c222098a18b
+  name:   Tombs & Treasure (USA)
+  title:  Tombs & Treasure (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: 33bd093a1b2d015dcd39b27d8cfebd5a9d013b634182867cd137df5c9e5831d4
   name:   Top Gun (Europe)
   title:  Top Gun (Europe)
@@ -30561,6 +44415,27 @@ game
       content: Character
 
 game
+  sha256: f7a10806b985cea7dce64cbf859d64053eac2efcee8e0ec86edce563c011cd5d
+  name:   Top Rider (Japan)
+  title:  Top Rider (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 5094752e3f001c1eeff60116cf64fd35a090e14bf95ef5f563afc41d59fc3445
   name:   Top Striker (Japan)
   title:  Top Striker (Japan)
@@ -30690,6 +44565,48 @@ game
       volatile
 
 game
+  sha256: 115fcca17cb77d7cfe9dab2fe749bfe57bb0995c4ecaa5bd5e16919c91a0aefc
+  name:   Touchdown Fever (USA)
+  title:  Touchdown Fever (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
+  sha256: 95043fed9bc791f9ca39041c64ed612d90c24b1e35be080c880e34303a3fa44a
+  name:   Touhou Kenbun Roku (Japan)
+  title:  Touhou Kenbun Roku (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 4fcadd486cdd108ffd1ebc6585658c86e89626dc86815b41bc28424a67e7d133
   name:   Toukon Club (Japan)
   title:  Toukon Club (Japan)
@@ -30708,6 +44625,48 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Character
+
+game
+  sha256: b10184b3a2bfccee72a336315dc233a57def2aa1b84683884e3d5ac708170ae0
+  name:   Toukyou Pachi-Slot Adventure (Japan)
+  title:  Toukyou Pachi-Slot Adventure (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 42491f17fca763b73ef64eca5e8960f6a4b92736537bf7e22a7cd5c5ee88a53c
+  name:   Toukyou Pachi-Slot Adventure (Japan) (Rev 1)
+  title:  Toukyou Pachi-Slot Adventure (Japan) (Rev 1)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -30795,6 +44754,69 @@ game
       content: Character
 
 game
+  sha256: c9543d9f60001ac7c9a431e43754d722b0784cb52605565772353f15534e5199
+  name:   Track & Field II (Europe)
+  title:  Track & Field II (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: f10330f025a93cd4a9b16d62ad4a03315be8d90d03b14b9ed13262b4387b2880
+  name:   Track & Field II (USA)
+  title:  Track & Field II (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: b7c0c863084e6924daab876bf693f764101d3e26d3b9812b299ddd6c9c1258f6
+  name:   Track & Field II (USA) (Rev 1)
+  title:  Track & Field II (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 277b2f8f14744cac1f3ba01131e6ed2528b978476bd75bcfe91df7bec9738df6
   name:   Track & Field in Barcelona (Europe)
   title:  Track & Field in Barcelona (Europe)
@@ -30813,6 +44835,48 @@ game
     memory
       type: ROM
       size: 0x8000
+      content: Character
+
+game
+  sha256: 58d2f6abe4445dadc332f37a34af54e78b6af47a8c0e6313ef898ef6db046f4f
+  name:   Treasure Master (USA)
+  title:  Treasure Master (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 095274c24800ecdc73fe79cfece7fc8f555d0a19f886f254eeb79132fdb1c42c
+  name:   Triathron, The (Japan)
+  title:  Triathron, The (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
       content: Character
 
 game
@@ -30946,6 +45010,31 @@ game
       content: Character
 
 game
+  sha256: f6cbe1c0b4811eaf9d299f17f1fde8880a936002bfcc37d5c11e81c050bbcad7
+  name:   Tsuppari Wars (Japan)
+  title:  Tsuppari Wars (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 7de2ef8418ededae391764b92e199f4a6b250da563dc2a0a053d7a707bb89764
   name:   Tsuri Kichi Sanpei - Blue Marlin Hen (Japan)
   title:  Tsuri Kichi Sanpei - Blue Marlin Hen (Japan)
@@ -30983,6 +45072,31 @@ game
       type: ROM
       size: 0x20000
       content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 09199a9293eb55121cf3ad4f867ce880093f2398ee3a0aa3f79434cfdf00babe
+  name:   Turbo Racing (Europe)
+  title:  Turbo Racing (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
     memory
       type: ROM
       size: 0x20000
@@ -31158,6 +45272,136 @@ game
       type: ROM
       size: 0x20000
       content: Character
+
+game
+  sha256: af5ac55d6283b709bcd96889708a6e7ad3c77e3bdd377aae796fd87b4b90dc4b
+  name:   Ultima - Exodus (USA)
+  title:  Ultima - Exodus (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 9d499e48bd7ff377d357ebcada90bc1141440671d3e7334b1391b31579d6b76d
+  name:   Ultima - Kyoufu no Exodus (Japan)
+  title:  Ultima - Kyoufu no Exodus (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: bb625b8df6ddbeb991bb1cbf9b818a5352dcd4856d84640612b2df66148c442f
+  name:   Ultima - Quest of the Avatar (USA)
+  title:  Ultima - Quest of the Avatar (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 8db8fb31e4bfa08277ddb802e9b5e2f66cb290f5246b4290e1f5f6f6fb6be71f
+  name:   Ultima - Seija e no Michi (Japan)
+  title:  Ultima - Seija e no Michi (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 1e8966fd8c9baf57c514fbf4d67ddd8c1ffd184be164f99342ccdec62def8db2
+  name:   Ultima - Warriors of Destiny (USA)
+  title:  Ultima - Warriors of Destiny (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
 
 game
   sha256: 5fc575035c9d7cf5e43feb3c020b11be635adb7e8e951e33f04012d4a0017bf4
@@ -31337,6 +45581,90 @@ game
       content: Character
 
 game
+  sha256: efe807cc9235dba5fa981746149fb58a0e10ef5693a82c91fb5a46ba9e73a318
+  name:   Untouchables, The (Japan)
+  title:  Untouchables, The (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 43198592f96005c1492165d5af8d41859dc164a99e39e37eff264ae5e0c63b75
+  name:   Untouchables, The (USA)
+  title:  Untouchables, The (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 9048cc77abdfd688395b2f8d1889d3d295d378c649cccbdf79f364fc73217051
+  name:   Untouchables, The (USA) (Rev 1)
+  title:  Untouchables, The (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 018f8a4f35d15af7891070cbfe6232791d603e92cbd95a49527e80f3825e770d
+  name:   Untouchables, The (USA) (Rev 2)
+  title:  Untouchables, The (USA) (Rev 2)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 7255ab27932f7c07fa61c230a51342b0441ea9b24ba094ae3129ec7453de2449
   name:   Urban Champion (World)
   title:  Urban Champion (World)
@@ -31469,6 +45797,78 @@ game
       content: Character
 
 game
+  sha256: e01b52d74babdc3506485020dd682ba1db777587c5f995b97d297bd3f9339695
+  name:   Vegas Connection - Casino kara Ai o Komete (Japan)
+  title:  Vegas Connection - Casino kara Ai o Komete (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: cfbb785f7227e87e75e483176d5823f4a6479527bcc6be792a63f57853504412
+  name:   Vegas Dream (USA)
+  title:  Vegas Dream (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: a9e86d268af613e506f90e41b1e7a75580a1f54a2871e1b5fd8562ed49843ce3
+  name:   Venus Senki - Back the City (Japan)
+  title:  Venus Senki - Back the City (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 433f6bcbd59a9d5916d2209ddeacd39d24810c1ed21a33366171b4991fc7e844
   name:   Vice - Project Doom (USA)
   title:  Vice - Project Doom (USA)
@@ -31510,6 +45910,31 @@ game
       size: 0x4000
       content: Character
       volatile
+
+game
+  sha256: bac84bf6865da1fd194c33af570021a7e902d91da881409739816eb56968757d
+  name:   Viva! Las Vegas (Japan)
+  title:  Viva! Las Vegas (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: 9a6a05ac119878195ff9c0f6f552957ce6971cc60ae3ea8edbf0b4ba9af5f799
@@ -32102,6 +46527,31 @@ game
       content: Character
 
 game
+  sha256: 5b8d82c35ca180af064eecdd15c93c32714be43ebdc66ef131cef0b140c07a2e
+  name:   White Lion Densetsu - Pyramid no Kanata ni (Japan)
+  title:  White Lion Densetsu - Pyramid no Kanata ni (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 700ebc3c2dd27420bbdcccb987ba60d3f0680469101353de15a1b2bd565ac701
   name:   Who Framed Roger Rabbit (USA)
   title:  Who Framed Roger Rabbit (USA)
@@ -32206,6 +46656,69 @@ game
       content: Character
 
 game
+  sha256: f7f67eb1bd4526e74ffb0247c21f6d685a05a6175baa4e354c1e381859bdc816
+  name:   Willow (Europe)
+  title:  Willow (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: da7f1285691735ba79128b9e5799f3e3b68d0a026e9bc1f23942d849b6e07ade
+  name:   Willow (Japan)
+  title:  Willow (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: adb1a1a9e853c2390a702e40573d145d08ca6c649cc789e4c8b41fcb63503bb6
+  name:   Willow (USA)
+  title:  Willow (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: df4e1e14d4df078083f9ec0104f200ed3ad4cb69fd1792f7a70c588e9c9ce46d
   name:   Wily & Right no Rockboard - That's Paradise (Japan)
   title:  Wily & Right no Rockboard - That's Paradise (Japan)
@@ -32220,6 +46733,50 @@ game
     memory
       type: ROM
       size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 818c7648979f86afe15f8f07ad267befe4b462d64a1e07decf49cf132ea436bd
+  name:   Win, Lose or Draw (USA)
+  title:  Win, Lose or Draw (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
+  sha256: 4823c66e9a1ef9597445d21cb205035005888c1287f1956a8b88e9766a13b6db
+  name:   Winter Games (USA)
+  title:  Winter Games (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
       content: Program
     memory
       type: RAM
@@ -32279,6 +46836,56 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 1c390e81f88af6e085230c99e52218dccb265a03bca343731656f7b05227d9d6
+  name:   Wizardry - Proving Grounds of the Mad Overlord (Japan)
+  title:  Wizardry - Proving Grounds of the Mad Overlord (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: c3136379fc4e9401dec41be356fd6963e79dd46193c61cc03b59d9935835401f
+  name:   Wizardry - Proving Grounds of the Mad Overlord (USA)
+  title:  Wizardry - Proving Grounds of the Mad Overlord (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -32490,6 +47097,27 @@ game
       volatile
 
 game
+  sha256: 67edf42c7856e0e5e394e43d2de130e9fb7f3d30fd9af1a13be40d47fa419bc5
+  name:   World Boxing (Japan)
+  title:  World Boxing (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: 6accb108e62c0c47b939694796bd5c193a6f5a9ae896af74e010232937fa55d1
   name:   World Champ (Europe)
   title:  World Champ (Europe)
@@ -32592,6 +47220,115 @@ game
       size: 0x2000
       content: Character
       volatile
+
+game
+  sha256: 9ec58c142f6f4f26bcb6dceb93329f2b24502ecc89303d2b8990552200e02c32
+  name:   World Grand-Prix - Pole to Finish (Japan)
+  title:  World Grand-Prix - Pole to Finish (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 675b1b006fe098aea144cb92e2974772a147f8911ae148fe936c78c124092cd9
+  name:   World Super Tennis (Japan)
+  title:  World Super Tennis (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d0334ee2e7a04e5ae281aba7137433fadb5c7d19944bc3a4448c29b753de05a8
+  name:   Wrath of the Black Manta (Europe)
+  title:  Wrath of the Black Manta (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 545a5533481f4f7bd8f7e9d6c7ccad9195f870522d7d2a9d83c18958804da008
+  name:   Wrath of the Black Manta (USA)
+  title:  Wrath of the Black Manta (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 3950d679fd6bbd5b59b720ef0284cb916f916a985103ccec60de2f256bcd8786
+  name:   Wrath of the Black Manta (USA) (Rev 1)
+  title:  Wrath of the Black Manta (USA) (Rev 1)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
 
 game
   sha256: f1eb29dd1c7b2b29f4932df853f32a7560bbfe64997281aa79f61ba9f131fb17
@@ -32826,6 +47563,27 @@ game
       volatile
 
 game
+  sha256: 4b11689be770a7dd6ef560568ba1fd70d6c585babedd8c9088769a0d63d89cf1
+  name:   Xenophobe (USA)
+  title:  Xenophobe (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: 60e66e87098e68d466f554597cc81a05533e5e1d3b83b47de32995bc0d71660a
   name:   Xevious (Europe)
   title:  Xevious (Europe)
@@ -32910,6 +47668,27 @@ game
       content: Character
 
 game
+  sha256: 2508e4eada73f233b2df86af2248a370b2d40ec2de590c8886a8750ddfb5b79c
+  name:   Xexyz (USA)
+  title:  Xexyz (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
   sha256: ca3be04cea2d32aaa51cc8484fda363d6afacb6bb89e03714f3eb2b74605b6fe
   name:   Yamamura Misa Suspense Series - Kyoto Zai-Tech Satsujin Jiken (Japan)
   title:  Yamamura Misa Suspense Series - Kyoto Zai-Tech Satsujin Jiken (Japan)
@@ -32956,6 +47735,27 @@ game
       content: Character
 
 game
+  sha256: 9f9374098470b8ef84aaeef1ed12806c65a3417e2cd833c310861fdb69b3a958
+  name:   Yasuda Fire & Marine - Safety Rally (Japan)
+  title:  Yasuda Fire & Marine - Safety Rally (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: dbe10104fc90c36ff7c95424cb192dfd9619fb7c1238bbae8da87e0bc9cc5a4e
   name:   Yie Ar Kung-Fu (Japan)
   title:  Yie Ar Kung-Fu (Japan)
@@ -32998,6 +47798,48 @@ game
       content: Character
 
 game
+  sha256: 62a3551ce546fa7df5fd4970e725e36f1ca269be62b1e33f92546d6e649b8371
+  name:   Yo! Noid (USA)
+  title:  Yo! Noid (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 56a169bb3a6101057fb278f2febd58cb1dbf056e5aaeb709c51a55ce4cfac20d
+  name:   Yoshi (USA)
+  title:  Yoshi (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
+      content: Character
+
+game
   sha256: bcd3abd5e767b8ce102dd0a037a85b827fd219b750edce90c431e038e9287ff1
   name:   Yoshi no Cookie (Japan)
   title:  Yoshi no Cookie (Japan)
@@ -33016,6 +47858,27 @@ game
     memory
       type: ROM
       size: 0x10000
+      content: Character
+
+game
+  sha256: a66fe5d61b7a82150e0e7ce3790011ffd7cfa5a4b12ea8524d5bd0c7f1d44722
+  name:   Yoshi no Tamago (Japan)
+  title:  Yoshi no Tamago (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game
@@ -33146,6 +48009,32 @@ game
       volatile
 
 game
+  sha256: 1c11c09519822855b512dbbf69571c96a25cae95d55a0732b1e17a06eb31521a
+  name:   Ys (Japan)
+  title:  Ys (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: c79202082042baeb3a45e747a1675c9530137f847c357c393270715efc32217e
   name:   Ys II - Ancient Ys Vanished - The Final Chapter (Japan)
   title:  Ys II - Ancient Ys Vanished - The Final Chapter (Japan)
@@ -33239,6 +48128,132 @@ game
       volatile
 
 game
+  sha256: 8bf0943bf9eb877b9d50e6d66cfbdea3f686515595ee87cd2c652de232561aff
+  name:   Zelda II - The Adventure of Link (Europe)
+  title:  Zelda II - The Adventure of Link (Europe)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: ebbdd789959d741c00b31b9dce7181ebf23186d2ad1dd6211919ccac23177d95
+  name:   Zelda II - The Adventure of Link (Europe) (Rev 1)
+  title:  Zelda II - The Adventure of Link (Europe) (Rev 1)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 91d3c9bd17e9e88baa1404f5f672eba7c80484079fe3581446f443526ce58dd8
+  name:   Zelda II - The Adventure of Link (Europe) (Rev 2)
+  title:  Zelda II - The Adventure of Link (Europe) (Rev 2)
+  region: PAL
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 4cfc55e1521e58039d502f2a5ff16c233b84c0a05b1048185c75c971f3814c16
+  name:   Zelda II - The Adventure of Link (USA)
+  title:  Zelda II - The Adventure of Link (USA)
+  region: NTSC-U
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: 8da8a934647053857f68aaf6d4a2aeb923d78e79ea886ae8fe5c9e60c1b0444e
+  name:   Zelda no Densetsu 1 - The Hyrule Fantasy (Japan)
+  title:  Zelda no Densetsu 1 - The Hyrule Fantasy (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: ef43a3d30fee2283cd87c99ebbf67632440d4d09cbb5356637d7b2df44356cf0
   name:   Zen - Intergalactic Ninja (Europe)
   title:  Zen - Intergalactic Ninja (Europe)
@@ -33267,6 +48282,27 @@ game
   board:  HVC-TLROM
     chip
       type: MMC3B
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x20000
+      content: Character
+
+game
+  sha256: d7b33d8eff6075374ee9a564a098a04929a521fa520b7b5c3c28b51165777e20
+  name:   Zenbei Pro Basket (Japan)
+  title:  Zenbei Pro Basket (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
     memory
       type: ROM
       size: 0x10
@@ -33371,6 +48407,32 @@ game
       volatile
 
 game
+  sha256: d64a573cf5807858120541312805cfdfbe915e9c0dfa301838fa30a8da8f6e9b
+  name:   Zoids 2 - Zenebas no Gyakushuu (Japan)
+  title:  Zoids 2 - Zenebas no Gyakushuu (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: RAM
+      size: 0x2000
+      content: Character
+      volatile
+
+game
   sha256: d73e3c30943e67e63c36cdc29830555b67cd2f09838c8fab3020e578464de7ea
   name:   Zoids Mokushiroku (Japan)
   title:  Zoids Mokushiroku (Japan)
@@ -33389,6 +48451,27 @@ game
     memory
       type: ROM
       size: 0x20000
+      content: Character
+
+game
+  sha256: a18476a3b06ec3d9767ed6b6cf528dd204440a64e7781a3b18c1250c3c18f2ec
+  name:   Zombie Hunter (Japan)
+  title:  Zombie Hunter (Japan)
+  region: NTSC-J
+  board:  HVC-SXROM
+    chip
+      type: MMC1B2
+    memory
+      type: ROM
+      size: 0x10
+      content: iNES
+    memory
+      type: ROM
+      size: 0x20000
+      content: Program
+    memory
+      type: ROM
+      size: 0x8000
       content: Character
 
 game


### PR DESCRIPTION
Updates for Famicom PPU and MMC1.

According to nesdev: "OAMADDR is set to 0 during each of ticks 257-320 [...] of the pre-render and visible scanlines". Mesen source additionally states that this clearing happens only when rendering is enabled. Here I'm clearing the register every 8 ppu cycles in that range, which should serve the same purpose, to maintain code readability.

Source: https://wiki.nesdev.org/w/index.php?title=PPU_registers#OAMADDR

This change fixes the following bugs:
- Akira (Japan) * hangs after starting game
- Dusty Diamond's All-Star Softball (USA) * hangs after field select
- Hudson Hawk (USA) * corrupted graphics
- SD Battle Oozumou Heisei Hero Basho (Japan) * corrupted graphics
- Softball Tengoku (Japan) * hangs after field select

Also in this pr Famicom database is updated with MMC1 entries, and MMC1 implementation is updated to take games without ram into account.