### PR TITLE
md: persist VDP state on reset

### DIFF
--- a/ares/md/system/system.cpp
+++ b/ares/md/system/system.cpp
@@ -159,7 +159,7 @@ auto System::power(bool reset) -> void {
   bus.power(reset);
   cpu.power(reset);
   apu.power(reset);  //apu.power() calls opn2.power()
-  vdp.power(reset);  //vdp.power() calls vdp.psg.power()
+  if(!reset) vdp.power(reset);  //vdp.power() calls vdp.psg.power()
   controllerPort1.power(reset);
   controllerPort2.power(reset);
   extensionPort.power(reset);


### PR DESCRIPTION
The game Skitchin' performs a fade out effect after reset with the
expectation that VDP state was persisted across the reset.

This also fixes garbage in the intro of Star Trek - The Next Generation
after resetting from gameplay.