### PR TITLE
md: detect region 'K' as NTSC-J

### DIFF
--- a/mia/medium/mega-drive.cpp
+++ b/mia/medium/mega-drive.cpp
@@ -147,7 +147,8 @@ auto MegaDrive::analyze(vector<u8>& rom) -> string {
     if(region == "EUROPE") regions.append("PAL");
   }
   if(!regions) {
-    if(region.find("J")) regions.append("NTSC-J");
+    if(region.find("J")
+    || region.find("K")) regions.append("NTSC-J");
     if(region.find("U")) regions.append("NTSC-U");
     if(region.find("E")) regions.append("PAL");
   }


### PR DESCRIPTION
The Korean release of Tiny Toon Adventures specifies its region with a
'K' and, like several other Korean releases, is region locked to
Japanese consoles. It may be the only one with a 'K' specifier, though.