### PR TITLE
[N64] Change PI DMA to use 16 bit fetches

### DIFF
--- a/ares/n64/pi/dma.cpp
+++ b/ares/n64/pi/dma.cpp
@@ -27,8 +27,12 @@ auto PI::dmaWrite() -> void {
     if (length.bit(0)) length += 1;
 
     i32 rom_len = (cur_len + 1) & ~1;
-    for (u32 i = 0; i < rom_len; i++)
-      mem[i] = bus.read<Byte>(io.pbusAddress++);
+    for (u32 i = 0; i < rom_len; i += 2) {
+      u16 data = bus.read<Half>(io.pbusAddress);
+      mem[i + 0] = data >> 8;
+      mem[i + 1] = data & 0xFF;
+      io.pbusAddress += 2;
+    }
 
     if (first_block) {
       if (cur_len == block_len-1) cur_len++;


### PR DESCRIPTION
Using the read<Byte> currently in use breaks DMAs from Flash (breaking Paper Mario, probably others), which always return 0. I assume 8 bit reads are just not allowed for Flash, although I can't verify this myself.

Checking https://github.com/n64dev/cen64/commit/8367698e20cca7eb262779f19c8c7847ae31bb29 comments, it seems that fetches should always be 16 bits anyways, so I presume this is the correct behavior, and fixes DMAs from Flash. Would like @rasky's opinion on this as this might be complete bullshit interpreting his work from me.

Noting no regressions with the original testrom have occurred.

Resolves https://github.com/ares-emulator/ares/issues/351