### PR TITLE
Sprite fixes for Super Famicom

### DIFF
--- a/ares/sfc/ppu-performance/object.cpp
+++ b/ares/sfc/ppu-performance/object.cpp
@@ -32,7 +32,7 @@ auto PPU::Object::render() -> void {
     item.width  = object.width();
     item.height = object.height();
 
-    if(within<-128,+383>(object.x, item.width, x1, x2)) {
+    if(object.x == width || within<-128,+383>(object.x, item.width, x1, x2)) {
       u32 height = item.height >> io.interlace;
       if(auto y = within<0,511>(object.y, height, self.vcounter())) {
         item.y = y();

--- a/ares/sfc/ppu-performance/object.cpp
+++ b/ares/sfc/ppu-performance/object.cpp
@@ -34,7 +34,7 @@ auto PPU::Object::render() -> void {
 
     if(object.x == width || within<-128,+383>(object.x, item.width, x1, x2)) {
       u32 height = item.height >> io.interlace;
-      if(auto y = within<0,511>(object.y, height, self.vcounter())) {
+      if(auto y = within<0,255>(object.y, height, self.vcounter())) {
         item.y = y();
         if(itemCount++ >= 32) break;
         items[itemCount - 1] = item;

--- a/ares/sfc/ppu/object.cpp
+++ b/ares/sfc/ppu/object.cpp
@@ -51,7 +51,7 @@ auto PPU::Object::evaluate(n7 index) -> void {
 auto PPU::Object::onScanline(PPU::OAM::Object& sprite) -> bool {
   if(sprite.x > 256 && sprite.x + sprite.width() - 1 < 512) return false;
   u32 height = sprite.height() >> io.interlace;
-  return (bool)within<0,511>(sprite.y, height, t.y);
+  return (bool)within<0,255>(sprite.y, height, t.y);
 }
 
 auto PPU::Object::run() -> void {

--- a/nall/range.hpp
+++ b/nall/range.hpp
@@ -60,14 +60,10 @@ inline auto within(s64 offset, s64 length, s64 min, s64 max) -> bool {
   static_assert(lo <= hi);
   static constexpr s64 range = hi - lo + 1;
   s64 lhs = (offset - lo) % range;
-  s64 rhs = (offset + length - 1) % range;
+  s64 rhs = (lhs + length - 1) % range;
   min = (min - lo) % range;
   max = (max - lo) % range;
-  if(rhs < lhs) {
-    return lhs <= max || rhs >= min;
-  } else {
-    return max >= lhs && min <= rhs;
-  }
+  return lhs >= min && lhs <= max || rhs >= min && rhs <= max;
 }
 
 //returns index of target within {offset ... offset+length-1} in range {lo ... hi}


### PR DESCRIPTION
fix missing sprites in Jurassic Park that are partly offscreen for performance/accuracy PPU
fix horizontal off-screen test for sprites; fixes SNES test card Burn-In test, maybe others for performance PPU
fix missing sprite tile on Super Conflict title screen; sprites that start on x==256 (offscreen) are considered for the range-tile-over checks (that was broken because of the previous fix, x==256 was falsely considered on-screen)