### PR TITLE
[MD] A few fixes to SRAM save game

### DIFF
--- a/ares/md/cartridge/board/board.cpp
+++ b/ares/md/cartridge/board/board.cpp
@@ -26,11 +26,13 @@ auto Interface::load(Memory::Readable<n16>& rom, string name) -> bool {
   return false;
 }
 
-auto Interface::load(Memory::Writable<n16>& wram, Memory::Writable<n8>& uram, Memory::Writable<n8>& lram, string name) -> bool {
+auto Interface::load(u32& addr, u32& size, Memory::Writable<n16>& wram, Memory::Writable<n8>& uram, Memory::Writable<n8>& lram, string name) -> bool {
   wram.reset();
   uram.reset();
   lram.reset();
   if(auto fp = pak->read(name)) {
+    addr = fp->attribute("address").natural();
+    size = fp->size() << 1;
     auto mode = fp->attribute("mode");
     if(mode == "word") {
       wram.allocate(fp->size() >> 1);

--- a/ares/md/cartridge/board/board.hpp
+++ b/ares/md/cartridge/board/board.hpp
@@ -21,7 +21,7 @@ struct Interface {
   virtual auto serialize(serializer&) -> void {}
 
   auto load(Memory::Readable<n16>& rom, string name) -> bool;
-  auto load(Memory::Writable<n16>& wram, Memory::Writable<n8>& uram, Memory::Writable<n8>& lram, string name) -> bool;
+  auto load(u32& addr, u32 &size, Memory::Writable<n16>& wram, Memory::Writable<n8>& uram, Memory::Writable<n8>& lram, string name) -> bool;
   auto load(M24C& m24c, string name) -> bool;
 
   auto save(Memory::Writable<n16>& wram, Memory::Writable<n8>& uram, Memory::Writable<n8>& lram, string name) -> bool;

--- a/ares/md/cartridge/board/mega-32x.cpp
+++ b/ares/md/cartridge/board/mega-32x.cpp
@@ -3,6 +3,7 @@ struct Mega32X : Interface {
   Memory::Writable<n16> wram;
   Memory::Writable<n8 > uram;
   Memory::Writable<n8 > lram;
+  u32 sramAddr, sramSize;
   M24C m24c;
 
   auto load() -> void override {
@@ -14,7 +15,7 @@ struct Mega32X : Interface {
     }
 
     if(auto fp = pak->read("save.ram")) {
-      Interface::load(wram, uram, lram, "save.ram");
+      Interface::load(sramAddr, sramSize, wram, uram, lram, "save.ram");
     }
 
     if(auto fp = pak->read("save.eeprom")) {
@@ -36,7 +37,7 @@ struct Mega32X : Interface {
   }
 
   auto read(n1 upper, n1 lower, n22 address, n16 data) -> n16 override {
-    if(address >= 0x200000) {
+    if(address >= sramAddr && address < sramAddr+sramSize) {
       if(wram) {
         return wram[address >> 1];
       }
@@ -60,7 +61,7 @@ struct Mega32X : Interface {
   }
 
   auto write(n1 upper, n1 lower, n22 address, n16 data) -> void override {
-    if(address >= 0x200000) {
+    if(address >= sramAddr && address < sramAddr+sramSize) {
       if(wram) {
         if(upper) wram[address >> 1].byte(1) = data.byte(1);
         if(lower) wram[address >> 1].byte(0) = data.byte(0);

--- a/mia/medium/mega-drive.cpp
+++ b/mia/medium/mega-drive.cpp
@@ -12,6 +12,7 @@ struct MegaDrive : Cartridge {
     explicit operator bool() const { return mode && size != 0; }
 
     string mode;
+    u32 address = 0x200000;
     u32 size = 0;
   } ram;
 
@@ -72,6 +73,7 @@ auto MegaDrive::load(string location) -> bool {
     Medium::load(node, ".ram");
     if(auto fp = pak->read("save.ram")) {
       fp->setAttribute("mode", node["mode"].string());
+      fp->setAttribute("address", node["address"].natural());
     }
   }
 
@@ -239,6 +241,7 @@ auto MegaDrive::analyze(vector<u8>& rom) -> string {
   } else if(ram) {
     s += "    memory\n";
     s += "      type: RAM\n";
+    s +={"      address: 0x", hex(ram.address), "\n"};
     s +={"      size: 0x", hex(ram.size), "\n"};
     s += "      content: Save\n";
     s +={"      mode: ", ram.mode, "\n"};
@@ -275,6 +278,8 @@ auto MegaDrive::analyzeStorage(vector<u8>& rom, string hash) -> void {
     if(ram.mode == "upper") ram.size = (ramTo - ramFrom + 2) >> 1;
     if(ram.mode == "lower") ram.size = (ramTo - ramFrom + 2) >> 1;
     if(ram.mode == "word" ) ram.size = (ramTo - ramFrom + 1);
+
+    ram.address = ramFrom & ~1;
   }
 
   //Buck Rogers: Countdown to Doomsday (USA, Europe)
@@ -311,6 +316,24 @@ auto MegaDrive::analyzeStorage(vector<u8>& rom, string hash) -> void {
   if(hash == "30749097096807abf67cd1f7b2392f5789f5149ee33661e6d13113396f06a121") {
     ram.mode = "lower";
     ram.size = 8192;
+  }
+
+  //NBA Live '98 (USA)
+  if(hash == "9de38bd95d7ae8910fe5440651feafaef540ed743ea61925503dce6605192b0e") {
+    ram.mode = "lower";
+    ram.size = 8192;
+  }
+
+  //NHL '96 (USA, Europe)
+  if(hash == "dce28c858bb368d8095267e04a8bdff17d913787efd783352334b0dba1e480da") {
+    ram.mode = "lower";
+    ram.size = 8192;
+  }
+
+  //NHL '98 (USA)
+  if(hash == "ed68ec25c676f7b935414d07657b9721a6ec3b43cecf1bc9dc1d069d0a14e974") {
+    ram.mode = "lower";
+    ram.size = 32768;
   }
 
   //M28C16


### PR DESCRIPTION
 * Allow MIA to declare address for mapping (typically from ROM header)
   rather than hardcoding 0x200000.
 * Autoenable SRAM if the ROM size is smaller. Also make the ramEnable
   I/O conditional to the same layout.
 * Add MIA entries for NBA Live 98, NHL 96 and NHL 98, which have a 8-bit SRAM
   not declared in the header.