### PR TITLE
md: fix Triple Play Gold

### DIFF
--- a/ares/md/cartridge/board/banked.cpp
+++ b/ares/md/cartridge/board/banked.cpp
@@ -10,7 +10,7 @@ struct Banked : Interface {
   auto load() -> void override {
     Interface::load(rom, "program.rom");
     if(auto fp = pak->read("save.ram")) {
-      Interface::load(sramAddr, sramSize, wram, uram, lram, "save.ram");
+      Interface::load(sramAddr, sramSize, ramAlwaysEnabled, wram, uram, lram, "save.ram");
     }
     if(auto fp = pak->read("save.eeprom")) {
       Interface::load(m24c, "save.eeprom");
@@ -107,7 +107,7 @@ struct Banked : Interface {
       return;
     }
 
-    if(address == 0xa130f0) {
+    if(address == 0xa130f0 && !ramAlwaysEnabled) {
       ramEnable   = data.bit(0);
       ramWritable = data.bit(1);
     }
@@ -123,6 +123,7 @@ struct Banked : Interface {
 
   auto power(bool reset) -> void override {
     for(auto index : range(8)) romBank[index] = index;
+    ramEnable = ramAlwaysEnabled;
   }
 
   auto serialize(serializer& s) -> void override {
@@ -131,6 +132,7 @@ struct Banked : Interface {
     s(uram);
     s(lram);
     s(m24c);
+    s(ramAlwaysEnabled);
     s(ramEnable);
     s(ramWritable);
     s(eepromEnable);
@@ -140,6 +142,7 @@ struct Banked : Interface {
   }
 
   n6 romBank[8];
+  n1 ramAlwaysEnabled;
   n1 ramEnable;
   n1 ramWritable;
   n1 eepromEnable;

--- a/ares/md/cartridge/board/board.cpp
+++ b/ares/md/cartridge/board/board.cpp
@@ -26,13 +26,14 @@ auto Interface::load(Memory::Readable<n16>& rom, string name) -> bool {
   return false;
 }
 
-auto Interface::load(u32& addr, u32& size, Memory::Writable<n16>& wram, Memory::Writable<n8>& uram, Memory::Writable<n8>& lram, string name) -> bool {
+auto Interface::load(u32& addr, u32& size, n1& alwaysEnabled, Memory::Writable<n16>& wram, Memory::Writable<n8>& uram, Memory::Writable<n8>& lram, string name) -> bool {
   wram.reset();
   uram.reset();
   lram.reset();
   if(auto fp = pak->read(name)) {
     addr = fp->attribute("address").natural();
     size = fp->size() << 1;
+    alwaysEnabled = fp->attribute("hardwired").natural();
     auto mode = fp->attribute("mode");
     if(mode == "word") {
       wram.allocate(fp->size() >> 1);

--- a/ares/md/cartridge/board/board.hpp
+++ b/ares/md/cartridge/board/board.hpp
@@ -21,7 +21,7 @@ struct Interface {
   virtual auto serialize(serializer&) -> void {}
 
   auto load(Memory::Readable<n16>& rom, string name) -> bool;
-  auto load(u32& addr, u32 &size, Memory::Writable<n16>& wram, Memory::Writable<n8>& uram, Memory::Writable<n8>& lram, string name) -> bool;
+  auto load(u32& addr, u32 &size, n1& alwaysEnabled, Memory::Writable<n16>& wram, Memory::Writable<n8>& uram, Memory::Writable<n8>& lram, string name) -> bool;
   auto load(M24C& m24c, string name) -> bool;
 
   auto save(Memory::Writable<n16>& wram, Memory::Writable<n8>& uram, Memory::Writable<n8>& lram, string name) -> bool;

--- a/ares/md/cartridge/board/linear.cpp
+++ b/ares/md/cartridge/board/linear.cpp
@@ -10,7 +10,7 @@ struct Linear : Interface {
   auto load() -> void override {
     Interface::load(rom, "program.rom");
     if(auto fp = pak->read("save.ram")) {
-      Interface::load(sramAddr, sramSize, wram, uram, lram, "save.ram");
+      Interface::load(sramAddr, sramSize, ramAlwaysEnabled, wram, uram, lram, "save.ram");
     }
     if(auto fp = pak->read("save.eeprom")) {
       Interface::load(m24c, "save.eeprom");
@@ -99,14 +99,14 @@ struct Linear : Interface {
   }
 
   auto writeIO(n1 upper, n1 lower, n24 address, n16 data) -> void override {
-    if(rom.size() * 2 > sramAddr && address == 0xa130f0) {
+    if(!ramAlwaysEnabled && rom.size() * 2 > sramAddr && address == 0xa130f0) {
       ramEnable   = data.bit(0);
       ramWritable = data.bit(1);
     }
   }
 
   auto power(bool reset) -> void override {
-    ramEnable = rom.size() * 2 <= sramAddr;
+    ramEnable = ramAlwaysEnabled || rom.size() * 2 <= sramAddr;
     ramWritable = 1;
     eepromEnable = rom.size() * 2 <= sramAddr;
     m24c.power();
@@ -117,6 +117,7 @@ struct Linear : Interface {
     s(uram);
     s(lram);
     s(m24c);
+    s(ramAlwaysEnabled);
     s(ramEnable);
     s(ramWritable);
     s(eepromEnable);
@@ -125,6 +126,7 @@ struct Linear : Interface {
     s(wscl);
   }
 
+  n1 ramAlwaysEnabled;
   n1 ramEnable;
   n1 ramWritable;
   n1 eepromEnable;

--- a/ares/md/cartridge/board/mega-32x.cpp
+++ b/ares/md/cartridge/board/mega-32x.cpp
@@ -15,7 +15,7 @@ struct Mega32X : Interface {
     }
 
     if(auto fp = pak->read("save.ram")) {
-      Interface::load(sramAddr, sramSize, wram, uram, lram, "save.ram");
+      Interface::load(sramAddr, sramSize, ramAlwaysEnabled, wram, uram, lram, "save.ram");
     }
 
     if(auto fp = pak->read("save.eeprom")) {
@@ -127,6 +127,7 @@ struct Mega32X : Interface {
   }
 
   n1 eepromEnable;
+  n1 ramAlwaysEnabled;
   n4 rsda;
   n4 wsda;
   n4 wscl;

--- a/mia/medium/mega-drive.cpp
+++ b/mia/medium/mega-drive.cpp
@@ -14,6 +14,7 @@ struct MegaDrive : Cartridge {
     string mode;
     u32 address = 0x200000;
     u32 size = 0;
+    u1 hardwired = 0;
   } ram;
 
   struct EEPROM {
@@ -74,6 +75,7 @@ auto MegaDrive::load(string location) -> bool {
     if(auto fp = pak->read("save.ram")) {
       fp->setAttribute("mode", node["mode"].string());
       fp->setAttribute("address", node["address"].natural());
+      fp->setAttribute("hardwired", node["hardwired"].natural());
     }
   }
 
@@ -245,6 +247,7 @@ auto MegaDrive::analyze(vector<u8>& rom) -> string {
     s +={"      size: 0x", hex(ram.size), "\n"};
     s += "      content: Save\n";
     s +={"      mode: ", ram.mode, "\n"};
+    s +={"      hardwired: ", ram.hardwired, "\n"};
   }
 
   if(peripherals.jcart) {
@@ -312,12 +315,6 @@ auto MegaDrive::analyzeStorage(vector<u8>& rom, string hash) -> void {
     ram.size = 32768;
   }
 
-  //Super Hydlide (Japan)
-  if(hash == "30749097096807abf67cd1f7b2392f5789f5149ee33661e6d13113396f06a121") {
-    ram.mode = "lower";
-    ram.size = 8192;
-  }
-
   //NBA Live '98 (USA)
   if(hash == "9de38bd95d7ae8910fe5440651feafaef540ed743ea61925503dce6605192b0e") {
     ram.mode = "lower";
@@ -334,6 +331,17 @@ auto MegaDrive::analyzeStorage(vector<u8>& rom, string hash) -> void {
   if(hash == "ed68ec25c676f7b935414d07657b9721a6ec3b43cecf1bc9dc1d069d0a14e974") {
     ram.mode = "lower";
     ram.size = 32768;
+  }
+
+  //Super Hydlide (Japan)
+  if(hash == "30749097096807abf67cd1f7b2392f5789f5149ee33661e6d13113396f06a121") {
+    ram.mode = "lower";
+    ram.size = 8192;
+  }
+
+  //Triple Play Gold (USA)
+  if(hash == "8f98a245db4a5c710469c168a5f2afe1c2f9309ef89b40942258494c61d23c68") {
+    ram.hardwired = 1;
   }
 
   //M28C16


### PR DESCRIPTION
This game is unusual because the SRAM is always mapped (by default, with
no way to turn it off), even though the ROM is bigger than 2Mb.
A portion of the ROM seems to be always shadowed, though it's unclear
whether the ROMs contain FF data in that area, or simply the ROM mapper
skips it. There is related confusion in the existing dumps, as most
dumps seem to contain SRAM contents in the 0x200000 area, as expected.