### PR TITLE
md: fix VDP behaviors in corner / undocumented cases

### DIFF
--- a/ares/component/processor/m68000/m68000.hpp
+++ b/ares/component/processor/m68000/m68000.hpp
@@ -12,6 +12,7 @@ struct M68000 {
   virtual auto lockable() -> bool { return true; }
 
   auto ird() const -> n16 { return r.ird; }
+  auto irc() const -> n16 { return r.irc; }
 
   enum : bool { User, Supervisor };
   enum : u32  { Byte, Word, Long };

--- a/ares/md/vdp/io.cpp
+++ b/ares/md/vdp/io.cpp
@@ -151,22 +151,17 @@ auto VDP::readControlPort() -> n16 {
   command.latch = 0;
 
   n16 result;
-  result.bit( 0) = Region::PAL();
-  result.bit( 1) = command.pending;
-  result.bit( 2) = hblank();
-  result.bit( 3) = vblank() || !io.displayEnable;
-  result.bit( 4) = io.interlaceMode.bit(0) && field();
-  result.bit( 5) = sprite.collision;
-  result.bit( 6) = sprite.overflow;
-  result.bit( 7) = irq.vblank.pending;
-  result.bit( 8) = fifo.full();
-  result.bit( 9) = fifo.empty();
-  result.bit(10) = 1;  //constants (bits 10-15)
-  result.bit(11) = 0;  //todo: should these bits be open bus instead?
-  result.bit(12) = 1;
-  result.bit(13) = 1;
-  result.bit(14) = 0;
-  result.bit(15) = 0;
+  result.bit( 0)    = Region::PAL();
+  result.bit( 1)    = command.pending;
+  result.bit( 2)    = hblank();
+  result.bit( 3)    = vblank() || !io.displayEnable;
+  result.bit( 4)    = io.interlaceMode.bit(0) && field();
+  result.bit( 5)    = sprite.collision;
+  result.bit( 6)    = sprite.overflow;
+  result.bit( 7)    = irq.vblank.pending;
+  result.bit( 8)    = fifo.full();
+  result.bit( 9)    = fifo.empty();
+  result.bit(10,15) = cpu.irc().bit(10,15); // open bus
 
   sprite.collision = 0;
   sprite.overflow  = 0;

--- a/ares/md/vdp/io.cpp
+++ b/ares/md/vdp/io.cpp
@@ -205,7 +205,9 @@ auto VDP::writeControlPort(n16 data) -> void {
   debugger.io(n5(data >> 8), n8(data));
 
   //register write (d13 is ignored)
-  switch(data.bit(8,12)) {
+  u5 reg = data.bit(8,12);
+  if(!io.videoMode5 && reg > 0xA) return;
+  switch(reg) {
 
   //mode register 1
   case 0x00: {

--- a/ares/md/vdp/memory.cpp
+++ b/ares/md/vdp/memory.cpp
@@ -28,12 +28,12 @@ auto VDP::VRAM::writeByte(n17 address, n8 data) -> void {
   write(address >> 1, word);
 }
 
-auto VDP::VSRAM::read(n6 address) const -> n10 {
-  if(address >= 40) return 0x0000;
+auto VDP::VSRAM::read(n6 address) const -> n11 {
+  if(address >= 40) address = 0;
   return memory[address];
 }
 
-auto VDP::VSRAM::write(n6 address, n10 data) -> void {
+auto VDP::VSRAM::write(n6 address, n11 data) -> void {
   if(address >= 40) return;
   memory[address] = data;
 }

--- a/ares/md/vdp/prefetch.cpp
+++ b/ares/md/vdp/prefetch.cpp
@@ -29,6 +29,7 @@ auto VDP::Prefetch::run() -> bool {
     slot.lower = 1;
     slot.upper = 1;
     slot.data = vdp.vsram.read(vdp.command.address >> 1);
+    slot.data = (slot.data & 0x07FF) | (vdp.fifo.slots[0].data & 0xF800);
     vdp.command.ready = 1;
     return true;
   }
@@ -37,6 +38,7 @@ auto VDP::Prefetch::run() -> bool {
     slot.lower = 1;
     slot.upper = 1;
     slot.data = vdp.cram.read(vdp.command.address >> 1);
+    slot.data = slot.data & 0x0EEE | vdp.fifo.slots[0].data & ~0x0EEE;
     vdp.command.ready = 1;
     return true;
   }

--- a/ares/md/vdp/prefetch.cpp
+++ b/ares/md/vdp/prefetch.cpp
@@ -43,6 +43,15 @@ auto VDP::Prefetch::run() -> bool {
     return true;
   }
 
+  if(vdp.command.target == 12) {
+    slot.lower = 1;
+    slot.upper = 1;
+    slot.data.byte(0) = vdp.vram.readByte(vdp.command.address ^ 1);
+    slot.data.byte(1) = vdp.fifo.slots[0].data.byte(1);
+    vdp.command.ready = 1;
+    return true;
+  }
+
   slot.lower = 1;
   slot.upper = 1;
   vdp.command.ready = 1;

--- a/ares/md/vdp/prefetch.cpp
+++ b/ares/md/vdp/prefetch.cpp
@@ -2,18 +2,12 @@ auto VDP::Prefetch::run() -> bool {
   if(full()) return false;
 
   if(vdp.command.target == 0 && vdp.vram.mode == 0) {
-    if(!slot.lower) {
-      slot.lower = 1;
-      slot.data.byte(0) = vdp.vram.readByte(vdp.command.address & ~1 | 1);
-      vdp.command.ready = 1;
-      return true;
-    }
-    if(!slot.upper) {
-      slot.upper = 1;
-      slot.data.byte(1) = vdp.vram.readByte(vdp.command.address & ~1 | 0);
-      vdp.command.ready = 1;
-      return true;
-    }
+    slot.lower = 1;
+    slot.upper = 1;
+    slot.data.byte(0) = vdp.vram.readByte(vdp.command.address & ~1 | 1);
+    slot.data.byte(1) = vdp.vram.readByte(vdp.command.address & ~1 | 0);
+    vdp.command.ready = 1;
+    return true;
   }
 
   if(vdp.command.target == 0 && vdp.vram.mode == 1) {
@@ -61,7 +55,7 @@ auto VDP::Prefetch::run() -> bool {
 
 auto VDP::Prefetch::read(n4 target, n17 address) -> void {
   if(target.bit(0) != 0) return;
-  slot.upper = address.bit(0) && target == 0;
+  slot.upper = 0;
   slot.lower = 0;
 }
 

--- a/ares/md/vdp/vdp.hpp
+++ b/ares/md/vdp/vdp.hpp
@@ -418,13 +418,13 @@ private:
   //vertical scroll RAM
   struct VSRAM {
     //memory.cpp
-    auto read(n6 address) const -> n10;
-    auto write(n6 address, n10 data) -> void;
+    auto read(n6 address) const -> n11;
+    auto write(n6 address, n11 data) -> void;
 
     //serialization.cpp
     auto serialize(serializer&) -> void;
 
-    n10 memory[40];
+    n11 memory[40];
   } vsram;
 
   //color RAM


### PR DESCRIPTION
This commit series fixes VDP behaviors in several corner (undocumented) cases, as verified by VDPFifoTesting. After this PR lands, 121 tests out of 122 pass. The last failing test is the infamous test #16 which relates to VDP FIFO timings; Ares already performs very well in that last test (only one word is wrong), but it is tricky to fix. I'll leave that for later.

<img width="752" alt="Schermata 2022-02-17 alle 19 24 10" src="https://user-images.githubusercontent.com/1014109/154546855-efe9b7d4-afbe-4e63-b590-ddc2e54408ae.png">

