### PR TITLE
megadrive quick fixes

### DIFF
--- a/ares/component/processor/m68000/instructions.cpp
+++ b/ares/component/processor/m68000/instructions.cpp
@@ -413,6 +413,7 @@ auto M68000::instructionDIVS(EffectiveAddress from, DataRegister with) -> void {
   n32 divisor  = read<Word>(from) << 16, odivisor = divisor;
 
   if(divisor == 0) {
+    prefetch();
     return exception(Exception::DivisionByZero, Vector::DivisionByZero);
   }
 
@@ -489,6 +490,7 @@ auto M68000::instructionDIVU(EffectiveAddress from, DataRegister with) -> void {
   n32 divisor  = read<Word>(from) << 16;
 
   if(divisor == 0) {
+    prefetch();
     return exception(Exception::DivisionByZero, Vector::DivisionByZero);
   }
 

--- a/ares/md/vdp/main.cpp
+++ b/ares/md/vdp/main.cpp
@@ -78,17 +78,12 @@ auto VDP::vedge() -> void {
 }
 
 auto VDP::slot() -> void {
-  if(state.refreshing) {
-    state.refreshing = 0;
-    return;
-  }
   if(!fifo.run()) prefetch.run();
   dma.run();
 }
 
 auto VDP::refresh() -> void {
-  vram.refreshing  = 1;
-  state.refreshing = !displayEnable();
+  vram.refreshing = 1;
 }
 
 auto VDP::main() -> void {
@@ -136,7 +131,7 @@ auto VDP::mainH32() -> void {
   for(auto cycle : range(13)) {
     tick(); sprite.patternFetch(cycle + 0);
   }
-  tick(); displayEnable() ? slot() : refresh();
+  tick(); slot();
   for(auto cycle : range(13)) {
     tick(); sprite.patternFetch(cycle + 13);
   }
@@ -197,7 +192,7 @@ auto VDP::mainH40() -> void {
   for(auto cycle : range(23)) {
     tick(); sprite.patternFetch(cycle + 0);
   }
-  tick(); displayEnable() ? slot() : refresh();
+  tick(); slot();
   for(auto cycle : range(11)) {
     tick(); sprite.patternFetch(cycle + 23);
   }


### PR DESCRIPTION
1. For unknown reasons, a free VDP slot was being stolen by refresh when the display was disabled, thus limiting VRAM bandwidth. This fixes major flicker on Shadow of the Beast II CD (J) and may affect other games with high transfer demands.
2. Allow normal recovery from M68k divide by zero. Fixes #241.