### PR TITLE
MD/MS overscan & bg render fixes

### DIFF
--- a/ares/md/vdp/dac.cpp
+++ b/ares/md/vdp/dac.cpp
@@ -1,6 +1,11 @@
 auto VDP::DAC::pixel(u32 x) -> void {
   if(!pixels) return;
 
+  if(!vdp.displayEnable() || vdp.vcounter() == 0x1ff) {
+    output(0b101 << 9 | vdp.cram.color(vdp.io.backgroundColor));
+    return;
+  }
+
   Pixel g = {vdp.io.backgroundColor, 0, 1};
   Pixel a = vdp.layerA.pixel(x);
   Pixel b = vdp.layerB.pixel(x);

--- a/ares/md/vdp/vdp.cpp
+++ b/ares/md/vdp/vdp.cpp
@@ -74,10 +74,16 @@ auto VDP::pixels() -> u32* {
     output = screen->pixels().data() + (vcounter() - 8) * 2 * 1280;
   }
   if(overscan->value() == 1 && latch.overscan == 0) {
-    if(vcounter() >= 232) return nullptr;
-    output = screen->pixels().data() + (vcounter() + 8) * 2 * 1280;
+    if(vcounter() >= 0x1f8) { // top border
+      output = screen->pixels().data() + (vcounter() - 0x1f8) * 2 * 1280;
+    } else if(vcounter() >= 232) {
+      return nullptr;
+    } else {
+      output = screen->pixels().data() + (vcounter() + 8) * 2 * 1280;
+    }
   }
   if(overscan->value() == 1 && latch.overscan == 1) {
+    if(vcounter() >= 240) return nullptr;
     output = screen->pixels().data() + (vcounter() + 0) * 2 * 1280;
   }
   if(latch.interlace) output += field() * 1280;

--- a/ares/ms/vdp/dac.cpp
+++ b/ares/ms/vdp/dac.cpp
@@ -1,5 +1,6 @@
 auto VDP::DAC::setup(n8 y) -> void {
-  output = self.screen->pixels().data() + (24 + y) * 256;
+  self.screen->setFillColor(palette(16 | io.backdropColor));
+  output = self.screen->pixels().data() + ((240-self.vlines())/2 + y) * 256;
 }
 
 auto VDP::DAC::run(n8 x, n8 y) -> void {
@@ -11,7 +12,6 @@ auto VDP::DAC::run(n8 x, n8 y) -> void {
       color = palette(16 | self.sprite.output.color);
     }
   }
-  if(!self.displayEnable()) color = 0;
   output[x] = color;
 }
 

--- a/ares/ms/vdp/io.cpp
+++ b/ares/ms/vdp/io.cpp
@@ -117,6 +117,7 @@ auto VDP::registerWrite(n4 address, n8 data) -> void {
     background.io.vscrollLock = data.bit(7);
     irq.line.pending &= irq.line.enable;
     irq.poll();
+    updateScreenSize();
     return;
 
   case 0x1:  //mode control 2
@@ -128,6 +129,7 @@ auto VDP::registerWrite(n4 address, n8 data) -> void {
     io.displayEnable     = data.bit(6);
     irq.frame.pending &= irq.frame.enable;
     irq.poll();
+    updateScreenSize();
     return;
 
   case 0x2:  //name table base address

--- a/ares/ms/vdp/vdp.hpp
+++ b/ares/ms/vdp/vdp.hpp
@@ -5,6 +5,7 @@
 struct VDP : Thread {
   Node::Object node;
   Node::Video::Screen screen;
+  Node::Setting::Boolean overscan;
   Node::Setting::Natural revision;
   Node::Setting::Boolean interframeBlending;  //Game Gear only
   Memory::Writable<n8 > vram;  //16KB
@@ -36,6 +37,8 @@ struct VDP : Thread {
 
   auto main() -> void;
   auto step(u32 clocks) -> void;
+
+  auto updateScreenSize() -> void;
 
   auto vlines() -> u32;
   auto vblank() -> bool;


### PR DESCRIPTION
1. Megadrive now outputs background color when display is disabled (including borders) as expected. Also fixes #384 (buffer overrun).

2. Master System gets improved overscan support and similar fix to bg render as md. Disabling Overscan will remove top and bottom borders in 192-line and 224-line modes, and Adaptive Resize should work for display mode changes.