### PR TITLE
md: fix debug register sprite masking

### DIFF
--- a/ares/md/vdp/dac.cpp
+++ b/ares/md/vdp/dac.cpp
@@ -20,8 +20,8 @@ auto VDP::DAC::pixel(u32 x) -> void {
     s = {};
   }
 
-  auto& bg = a.above() || a.color && !b.above() ? a : b.color ? b : g;
-  auto& fg = s.above() || s.color && !b.above() && !a.above() ? s : bg;
+  auto& bg = a.above() || a.solid() && !b.above() ? a : b.solid() ? b : g;
+  auto& fg = s.above() || s.solid() && !b.above() && !a.above() ? s : bg;
 
   auto pixel = fg;
   auto mode  = 1;  //0 = shadow, 1 = normal, 2 = highlight

--- a/ares/md/vdp/sprite.cpp
+++ b/ares/md/vdp/sprite.cpp
@@ -112,10 +112,11 @@ auto VDP::Sprite::patternFetch(u32) -> void {
           n9 x = object.x + patternSlice * 8 + index - 128;
           n6 color = data >> 28;
           data <<= 4;
-          if(!color) continue;
-          if(pixels[x].color) {
-            collision = 1;
+          if(pixels[x].solid()) {
+            if (color) collision = 1;
           } else {
+            // Transparent pixels must still be written to the sprite buffer. 
+            // Test case: Titan - OverDrive 2 (logo scene)
             color |= object.palette << 4;
             pixels[x] = {color, object.priority};
           }

--- a/ares/md/vdp/vdp.hpp
+++ b/ares/md/vdp/vdp.hpp
@@ -211,8 +211,9 @@ struct VDP : Thread {
   } dma;
 
   struct Pixel {
-    auto above() const -> bool { return priority == 1 && color; }
-    auto below() const -> bool { return priority == 0 && color; }
+    auto solid() const -> bool { return color & 0xF; }
+    auto above() const -> bool { return priority == 1 && solid(); }
+    auto below() const -> bool { return priority == 0 && solid(); }
 
     //serialization.cpp
     auto serialize(serializer&) -> void;


### PR DESCRIPTION
VDP always writes transparent pixels to the internal sprite buffers,
overwriting previous transparent pixels; then the first non-transparent
pixel sticks and wins. This implementation detail only reveals itself
when sprite plane masking is activated using the VDP debug register:
in that case, the palette number of transparent pixels concurs in the
AND of the visible pixels, and thus the correct palette number should
be found in the buffer.

Fixes the logo effect of Overdrive 2 (ref #255)

<img width="752" alt="Schermata 2022-02-22 alle 11 30 28" src="https://user-images.githubusercontent.com/1014109/155237186-c4acd9f3-304b-4bd2-bdbd-98ed9dbb36ab.png">


