### PR TITLE
md: fix APU port in

### DIFF
--- a/ares/md/apu/bus.cpp
+++ b/ares/md/apu/bus.cpp
@@ -89,7 +89,7 @@ auto APU::writeExternal(n24 address, n8 data) -> void {
 
 auto APU::in(n16 address) -> n8 {
   //unused on Mega Drive
-  return 0x00;
+  return 0xff;
 }
 
 auto APU::out(n16 address, n8 data) -> void {


### PR DESCRIPTION
It's technically unused, but it must return 0xFF. Looks like some
game erroneously read it anyway.

Fixes #286