### PR TITLE
n64: invalidate recompiler on icache invalidation

### DIFF
--- a/ares/n64/cpu/interpreter-ipu.cpp
+++ b/ares/n64/cpu/interpreter-ipu.cpp
@@ -116,6 +116,7 @@ auto CPU::CACHE(u8 operation, cr64& rs, s16 imm) -> void {
 
   case 0x00: {  //icache index invalidate
     auto& line = icache.line(address);
+    cpu.recompiler.invalidate(address);
     line.valid = 0;
     break;
   }
@@ -138,7 +139,13 @@ auto CPU::CACHE(u8 operation, cr64& rs, s16 imm) -> void {
 
   case 0x10: {  //icache hit invalidate
     auto& line = icache.line(address);
-    if(line.hit(address)) line.valid = 0;
+    // Invalidate recompiler also on non-hits. icache invalidate is a signal
+    // that something was changed in memory, even though the memory is not in
+    // the icache anymore.
+    cpu.recompiler.invalidate(address);
+    if(line.hit(address)) {
+      line.valid = 0;
+    }
     break;
   }
 

--- a/ares/n64/memory/bus.hpp
+++ b/ares/n64/memory/bus.hpp
@@ -49,8 +49,6 @@ inline auto Bus::read(u32 address) -> u64 {
 template<u32 Size>
 inline auto Bus::write(u32 address, u64 data) -> void {
   address &= 0x1fff'ffff - (Size - 1);
-  cpu.recompiler.invalidate(address + 0); if constexpr(Size == Dual)
-  cpu.recompiler.invalidate(address + 4);
 
   if(address <= 0x007f'ffff) return rdram.ram.write<Size>(address, data);
   if(address <= 0x03ef'ffff) return;


### PR DESCRIPTION
The test ROM https://github.com/Mr-Wiseguy/N64-Cache-Emulation-Tests
changes the body of an already-run function, without invalidating
the icache, and verifies that the previous body is run. This was
failing on Ares with the recompiler because we currently invalidate
the recompiled functions on memory writes.

This commit changes the behavior to invalidate recompiled functions
only on icache explicit invalidations (via opcode CACHE). It fixes
the test ROM, as the behavior is now consistent with the expectation
of the cache opcode to actually matter.

Notice that we are trading one not fully conformant behavior
with another one, because after this commit a game that loads code
into memory and forgets to invalidate the icache will always fail,
even though it might work by chance on a real system. On the other
hand, icache address conflics are pretty random especially during
development when linkers shuffle around functions continuously, so it
is really hard to get away with forgetting icache invalidation.
Relying on this bug is extremely unlikely, I think.