### PR TITLE
Add Linux manual build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ Nightly Builds
 
 Automated, untested builds of ares are available for Windows and macOS as a [pre-release](https://github.com/higan-emu/ares/releases/tag/nightly). 
 Only the latest nightly build is kept.
+
+Manual Build (Linux)
+--------------------
+
+To build Ares from source, first ensure the following dependencies are installed (Debian/Ubuntu package names): build-essential libsdl2-dev libgtksourceview2.0-dev libgtk2.0-dev libao-dev libopenal-dev.
+Then, run ./build-linux.sh.

--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ Only the latest nightly build is kept.
 Manual Build (Linux)
 --------------------
 
-To build Ares from source, first ensure the following dependencies are installed (Debian/Ubuntu package names): build-essential libsdl2-dev libgtksourceview2.0-dev libgtk2.0-dev libao-dev libopenal-dev.
+To build Ares from source, first ensure the following dependencies are installed (Debian/Ubuntu package names): build-essential libsdl2-dev libgtksourceview2.0-dev libgtk2.0-dev libao-dev libopenal-dev. \
 Then, run ./build-linux.sh.

--- a/README.md
+++ b/README.md
@@ -21,4 +21,5 @@ Manual Build (Linux)
 --------------------
 
 To build Ares from source, first ensure the following dependencies are installed (Debian/Ubuntu package names): build-essential libsdl2-dev libgtksourceview2.0-dev libgtk2.0-dev libao-dev libopenal-dev. \
-Then, run ./build-linux.sh.
+Then, run ./build-linux.sh. \
+The resulting build artifact will be found in desktop-ui/out/.

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+make -j$(nproc) -C desktop-ui build=optimized local=false lto=true compiler=g++


### PR DESCRIPTION
I noticed on the Ares website download section, under Linux it states "It is preferred that Linux users compile from source code" and does not provide an official build.  However there are no instructions readily available for how to compile on Linux.  I've added a basic compile script for Linux, as well as usage instructions in the readme.