### PR TITLE
[MD] various timing fixes and adjustments

### DIFF
--- a/ares/ares/ares.hpp
+++ b/ares/ares/ares.hpp
@@ -47,7 +47,7 @@ namespace ares {
 
   //incremented only when serialization format changes
   static const u32    SerializerSignature = 0x31545342;  //"BST1" (little-endian)
-  static const string SerializerVersion   = "127";
+  static const string SerializerVersion   = "127.1";
 
   namespace VFS {
     using Pak = shared_pointer<vfs::directory>;

--- a/ares/md/cpu/cpu.cpp
+++ b/ares/md/cpu/cpu.cpp
@@ -61,7 +61,6 @@ auto CPU::main() -> void {
 
 auto CPU::step(u32 clocks) -> void {
   refresh.ram += clocks;
-  while(refresh.ram >= 133) refresh.ram -= 133;
   refresh.external += clocks;
   Thread::step(clocks);
   cyclesUntilSync -= clocks;

--- a/ares/md/cpu/cpu.hpp
+++ b/ares/md/cpu/cpu.hpp
@@ -66,8 +66,18 @@ struct CPU : M68000, Thread {
   } io;
 
   struct Refresh {
-    n8 ram;
-    n7 external;
+    int ram;
+    int ramEnd;
+    int external;
+    int externalEnd;
+
+    static constexpr int ramLowBound       = 113;
+    static constexpr int ramHighBound      = 132;
+    static constexpr int ramLength         = 3;
+    static constexpr int externalLowBound  = 126;
+    static constexpr int externalHighBound = 132;
+    static constexpr int externalLength    = 2;
+
   } refresh;
 
   struct State {

--- a/ares/md/cpu/serialization.cpp
+++ b/ares/md/cpu/serialization.cpp
@@ -6,6 +6,8 @@ auto CPU::serialize(serializer& s) -> void {
   s(io.romEnable);
   s(io.vdpEnable);
   s(refresh.ram);
+  s(refresh.ramEnd);
   s(refresh.external);
+  s(refresh.externalEnd);
   s(state.interruptPending);
 }

--- a/ares/md/system/system.cpp
+++ b/ares/md/system/system.cpp
@@ -67,7 +67,7 @@ auto System::load(Node::System& root, string name) -> bool {
     information.name = "Mega Drive";
     information.mega32X = 1;
     information.megaCD = 0;
-    cpu.minCyclesBetweenSyncs = 15; // sync approx every 25-26 pixels
+    cpu.minCyclesBetweenSyncs = 14; // sync approx every 24-25 pixels
   }
   if(name.match("[Sega] Mega CD (*)")) {
     information.name = "Mega Drive";

--- a/ares/md/vdp/dma.cpp
+++ b/ares/md/vdp/dma.cpp
@@ -23,6 +23,7 @@ auto VDP::DMA::run() -> bool {
 }
 
 auto VDP::DMA::load() -> void {
+  if(delay > 0) { delay--; return; }
   auto address = mode.bit(0) << 23 | source << 1;
   auto data = bus.read(1, 1, address);
   vdp.writeDataPort(data);

--- a/ares/md/vdp/io.cpp
+++ b/ares/md/vdp/io.cpp
@@ -187,6 +187,7 @@ auto VDP::writeControlPort(n16 data) -> void {
 
     prefetch.read(command.target, command.address);
 
+    if(command.pending && dma.mode == 1) dma.delay = 4; // based on measurement noted by Mask of Destiny
     dma.wait = dma.mode == 2;
     dma.synchronize();
     return;

--- a/ares/md/vdp/io.cpp
+++ b/ares/md/vdp/io.cpp
@@ -225,7 +225,10 @@ auto VDP::writeControlPort(n16 data) -> void {
   //mode register 2
   case 0x01: {
     io.videoMode5      = data.bit(2);
-    io.overscan        = data.bit(3);
+    if(io.overscan ^ data.bit(3)) {
+      io.overscan      = data.bit(3);
+      vblankcheck();
+    }
     dma.enable         = data.bit(4);
     irq.vblank.enable  = data.bit(5);
     io.displayEnable   = data.bit(6);

--- a/ares/md/vdp/layers.cpp
+++ b/ares/md/vdp/layers.cpp
@@ -18,9 +18,16 @@ auto VDP::Layers::vscrollFetch() -> void {
 
 auto VDP::Layers::vscrollFetch(s32 index) -> void {
   if(vscrollMode == 0) return;
-  n16 address = index << 1;
-  vdp.layerA.vscroll = vdp.vsram.read(address++);
-  vdp.layerB.vscroll = vdp.vsram.read(address++);
+  if(index == -1) {
+    // Confirmed hardware bug that affects vertical scrolling of the left-most partial column.
+    // This bug can be observed in Wing of Wor / Gynoug during screen tilts.
+    n10 val = vdp.h40() ? vdp.vsram.read(38) & vdp.vsram.read(39) : 0;
+    vdp.layerA.vscroll = vdp.layerB.vscroll = val;
+  } else {
+    n16 address = index << 1;
+    vdp.layerA.vscroll = vdp.vsram.read(address++);
+    vdp.layerB.vscroll = vdp.vsram.read(address++);
+  }
 }
 
 auto VDP::Layers::power(bool reset) -> void {

--- a/ares/md/vdp/serialization.cpp
+++ b/ares/md/vdp/serialization.cpp
@@ -102,6 +102,7 @@ auto VDP::DMA::serialize(serializer& s) -> void {
   s(wait);
   s(read);
   s(enable);
+  s(delay);
 }
 
 auto VDP::Pixel::serialize(serializer& s) -> void {

--- a/ares/md/vdp/vdp.hpp
+++ b/ares/md/vdp/vdp.hpp
@@ -208,6 +208,7 @@ struct VDP : Thread {
     n1  wait;
     n1  read;
     n1  enable;
+    n4  delay;
   } dma;
 
   struct Pixel {


### PR DESCRIPTION
1. VDP timing adjustments, noted in the commit message. Not currently supporting DMA direct color or anything requiring absolute perfect sync. Stuff like that could require shifting things around in the render, hcounter realignment, etc.
2. Emulate DMA delay noted by Mask of Destiny. Fixes the only broken scene in Overdrive, now just left with very minor glitches.
3. For accuracy, implement a hardware V-scroll bug that causes scrolling of the leftmost partial column to break. Tester's note: this fixes a minor graphical glitch in Overdrive (seen in top left corner of the robot scene), but exposes a glitch in the leftmost column of Wing of Wor / Gynoug when the screen tilts (see https://youtu.be/8pNGK1lDdIk?t=87).
4. Improved accuracy of the cpu refresh timings, mostly based on info from Mask of Destiny (see http://gendev.spritesmind.net/forum/viewtopic.php?f=2&t=2323). Some value tweaking was done based on preliminary tests against hardware. More tests are forthcoming. 
5. Accurate m68000 interrupt/exception timing based on Motorola documentation (ref: AN1012/D). Note, there are some random delays in the autovectoring which have been approximated.
6. 32X / cpu sync was affected by recent changes, so the sync threshold was tweaked just enough to get Kolibri to boot. Need regression testing on 32X games to determine if this warrants further adjustment.

Update to #212 (fixes "GFX" and "TITAN 512C FOREVER" glitches).