### PR TITLE
Add top-level makefile and codesign binary on Mac

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,6 @@
+all: desktop
+
+desktop:
+	$(MAKE) -C desktop-ui
+
+.PHONY: all desktop

--- a/desktop-ui/GNUmakefile
+++ b/desktop-ui/GNUmakefile
@@ -86,6 +86,7 @@ ifeq ($(platform),macos)
 	cp -R $(ares.path)/Shaders $(output.path)/$(name).app/Contents/Resources/
 	cp -R $(mia.path)/Database $(output.path)/$(name).app/Contents/Resources/	
 	sips -s format icns resource/$(name).png --out $(output.path)/$(name).app/Contents/Resources/$(name).icns
+	codesign --force --deep --sign - $(output.path)/$(name).app
 else ifeq ($(platform),windows)
 	cp -R $(ares.path)/Shaders $(output.path)/
 	cp -R $(mia.path)/Database $(output.path)/


### PR DESCRIPTION
The top-level Makefile should cover most concerns of #422 and in general removes confusion from people first building ares. New targets can be added if we need to build multiple UIs in the future.

Codesigning on Mac is required on Apple Silicon to run the app bundle 