### PR TITLE
md/32x: add missing initialization during power-on

### DIFF
--- a/ares/component/processor/sh2/sh2.cpp
+++ b/ares/component/processor/sh2/sh2.cpp
@@ -42,6 +42,7 @@ auto SH2::power(bool reset) -> void {
   SR.M = undefined;
   PPC = 0;
   PPM = Branch::Step;
+  ET = 0;
   ID = 0;
   exceptions = !reset ? ResetCold : ResetWarm;
 

--- a/ares/md/m32x/pwm.cpp
+++ b/ares/md/m32x/pwm.cpp
@@ -50,6 +50,16 @@ auto M32X::PWM::step(u32 clocks) -> void {
 
 auto M32X::PWM::power(bool reset) -> void {
   Thread::create(23'020'200, {&M32X::PWM::main, this});
+  lmode = 0;
+  rmode = 0;
+  mono = 0;
+  dreqIRQ = 0;
+  timer = 0;
+  cycle = 0;
+  periods = 0;
+  counter = 0;
+  lsample = 0;
+  rsample = 0;
   lfifo.flush();
   rfifo.flush();
 }

--- a/ares/md/m32x/vdp.cpp
+++ b/ares/md/m32x/vdp.cpp
@@ -13,6 +13,17 @@ auto M32X::VDP::unload() -> void {
 auto M32X::VDP::power(bool reset) -> void {
   dram.fill(0);
   cram.fill(0);
+  mode = 0;
+  lines = 0;
+  priority = 0;
+  dotshift = 0;
+  autofillLength = 0;
+  autofillAddress = 0;
+  autofillData = 0;
+  framebufferAccess = 0;
+  framebufferActive = 0;
+  framebufferSelect = 0;
+  hblank = 0;
   vblank = 1;
   selectFramebuffer(framebufferSelect);
 }

--- a/ares/md/vdp/dma.cpp
+++ b/ares/md/vdp/dma.cpp
@@ -77,6 +77,7 @@ auto VDP::DMA::power(bool reset) -> void {
   mode = 0;
   source = 0;
   length = 0;
+  data = 0;
   wait = 1;
   read = 0;
   enable = 0;

--- a/ares/md/vdp/layer.cpp
+++ b/ares/md/vdp/layer.cpp
@@ -103,5 +103,8 @@ auto VDP::Layer::power(bool reset) -> void {
   nametableAddress = 0;
   attributes = {};
   for(auto& pixel : pixels) pixel = {};
+  colors = 0;
+  extras = 0;
+  for(auto& window : windowed) window = 0;
   for(auto& mapping : mappings) mapping = {};
 }

--- a/ares/md/vdp/vdp.cpp
+++ b/ares/md/vdp/vdp.cpp
@@ -109,6 +109,7 @@ auto VDP::power(bool reset) -> void {
   }
 
   vram.mode = 0;
+  vram.refreshing = 0;
   command = {};
   io = {};
   test = {};


### PR DESCRIPTION
Nearly all state is initialized to a fixed or random value during
power-on, though a few things are deliberately left alone on soft reset.

A handful of fields weren't being initialized at all, save for the zero
initialization that occurs during process creation. This state would be
persisted from one ROM load to the next.

This fix is intended to address 32x PWM audio eventually going silent
after switching between multiple roms.