### PR TITLE
ruby: pulseaudio shouldn't block for events

### DIFF
--- a/ruby/audio/pulseaudio.cpp
+++ b/ruby/audio/pulseaudio.cpp
@@ -67,7 +67,9 @@ private:
 
     pa_context_state_t contextState;
     do {
-      pa_mainloop_iterate(_mainLoop, 1, nullptr);
+      if (pa_mainloop_prepare(_mainLoop, 1000000) < 0) return false;
+      pa_mainloop_poll(_mainLoop);
+      pa_mainloop_dispatch(_mainLoop);
       contextState = pa_context_get_state(_context);
       if(!PA_CONTEXT_IS_GOOD(contextState)) return false;
     } while(contextState != PA_CONTEXT_READY);
@@ -89,7 +91,9 @@ private:
 
     pa_stream_state_t streamState;
     do {
-      pa_mainloop_iterate(_mainLoop, 1, nullptr);
+      if (pa_mainloop_prepare(_mainLoop, 1000000) < 0) return false;
+      pa_mainloop_poll(_mainLoop);
+      pa_mainloop_dispatch(_mainLoop)
       streamState = pa_stream_get_state(_stream);
       if(!PA_STREAM_IS_GOOD(streamState)) return false;
     } while(streamState != PA_STREAM_READY);


### PR DESCRIPTION
Now it sets a timeout of one second