### PR TITLE
sfc: fix "Super FX voxel demo"

### DIFF
--- a/ares/sfc/coprocessor/superfx/memory.cpp
+++ b/ares/sfc/coprocessor/superfx/memory.cpp
@@ -1,29 +1,32 @@
 auto SuperFX::read(n24 address, n8 data) -> n8 {
   if((address & 0xc00000) == 0x000000) {  //$00-3f:0000-7fff,:8000-ffff
+    address = Bus::mirror(address, rom.size());
     while(!regs.scmr.ron) {
       step(6);
       synchronize(cpu);
       if(scheduler.synchronizing()) break;
     }
-    return rom.read((((address & 0x3f0000) >> 1) | (address & 0x7fff)) & romMask);
+    return rom.read((((address & 0x3f0000) >> 1) | (address & 0x7fff)));
   }
 
   if((address & 0xe00000) == 0x400000) {  //$40-5f:0000-ffff
+    address = Bus::mirror(address, rom.size());
     while(!regs.scmr.ron) {
       step(6);
       synchronize(cpu);
       if(scheduler.synchronizing()) break;
     }
-    return rom.read(address & romMask);
+    return rom.read(address);
   }
 
   if((address & 0xfe0000) == 0x700000) {  //$70-71:0000-ffff
+    address = Bus::mirror(address, ram.size());
     while(!regs.scmr.ran) {
       step(6);
       synchronize(cpu);
       if(scheduler.synchronizing()) break;
     }
-    return ram.read(address & ramMask);
+    return ram.read(address);
   }
 
   return data;
@@ -31,12 +34,13 @@ auto SuperFX::read(n24 address, n8 data) -> n8 {
 
 auto SuperFX::write(n24 address, n8 data) -> void {
   if((address & 0xfe0000) == 0x700000) {  //$70-71:0000-ffff
+    address = Bus::mirror(address, ram.size());
     while(!regs.scmr.ran) {
       step(6);
       synchronize(cpu);
       if(scheduler.synchronizing()) break;
     }
-    return ram.write(address & ramMask, data);
+    return ram.write(address, data);
   }
 }
 

--- a/mia/Database/Super Famicom.bml
+++ b/mia/Database/Super Famicom.bml
@@ -30,6 +30,30 @@ game
       size: 0x80000
       content: Program
 
+//Prototypes (USA)
+
+database
+  revision: 2022-03-14
+
+game
+  sha256:   4362afe51da8a01a67a1c2d6c2545d9e7cbaf8c42fd8f319dd8b61fe328512e1
+  name:     Super FX voxel demo
+  title:    Super FX voxel demo
+  label:    Voxels in progress
+  region:   USA
+  revision: 1.0
+  board:    GSU-RAM
+    memory
+      type: ROM
+      size: 0x60000
+      content: Program
+    memory
+      type: RAM
+      size: 0x10000
+      content: Save
+    oscillator
+      frequency: 21440000
+
 //Super Comboy (KOR)
 
 database


### PR DESCRIPTION
sfc: Add database entry for the "Super FX voxel demo" to specify a RAM size of 64k instead of 32k
Support ROM/RAM addressing for Super FX ROMs that are not a power of 2 (i.e. Voxel)

should fix 436