### PR TITLE
m68000: fix opcode validations & exception processing

### DIFF
--- a/ares/component/processor/m68000/instruction.cpp
+++ b/ares/component/processor/m68000/instruction.cpp
@@ -414,6 +414,7 @@ M68000::M68000() {
   for(n3 mode : range(8))
   for(n3 reg  : range(8)) {
     auto opcode = pattern("1011 ---+ 11-- ----") | areg << 9 | mode << 3 | reg << 0;
+    if(mode == 7 && reg >= 5) continue;
 
     AddressRegister with{areg};
     EffectiveAddress from{mode, reg};
@@ -1256,7 +1257,7 @@ M68000::M68000() {
   for(n3 mode : range(8))
   for(n3 reg  : range(8)) {
     auto opcode = pattern("0100 1010 ++-- ----") | mode << 3 | reg << 0;
-    if(mode == 7 && reg >= 2) continue;
+    if(mode == 1 || mode == 7 && reg >= 2) continue;
 
     EffectiveAddress from{mode, reg};
     bind(opcode | 0 << 6, TST<Byte>, from);

--- a/ares/component/processor/m68000/instructions.cpp
+++ b/ares/component/processor/m68000/instructions.cpp
@@ -332,14 +332,20 @@ auto M68000::instructionCHK(DataRegister compare, EffectiveAddress maximum) -> v
 
   r.z = clip<Word>(target) == 0;
   r.n = sign<Word>(target) < 0;
-  if(r.n) return exception(Exception::BoundsCheck, Vector::BoundsCheck);
+  if(r.n) {
+    prefetched();
+    return exception(Exception::BoundsCheck, Vector::BoundsCheck);
+  }
 
   auto result = (n64)target - source;
   r.c = sign<Word>(result >> 1) < 0;
   r.v = sign<Word>((target ^ source) & (target ^ result)) < 0;
   r.z = clip<Word>(result) == 0;
   r.n = sign<Word>(result) < 0;
-  if(r.n == r.v && !r.z) return exception(Exception::BoundsCheck, Vector::BoundsCheck);
+  if(r.n == r.v && !r.z) {
+    prefetched();
+    return exception(Exception::BoundsCheck, Vector::BoundsCheck);
+  }
   prefetch();
 }
 
@@ -421,7 +427,7 @@ auto M68000::instructionDIVS(EffectiveAddress from, DataRegister with) -> void {
   n32 divisor  = read<Word>(from) << 16, odivisor = divisor;
 
   if(divisor == 0) {
-    prefetch();
+    prefetched();
     return exception(Exception::DivisionByZero, Vector::DivisionByZero);
   }
 
@@ -498,7 +504,7 @@ auto M68000::instructionDIVU(EffectiveAddress from, DataRegister with) -> void {
   n32 divisor  = read<Word>(from) << 16;
 
   if(divisor == 0) {
-    prefetch();
+    prefetched();
     return exception(Exception::DivisionByZero, Vector::DivisionByZero);
   }
 


### PR DESCRIPTION
*Validated according to MegaDrive test rom: M68K Opcode Sizes Test by r57shell

1. Fixes hang in the test rom caused by bad CHK exception processing. DIV by zero exception (prefetch) was also adjusted to match up with other group 2 exceptions (includes CHK, TRAPs, DIV by zero).
2. Invalidates addressing modes for:
- CMPA: filter out illegal addressing modes
- TST: address register direct is only valid on M68020+ (for word & long sizes)