### PR TITLE
n64: add support for homebrew-specific special header flag

### DIFF
--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -577,6 +577,18 @@ auto Nintendo64::analyze(vector<u8>& data) -> string {
   if(id == "NOH") {rumble = true;}                                       //Transformers Beast Wars: Transmetals
   if(id == "NWF") {rumble = true;}                                       //Wheel of Fortune
 
+  //Homebrew (libdragon / Everdrive special header flag)
+  if(id[1] == 'E' && id[2] == 'D') {
+    n8 config = data[0x3f];
+    if(config.bit(4,7) == 1) {eeprom = 512;}
+    if(config.bit(4,7) == 2) {eeprom = 2_KiB;}
+    if(config.bit(4,7) == 3) {sram = 32_KiB;}
+    //if(config.bit(4,7) == 4) {sram = 96_KiB;}   //banked SRAM, not supported yet
+    if(config.bit(4,7) == 5) {flash = 128_KiB;}
+    if(config.bit(4,7) == 6) {sram = 128_KiB;}
+    rumble = true;
+    mempak = true;
+  }
 
   string s;
   s += "game\n";


### PR DESCRIPTION
Nintendo 64 homebrew community is standardizing on a convention to
declare the save memory type as a header flag. This convention has been
first introduced by EverDrive 64 as a way to handle games not present
in their DB, but it's been since adopted by libdragon as well.

With this commit, Ares will automatically configure the correct savetype
for homebrew ROMs using the special header flag.