### PR TITLE
n64: change dead zone from a large circle to a small square

### DIFF
--- a/ares/n64/controller/gamepad/gamepad.cpp
+++ b/ares/n64/controller/gamepad/gamepad.cpp
@@ -105,7 +105,7 @@ auto Gamepad::read() -> n32 {
   auto ax = x->value() * 85.0 / 32767.0;
   auto ay = y->value() * 85.0 / 32767.0;
 
-  //create sqaure dead-zone in range {-7 ... +7}
+  //create square dead-zone in range {-7 ... +7}
   auto lengthAbsoluteX = abs (ax);
   auto lengthAbsoluteY = abs (ay);
   if (lengthAbsoluteX < 7.0) {
@@ -117,7 +117,7 @@ auto Gamepad::read() -> n32 {
     ay *= lengthAbsoluteY;
   }
   
-  //create outer circular dead-zone in ranges {-inf ... -85} and {+85 ... +inf} and scale radially between the two dead-zones
+  //create outer circular dead-zone in ranges {-inf ... -85} and {+85 ... +inf} and scale between the two dead-zones according to the two-dimensional length
   auto length = sqrt(ax * ax + ay * ay);
   if(length > 85.0) {
     length = 85.0 / length;

--- a/ares/n64/controller/gamepad/gamepad.cpp
+++ b/ares/n64/controller/gamepad/gamepad.cpp
@@ -105,14 +105,24 @@ auto Gamepad::read() -> n32 {
   auto ax = x->value() * 85.0 / 32767.0;
   auto ay = y->value() * 85.0 / 32767.0;
 
-  //create scaled circular dead-zone in range {-15 ... +15}
+  //create sqaure dead-zone in range {-7 ... +7}
+  auto lengthAbsoluteX = abs (ax);
+  auto lengthAbsoluteY = abs (ay);
+  if (lengthAbsoluteX < 7.0) {
+    lengthAbsoluteX = 0.0;
+    ax *= lengthAbsoluteX;
+  }
+  if (lengthAbsoluteY < 7.0) {
+    lengthAbsoluteY = 0.0;
+    ay *= lengthAbsoluteY;
+  }
+  
+  //create outer circular dead-zone in ranges {-inf ... -85} and {+85 ... +inf} and scale radially between the two dead-zones
   auto length = sqrt(ax * ax + ay * ay);
-  if(length < 16.0) {
-    length = 0.0;
-  } else if(length > 85.0) {
+  if(length > 85.0) {
     length = 85.0 / length;
   } else {
-    length = (length - 16.0) * 85.0 / 69.0 / length;
+    length = (length - 7.0) * 85.0 / (85.0 - 7.0) / length;
   }
   ax *= length;
   ay *= length;


### PR DESCRIPTION
Currently, ares utilizes a circular dead zone of ~19%. This commit reduces this size by a little over 10.5% to be more in line with limited controller data (could use more) from lightly used controllers I have collected from a few individuals several months ago. The dead zone is intended to be representative of the mechanical play (loose gears and mating of mechanical parts) that ends up producing an area where the optical encoder does not pick up a single count from stick deflection. Therefore, the data used took into account the deflection angle of the stick and the optical encoder count in each cardinal direction as determined by Sanni's controller test ROM to be able to create a dead zone.

Lastly, a square dead zone is assumed because the controller only sends relative integers and no greater precision. Additionally, the N64 programming manual exhibits a square dead zone as a programming caution for game developers to consider. That said, a circle has not been effectively ruled out since deflection data has not been collected from controllers at the (+/-1, +/-1) corners.