### PR TITLE
Allow to disconnect devices from ports + MCD Corpse Killer fix

### DIFF
--- a/ares/md/controller/port.cpp
+++ b/ares/md/controller/port.cpp
@@ -11,6 +11,8 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setType("Controller");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
+  port->setDisconnect([&] { return disconnect(); });
+
   port->setSupported({"Control Pad", "Fighting Pad"});
 }
 
@@ -20,7 +22,6 @@ auto ControllerPort::unload() -> void {
 }
 
 auto ControllerPort::allocate(string name) -> Node::Peripheral {
-  device = nullptr;
   if(name == "Control Pad" ) device = new ControlPad(port);
   if(name == "Fighting Pad") device = new FightingPad(port);
   if(device) return device->node;

--- a/ares/md/controller/port.cpp
+++ b/ares/md/controller/port.cpp
@@ -20,6 +20,7 @@ auto ControllerPort::unload() -> void {
 }
 
 auto ControllerPort::allocate(string name) -> Node::Peripheral {
+  device = nullptr;
   if(name == "Control Pad" ) device = new ControlPad(port);
   if(name == "Fighting Pad") device = new FightingPad(port);
   if(device) return device->node;

--- a/ares/md/controller/port.hpp
+++ b/ares/md/controller/port.hpp
@@ -9,7 +9,7 @@ struct ControllerPort {
 
   ControllerPort(string name);
   auto connect(Node::Peripheral) -> void;
-  auto disconnect() -> void;
+  auto disconnect() -> void { device.reset(); }
 
   auto readControl() -> n8 { return control; }
   auto writeControl(n8 data) -> void { control = data; }

--- a/desktop-ui/emulator/mega-cd.cpp
+++ b/desktop-ui/emulator/mega-cd.cpp
@@ -74,8 +74,14 @@ auto MegaCD::load() -> bool {
   }
 
   if(auto port = root->find<ares::Node::Port>("Controller Port 2")) {
-    port->allocate("Control Pad");
-    port->connect();
+    if(game->pak->attribute("serial") == "GM T-162055-00") {
+      // CORPSE KILLER (U) -- GM T-162055-00
+      // Gamepad in controller port 2 breaks input polling, so leave it disconnected.
+      // No supported lightgun devices are currently emulated (Sega Menacer, ALG GameGun).
+    } else {
+      port->allocate("Control Pad");
+      port->connect();
+    }
   }
 
   return true;

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -417,7 +417,13 @@ auto Presentation::loadEmulator() -> void {
 
     Group peripheralGroup;
     { MenuRadioItem peripheralItem{&portMenu};
+      peripheralItem.setAttribute<ares::Node::Port>("port", port);
       peripheralItem.setText("Nothing");
+      peripheralItem.onActivate([=] {
+        auto port = peripheralItem.attribute<ares::Node::Port>("port");
+        port->disconnect();
+        port->allocate(); // deallocation for ports not implementing disconnect()
+      });
       peripheralGroup.append(peripheralItem);
     }
     for(auto peripheral : port->supported()) {
@@ -429,6 +435,7 @@ auto Presentation::loadEmulator() -> void {
       peripheralItem.setText(peripheral);
       peripheralItem.onActivate([=] {
         auto port = peripheralItem.attribute<ares::Node::Port>("port");
+        port->disconnect();
         port->allocate(peripheralItem.text());
         port->connect();
       });

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -422,7 +422,6 @@ auto Presentation::loadEmulator() -> void {
       peripheralItem.onActivate([=] {
         auto port = peripheralItem.attribute<ares::Node::Port>("port");
         port->disconnect();
-        port->allocate(); // deallocation for ports not implementing disconnect()
       });
       peripheralGroup.append(peripheralItem);
     }

--- a/mia/medium/mega-cd.cpp
+++ b/mia/medium/mega-cd.cpp
@@ -16,6 +16,7 @@ auto MegaCD::load(string location) -> bool {
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
+  pak->setAttribute("serial", document["game/serial"].string());
   pak->setAttribute("region", document["game/region"].string());
   pak->append("manifest.bml", manifest);
   if(directory::exists(location)) {
@@ -51,6 +52,8 @@ auto MegaCD::analyze(string location) -> string {
   }
   if(!regions) regions.append("NTSC-J","NTSC-U","PAL"); // unknown boot
 
+  string serialNumber = slice((const char*)(sector.data() + 0x180), 0, 14).trimRight(" ");
+
   vector<string> devices;
   string device = slice((const char*)(sector.data() + 0x190), 0, 16).trimRight(" ");
   for(auto& id : device) {
@@ -77,6 +80,7 @@ auto MegaCD::analyze(string location) -> string {
   s += "game\n";
   s +={"  name:   ", Medium::name(location), "\n"};
   s +={"  title:  ", Medium::name(location), "\n"};
+  s +={"  serial: ", serialNumber, "\n"};
   s +={"  region: ", regions.merge(", "), "\n"};
   if(devices)
   s +={"  device: ", devices.merge(", "), "\n"};


### PR DESCRIPTION
Short version: There's a bug in retail MCD Corpse Killer (U) which breaks input polling when a gamepad is plugged into controller port 2. This fix allows for unplugging of an offending device.

Long version:
1. Adds functionality to disconnect from port when swapping devices. Note, as with MD gamepads, disconnect() may not be implemented in some cases, so deallocation strategy is used (see following commit). Of course, this change will need to be reviewed for devices across the board to ensure safety.
2. A plugged MD gamepad device is deallocated before allocating a new device, since the disconnect action is not handled. In case a valid device name is not given, the device will remain unallocated (null). An alternative approach would be to implement disconnect() to do the same, but this is provided to be the simplest solution. Either way, **similar fixes will need to be done for devices in other cores**, otherwise this remains incomplete.
3. Extracts an identifiable text field -- product version/serial number -- from the MCD disc header. Otherwise, only the file name is made available (as Title/Name).
4. Skip plugging of control pad into port 2 when Corpse Killer CD is loaded. This is handled on first init of the controller ports.

Please take as much time as you need on this PR, and feel free to suggest any alternative approaches if deemed necessary. I can make no guarantees that these changes are safe for all devices outside of the MD core.