### PR TITLE
nall: Fix typo in nall/decode/chd.hpp

### DIFF
--- a/nall/decode/chd.hpp
+++ b/nall/decode/chd.hpp
@@ -110,7 +110,7 @@ inline auto CHD::load(const string& location) -> bool {
 
     // Ensure two second pregap is present
     const bool pregap_in_file = (pregap_frames > 0 && pgtype[0] == 'V');
-    if (pregap_frames <= 0 && type != "AUDIO") {
+    if (pregap_frames <= 0 && strcmp(type, "AUDIO") != 0) {
       pregap_frames = 2 * 75;
     }
 


### PR DESCRIPTION
Disclaimer: Not a c++ coder. This could fix the issue or break the code. 

Issue: When compiling on an M1 I get a warning for every module that includes /nall/decode/chd.hpp: `../nall/decode/chd.hpp:113:36: warning: result of comparison against a string literal is unspecified (use an explicit string comparison function instead) [-Wstring-compare]`.

I read on stackoverflow that using a comparison operator will compare if the pointers are the same, not the actual string, so strcmp() should be used instead. 
https://stackoverflow.com/questions/2603039/warning-comparison-with-string-literals-results-in-unspecified-behaviour

According to cplusplus.com if you use strcmp with two values, they are the same if the return value is 0, and different if it is greater or less than zero. 
https://www.cplusplus.com/reference/cstring/strcmp/

Replacing with `strcmp(type, "AUDIO") != 0` does fix the warnings, but it should be tested to see if the check still works as intended.