### PR TITLE
Nall: Fix typo in nall/decode/chd.hpp:    type --> typeStr

### DIFF
--- a/nall/decode/chd.hpp
+++ b/nall/decode/chd.hpp
@@ -110,7 +110,7 @@ inline auto CHD::load(const string& location) -> bool {
 
     // Ensure two second pregap is present
     const bool pregap_in_file = (pregap_frames > 0 && pgtype[0] == 'V');
-    if (pregap_frames <= 0 && type != "AUDIO") {
+    if (pregap_frames <= 0 && typeStr != "AUDIO") {
       pregap_frames = 2 * 75;
     }
 


### PR DESCRIPTION
Using `type` results in compiler warnings: `warning: result of comparison against a string literal is unspecified (use an explicit string comparison function instead)` 

Was informed by merryhime that `typeStr` was probably intended.

Changing to `typeStr` fixes the warnings. 

Should probably be tested to ensure the comparison still works as intended.

This is following up from #525 