### PR TITLE
n64: implement proper PI bus writes with IO busy bit

### DIFF
--- a/ares/n64/cartridge/cartridge.hpp
+++ b/ares/n64/cartridge/cartridge.hpp
@@ -1,16 +1,9 @@
 struct Cartridge {
   Node::Peripheral node;
   VFS::Pak pak;
-  Memory::Writable ram;
-  Memory::Writable eeprom;
-  struct Rom : Memory::Readable {
-    template<u32 Size>
-    auto read(u32 address) -> u64 {
-      if constexpr(Size == Byte) return Memory::Readable::read<Byte>(address + (address & 2));
-      if constexpr(Size == Half) return Memory::Readable::read<Half>(address + (address & 2));
-      return Memory::Readable::read<Size>(address);
-    }
-  } rom;
+  Memory::Readable16 rom;
+  Memory::Writable16 ram;
+  Memory::Writable16 eeprom;
   struct Flash : Memory::Writable {
     template<u32 Size>
     auto read(u32 address) -> u64 {

--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -55,6 +55,7 @@ auto CPU::synchronize() -> void {
     case Queue::RSP_DMA:       return rsp.dmaTransfer();
     case Queue::PI_DMA_Read:   return pi.dmaRead();
     case Queue::PI_DMA_Write:  return pi.dmaWrite();
+    case Queue::PI_BUS_Write:  return pi.writeFinished();
     case Queue::SI_DMA_Read:   return si.dmaRead();
     case Queue::SI_DMA_Write:  return si.dmaWrite();
     }

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -703,6 +703,11 @@ struct CPU : Thread {
     auto invalidate(u32 address) -> void {
       pools[address >> 8 & 0x1fffff] = nullptr;
     }
+    auto invalidateRange(u32 address, u32 length) -> void {
+      for (u32 s = 0; s < length; s += 256)
+        invalidate(address + s);
+      invalidate(address + length - 1);
+    }
 
     auto pool(u32 address) -> Pool*;
     auto block(u32 address) -> Block*;

--- a/ares/n64/memory/bus.hpp
+++ b/ares/n64/memory/bus.hpp
@@ -17,24 +17,7 @@ inline auto Bus::read(u32 address) -> u64 {
   if(address <= 0x047f'ffff) return ri.read<Size>(address);
   if(address <= 0x048f'ffff) return si.read<Size>(address);
   if(address <= 0x04ff'ffff) return unmapped;
-  if(address <= 0x0500'03ff) return dd.c2s.read<Size>(address);
-  if(address <= 0x0500'04ff) return dd.ds.read<Size>(address);
-  if(address <= 0x0500'057f) return dd.read<Size>(address);
-  if(address <= 0x0500'05bf) return dd.ms.read<Size>(address);
-  if(address <= 0x05ff'ffff) return unmapped;
-  if(address <= 0x063f'ffff) return dd.iplrom.read<Size>(address);
-  if(address <= 0x07ff'ffff) return unmapped;
-  if(address <= 0x0fff'ffff) {
-    if(cartridge.ram  ) return cartridge.ram.read<Size>(address);
-    if(cartridge.flash) return cartridge.flash.read<Size>(address);
-    return unmapped;
-  }
-  if(address <= 0x1fbf'ffff) {
-    if(address >= 0x13ff'0000 && address <= 0x13ff'ffff) {
-      return cartridge.isviewer.read<Size>(address);
-    }
-    return cartridge.rom.read<Size>(address);
-  }
+  if(address <= 0x1fbf'ffff) return pi.read<Size>(address);
   if(address <= 0x1fc0'07bf) {
     if(pi.io.romLockout) return unmapped;
     return pi.rom.read<Size>(address);
@@ -46,8 +29,10 @@ inline auto Bus::read(u32 address) -> u64 {
 template<u32 Size>
 inline auto Bus::write(u32 address, u64 data) -> void {
   address &= 0x1fff'ffff - (Size - 1);
-  cpu.recompiler.invalidate(address + 0); if constexpr(Size == Dual)
-  cpu.recompiler.invalidate(address + 4);
+  if constexpr(Accuracy::CPU::Recompiler) {
+    cpu.recompiler.invalidate(address + 0); if constexpr(Size == Dual)
+    cpu.recompiler.invalidate(address + 4);
+  }
 
   if(address <= 0x007f'ffff) return rdram.ram.write<Size>(address, data);
   if(address <= 0x03ef'ffff) return;
@@ -63,24 +48,7 @@ inline auto Bus::write(u32 address, u64 data) -> void {
   if(address <= 0x047f'ffff) return ri.write<Size>(address, data);
   if(address <= 0x048f'ffff) return si.write<Size>(address, data);
   if(address <= 0x04ff'ffff) return;
-  if(address <= 0x0500'03ff) return dd.c2s.write<Size>(address, data);
-  if(address <= 0x0500'04ff) return dd.ds.write<Size>(address, data);
-  if(address <= 0x0500'057f) return dd.write<Size>(address, data);
-  if(address <= 0x0500'05bf) return dd.ms.write<Size>(address, data);
-  if(address <= 0x05ff'ffff) return;
-  if(address <= 0x063f'ffff) return dd.iplrom.write<Size>(address, data);
-  if(address <= 0x07ff'ffff) return;
-  if(address <= 0x0fff'ffff) {
-    if(cartridge.ram  ) return cartridge.ram.write<Size>(address, data);
-    if(cartridge.flash) return cartridge.flash.write<Size>(address, data);
-    return;
-  }
-  if(address <= 0x1fbf'ffff) {
-    if(address >= 0x13ff'0000 && address <= 0x13ff'ffff) {
-      cartridge.isviewer.write<Size>(address, data);
-    }
-    return cartridge.rom.write<Size>(address, data);
-  }
+  if(address <= 0x1fbf'ffff) return pi.write<Size>(address, data);
   if(address <= 0x1fc0'07bf) {
     if(pi.io.romLockout) return;
     return pi.rom.write<Size>(address, data);

--- a/ares/n64/memory/memory.hpp
+++ b/ares/n64/memory/memory.hpp
@@ -2,6 +2,31 @@ namespace Memory {
   #include "lsb/readable.hpp"
   #include "lsb/writable.hpp"
   #include "io.hpp"
+
+  struct Readable16 : Memory::Readable {
+    template<u32 Size>
+    auto read(u32 address) -> u64 {
+      if constexpr(Size == Dual) return (read<Word>(address) << 32) | read<Word>(address+4);
+      if constexpr(Size == Word) return (read<Half>(address) << 16) | read<Half>(address+2);
+      return Memory::Readable::read<Size>(address);
+    }
+  };
+
+  struct Writable16 : Memory::Writable {
+    template<u32 Size>
+    auto read(u32 address) -> u64 {
+      if constexpr(Size == Dual) return (read<Word>(address) << 32) | read<Word>(address+4);
+      if constexpr(Size == Word) return (read<Half>(address) << 16) | read<Half>(address+2);
+      return Memory::Writable::read<Size>(address);
+    }
+
+    template<u32 Size>
+    auto write(u32 address, u64 data) -> void {
+      if constexpr(Size == Dual) return write<Word>(address, data >> 32), write<Word>(address+4, data);
+      if constexpr(Size == Word) return write<Half>(address, data >> 16), write<Half>(address+2, data);
+      return Memory::Writable::write<Size>(address, data);
+    }
+  };
 }
 
 struct Bus {

--- a/ares/n64/n64.hpp
+++ b/ares/n64/n64.hpp
@@ -49,6 +49,7 @@ namespace ares::Nintendo64 {
       RSP_DMA,
       PI_DMA_Read,
       PI_DMA_Write,
+      PI_BUS_Write,
       SI_DMA_Read,
       SI_DMA_Write,
     };
@@ -72,4 +73,5 @@ namespace ares::Nintendo64 {
   #include <n64/rsp/rsp.hpp>
   #include <n64/rdp/rdp.hpp>
   #include <n64/memory/bus.hpp>
+  #include <n64/pi/bus.hpp>
 }

--- a/ares/n64/pi/bus.hpp
+++ b/ares/n64/pi/bus.hpp
@@ -1,0 +1,76 @@
+inline auto PI::readWord(u32 address) -> u32 {
+  if(address <= 0x046f'ffff) return ioRead(address);
+
+  if (unlikely(io.ioBusy)) {
+    writeForceFinish(); //technically, we should wait until Queue::PI_BUS_Write
+    return io.busLatch;
+  }
+  return busRead<Word>(address);
+}
+
+template <u32 Size>
+inline auto PI::busRead(u32 address) -> u32 {
+  static_assert(Size == Half || Size == Word);  //PI bus will do 32-bit (CPU) or 16-bit (DMA) only
+  static constexpr u32 unmapped = 0;
+
+  if(address <= 0x04ff'ffff) return unmapped; //Address range not memory mapped, only accessible via DMA
+  if(address <= 0x0500'03ff) return dd.c2s.read<Size>(address);
+  if(address <= 0x0500'04ff) return dd.ds.read<Size>(address);
+  if(address <= 0x0500'057f) return dd.read<Size>(address);
+  if(address <= 0x0500'05bf) return dd.ms.read<Size>(address);
+  if(address <= 0x05ff'ffff) return unmapped;
+  if(address <= 0x063f'ffff) return dd.iplrom.read<Size>(address);
+  if(address <= 0x07ff'ffff) return unmapped;
+  if(address <= 0x0fff'ffff) {
+    if(cartridge.ram  ) return cartridge.ram.read<Size>(address);
+    if(cartridge.flash) return cartridge.flash.read<Size>(address);
+    return unmapped;
+  }
+  if(address <= 0x13fe'ffff) return cartridge.rom.read<Size>(address);
+  if(address <= 0x13ff'ffff) return cartridge.isviewer.read<Size>(address);
+  if(address <= 0x7fff'ffff) return unmapped;
+  return unmapped; //accesses here actually lock out the RCP
+}
+
+inline auto PI::writeWord(u32 address, u32 data) -> void {
+  if(address <= 0x046f'ffff) return ioWrite(address, data);
+
+  if(io.ioBusy) return;
+  io.ioBusy = 1;
+  io.busLatch = data;
+  queue.insert(Queue::PI_BUS_Write, 300);
+  return busWrite<Word>(address, data);
+}
+
+template <u32 Size>
+inline auto PI::busWrite(u32 address, u32 data) -> void {
+  static_assert(Size == Half || Size == Word);  //PI bus will do 32-bit (CPU) or 16-bit (DMA) only
+  if(address <= 0x04ff'ffff) return; //Address range not memory mapped, only accessible via DMA
+  if(address <= 0x0500'03ff) return dd.c2s.write<Size>(address, data);
+  if(address <= 0x0500'04ff) return dd.ds.write<Size>(address, data);
+  if(address <= 0x0500'057f) return dd.write<Size>(address, data);
+  if(address <= 0x0500'05bf) return dd.ms.write<Size>(address, data);
+  if(address <= 0x05ff'ffff) return;
+  if(address <= 0x063f'ffff) return dd.iplrom.write<Size>(address, data);
+  if(address <= 0x07ff'ffff) return;
+  if(address <= 0x0fff'ffff) {
+    if(cartridge.ram  ) return cartridge.ram.write<Size>(address, data);
+    if(cartridge.flash) return cartridge.flash.write<Size>(address, data);
+    return;
+  }
+  if(address <= 0x13fe'ffff) return cartridge.rom.write<Size>(address, data);
+  if(address <= 0x13ff'ffff) {
+    writeForceFinish(); //Debugging channel for homebrew, be gentle
+    return cartridge.isviewer.write<Size>(address, data);
+  }
+  if(address <= 0x7fff'ffff) return;
+}
+
+inline auto PI::writeFinished() -> void {
+  io.ioBusy = 0;
+}
+
+inline auto PI::writeForceFinish() -> void {
+  io.ioBusy = 0;
+  queue.remove(Queue::PI_BUS_Write);
+}

--- a/ares/n64/pi/dma.cpp
+++ b/ares/n64/pi/dma.cpp
@@ -1,8 +1,8 @@
 auto PI::dmaRead() -> void {
   io.readLength = (io.readLength | 1) + 1;
   for(u32 address = 0; address < io.readLength; address += 2) {
-    u16 data = bus.read<Half>(io.dramAddress + address);
-    bus.write<Half>(io.pbusAddress + address, data);
+    u16 data = rdram.ram.read<Half>(io.dramAddress + address);
+    busWrite<Half>(io.pbusAddress + address, data);
   }
   io.dmaBusy = 0;
   io.interrupt = 1;
@@ -28,8 +28,7 @@ auto PI::dmaWrite() -> void {
 
     i32 rom_len = (cur_len + 1) & ~1;
     for (u32 i = 0; i < rom_len; i += 2) {
-      //Do Word accesses to the cartridge because Half accesses are broken
-      u16 data = bus.read<Word>(io.pbusAddress) >> (io.pbusAddress & 2 ? 0 : 16);
+      u16 data = busRead<Half>(io.pbusAddress);
       mem[i + 0] = data >> 8;
       mem[i + 1] = data & 0xFF;
       io.pbusAddress += 2;
@@ -40,8 +39,11 @@ auto PI::dmaWrite() -> void {
       cur_len = max(cur_len-misalign, 0);
     }
 
+    if constexpr(Accuracy::CPU::Recompiler) {
+      cpu.recompiler.invalidateRange(io.dramAddress, io.dramAddress + cur_len);
+    }
     for (u32 i = 0; i < cur_len; i++)
-      bus.write<Byte>(io.dramAddress++, mem[i]);
+      rdram.ram.write<Byte>(io.dramAddress++, mem[i]);
     io.dramAddress = (io.dramAddress + 7) & ~7;
 
     first_block = false;

--- a/ares/n64/pi/io.cpp
+++ b/ares/n64/pi/io.cpp
@@ -1,4 +1,4 @@
-auto PI::readWord(u32 address) -> u32 {
+auto PI::ioRead(u32 address) -> u32 {
   address = (address & 0xfffff) >> 2;
   n32 data;
 
@@ -74,7 +74,7 @@ auto PI::readWord(u32 address) -> u32 {
   return data;
 }
 
-auto PI::writeWord(u32 address, u32 data_) -> void {
+auto PI::ioWrite(u32 address, u32 data_) -> void {
   address = (address & 0xfffff) >> 2;
   n32 data = data_;
 
@@ -91,7 +91,7 @@ auto PI::writeWord(u32 address, u32 data_) -> void {
 
   if(address == 1) {
     //PI_PBUS_ADDRESS
-    io.pbusAddress = n29(data) & ~1;
+    io.pbusAddress = n32(data) & ~1;
   }
 
   if(address == 2) {

--- a/ares/n64/pi/pi.hpp
+++ b/ares/n64/pi/pi.hpp
@@ -29,9 +29,19 @@ struct PI : Memory::IO<PI> {
   auto dmaWrite() -> void;
 
   //io.cpp
+  auto ioRead(u32 address) -> u32;
+  auto ioWrite(u32 address, u32 data) -> void;
+
+  //bus.hpp
   auto readWord(u32 address) -> u32;
   auto writeWord(u32 address, u32 data) -> void;
-
+  auto writeFinished() -> void;
+  auto writeForceFinish() -> void;
+  template <u32 Size>
+  auto busRead(u32 address) -> u32;
+  template <u32 Size>
+  auto busWrite(u32 address, u32 data) -> void;
+  
   //serialization.cpp
   auto serialize(serializer&) -> void;
 
@@ -45,6 +55,7 @@ struct PI : Memory::IO<PI> {
     n32 readLength;
     n32 writeLength;
     n1  romLockout;
+    n32 busLatch;
   } io;
 
   struct BSD {

--- a/ares/n64/pi/serialization.cpp
+++ b/ares/n64/pi/serialization.cpp
@@ -10,6 +10,7 @@ auto PI::serialize(serializer& s) -> void {
   s(io.readLength);
   s(io.writeLength);
   s(io.romLockout);
+  s(io.busLatch);
 
   s(bsd1.latency);
   s(bsd1.pulseWidth);

--- a/nall/priority-queue.hpp
+++ b/nall/priority-queue.hpp
@@ -83,8 +83,8 @@ struct priority_queue<T[Size]> {
   }
 
   auto remove(const T& event) -> void {
-    for(auto& entry : heap) {
-      if(entry.event == event) entry.valid = false;
+    for(u32 i = 0; i < size; i++) {
+      if(heap[i].event == event) heap[i].valid = false;
     }
   }
 


### PR DESCRIPTION
All writes through the PI bus are actually performed asynchronous by
the hardware, and the status is reflected in the PI IO busy bit.

This commit emulates this properly, and also emulates what happens while
the busy bit is set: further writes are ignored, and reads at any
address return the word being written.

This fixes A Bug's Life and Toy Story 2.