### PR TITLE
n64: add separate CIC 7102 detection

### DIFF
--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -116,12 +116,15 @@ auto Nintendo64::analyze(vector<u8>& data) -> string {
   u8 revision = data[0x3f];
 
   //detect the CIC used for a given gamepak based on checksumming its bootcode
-  //note: NTSC 6101 = PAL 7102 and NTSC 6102 = PAL 7101 (IDs are swapped)
+  //note: NTSC 6101 != PAL 7102; they use different bootcodes
+  //note: NTSC 6102 == PAL 7101
   //note: NTSC 6104 / PAL 7104 was never officially used
+  //note: Except for above cases, NTSC 610x == PAL 710x
   bool ntsc = region == "NTSC";
   string cic = ntsc ? "CIC-NUS-6102" : "CIC-NUS-7101";  //fallback; most common
   u32 crc32 = Hash::CRC32({&data[0x40], 0x9c0}).value();
-  if(crc32 == 0x1deb51a9) cic = ntsc ? "CIC-NUS-6101" : "CIC-NUS-7102";
+  if(crc32 == 0x1deb51a9) cic = "CIC-NUS-6101"; // Always NTSC (Star Fox 64)
+  if(crc32 == 0xec8b1325) cic = "CIC-NUS-7102"; // Always PAL (Lylat Wars)
   if(crc32 == 0xc08e5bd6) cic = ntsc ? "CIC-NUS-6102" : "CIC-NUS-7101";
   if(crc32 == 0x03b8376a) cic = ntsc ? "CIC-NUS-6103" : "CIC-NUS-7103";
   if(crc32 == 0xcf7f41dc) cic = ntsc ? "CIC-NUS-6105" : "CIC-NUS-7105";


### PR DESCRIPTION
The IPL3 bootcode associated with CIC-NUS-7102 (used in Lylat Wars), is not the same as the IPL3 used with CIC-NUS-6101 (used in Star Fox 64). Ares doesn't make this distinction.

Without knowing more about how each IPL3 differs in a functional sense, it's tough to say how exactly they are different; but at the least, the CRC calculated over this section of the rom, is different. Thus, Ares incorrectly detects Lylat Wars as using the 7101 (the PAL version of the fallback case).

While the game still appears to work on Ares despite this incorrect detection, I believe that may be due to some other inaccuracy in Ares. (Using the 64Drive) When Lylat Wars is played on an NTSC console, using CIC 7101, the game just shows a black screen. However, when using CIC 7102, as the official cartridge would, the game works correctly. Note, I don't have a PAL console to test this with.