### PR TITLE
Revert "n64: update RSP DMA registers after transfers."

### DIFF
--- a/ares/n64/rsp/dma.cpp
+++ b/ares/n64/rsp/dma.cpp
@@ -23,14 +23,5 @@ auto RSP::dmaTransfer() -> void {
       request.pbusAddress += request.length;
       request.dramAddress += request.length + request.skip;
     }
-    dma.pbusRegion = request.pbusRegion;
-    dma.pbusAddress = request.pbusAddress;
-    dma.dramAddress = request.dramAddress;
   }
-
-  dma.pbusRegion  = request.pbusRegion;
-  dma.pbusAddress = request.pbusAddress;
-  dma.dramAddress = request.dramAddress;
-  dma.read.length = dma.write.length = 0xFF8;
-  dma.read.count  = dma.write.count  = 0;
 }


### PR DESCRIPTION
This reverts commit 5e4e64dbd7ff0de4f41447dfdb532a23631f208e.

Reason: it breaks Zelda OOT. Requires more thinking.