### PR TITLE
n64: fix (again) TLB logic in case of invalid TLBs

### DIFF
--- a/ares/n64/cpu/tlb.cpp
+++ b/ares/n64/cpu/tlb.cpp
@@ -2,6 +2,7 @@
 
 auto CPU::TLB::load(u32 address) -> Match {
   for(auto& entry : this->entry) {
+    if(!entry.globals && entry.addressSpaceID != self.scc.tlb.addressSpaceID) continue;
     if((address & entry.addressMaskHi) != (u32)entry.addressCompare) continue;
     bool lo = address & entry.addressSelect;
     if(!entry.valid[lo]) {
@@ -10,7 +11,6 @@ auto CPU::TLB::load(u32 address) -> Match {
       self.exception.tlbLoadInvalid();
       return {false};
     }
-    if(!entry.globals && entry.addressSpaceID != self.scc.tlb.addressSpaceID) continue;
     physicalAddress = entry.physicalAddress[lo] + (address & entry.addressMaskLo);
     self.debugger.tlbLoad(address, physicalAddress);
     return {true, entry.cacheAlgorithm[lo] != 2, physicalAddress};
@@ -23,6 +23,7 @@ auto CPU::TLB::load(u32 address) -> Match {
 
 auto CPU::TLB::store(u32 address) -> Match {
   for(auto& entry : this->entry) {
+    if(!entry.globals && entry.addressSpaceID != self.scc.tlb.addressSpaceID) continue;
     if((address & entry.addressMaskHi) != (u32)entry.addressCompare) continue;
     bool lo = address & entry.addressSelect;
     if(!entry.valid[lo]) {
@@ -37,7 +38,6 @@ auto CPU::TLB::store(u32 address) -> Match {
       self.exception.tlbModification();
       return {false};
     }
-    if(!entry.globals && entry.addressSpaceID != self.scc.tlb.addressSpaceID) continue;
     physicalAddress = entry.physicalAddress[lo] + (address & entry.addressMaskLo);
     self.debugger.tlbStore(address, physicalAddress);
     return {true, entry.cacheAlgorithm[lo] != 2, physicalAddress};


### PR DESCRIPTION
This is a revert of 56458d5b, while keeping b7f96b7109 which is the
real fix that should have been done all along. The former just papered
over the issue and actually introduced a regression (Goldeneye wouldn't
boot).

Thanks to @remutro for having investigated this bug.