### PR TITLE
n64: make sure TLB entries are correctly initialized at power

### DIFF
--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -121,7 +121,7 @@ auto CPU::power(bool reset) -> void {
   for(auto& segment : context.segment) segment = Context::Segment::Unused;
   icache.power(reset);
   dcache.power(reset);
-  for(auto& entry : tlb.entry) entry = {};
+  for(auto& entry : tlb.entry) entry = {}, entry.synchronize();
   tlb.physicalAddress = 0;
   for(auto& r : ipu.r) r.u64 = 0;
   ipu.lo.u64 = 0;

--- a/ares/n64/cpu/debugger.cpp
+++ b/ares/n64/cpu/debugger.cpp
@@ -72,6 +72,7 @@ auto CPU::Debugger::tlbWrite(u32 index) -> void {
     auto entry = cpu.tlb.entry[index & 31];
     tracer.tlb->notify({"write: ", index, " {"});
     tracer.tlb->notify({"  global:           ", entry.global[0], ",", entry.global[1]});
+    tracer.tlb->notify({"  valid:            ", entry.valid[0],  ",", entry.valid[1]});
     tracer.tlb->notify({"  physical address: 0x", hex(entry.physicalAddress[0]), ",0x", hex(entry.physicalAddress[1])});
     tracer.tlb->notify({"  page mask:        0x", hex(entry.pageMask)});
     tracer.tlb->notify({"  virtual address:  0x", hex(entry.virtualAddress)});


### PR DESCRIPTION
This bug has always been there, but was hidden by the incorrect TLB
matching logic. After fixing the logic in 0bf24b3, this bug was
uncovered.

Fixes Goldeneye.