### PR TITLE
n64: fix cache to use physical addresses

### DIFF
--- a/ares/n64/cpu/dcache.cpp
+++ b/ares/n64/cpu/dcache.cpp
@@ -1,12 +1,12 @@
 auto CPU::DataCache::Line::hit(u32 address) const -> bool {
-  return valid && tag == (address & ~0xfff);
+  return valid && tag == (address & ~0xe000'0fff);
 }
 
 template<u32 Size> auto CPU::DataCache::Line::fill(u32 address, u64 data) -> void {
   cpu.step(40);
   valid = 1;
   dirty = 1;
-  tag   = address & ~0xfff;
+  tag   = address & ~0xe000'0fff;
   //read words according to critical doubleword first scheme
   switch(address & 8) {
   case 0:
@@ -34,7 +34,7 @@ auto CPU::DataCache::Line::fill(u32 address) -> void {
   cpu.step(40);
   valid = 1;
   dirty = 0;
-  tag   = address & ~0xfff;
+  tag   = address & ~0xe000'0fff;
   //read words according to critical doubleword first scheme
   switch(address & 8) {
   case 0:

--- a/ares/n64/cpu/icache.cpp
+++ b/ares/n64/cpu/icache.cpp
@@ -1,11 +1,11 @@
 auto CPU::InstructionCache::Line::hit(u32 address) const -> bool {
-  return valid && tag == (address & ~0xfff);
+  return valid && tag == (address & ~0xe000'0fff);
 }
 
 auto CPU::InstructionCache::Line::fill(u32 address) -> void {
   cpu.step(48);
   valid = 1;
-  tag   = address & ~0xfff;
+  tag   = address & ~0xe000'0fff;
   words[0] = bus.read<Word>(tag | index | 0x00);
   words[1] = bus.read<Word>(tag | index | 0x04);
   words[2] = bus.read<Word>(tag | index | 0x08);
@@ -42,7 +42,7 @@ auto CPU::InstructionCache::step(u32 address) -> void {
   if(!line.hit(address)) {
     cpu.step(48);
     line.valid = 1;
-    line.tag   = address & ~0xfff;
+    line.tag   = address & ~0xe000'0fff;
   } else {
     cpu.step(2);
   }

--- a/ares/n64/cpu/interpreter-ipu.cpp
+++ b/ares/n64/cpu/interpreter-ipu.cpp
@@ -111,6 +111,8 @@ auto CPU::BREAK() -> void {
 
 auto CPU::CACHE(u8 operation, cr64& rs, s16 imm) -> void {
   u32 address = rs.u64 + imm;
+  if (auto phys = devirtualize(address)) address = *phys;
+  else return;
 
   switch(operation) {
 


### PR DESCRIPTION
There is a bit confusion of virtual vs physical addresses in Ares,
so dcache/icache were sometimes using a virtual address, sometimes
a physical one. This is wrong: cache is based on physical addresses
only.

Moreover, the CACHE opcode was not even going through TLBs, while it
should. So a CACHE opcode on a TLB-mapped address wasn't working before.