### PR TITLE
n64: fix LL / SC / LLD / SCD opcodes

### DIFF
--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -486,7 +486,7 @@ struct CPU : Thread {
     } configuration;
 
     //17: Load Linked Address
-    n64 ll;
+    n32 ll;
     n1  llbit;
 
     //18


### PR DESCRIPTION
Updates #140.

Unfortunately this doesn't fix Gauntlet Legends.

<img width="752" alt="Schermata 2022-05-06 alle 01 00 10" src="https://user-images.githubusercontent.com/1014109/167040541-f76b70dc-987e-4f49-bec5-f58b702a808d.png">
