### PR TITLE
n64: fix controller input after PIF refactoring

### DIFF
--- a/ares/n64/si/dma.cpp
+++ b/ares/n64/si/dma.cpp
@@ -1,8 +1,8 @@
 auto SI::dmaRead() -> void {
   pif.run();
-  for(u32 offset = 0; offset < 64; offset += 2) {
-    u16 data = bus.read<Half>(io.readAddress + offset);
-    bus.write<Half>(io.dramAddress + offset, data);
+  for(u32 offset = 0; offset < 64; offset += 4) {
+    u32 data = pif.readWord(io.readAddress + offset);
+    rdram.ram.write<Word>(io.dramAddress + offset, data);
   }
   io.dmaBusy = 0;
   io.interrupt = 1;
@@ -10,9 +10,9 @@ auto SI::dmaRead() -> void {
 }
 
 auto SI::dmaWrite() -> void {
-  for(u32 offset = 0; offset < 64; offset += 2) {
-    u16 data = bus.read<Half>(io.dramAddress + offset);
-    bus.write<Half>(io.writeAddress + offset, data);
+  for(u32 offset = 0; offset < 64; offset += 4) {
+    u32 data = rdram.ram.read<Word>(io.dramAddress + offset);
+    pif.writeWord(io.writeAddress + offset, data);
   }
   io.dmaBusy = 0;
   io.interrupt = 1;


### PR DESCRIPTION
A last minute change in 741320e0be introduced a regression in controller
input.

Similar to what we did with PI DMA, SI DMA does not go through the main
bus (SysAD bus) but directly communicate with pif and rdram. This is not
just for the sake of correctness, but SysAD bus half-word writes are
now emulated with the same brokeness they have on real hardware, and
obviously DMA works instead. Moreover, since SI only reads/writes
32-bit words, also switch to word access.