### PR TITLE
n64: add mouse, seperated per controller specific communication

### DIFF
--- a/ares/n64/controller/controller.cpp
+++ b/ares/n64/controller/controller.cpp
@@ -4,5 +4,6 @@ namespace ares::Nintendo64 {
 
 #include "port.cpp"
 #include "gamepad/gamepad.cpp"
+#include "mouse/mouse.cpp"
 
 }

--- a/ares/n64/controller/controller.hpp
+++ b/ares/n64/controller/controller.hpp
@@ -4,8 +4,10 @@ struct Controller {
   virtual ~Controller() = default;
   virtual auto save() -> void {}
   virtual auto read() -> n32 { return 0; }
+  virtual auto readId() -> u16 { return 0; }
   virtual auto serialize(serializer&) -> void {}
 };
 
 #include "port.hpp"
 #include "gamepad/gamepad.hpp"
+#include "mouse/mouse.hpp"

--- a/ares/n64/controller/controller.hpp
+++ b/ares/n64/controller/controller.hpp
@@ -5,7 +5,6 @@ struct Controller {
   virtual auto save() -> void {}
   virtual auto comm(n8 send, n8 recv, n8 input[], n8 output[]) -> n2 { return 1; }
   virtual auto read() -> n32 { return 0; }
-  virtual auto readId() -> u16 { return 0; }
   virtual auto serialize(serializer&) -> void {}
 };
 

--- a/ares/n64/controller/controller.hpp
+++ b/ares/n64/controller/controller.hpp
@@ -3,6 +3,7 @@ struct Controller {
 
   virtual ~Controller() = default;
   virtual auto save() -> void {}
+  virtual auto comm(n8 send, n8 recv, n8 input[], n8 output[]) -> n2 { return 1; }
   virtual auto read() -> n32 { return 0; }
   virtual auto readId() -> u16 { return 0; }
   virtual auto serialize(serializer&) -> void {}

--- a/ares/n64/controller/gamepad/gamepad.cpp
+++ b/ares/n64/controller/gamepad/gamepad.cpp
@@ -89,9 +89,8 @@ auto Gamepad::comm(n8 send, n8 recv, n8 input[], n8 output[]) -> n2 {
 
   //status
   if(input[0] == 0x00 || input[0] == 0xff) {
-    u32 dataId = readId();
-    output[0] = dataId >> 0;  //0x05 = gamepad; 0x02 = mouse
-    output[1] = dataId >> 8;
+    output[0] = 0x05;  //0x05 = gamepad; 0x02 = mouse
+    output[1] = 0x00;
     output[2] = 0x02;  //0x02 = nothing present in controller slot
     if(ram || motor) {
       output[2] = 0x01;  //0x01 = pak present
@@ -257,10 +256,6 @@ auto Gamepad::read() -> n32 {
   }
 
   return data;
-}
-
-auto Gamepad::readId() -> u16 {
-  return 0x0005;
 }
 
 //controller paks contain 32KB of SRAM split into 128 pages of 256 bytes each.

--- a/ares/n64/controller/gamepad/gamepad.cpp
+++ b/ares/n64/controller/gamepad/gamepad.cpp
@@ -170,6 +170,10 @@ auto Gamepad::read() -> n32 {
   return data;
 }
 
+auto Gamepad::readId() -> u16 {
+  return 0x0005;
+}
+
 //controller paks contain 32KB of SRAM split into 128 pages of 256 bytes each.
 //the first 5 pages are for storing system data, and the remaining 123 for game data.
 auto Gamepad::formatControllerPak() -> void {

--- a/ares/n64/controller/gamepad/gamepad.hpp
+++ b/ares/n64/controller/gamepad/gamepad.hpp
@@ -29,6 +29,7 @@ struct Gamepad : Controller {
   auto connect() -> void;
   auto disconnect() -> void;
   auto rumble(bool enable) -> void;
+  auto comm(n8 send, n8 recv, n8 input[], n8 output[]) -> n2 override;
   auto read() -> n32 override;
   auto readId() -> u16 override;
   auto formatControllerPak() -> void;

--- a/ares/n64/controller/gamepad/gamepad.hpp
+++ b/ares/n64/controller/gamepad/gamepad.hpp
@@ -30,6 +30,7 @@ struct Gamepad : Controller {
   auto disconnect() -> void;
   auto rumble(bool enable) -> void;
   auto read() -> n32 override;
+  auto readId() -> u16 override;
   auto formatControllerPak() -> void;
   auto serialize(serializer&) -> void override;
 };

--- a/ares/n64/controller/gamepad/gamepad.hpp
+++ b/ares/n64/controller/gamepad/gamepad.hpp
@@ -31,7 +31,6 @@ struct Gamepad : Controller {
   auto rumble(bool enable) -> void;
   auto comm(n8 send, n8 recv, n8 input[], n8 output[]) -> n2 override;
   auto read() -> n32 override;
-  auto readId() -> u16 override;
   auto formatControllerPak() -> void;
   auto serialize(serializer&) -> void override;
 };

--- a/ares/n64/controller/mouse/mouse.cpp
+++ b/ares/n64/controller/mouse/mouse.cpp
@@ -10,6 +10,40 @@ Mouse::Mouse(Node::Port parent) {
 Mouse::~Mouse() {
 }
 
+auto Mouse::comm(n8 send, n8 recv, n8 input[], n8 output[]) -> n2 {
+  b1 valid = 0;
+  b1 over = 0;
+
+  //status
+  if(input[0] == 0x00 || input[0] == 0xff) {
+    u32 dataId = readId();
+    output[0] = dataId >> 0;  //0x05 = gamepad; 0x02 = mouse
+    output[1] = dataId >> 8;
+    output[2] = 0x02;  //0x02 = nothing present in controller slot
+    valid = 1;
+  }
+
+  //read controller state
+  if(input[0] == 0x01) {
+    u32 data = read();
+    output[0] = data >> 24;
+    output[1] = data >> 16;
+    output[2] = data >>  8;
+    output[3] = data >>  0;
+    if(recv <= 4) {
+      over = 0;
+    } else {
+      over = 1;
+    }
+    valid = 1;
+  }
+
+  n2 status = 0;
+  status.bit(0) = valid;
+  status.bit(1) = over;
+  return status;
+}
+
 auto Mouse::read() -> n32 {
   platform->input(x);
   platform->input(y);

--- a/ares/n64/controller/mouse/mouse.cpp
+++ b/ares/n64/controller/mouse/mouse.cpp
@@ -1,0 +1,34 @@
+Mouse::Mouse(Node::Port parent) {
+  node = parent->append<Node::Peripheral>("Mouse");
+
+  x           = node->append<Node::Input::Axis>  ("X");
+  y           = node->append<Node::Input::Axis>  ("Y");
+  left        = node->append<Node::Input::Button>("Left");
+  right       = node->append<Node::Input::Button>("Right");
+}
+
+Mouse::~Mouse() {
+}
+
+auto Mouse::read() -> n32 {
+  platform->input(x);
+  platform->input(y);
+  platform->input(left);
+  platform->input(right);
+
+  //TODO: Deal with more reasonable values for Mouse axis
+  auto ax = x->value();
+  auto ay = -y->value();
+
+  n32 data;
+  data.byte(0) = ay;
+  data.byte(1) = ax;
+  data.bit(30) = right->value();
+  data.bit(31) = left->value();
+
+  return data;
+}
+
+auto Mouse::readId() -> u16 {
+  return 0x0002;
+}

--- a/ares/n64/controller/mouse/mouse.cpp
+++ b/ares/n64/controller/mouse/mouse.cpp
@@ -16,9 +16,8 @@ auto Mouse::comm(n8 send, n8 recv, n8 input[], n8 output[]) -> n2 {
 
   //status
   if(input[0] == 0x00 || input[0] == 0xff) {
-    u32 dataId = readId();
-    output[0] = dataId >> 0;  //0x05 = gamepad; 0x02 = mouse
-    output[1] = dataId >> 8;
+    output[0] = 0x02;  //0x05 = gamepad; 0x02 = mouse
+    output[1] = 0x00;
     output[2] = 0x02;  //0x02 = nothing present in controller slot
     valid = 1;
   }
@@ -61,8 +60,4 @@ auto Mouse::read() -> n32 {
   data.bit(31) = left->value();
 
   return data;
-}
-
-auto Mouse::readId() -> u16 {
-  return 0x0002;
 }

--- a/ares/n64/controller/mouse/mouse.hpp
+++ b/ares/n64/controller/mouse/mouse.hpp
@@ -1,0 +1,12 @@
+struct Mouse : Controller {
+  Node::Input::Axis x;
+  Node::Input::Axis y;
+  Node::Input::Button left;
+  Node::Input::Button right;
+
+  Mouse(Node::Port);
+  ~Mouse();
+
+  auto read() -> n32 override;
+  auto readId() -> u16 override;
+};

--- a/ares/n64/controller/mouse/mouse.hpp
+++ b/ares/n64/controller/mouse/mouse.hpp
@@ -9,5 +9,4 @@ struct Mouse : Controller {
 
   auto comm(n8 send, n8 recv, n8 input[], n8 output[]) -> n2 override;
   auto read() -> n32 override;
-  auto readId() -> u16 override;
 };

--- a/ares/n64/controller/mouse/mouse.hpp
+++ b/ares/n64/controller/mouse/mouse.hpp
@@ -7,6 +7,7 @@ struct Mouse : Controller {
   Mouse(Node::Port);
   ~Mouse();
 
+  auto comm(n8 send, n8 recv, n8 input[], n8 output[]) -> n2 override;
   auto read() -> n32 override;
   auto readId() -> u16 override;
 };

--- a/ares/n64/controller/port.cpp
+++ b/ares/n64/controller/port.cpp
@@ -12,7 +12,7 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setType("Controller");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
-  port->setSupported({"Gamepad"});
+  port->setSupported({"Gamepad", "Mouse"});
 }
 
 auto ControllerPort::unload() -> void {
@@ -26,6 +26,7 @@ auto ControllerPort::save() -> void {
 
 auto ControllerPort::allocate(string name) -> Node::Peripheral {
   if(name == "Gamepad") device = new Gamepad(port);
+  if(name == "Mouse"  ) device = new Mouse(port);
   if(device) return device->node;
   return {};
 }

--- a/ares/n64/pif/pif.cpp
+++ b/ares/n64/pif/pif.cpp
@@ -145,8 +145,9 @@ auto PIF::scan() -> void {
     if(input[0] == 0x00 || input[0] == 0xff) {
       //controller
       if(channel < 4 && controllers[channel]->device) {
-        output[0] = 0x05;  //0x05 = gamepad; 0x02 = mouse
-        output[1] = 0x00;
+        u32 dataId = controllers[channel]->device->readId();
+        output[0] = dataId >> 0;  //0x05 = gamepad; 0x02 = mouse
+        output[1] = dataId >> 8;
         output[2] = 0x02;  //0x02 = nothing present in controller slot
         if(auto& device = controllers[channel]->device) {
           if(auto gamepad = dynamic_cast<Gamepad*>(device.data())) {

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -38,6 +38,13 @@ Nintendo64::Nintendo64() {
     device.analog ("Y-Axis",  virtualPorts[id].pad.lstick_up,   virtualPorts[id].pad.lstick_down);
     port.append(device); }
 
+  { InputDevice device{"Mouse"};
+    device.relative("X",     virtualPorts[id].mouse.x);
+    device.relative("Y",     virtualPorts[id].mouse.y);
+    device.digital ("Left",  virtualPorts[id].mouse.left);
+    device.digital ("Right", virtualPorts[id].mouse.right);
+    port.append(device); }
+  
     ports.append(port);
   }
 }


### PR DESCRIPTION
This does the following:
 - Adds N64 Mouse emulation.
 - Puts Controller JoyBus communication into N64 controller objects.
   - readId() was added for unique Controller type identifications before the controller communication refactor, then removed again.

I tested this with Memory Pak, Rumble Pak games, seems to work correctly.

Dezaemon 3D can be tested for N64 Mouse support, just as a warning: when the game sees a N64 Mouse, you cannot use a N64 regular controller to control the pointer.
Due to the lack of save support, it also always puts out a save error at the start but you can just press Start to continue.