### PR TITLE
n64: improve DMA timings a bit

### DIFF
--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -53,8 +53,8 @@ auto CPU::synchronize() -> void {
   queue.step(clocks, [](u32 event) {
     switch(event) {
     case Queue::RSP_DMA:       return rsp.dmaTransfer();
-    case Queue::PI_DMA_Read:   return pi.dmaRead();
-    case Queue::PI_DMA_Write:  return pi.dmaWrite();
+    case Queue::PI_DMA_Read:   return pi.dmaFinished();
+    case Queue::PI_DMA_Write:  return pi.dmaFinished();
     case Queue::PI_BUS_Write:  return pi.writeFinished();
     case Queue::SI_DMA_Read:   return si.dmaRead();
     case Queue::SI_DMA_Write:  return si.dmaWrite();

--- a/ares/n64/pi/dma.cpp
+++ b/ares/n64/pi/dma.cpp
@@ -4,9 +4,6 @@ auto PI::dmaRead() -> void {
     u16 data = rdram.ram.read<Half>(io.dramAddress + address);
     busWrite<Half>(io.pbusAddress + address, data);
   }
-  io.dmaBusy = 0;
-  io.interrupt = 1;
-  mi.raise(MI::IRQ::PI);
 }
 
 auto PI::dmaWrite() -> void {
@@ -48,7 +45,9 @@ auto PI::dmaWrite() -> void {
 
     first_block = false;
   }
+}
 
+auto PI::dmaFinished() -> void {
   io.dmaBusy = 0;
   io.interrupt = 1;
   mi.raise(MI::IRQ::PI);

--- a/ares/n64/pi/io.cpp
+++ b/ares/n64/pi/io.cpp
@@ -98,16 +98,16 @@ auto PI::ioWrite(u32 address, u32 data_) -> void {
     //PI_READ_LENGTH
     io.readLength = n24(data);
     io.dmaBusy = 1;
-    queue.insert(Queue::PI_DMA_Read, io.readLength * 9);
     dmaRead();
+    queue.insert(Queue::PI_DMA_Read, io.readLength * 36);
   }
 
   if(address == 3) {
     //PI_WRITE_LENGTH
     io.writeLength = n24(data);
     io.dmaBusy = 1;
-    queue.insert(Queue::PI_DMA_Write, io.writeLength * 9);
     dmaWrite();
+    queue.insert(Queue::PI_DMA_Write, io.writeLength * 36);
   }
 
   if(address == 4) {

--- a/ares/n64/pi/io.cpp
+++ b/ares/n64/pi/io.cpp
@@ -99,6 +99,7 @@ auto PI::ioWrite(u32 address, u32 data_) -> void {
     io.readLength = n24(data);
     io.dmaBusy = 1;
     queue.insert(Queue::PI_DMA_Read, io.readLength * 9);
+    dmaRead();
   }
 
   if(address == 3) {
@@ -106,6 +107,7 @@ auto PI::ioWrite(u32 address, u32 data_) -> void {
     io.writeLength = n24(data);
     io.dmaBusy = 1;
     queue.insert(Queue::PI_DMA_Write, io.writeLength * 9);
+    dmaWrite();
   }
 
   if(address == 4) {

--- a/ares/n64/pi/pi.hpp
+++ b/ares/n64/pi/pi.hpp
@@ -21,6 +21,7 @@ struct PI : Memory::IO<PI> {
   //dma.cpp
   auto dmaRead() -> void;
   auto dmaWrite() -> void;
+  auto dmaFinished() -> void;
 
   //io.cpp
   auto ioRead(u32 address) -> u32;

--- a/ares/n64/rsp/io.cpp
+++ b/ares/n64/rsp/io.cpp
@@ -113,7 +113,7 @@ auto RSP::ioWrite(u32 address, u32 data_) -> void {
       request.count       = 1 + (dma.read.count);
       request.skip        = dma.read.skip & ~7;
       dma.requests.write(request);
-      queue.insert(Queue::RSP_DMA, request.length * request.count / 4);
+      queue.insert(Queue::RSP_DMA, request.length * request.count / 8 * 3);
     }
   }
 
@@ -132,7 +132,7 @@ auto RSP::ioWrite(u32 address, u32 data_) -> void {
       request.count       = 1 + (dma.write.count);
       request.skip        = dma.write.skip & ~7;
       dma.requests.write(request);
-      queue.insert(Queue::RSP_DMA, request.length * request.count / 4);
+      queue.insert(Queue::RSP_DMA, request.length * request.count / 8 * 3);
     }
   }
 


### PR DESCRIPTION
Some tweaking to DMA timings according to real hardware beahvior.

On top of that, change the way PI DMA is emulated (transfer data immediately, delay only the interrupt), which makes DK64 boot.