### PR TITLE
n64: rework RSP DMA double buffering

### DIFF
--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -52,7 +52,7 @@ auto CPU::synchronize() -> void {
 
   queue.step(clocks, [](u32 event) {
     switch(event) {
-    case Queue::RSP_DMA:       return rsp.dmaTransfer();
+    case Queue::RSP_DMA:       return rsp.dmaTransferStep();
     case Queue::PI_DMA_Read:   return pi.dmaFinished();
     case Queue::PI_DMA_Write:  return pi.dmaFinished();
     case Queue::PI_BUS_Write:  return pi.writeFinished();

--- a/ares/n64/rsp/dma.cpp
+++ b/ares/n64/rsp/dma.cpp
@@ -1,27 +1,43 @@
-auto RSP::dmaTransfer() -> void {
-  if(dma.requests.empty()) return;
-  auto request = *dma.requests.read();
-  auto region = !request.pbusRegion ? 0x0400'0000 : 0x0400'1000;
+auto RSP::dmaTransferStart(void) -> void {
+  if(dma.busy.any()) return;
+  if(dma.full.any()) {
+    dma.current = dma.pending;
+    dma.busy    = dma.full;
+    dma.full    = {0,0};
+    queue.insert(Queue::RSP_DMA, (dma.current.length+8) / 8 * 3);
+  }
+}
 
-  if(request.type == DMA::Request::Type::Read) {
-    for(u32 block : range(request.count)) {
-      for(u32 offset = 0; offset < request.length; offset += 4) {
-        u32 data = bus.read<Word>(request.dramAddress + offset);
-        bus.write<Word>(region + (request.pbusAddress + offset & 0xFFF), data);
-      }
-      request.pbusAddress += request.length;
-      request.dramAddress += request.length + request.skip;
+auto RSP::dmaTransferStep() -> void {
+  auto& region = !dma.current.pbusRegion ? dmem : imem;
+
+  if(dma.busy.read) {
+    if constexpr(Accuracy::RSP::Recompiler) {
+      if(dma.current.pbusRegion) recompiler.invalidate();
+    }
+    for(u32 i = 0; i <= dma.current.length; i += 8) {
+        u64 data = rdram.ram.read<Dual>(dma.current.dramAddress);
+        region.write<Dual>(dma.current.pbusAddress, data);
+        dma.current.dramAddress += 8;
+        dma.current.pbusAddress += 8;
+    }
+  }
+  if(dma.busy.write) {
+    for(u32 i = 0; i <= dma.current.length; i += 8) {
+        u64 data = region.read<Dual>(dma.current.pbusAddress);
+        rdram.ram.write<Dual>(dma.current.dramAddress, data);
+        dma.current.dramAddress += 8;
+        dma.current.pbusAddress += 8;
     }
   }
 
-  if(request.type == DMA::Request::Type::Write) {
-    for(u32 block : range(request.count)) {
-      for(u32 offset = 0; offset < request.length; offset += 4) {
-        u32 data = bus.read<Word>(region + (request.pbusAddress + offset & 0xFFF));
-        bus.write<Word>(request.dramAddress + offset, data);
-      }
-      request.pbusAddress += request.length;
-      request.dramAddress += request.length + request.skip;
-    }
+  if(dma.current.count) {
+    dma.current.count -= 1;
+    dma.current.dramAddress += dma.current.skip;
+    queue.insert(Queue::RSP_DMA, (dma.current.length+8) / 8 * 3);
+  } else {
+    dma.busy = {0,0};
+    dma.current.length = 0xFF8;
+    dmaTransferStart();
   }
 }

--- a/ares/n64/rsp/rsp.hpp
+++ b/ares/n64/rsp/rsp.hpp
@@ -43,7 +43,8 @@ struct RSP : Thread, Memory::IO<RSP> {
   } pipeline;
 
   //dma.cpp
-  auto dmaTransfer() -> void;
+  auto dmaTransferStart() -> void;
+  auto dmaTransferStep() -> void;
 
   //io.cpp
   auto readWord(u32 address) -> u32;
@@ -55,29 +56,23 @@ struct RSP : Thread, Memory::IO<RSP> {
   auto serialize(serializer&) -> void;
 
   struct DMA {
-    n1  pbusRegion;
-    n12 pbusAddress;
-    n24 dramAddress;
-
-    struct Transfer {
-      n12 length;
-      n12 skip;
-      n8  count;
-    } read, write;
-
-    struct Request {
-      //serialization.cpp
-      auto serialize(serializer&) -> void;
-
-      enum class Type : u32 { Read, Write } type;
+    struct Regs {    
       n1  pbusRegion;
       n12 pbusAddress;
       n24 dramAddress;
-      n16 length;
-      n16 skip;
-      n16 count;
-    };
-    nall::queue<Request[2]> requests;
+      n12 length;
+      n12 skip;
+      n8  count;
+      
+      auto serialize(serializer&) -> void;
+    } pending, current;
+
+    struct Status {
+      n1 read;
+      n1 write;
+
+      auto any() -> n1 { return read | write; }
+    } busy, full;
   } dma;
 
   struct Status : Memory::IO<Status> {

--- a/ares/n64/rsp/serialization.cpp
+++ b/ares/n64/rsp/serialization.cpp
@@ -6,16 +6,12 @@ auto RSP::serialize(serializer& s) -> void {
   s(pipeline.address);
   s(pipeline.instruction);
 
-  s(dma.pbusRegion);
-  s(dma.pbusAddress);
-  s(dma.dramAddress);
-  s(dma.read.length);
-  s(dma.read.skip);
-  s(dma.read.count);
-  s(dma.write.length);
-  s(dma.write.skip);
-  s(dma.write.count);
-  s(dma.requests);
+  s(dma.pending);
+  s(dma.current);
+  s(dma.busy.read);
+  s(dma.busy.write);
+  s(dma.full.read);
+  s(dma.full.write);
 
   s(status.semaphore);
   s(status.halted);
@@ -49,8 +45,7 @@ auto RSP::serialize(serializer& s) -> void {
   }
 }
 
-auto RSP::DMA::Request::serialize(serializer& s) -> void {
-  s((u32&)type);
+auto RSP::DMA::Regs::serialize(serializer& s) -> void {
   s(pbusRegion);
   s(pbusAddress);
   s(dramAddress);


### PR DESCRIPTION
This change implements RSP DMA double buffering in a more faithful
way, so that reads from the registers always return the current values
(ongoing transfer or finished transfer) rather than the pending ones.

Moreover, this also makes Ares transfer bytes in background a row at
a time, rather than all of them at the end. It is a bit more accurate,
and it was also easier to implement in the new architecture.

This also fixes several tests in n64-systemtest.