### PR TITLE
n64: reactivate 64-bit memory map

### DIFF
--- a/ares/n64/cpu/memory.cpp
+++ b/ares/n64/cpu/memory.cpp
@@ -75,8 +75,8 @@ auto CPU::userSegment64(u64 address) const -> Context::Segment {
 
 auto CPU::segment(u64 address) -> Context::Segment {
   auto segment = context.segment[address >> 29 & 7];
-//if(likely(context.bits == 32))
-  return (Context::Segment)segment;
+  if(likely(context.bits == 32))
+    return (Context::Segment)segment;
   switch(segment) {
   case Context::Segment::Kernel64:
     return kernelSegment64(address);


### PR DESCRIPTION
Ares used to have full 64-bit TLB support but it was removed at some
point because of some wrong testing that apparently made us believe
that the CPU didn't support that mode. It will have to be restored from
the git history in the future, though it's not very urgent because
nobody is using 64-bit pointers on N64 (there is no toolchain with
64-bit pointers, nor it seems useful).

Luckily, at least the segment parsing was left in and just commented out.
This allows to pass the last two remaining tests in n64-systemtest.