### PR TITLE
debugger: fix address masking in instruction tracer (for 64 bit addresses)

### DIFF
--- a/ares/ares/node/debugger/tracer/instruction.hpp
+++ b/ares/ares/node/debugger/tracer/instruction.hpp
@@ -28,7 +28,7 @@ struct Instruction : Tracer {
   }
 
   auto address(u64 address) -> bool {
-    address &= (1ull << _addressBits) - 1;  //mask upper bits of address
+    address &= (u128(1) << _addressBits) - 1;  //mask upper bits of address
     _address = address;
     address >>= _addressMask;  //clip unneeded alignment bits (to reduce _masks size)
 
@@ -57,7 +57,7 @@ struct Instruction : Tracer {
   //call when writing to executable RAM to support self-modifying code.
   auto invalidate(u64 address) -> void {
     if(unlikely(_mask && updateMasks())) {
-      address &= (1ull << _addressBits) - 1;
+      address &= (u128(1) << _addressBits) - 1;
       address >>= _addressMask;
       _masks[address >> 3] &= ~(1 << (address & 7));
     }

--- a/ares/ares/node/debugger/tracer/instruction.hpp
+++ b/ares/ares/node/debugger/tracer/instruction.hpp
@@ -28,7 +28,7 @@ struct Instruction : Tracer {
   }
 
   auto address(u64 address) -> bool {
-    address &= (u128(1) << _addressBits) - 1;  //mask upper bits of address
+    address &= (1ull << (_addressBits % 64)) - 1;  //mask upper bits of address
     _address = address;
     address >>= _addressMask;  //clip unneeded alignment bits (to reduce _masks size)
 
@@ -57,7 +57,7 @@ struct Instruction : Tracer {
   //call when writing to executable RAM to support self-modifying code.
   auto invalidate(u64 address) -> void {
     if(unlikely(_mask && updateMasks())) {
-      address &= (u128(1) << _addressBits) - 1;
+      address &= (1ull << (_addressBits % 64)) - 1;
       address >>= _addressMask;
       _masks[address >> 3] &= ~(1 << (address & 7));
     }
@@ -104,7 +104,7 @@ struct Instruction : Tracer {
 
 protected:
   auto updateMasks() -> bool {
-    auto size = 1ull << _addressBits >> _addressMask >> 3;
+    auto size = _addressBits == 64 ? 1ull << (_addressBits - 3) >> _addressMask : 1ull << _addressBits >> _addressMask >> 3;
     if(!_mask || !size) return _masks.reset(), false;
     if(_masks.size() == size) return true;
     _masks.reset();

--- a/ares/ares/node/debugger/tracer/instruction.hpp
+++ b/ares/ares/node/debugger/tracer/instruction.hpp
@@ -28,7 +28,7 @@ struct Instruction : Tracer {
   }
 
   auto address(u64 address) -> bool {
-    address &= (1ull << (_addressBits % 64)) - 1;  //mask upper bits of address
+    address &= ~0ull >> (64 - _addressBits);  //mask upper bits of address
     _address = address;
     address >>= _addressMask;  //clip unneeded alignment bits (to reduce _masks size)
 
@@ -57,7 +57,7 @@ struct Instruction : Tracer {
   //call when writing to executable RAM to support self-modifying code.
   auto invalidate(u64 address) -> void {
     if(unlikely(_mask && updateMasks())) {
-      address &= (1ull << (_addressBits % 64)) - 1;
+      address &= ~0ull >> (64 - _addressBits);
       address >>= _addressMask;
       _masks[address >> 3] &= ~(1 << (address & 7));
     }
@@ -104,7 +104,7 @@ struct Instruction : Tracer {
 
 protected:
   auto updateMasks() -> bool {
-    auto size = _addressBits == 64 ? 1ull << (_addressBits - 3) >> _addressMask : 1ull << _addressBits >> _addressMask >> 3;
+    auto size = 1ull << (_addressBits - _addressMask - 3);
     if(!_mask || !size) return _masks.reset(), false;
     if(_masks.size() == size) return true;
     _masks.reset();


### PR DESCRIPTION
This is similar to https://github.com/ares-emulator/ares/commit/822186413c9274295e49b922297f0cc744921eda, but fixes masking for N64 as it has 64 bit addresses.