### PR TITLE
n64: fix RDP scissoring in copy/fill mode

### DIFF
--- a/thirdparty/mame/mame/video/n64.cpp
+++ b/thirdparty/mame/mame/video/n64.cpp
@@ -4364,7 +4364,7 @@ void n64_rdp::span_draw_copy(int32_t scanline, const extent_t &extent, const rdp
 	{
 		const bool valid_x = (flip) ? (x >= xend_scissored) : (x <= xend_scissored);
 
-		if (x >= clipx1 && x < clipx2 && valid_x)
+		if (x >= clipx1 && x <= clipx2 && valid_x)
 		{
 			int32_t sss = s.h.h;
 			int32_t sst = t.h.h;
@@ -4405,7 +4405,7 @@ void n64_rdp::span_draw_fill(int32_t scanline, const extent_t &extent, const rdp
 
 	for (int32_t j = 0; j <= length; j++)
 	{
-		if (x >= clipx1 && x < clipx2)
+		if (x >= clipx1 && x <= clipx2)
 		{
 			((this)->*(m_fill_pixel[object.m_misc_state.m_fb_size]))(fb_index + x, object);
 		}


### PR DESCRIPTION
This fixes a bug in mame RDP with respect to scissoring: the upper X
bound is inclusive in copy and fill modes (and exclusives in the others).

This seems another bug in Mame's refactorings that doesn't appear
in upstream angrylion, given the fact that both cen64 and parallel-RDP
emulates this correctly.

Fixes some tests in libdragon testsuite in an ongoing development branch.
This is a simplified ROM to test this.
[testrom_emu.z64.zip](https://github.com/ares-emulator/ares/files/8835485/testrom_emu.z64.zip)

