### PR TITLE
Validate NeoGeo Bios Files

### DIFF
--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -551,7 +551,7 @@ auto Nintendo64::analyze(vector<u8>& data) -> string {
   if(id == "NVC") {mempak = true;}                                       //Virtual Chess 64
   if(id == "NVR") {mempak = true;}                                       //Virtual Pool 64
   if(id == "NWV") {mempak = true; rumble = true;}                        //WCW: Backstage Assault
-  if(id == "NWV") {mempak = true; rumble = true;}                        //WCW: Mayhem
+  if(id == "NWM") {mempak = true; rumble = true;}                        //WCW: Mayhem
   if(id == "NW3") {mempak = true; rumble = true;}                        //WCW: Nitro
   if(id == "NWN") {mempak = true; rumble = true;}                        //WCW vs. nWo - World Tour
   if(id == "NWW") {mempak = true; rumble = true;}                        //WWF: War Zone

--- a/mia/system/neo-geo-aes.cpp
+++ b/mia/system/neo-geo-aes.cpp
@@ -22,6 +22,8 @@ auto NeoGeoAES::load(string location) -> bool {
     }
   }
 
+  if(pak->count() != 1) return false;
+
   return true;
 }
 

--- a/mia/system/neo-geo-mvs.cpp
+++ b/mia/system/neo-geo-mvs.cpp
@@ -22,6 +22,8 @@ auto NeoGeoMVS::load(string location) -> bool {
     }
   }
 
+  if(pak->count() != 1) return false;
+
   return true;
 }
 


### PR DESCRIPTION
As the NeoGeo could have multiple Bios files, this check validates that we found the the correct number of files and prevents reading from them if they were not located, preventing ares from crashing.

Although we currently only check for one file, this will likely change, and the count will just need to be updated as files are added.