### PR TITLE
n64: implement invalid COP0 register access

### DIFF
--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -522,6 +522,9 @@ struct CPU : Thread {
 
     //30: Error Exception Program Counter
     n64 epcError;
+
+    //other
+    n64 latch;
   } scc;
 
   //interpreter-scc.cpp

--- a/ares/n64/cpu/interpreter-scc.cpp
+++ b/ares/n64/cpu/interpreter-scc.cpp
@@ -126,11 +126,15 @@ auto CPU::getControlRegister(n5 index) -> u64 {
   case 30:  //error exception program counter
     data = scc.epcError;
     break;
+  default:
+    data = scc.latch;
+    break;
   }
   return data;
 }
 
 auto CPU::setControlRegister(n5 index, n64 data) -> void {
+  scc.latch = data;
   //read-only variables are defined but commented out for documentation purposes
   switch(index) {
   case  0:  //index


### PR DESCRIPTION
Fix a few tests in n64-systemtest