### PR TITLE
Implement 64-bit memory addressing and TLBs

### DIFF
--- a/ares/n64/cpu/context.cpp
+++ b/ares/n64/cpu/context.cpp
@@ -18,7 +18,8 @@ auto CPU::Context::setMode() -> void {
     break;
   }
 
-  if(bits == 32 || bits == 64) {
+  if(bits == 32) {
+    physMask = 0x1fff'ffff;
     segment[0] = Segment::Mapped;
     segment[1] = Segment::Mapped;
     segment[2] = Segment::Mapped;
@@ -47,6 +48,7 @@ auto CPU::Context::setMode() -> void {
   }
 
   if(bits == 64) {
+    physMask = 0x7fff'ffff;
     for(auto n : range(8))
     switch(mode) {
     case Mode::Kernel:

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -95,6 +95,7 @@ struct CPU : Thread {
     auto setMode() -> void;
 
     bool endian;
+    u64  physMask;
     u32  mode;
     u32  bits;
     u32  segment[8];  //512_MiB chunks

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -168,9 +168,9 @@ struct CPU : Thread {
     };
 
     //tlb.cpp
-    auto load(u32 address) -> Match;
-    auto store(u32 address) -> Match;
-    auto exception(u32 address) -> void;
+    auto load(u32 vaddr) -> Match;
+    auto store(u32 vaddr) -> Match;
+    auto exception(u32 vaddr) -> void;
 
     struct Entry {
       //scc-tlb.cpp
@@ -196,20 +196,20 @@ struct CPU : Thread {
   } tlb{*this};
 
   //memory.cpp
-  auto kernelSegment32(u32 address) const -> Context::Segment;
-  auto supervisorSegment32(u32 address) const -> Context::Segment;
-  auto userSegment32(u32 address) const -> Context::Segment;
+  auto kernelSegment32(u32 vaddr) const -> Context::Segment;
+  auto supervisorSegment32(u32 vaddr) const -> Context::Segment;
+  auto userSegment32(u32 vaddr) const -> Context::Segment;
 
-  auto kernelSegment64(u64 address) const -> Context::Segment;
-  auto supervisorSegment64(u64 address) const -> Context::Segment;
-  auto userSegment64(u64 address) const -> Context::Segment;
+  auto kernelSegment64(u64 vaddr) const -> Context::Segment;
+  auto supervisorSegment64(u64 vaddr) const -> Context::Segment;
+  auto userSegment64(u64 vaddr) const -> Context::Segment;
 
-  auto segment(u64 address) -> Context::Segment;
-  auto devirtualize(u64 address) -> maybe<u64>;
-  auto fetch(u64 address) -> u32;
-  template<u32 Size> auto read(u64 address) -> maybe<u64>;
-  template<u32 Size> auto write(u64 address, u64 data) -> bool;
-  auto addressException(u64 address) -> void;
+  auto segment(u64 vaddr) -> Context::Segment;
+  auto devirtualize(u64 vaddr) -> maybe<u64>;
+  auto fetch(u64 vaddr) -> u32;
+  template<u32 Size> auto read(u64 vaddr) -> maybe<u64>;
+  template<u32 Size> auto write(u64 vaddr, u64 data) -> bool;
+  auto addressException(u64 vaddr) -> void;
 
   //serialization.cpp
   auto serialize(serializer&) -> void;

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -168,9 +168,8 @@ struct CPU : Thread {
     };
 
     //tlb.cpp
-    auto load(u32 vaddr) -> Match;
-    auto store(u32 vaddr) -> Match;
-    auto exception(u32 vaddr) -> void;
+    auto load(u64 vaddr) -> Match;
+    auto store(u64 vaddr) -> Match;
 
     struct Entry {
       //scc-tlb.cpp

--- a/ares/n64/cpu/dcache.cpp
+++ b/ares/n64/cpu/dcache.cpp
@@ -1,12 +1,12 @@
 auto CPU::DataCache::Line::hit(u32 address) const -> bool {
-  return valid && tag == (address & ~0xe000'0fff);
+  return valid && tag == (address & ~0x0000'0fff);
 }
 
 template<u32 Size> auto CPU::DataCache::Line::fill(u32 address, u64 data) -> void {
   cpu.step(40);
   valid = 1;
   dirty = 1;
-  tag   = address & ~0xe000'0fff;
+  tag   = address & ~0x0000'0fff;
   //read words according to critical doubleword first scheme
   switch(address & 8) {
   case 0:
@@ -34,7 +34,7 @@ auto CPU::DataCache::Line::fill(u32 address) -> void {
   cpu.step(40);
   valid = 1;
   dirty = 0;
-  tag   = address & ~0xe000'0fff;
+  tag   = address & ~0x0000'0fff;
   //read words according to critical doubleword first scheme
   switch(address & 8) {
   case 0:

--- a/ares/n64/cpu/icache.cpp
+++ b/ares/n64/cpu/icache.cpp
@@ -1,11 +1,11 @@
 auto CPU::InstructionCache::Line::hit(u32 address) const -> bool {
-  return valid && tag == (address & ~0xe000'0fff);
+  return valid && tag == (address & ~0x0000'0fff);
 }
 
 auto CPU::InstructionCache::Line::fill(u32 address) -> void {
   cpu.step(48);
   valid = 1;
-  tag   = address & ~0xe000'0fff;
+  tag   = address & ~0x0000'0fff;
   words[0] = bus.read<Word>(tag | index | 0x00);
   words[1] = bus.read<Word>(tag | index | 0x04);
   words[2] = bus.read<Word>(tag | index | 0x08);
@@ -42,7 +42,7 @@ auto CPU::InstructionCache::step(u32 address) -> void {
   if(!line.hit(address)) {
     cpu.step(48);
     line.valid = 1;
-    line.tag   = address & ~0xe000'0fff;
+    line.tag   = address & ~0x0000'0fff;
   } else {
     cpu.step(2);
   }

--- a/ares/n64/cpu/interpreter-ipu.cpp
+++ b/ares/n64/cpu/interpreter-ipu.cpp
@@ -394,88 +394,88 @@ auto CPU::LD(r64& rt, cr64& rs, s16 imm) -> void {
 
 auto CPU::LDL(r64& rt, cr64& rs, s16 imm) -> void {
   if(!context.kernelMode() && context.bits == 32) return exception.reservedInstruction();
-  u64 address = rs.u64 + imm;
+  u64 vaddr = rs.u64 + imm;
   u64 data = rt.u64;
 
   if(context.littleEndian())
-  switch(address & 7) {
+  switch(vaddr & 7) {
   case 0:
     data &= 0x00ffffffffffffffull;
-    if(auto byte = read<Byte>(address & ~7 | 7)) data |= byte() << 56; else return;
+    if(auto byte = read<Byte>(vaddr & ~7 | 7)) data |= byte() << 56; else return;
     break;
   case 1:
     data &= 0x0000ffffffffffffull;
-    if(auto half = read<Half>(address & ~7 | 6)) data |= half() << 48; else return;
+    if(auto half = read<Half>(vaddr & ~7 | 6)) data |= half() << 48; else return;
     break;
   case 2:
     data &= 0x000000ffffffffffull;
-    if(auto byte = read<Byte>(address & ~7 | 5)) data |= byte() << 56; else return;
-    if(auto half = read<Half>(address & ~7 | 6)) data |= half() << 40; else return;
+    if(auto byte = read<Byte>(vaddr & ~7 | 5)) data |= byte() << 56; else return;
+    if(auto half = read<Half>(vaddr & ~7 | 6)) data |= half() << 40; else return;
     break;
   case 3:
     data &= 0x00000000ffffffffull;
-    if(auto word = read<Word>(address & ~7 | 4)) data |= word() << 32; else return;
+    if(auto word = read<Word>(vaddr & ~7 | 4)) data |= word() << 32; else return;
     break;
   case 4:
     data &= 0x0000000000ffffffull;
-    if(auto byte = read<Byte>(address & ~7 | 3)) data |= byte() << 56; else return;
-    if(auto word = read<Word>(address & ~7 | 4)) data |= word() << 24; else return;
+    if(auto byte = read<Byte>(vaddr & ~7 | 3)) data |= byte() << 56; else return;
+    if(auto word = read<Word>(vaddr & ~7 | 4)) data |= word() << 24; else return;
     break;
   case 5:
     data &= 0x000000000000ffffull;
-    if(auto half = read<Half>(address & ~7 | 2)) data |= half() << 48; else return;
-    if(auto word = read<Word>(address & ~7 | 4)) data |= word() << 16; else return;
+    if(auto half = read<Half>(vaddr & ~7 | 2)) data |= half() << 48; else return;
+    if(auto word = read<Word>(vaddr & ~7 | 4)) data |= word() << 16; else return;
     break;
   case 6:
     data &= 0x00000000000000ffull;
-    if(auto byte = read<Byte>(address & ~7 | 1)) data |= byte() << 56; else return;
-    if(auto half = read<Half>(address & ~7 | 2)) data |= half() << 40; else return;
-    if(auto word = read<Word>(address & ~7 | 4)) data |= word() <<  8; else return;
+    if(auto byte = read<Byte>(vaddr & ~7 | 1)) data |= byte() << 56; else return;
+    if(auto half = read<Half>(vaddr & ~7 | 2)) data |= half() << 40; else return;
+    if(auto word = read<Word>(vaddr & ~7 | 4)) data |= word() <<  8; else return;
     break;
   case 7:
     data &= 0x0000000000000000ull;
-    if(auto dual = read<Dual>(address & ~7 | 0)) data |= dual() <<  0; else return;
+    if(auto dual = read<Dual>(vaddr & ~7 | 0)) data |= dual() <<  0; else return;
     break;
   }
 
   if(context.bigEndian())
-  switch(address & 7) {
+  switch(vaddr & 7) {
   case 0:
     data &= 0x0000000000000000ull;
-    if(auto dual = read<Dual>(address & ~7 | 0)) data |= dual() <<  0; else return;
+    if(auto dual = read<Dual>(vaddr & ~7 | 0)) data |= dual() <<  0; else return;
     break;
   case 1:
     data &= 0x00000000000000ffull;
-    if(auto byte = read<Byte>(address & ~7 | 1)) data |= byte() << 56; else return;
-    if(auto half = read<Half>(address & ~7 | 2)) data |= half() << 40; else return;
-    if(auto word = read<Word>(address & ~7 | 4)) data |= word() <<  8; else return;
+    if(auto byte = read<Byte>(vaddr & ~7 | 1)) data |= byte() << 56; else return;
+    if(auto half = read<Half>(vaddr & ~7 | 2)) data |= half() << 40; else return;
+    if(auto word = read<Word>(vaddr & ~7 | 4)) data |= word() <<  8; else return;
     break;
   case 2:
     data &= 0x000000000000ffffull;
-    if(auto half = read<Half>(address & ~7 | 2)) data |= half() << 48; else return;
-    if(auto word = read<Word>(address & ~7 | 4)) data |= word() << 16; else return;
+    if(auto half = read<Half>(vaddr & ~7 | 2)) data |= half() << 48; else return;
+    if(auto word = read<Word>(vaddr & ~7 | 4)) data |= word() << 16; else return;
     break;
   case 3:
     data &= 0x0000000000ffffffull;
-    if(auto byte = read<Byte>(address & ~7 | 3)) data |= byte() << 56; else return;
-    if(auto word = read<Word>(address & ~7 | 4)) data |= word() << 24; else return;
+    if(auto byte = read<Byte>(vaddr & ~7 | 3)) data |= byte() << 56; else return;
+    if(auto word = read<Word>(vaddr & ~7 | 4)) data |= word() << 24; else return;
     break;
   case 4:
     data &= 0x00000000ffffffffull;
-    if(auto word = read<Word>(address & ~7 | 4)) data |= word() << 32; else return;
+    if(auto word = read<Word>(vaddr & ~7 | 4)) data |= word() << 32; else return;
     break;
   case 5:
     data &= 0x000000ffffffffffull;
-    if(auto byte = read<Byte>(address & ~7 | 5)) data |= byte() << 56; else return;
-    if(auto half = read<Half>(address & ~7 | 6)) data |= half() << 40; else return;
+    if(auto byte = read<Byte>(vaddr & ~7 | 5)) data |= byte() << 56; else return;
+    if(auto half = read<Half>(vaddr & ~7 | 6)) data |= half() << 40; else return;
     break;
   case 6:
     data &= 0x0000ffffffffffffull;
-    if(auto half = read<Half>(address & ~7 | 6)) data |= half() << 48; else return;
+    if(auto half = read<Half>(vaddr & ~7 | 6)) data |= half() << 48; else return;
     break;
   case 7:
     data &= 0x00ffffffffffffffull;
-    if(auto byte = read<Byte>(address & ~7 | 7)) data |= byte() << 56; else return;
+    if(auto byte = read<Byte>(vaddr & ~7 | 7)) data |= byte() << 56; else return;
     break;
   }
 
@@ -484,88 +484,88 @@ auto CPU::LDL(r64& rt, cr64& rs, s16 imm) -> void {
 
 auto CPU::LDR(r64& rt, cr64& rs, s16 imm) -> void {
   if(!context.kernelMode() && context.bits == 32) return exception.reservedInstruction();
-  u64 address = rs.u64 + imm;
+  u64 vaddr = rs.u64 + imm;
   u64 data = rt.u64;
 
   if(context.littleEndian())
-  switch(address & 7) {
+  switch(vaddr & 7) {
   case 0:
     data &= 0x0000000000000000ull;
-    if(auto dual = read<Dual>(address & ~7 | 0)) data |= dual() <<  0; else return;
+    if(auto dual = read<Dual>(vaddr & ~7 | 0)) data |= dual() <<  0; else return;
     break;
   case 1:
     data &= 0xff00000000000000ull;
-    if(auto word = read<Word>(address & ~7 | 0)) data |= word() << 24; else return;
-    if(auto half = read<Half>(address & ~7 | 4)) data |= half() <<  8; else return;
-    if(auto byte = read<Byte>(address & ~7 | 6)) data |= byte() <<  0; else return;
+    if(auto word = read<Word>(vaddr & ~7 | 0)) data |= word() << 24; else return;
+    if(auto half = read<Half>(vaddr & ~7 | 4)) data |= half() <<  8; else return;
+    if(auto byte = read<Byte>(vaddr & ~7 | 6)) data |= byte() <<  0; else return;
     break;
   case 2:
     data &= 0xffff000000000000ull;
-    if(auto word = read<Word>(address & ~7 | 0)) data |= word() << 16; else return;
-    if(auto half = read<Half>(address & ~7 | 4)) data |= half() <<  0; else return;
+    if(auto word = read<Word>(vaddr & ~7 | 0)) data |= word() << 16; else return;
+    if(auto half = read<Half>(vaddr & ~7 | 4)) data |= half() <<  0; else return;
     break;
   case 3:
     data &= 0xffffff0000000000ull;
-    if(auto word = read<Word>(address & ~7 | 0)) data |= word() <<  8; else return;
-    if(auto byte = read<Byte>(address & ~7 | 4)) data |= byte() <<  0; else return;
+    if(auto word = read<Word>(vaddr & ~7 | 0)) data |= word() <<  8; else return;
+    if(auto byte = read<Byte>(vaddr & ~7 | 4)) data |= byte() <<  0; else return;
     break;
   case 4:
     data &= 0xffffffff00000000ull;
-    if(auto word = read<Word>(address & ~7 | 0)) data |= word() <<  0; else return;
+    if(auto word = read<Word>(vaddr & ~7 | 0)) data |= word() <<  0; else return;
     break;
   case 5:
     data &= 0xffffffffff000000ull;
-    if(auto half = read<Half>(address & ~7 | 0)) data |= half() <<  8; else return;
-    if(auto byte = read<Byte>(address & ~7 | 2)) data |= byte() <<  0; else return;
+    if(auto half = read<Half>(vaddr & ~7 | 0)) data |= half() <<  8; else return;
+    if(auto byte = read<Byte>(vaddr & ~7 | 2)) data |= byte() <<  0; else return;
     break;
   case 6:
     data &= 0xffffffffffff0000ull;
-    if(auto half = read<Half>(address & ~7 | 0)) data |= half() <<  0; else return;
+    if(auto half = read<Half>(vaddr & ~7 | 0)) data |= half() <<  0; else return;
     break;
   case 7:
     data &= 0xffffffffffffff00ull;
-    if(auto byte = read<Byte>(address & ~7 | 0)) data |= byte() <<  0; else return;
+    if(auto byte = read<Byte>(vaddr & ~7 | 0)) data |= byte() <<  0; else return;
     break;
   }
 
   if(context.bigEndian())
-  switch(address & 7) {
+  switch(vaddr & 7) {
   case 0:
     data &= 0xffffffffffffff00ull;
-    if(auto byte = read<Byte>(address & ~7 | 0)) data |= byte() <<  0; else return;
+    if(auto byte = read<Byte>(vaddr & ~7 | 0)) data |= byte() <<  0; else return;
     break;
   case 1:
     data &= 0xffffffffffff0000ull;
-    if(auto half = read<Half>(address & ~7 | 0)) data |= half() <<  0; else return;
+    if(auto half = read<Half>(vaddr & ~7 | 0)) data |= half() <<  0; else return;
     break;
   case 2:
     data &= 0xffffffffff000000ull;
-    if(auto half = read<Half>(address & ~7 | 0)) data |= half() <<  8; else return;
-    if(auto byte = read<Byte>(address & ~7 | 2)) data |= byte() <<  0; else return;
+    if(auto half = read<Half>(vaddr & ~7 | 0)) data |= half() <<  8; else return;
+    if(auto byte = read<Byte>(vaddr & ~7 | 2)) data |= byte() <<  0; else return;
     break;
   case 3:
     data &= 0xffffffff00000000ull;
-    if(auto word = read<Word>(address & ~7 | 0)) data |= word() <<  0; else return;
+    if(auto word = read<Word>(vaddr & ~7 | 0)) data |= word() <<  0; else return;
     break;
   case 4:
     data &= 0xffffff0000000000ull;
-    if(auto word = read<Word>(address & ~7 | 0)) data |= word() <<  8; else return;
-    if(auto byte = read<Byte>(address & ~7 | 4)) data |= byte() <<  0; else return;
+    if(auto word = read<Word>(vaddr & ~7 | 0)) data |= word() <<  8; else return;
+    if(auto byte = read<Byte>(vaddr & ~7 | 4)) data |= byte() <<  0; else return;
     break;
   case 5:
     data &= 0xffff000000000000ull;
-    if(auto word = read<Word>(address & ~7 | 0)) data |= word() << 16; else return;
-    if(auto half = read<Half>(address & ~7 | 4)) data |= half() <<  0; else return;
+    if(auto word = read<Word>(vaddr & ~7 | 0)) data |= word() << 16; else return;
+    if(auto half = read<Half>(vaddr & ~7 | 4)) data |= half() <<  0; else return;
     break;
   case 6:
     data &= 0xff00000000000000ull;
-    if(auto word = read<Word>(address & ~7 | 0)) data |= word() << 24; else return;
-    if(auto half = read<Half>(address & ~7 | 4)) data |= half() <<  8; else return;
-    if(auto byte = read<Byte>(address & ~7 | 6)) data |= byte() <<  0; else return;
+    if(auto word = read<Word>(vaddr & ~7 | 0)) data |= word() << 24; else return;
+    if(auto half = read<Half>(vaddr & ~7 | 4)) data |= half() <<  8; else return;
+    if(auto byte = read<Byte>(vaddr & ~7 | 6)) data |= byte() <<  0; else return;
     break;
   case 7:
     data &= 0x0000000000000000ull;
-    if(auto dual = read<Dual>(address & ~7 | 0)) data |= dual() <<  0; else return;
+    if(auto dual = read<Dual>(vaddr & ~7 | 0)) data |= dual() <<  0; else return;
     break;
   }
 
@@ -610,13 +610,13 @@ auto CPU::LW(r64& rt, cr64& rs, s16 imm) -> void {
 }
 
 auto CPU::LWL(r64& rt, cr64& rs, s16 imm) -> void {
-  u64 address = rs.u64 + imm;
+  u64 vaddr = rs.u64 + imm;
   u32 data = rt.u32;
-  auto mem = read<Word>(address & ~3);
+  auto mem = read<Word>(vaddr & ~3);
   if (!mem) return;
 
   if(context.littleEndian())
-  switch(address & 3) {
+  switch(vaddr & 3) {
   case 0:
     data &= 0x00ffffff;
     *mem <<= 24;
@@ -636,7 +636,7 @@ auto CPU::LWL(r64& rt, cr64& rs, s16 imm) -> void {
   }
 
   if(context.bigEndian())
-  switch(address & 3) {
+  switch(vaddr & 3) {
   case 0:
     data &= 0x00000000;
     *mem <<= 0;
@@ -660,13 +660,13 @@ auto CPU::LWL(r64& rt, cr64& rs, s16 imm) -> void {
 }
 
 auto CPU::LWR(r64& rt, cr64& rs, s16 imm) -> void {
-  u64 address = rs.u64 + imm;
+  u64 vaddr = rs.u64 + imm;
   u32 data = rt.u32;
-  auto mem = read<Word>(address & ~3);
+  auto mem = read<Word>(vaddr & ~3);
   if (!mem) return;
 
   if(context.littleEndian())
-  switch(address & 3) {
+  switch(vaddr & 3) {
   case 0:
     data &= 0x00000000;
     *mem >>= 0;
@@ -697,7 +697,7 @@ auto CPU::LWR(r64& rt, cr64& rs, s16 imm) -> void {
   }
 
   if(context.bigEndian())
-  switch(address & 3) {
+  switch(vaddr & 3) {
   case 0:
     data &= 0xffffff00;
     *mem >>= 24;
@@ -804,144 +804,144 @@ auto CPU::SD(cr64& rt, cr64& rs, s16 imm) -> void {
 
 auto CPU::SDL(cr64& rt, cr64& rs, s16 imm) -> void {
   if(!context.kernelMode() && context.bits == 32) return exception.reservedInstruction();
-  u64 address = rs.u64 + imm;
+  u64 vaddr = rs.u64 + imm;
   u64 data = rt.u64;
 
   if(context.littleEndian())
-  switch(address & 7) {
+  switch(vaddr & 7) {
   case 0:
-    if(!write<Byte>(address & ~7 | 7, data >> 56)) return;
+    if(!write<Byte>(vaddr & ~7 | 7, data >> 56)) return;
     break;
   case 1:
-    if(!write<Half>(address & ~7 | 6, data >> 48)) return;
+    if(!write<Half>(vaddr & ~7 | 6, data >> 48)) return;
     break;
   case 2:
-    if(!write<Byte>(address & ~7 | 5, data >> 56)) return;
-    if(!write<Half>(address & ~7 | 6, data >> 40)) return;
+    if(!write<Byte>(vaddr & ~7 | 5, data >> 56)) return;
+    if(!write<Half>(vaddr & ~7 | 6, data >> 40)) return;
     break;
   case 3:
-    if(!write<Word>(address & ~7 | 4, data >> 32)) return;
+    if(!write<Word>(vaddr & ~7 | 4, data >> 32)) return;
     break;
   case 4:
-    if(!write<Byte>(address & ~7 | 3, data >> 56)) return;
-    if(!write<Word>(address & ~7 | 4, data >> 24)) return;
+    if(!write<Byte>(vaddr & ~7 | 3, data >> 56)) return;
+    if(!write<Word>(vaddr & ~7 | 4, data >> 24)) return;
     break;
   case 5:
-    if(!write<Half>(address & ~7 | 2, data >> 48)) return;
-    if(!write<Word>(address & ~7 | 4, data >> 16)) return;
+    if(!write<Half>(vaddr & ~7 | 2, data >> 48)) return;
+    if(!write<Word>(vaddr & ~7 | 4, data >> 16)) return;
     break;
   case 6:
-    if(!write<Byte>(address & ~7 | 1, data >> 56)) return;
-    if(!write<Half>(address & ~7 | 2, data >> 40)) return;
-    if(!write<Word>(address & ~7 | 4, data >>  8)) return;
+    if(!write<Byte>(vaddr & ~7 | 1, data >> 56)) return;
+    if(!write<Half>(vaddr & ~7 | 2, data >> 40)) return;
+    if(!write<Word>(vaddr & ~7 | 4, data >>  8)) return;
     break;
   case 7:
-    if(!write<Dual>(address & ~7 | 0, data >>  0)) return;
+    if(!write<Dual>(vaddr & ~7 | 0, data >>  0)) return;
     break;
   }
 
   if(context.bigEndian())
-  switch(address & 7) {
+  switch(vaddr & 7) {
   case 0:
-    if(!write<Dual>(address & ~7 | 0, data >>  0)) return;
+    if(!write<Dual>(vaddr & ~7 | 0, data >>  0)) return;
     break;
   case 1:
-    if(!write<Byte>(address & ~7 | 1, data >> 56)) return;
-    if(!write<Half>(address & ~7 | 2, data >> 40)) return;
-    if(!write<Word>(address & ~7 | 4, data >>  8)) return;
+    if(!write<Byte>(vaddr & ~7 | 1, data >> 56)) return;
+    if(!write<Half>(vaddr & ~7 | 2, data >> 40)) return;
+    if(!write<Word>(vaddr & ~7 | 4, data >>  8)) return;
     break;
   case 2:
-    if(!write<Half>(address & ~7 | 2, data >> 48)) return;
-    if(!write<Word>(address & ~7 | 4, data >> 16)) return;
+    if(!write<Half>(vaddr & ~7 | 2, data >> 48)) return;
+    if(!write<Word>(vaddr & ~7 | 4, data >> 16)) return;
     break;
   case 3:
-    if(!write<Byte>(address & ~7 | 3, data >> 56)) return;
-    if(!write<Word>(address & ~7 | 4, data >> 24)) return;
+    if(!write<Byte>(vaddr & ~7 | 3, data >> 56)) return;
+    if(!write<Word>(vaddr & ~7 | 4, data >> 24)) return;
     break;
   case 4:
-    if(!write<Word>(address & ~7 | 4, data >> 32)) return;
+    if(!write<Word>(vaddr & ~7 | 4, data >> 32)) return;
     break;
   case 5:
-    if(!write<Byte>(address & ~7 | 5, data >> 56)) return;
-    if(!write<Half>(address & ~7 | 6, data >> 40)) return;
+    if(!write<Byte>(vaddr & ~7 | 5, data >> 56)) return;
+    if(!write<Half>(vaddr & ~7 | 6, data >> 40)) return;
     break;
   case 6:
-    if(!write<Half>(address & ~7 | 6, data >> 48)) return;
+    if(!write<Half>(vaddr & ~7 | 6, data >> 48)) return;
     break;
   case 7:
-    if(!write<Byte>(address & ~7 | 7, data >> 56)) return;
+    if(!write<Byte>(vaddr & ~7 | 7, data >> 56)) return;
     break;
   }
 }
 
 auto CPU::SDR(cr64& rt, cr64& rs, s16 imm) -> void {
   if(!context.kernelMode() && context.bits == 32) return exception.reservedInstruction();
-  u64 address = rs.u64 + imm;
+  u64 vaddr = rs.u64 + imm;
   u64 data = rt.u64;
 
   if(context.littleEndian())
-  switch(address & 7) {
+  switch(vaddr & 7) {
   case 0:
-    if(!write<Dual>(address & ~7 | 0, data >>  0)) return;
+    if(!write<Dual>(vaddr & ~7 | 0, data >>  0)) return;
     break;
   case 1:
-    if(!write<Word>(address & ~7 | 0, data >> 24)) return;
-    if(!write<Half>(address & ~7 | 4, data >>  8)) return;
-    if(!write<Byte>(address & ~7 | 6, data >>  0)) return;
+    if(!write<Word>(vaddr & ~7 | 0, data >> 24)) return;
+    if(!write<Half>(vaddr & ~7 | 4, data >>  8)) return;
+    if(!write<Byte>(vaddr & ~7 | 6, data >>  0)) return;
     break;
   case 2:
-    if(!write<Word>(address & ~7 | 0, data >> 16)) return;
-    if(!write<Half>(address & ~7 | 4, data >>  0)) return;
+    if(!write<Word>(vaddr & ~7 | 0, data >> 16)) return;
+    if(!write<Half>(vaddr & ~7 | 4, data >>  0)) return;
     break;
   case 3:
-    if(!write<Word>(address & ~7 | 0, data >>  8)) return;
-    if(!write<Byte>(address & ~7 | 4, data >>  0)) return;
+    if(!write<Word>(vaddr & ~7 | 0, data >>  8)) return;
+    if(!write<Byte>(vaddr & ~7 | 4, data >>  0)) return;
     break;
   case 4:
-    if(!write<Word>(address & ~7 | 0, data >>  0)) return;
+    if(!write<Word>(vaddr & ~7 | 0, data >>  0)) return;
     break;
   case 5:
-    if(!write<Half>(address & ~7 | 0, data >>  8)) return;
-    if(!write<Byte>(address & ~7 | 2, data >>  0)) return;
+    if(!write<Half>(vaddr & ~7 | 0, data >>  8)) return;
+    if(!write<Byte>(vaddr & ~7 | 2, data >>  0)) return;
     break;
   case 6:
-    if(!write<Half>(address & ~7 | 0, data >>  0)) return;
+    if(!write<Half>(vaddr & ~7 | 0, data >>  0)) return;
     break;
   case 7:
-    if(!write<Byte>(address & ~7 | 0, data >>  0)) return;
+    if(!write<Byte>(vaddr & ~7 | 0, data >>  0)) return;
     break;
   }
 
   if(context.bigEndian())
-  switch(address & 7) {
+  switch(vaddr & 7) {
   case 0:
-    if(!write<Byte>(address & ~7 | 0, data >>  0)) return;
+    if(!write<Byte>(vaddr & ~7 | 0, data >>  0)) return;
     break;
   case 1:
-    if(!write<Half>(address & ~7 | 0, data >>  0)) return;
+    if(!write<Half>(vaddr & ~7 | 0, data >>  0)) return;
     break;
   case 2:
-    if(!write<Half>(address & ~7 | 0, data >>  8)) return;
-    if(!write<Byte>(address & ~7 | 2, data >>  0)) return;
+    if(!write<Half>(vaddr & ~7 | 0, data >>  8)) return;
+    if(!write<Byte>(vaddr & ~7 | 2, data >>  0)) return;
     break;
   case 3:
-    if(!write<Word>(address & ~7 | 0, data >>  0)) return;
+    if(!write<Word>(vaddr & ~7 | 0, data >>  0)) return;
     break;
   case 4:
-    if(!write<Word>(address & ~7 | 0, data >>  8)) return;
-    if(!write<Byte>(address & ~7 | 4, data >>  0)) return;
+    if(!write<Word>(vaddr & ~7 | 0, data >>  8)) return;
+    if(!write<Byte>(vaddr & ~7 | 4, data >>  0)) return;
     break;
   case 5:
-    if(!write<Word>(address & ~7 | 0, data >> 16)) return;
-    if(!write<Half>(address & ~7 | 4, data >>  0)) return;
+    if(!write<Word>(vaddr & ~7 | 0, data >> 16)) return;
+    if(!write<Half>(vaddr & ~7 | 4, data >>  0)) return;
     break;
   case 6:
-    if(!write<Word>(address & ~7 | 0, data >> 24)) return;
-    if(!write<Half>(address & ~7 | 4, data >>  8)) return;
-    if(!write<Byte>(address & ~7 | 6, data >>  0)) return;
+    if(!write<Word>(vaddr & ~7 | 0, data >> 24)) return;
+    if(!write<Half>(vaddr & ~7 | 4, data >>  8)) return;
+    if(!write<Byte>(vaddr & ~7 | 6, data >>  0)) return;
     break;
   case 7:
-    if(!write<Dual>(address & ~7 | 0, data >>  0)) return;
+    if(!write<Dual>(vaddr & ~7 | 0, data >>  0)) return;
     break;
   }
 }
@@ -1004,79 +1004,79 @@ auto CPU::SW(cr64& rt, cr64& rs, s16 imm) -> void {
 }
 
 auto CPU::SWL(cr64& rt, cr64& rs, s16 imm) -> void {
-  u64 address = rs.u64 + imm;
+  u64 vaddr = rs.u64 + imm;
   u32 data = rt.u32;
 
   if(context.littleEndian())
-  switch(address & 3) {
+  switch(vaddr & 3) {
   case 0:
-    if(!write<Byte>(address & ~3 | 3, data >> 24)) return;
+    if(!write<Byte>(vaddr & ~3 | 3, data >> 24)) return;
     break;
   case 1:
-    if(!write<Half>(address & ~3 | 2, data >> 16)) return;
+    if(!write<Half>(vaddr & ~3 | 2, data >> 16)) return;
     break;
   case 2:
-    if(!write<Byte>(address & ~3 | 1, data >> 24)) return;
-    if(!write<Half>(address & ~3 | 2, data >>  8)) return;
+    if(!write<Byte>(vaddr & ~3 | 1, data >> 24)) return;
+    if(!write<Half>(vaddr & ~3 | 2, data >>  8)) return;
     break;
   case 3:
-    if(!write<Word>(address & ~3 | 0, data >>  0)) return;
+    if(!write<Word>(vaddr & ~3 | 0, data >>  0)) return;
     break;
   }
 
   if(context.bigEndian())
-  switch(address & 3) {
+  switch(vaddr & 3) {
   case 0:
-    if(!write<Word>(address & ~3 | 0, data >>  0)) return;
+    if(!write<Word>(vaddr & ~3 | 0, data >>  0)) return;
     break;
   case 1:
-    if(!write<Byte>(address & ~3 | 1, data >> 24)) return;
-    if(!write<Half>(address & ~3 | 2, data >>  8)) return;
+    if(!write<Byte>(vaddr & ~3 | 1, data >> 24)) return;
+    if(!write<Half>(vaddr & ~3 | 2, data >>  8)) return;
     break;
   case 2:
-    if(!write<Half>(address & ~3 | 2, data >> 16)) return;
+    if(!write<Half>(vaddr & ~3 | 2, data >> 16)) return;
     break;
   case 3:
-    if(!write<Byte>(address & ~3 | 3, data >> 24)) return;
+    if(!write<Byte>(vaddr & ~3 | 3, data >> 24)) return;
     break;
   }
 }
 
 auto CPU::SWR(cr64& rt, cr64& rs, s16 imm) -> void {
-  u64 address = rs.u64 + imm;
+  u64 vaddr = rs.u64 + imm;
   u32 data = rt.u32;
 
   if(context.littleEndian())
-  switch(address & 3) {
+  switch(vaddr & 3) {
   case 0:
-    if(!write<Word>(address & ~3 | 0, data >>  0)) return;
+    if(!write<Word>(vaddr & ~3 | 0, data >>  0)) return;
     break;
   case 1:
-    if(!write<Half>(address & ~3 | 0, data >>  8)) return;
-    if(!write<Byte>(address & ~3 | 2, data >>  0)) return;
+    if(!write<Half>(vaddr & ~3 | 0, data >>  8)) return;
+    if(!write<Byte>(vaddr & ~3 | 2, data >>  0)) return;
     break;
   case 2:
-    if(!write<Half>(address & ~3 | 0, data >>  0)) return;
+    if(!write<Half>(vaddr & ~3 | 0, data >>  0)) return;
     break;
   case 3:
-    if(!write<Byte>(address & ~3 | 0, data >>  0)) return;
+    if(!write<Byte>(vaddr & ~3 | 0, data >>  0)) return;
     break;
   }
 
   if(context.bigEndian())
-  switch(address & 3) {
+  switch(vaddr & 3) {
   case 0:
-    if(!write<Byte>(address & ~3 | 0, data >>  0)) return;
+    if(!write<Byte>(vaddr & ~3 | 0, data >>  0)) return;
     break;
   case 1:
-    if(!write<Half>(address & ~3 | 0, data >>  0)) return;
+    if(!write<Half>(vaddr & ~3 | 0, data >>  0)) return;
     break;
   case 2:
-    if(!write<Half>(address & ~3 | 0, data >>  8)) return;
-    if(!write<Byte>(address & ~3 | 2, data >>  0)) return;
+    if(!write<Half>(vaddr & ~3 | 0, data >>  8)) return;
+    if(!write<Byte>(vaddr & ~3 | 2, data >>  0)) return;
     break;
   case 3:
-    if(!write<Word>(address & ~3 | 0, data >>  0)) return;
+    if(!write<Word>(vaddr & ~3 | 0, data >>  0)) return;
     break;
   }
 }

--- a/ares/n64/cpu/memory.cpp
+++ b/ares/n64/cpu/memory.cpp
@@ -1,223 +1,223 @@
 //32-bit segments
 
-auto CPU::kernelSegment32(u32 address) const -> Context::Segment {
-  if(address <= 0x7fff'ffff) return Context::Segment::Mapped;  //kuseg
-  if(address <= 0x9fff'ffff) return Context::Segment::Cached;  //kseg0
-  if(address <= 0xbfff'ffff) return Context::Segment::Direct;  //kseg1
-  if(address <= 0xdfff'ffff) return Context::Segment::Mapped;  //ksseg
-  if(address <= 0xffff'ffff) return Context::Segment::Mapped;  //kseg3
+auto CPU::kernelSegment32(u32 vaddr) const -> Context::Segment {
+  if(vaddr <= 0x7fff'ffff) return Context::Segment::Mapped;  //kuseg
+  if(vaddr <= 0x9fff'ffff) return Context::Segment::Cached;  //kseg0
+  if(vaddr <= 0xbfff'ffff) return Context::Segment::Direct;  //kseg1
+  if(vaddr <= 0xdfff'ffff) return Context::Segment::Mapped;  //ksseg
+  if(vaddr <= 0xffff'ffff) return Context::Segment::Mapped;  //kseg3
   unreachable;
 }
 
-auto CPU::supervisorSegment32(u32 address) const -> Context::Segment {
-  if(address <= 0x7fff'ffff) return Context::Segment::Mapped;  //suseg
-  if(address <= 0xbfff'ffff) return Context::Segment::Unused;
-  if(address <= 0xdfff'ffff) return Context::Segment::Mapped;  //sseg
-  if(address <= 0xffff'ffff) return Context::Segment::Unused;
+auto CPU::supervisorSegment32(u32 vaddr) const -> Context::Segment {
+  if(vaddr <= 0x7fff'ffff) return Context::Segment::Mapped;  //suseg
+  if(vaddr <= 0xbfff'ffff) return Context::Segment::Unused;
+  if(vaddr <= 0xdfff'ffff) return Context::Segment::Mapped;  //sseg
+  if(vaddr <= 0xffff'ffff) return Context::Segment::Unused;
   unreachable;
 }
 
-auto CPU::userSegment32(u32 address) const -> Context::Segment {
-  if(address <= 0x7fff'ffff) return Context::Segment::Mapped;  //useg
-  if(address <= 0xffff'ffff) return Context::Segment::Unused;
+auto CPU::userSegment32(u32 vaddr) const -> Context::Segment {
+  if(vaddr <= 0x7fff'ffff) return Context::Segment::Mapped;  //useg
+  if(vaddr <= 0xffff'ffff) return Context::Segment::Unused;
   unreachable;
 }
 
 //64-bit segments
 
-auto CPU::kernelSegment64(u64 address) const -> Context::Segment {
-  if(address <= 0x0000'00ff'ffff'ffffull) return Context::Segment::Mapped;  //xkuseg
-  if(address <= 0x3fff'ffff'ffff'ffffull) return Context::Segment::Unused;
-  if(address <= 0x4000'00ff'ffff'ffffull) return Context::Segment::Mapped;  //xksseg
-  if(address <= 0x7fff'ffff'ffff'ffffull) return Context::Segment::Unused;
-  if(address <= 0x8000'0000'ffff'ffffull) return Context::Segment::Cached;  //xkphys*
-  if(address <= 0x87ff'ffff'ffff'ffffull) return Context::Segment::Unused;
-  if(address <= 0x8800'0000'ffff'ffffull) return Context::Segment::Cached;  //xkphys*
-  if(address <= 0x8fff'ffff'ffff'ffffull) return Context::Segment::Unused;
-  if(address <= 0x9000'0000'ffff'ffffull) return Context::Segment::Direct;  //xkphys*
-  if(address <= 0x97ff'ffff'ffff'ffffull) return Context::Segment::Unused;
-  if(address <= 0x9800'0000'ffff'ffffull) return Context::Segment::Cached;  //xkphys*
-  if(address <= 0x9fff'ffff'ffff'ffffull) return Context::Segment::Unused;
-  if(address <= 0xa000'0000'ffff'ffffull) return Context::Segment::Cached;  //xkphys*
-  if(address <= 0xa7ff'ffff'ffff'ffffull) return Context::Segment::Unused;
-  if(address <= 0xa800'0000'ffff'ffffull) return Context::Segment::Cached;  //xkphys*
-  if(address <= 0xafff'ffff'ffff'ffffull) return Context::Segment::Unused;
-  if(address <= 0xb000'0000'ffff'ffffull) return Context::Segment::Cached;  //xkphys*
-  if(address <= 0xb7ff'ffff'ffff'ffffull) return Context::Segment::Unused;
-  if(address <= 0xb800'0000'ffff'ffffull) return Context::Segment::Cached;  //xkphys*
-  if(address <= 0xbfff'ffff'ffff'ffffull) return Context::Segment::Unused;
-  if(address <= 0xc000'00ff'7fff'ffffull) return Context::Segment::Mapped;  //xkseg
-  if(address <= 0xffff'ffff'7fff'ffffull) return Context::Segment::Unused;
-  if(address <= 0xffff'ffff'9fff'ffffull) return Context::Segment::Cached;  //ckseg0
-  if(address <= 0xffff'ffff'bfff'ffffull) return Context::Segment::Direct;  //ckseg1
-  if(address <= 0xffff'ffff'dfff'ffffull) return Context::Segment::Mapped;  //ckseg2
-  if(address <= 0xffff'ffff'ffff'ffffull) return Context::Segment::Mapped;  //ckseg3
+auto CPU::kernelSegment64(u64 vaddr) const -> Context::Segment {
+  if(vaddr <= 0x0000'00ff'ffff'ffffull) return Context::Segment::Mapped;  //xkuseg
+  if(vaddr <= 0x3fff'ffff'ffff'ffffull) return Context::Segment::Unused;
+  if(vaddr <= 0x4000'00ff'ffff'ffffull) return Context::Segment::Mapped;  //xksseg
+  if(vaddr <= 0x7fff'ffff'ffff'ffffull) return Context::Segment::Unused;
+  if(vaddr <= 0x8000'0000'ffff'ffffull) return Context::Segment::Cached;  //xkphys*
+  if(vaddr <= 0x87ff'ffff'ffff'ffffull) return Context::Segment::Unused;
+  if(vaddr <= 0x8800'0000'ffff'ffffull) return Context::Segment::Cached;  //xkphys*
+  if(vaddr <= 0x8fff'ffff'ffff'ffffull) return Context::Segment::Unused;
+  if(vaddr <= 0x9000'0000'ffff'ffffull) return Context::Segment::Direct;  //xkphys*
+  if(vaddr <= 0x97ff'ffff'ffff'ffffull) return Context::Segment::Unused;
+  if(vaddr <= 0x9800'0000'ffff'ffffull) return Context::Segment::Cached;  //xkphys*
+  if(vaddr <= 0x9fff'ffff'ffff'ffffull) return Context::Segment::Unused;
+  if(vaddr <= 0xa000'0000'ffff'ffffull) return Context::Segment::Cached;  //xkphys*
+  if(vaddr <= 0xa7ff'ffff'ffff'ffffull) return Context::Segment::Unused;
+  if(vaddr <= 0xa800'0000'ffff'ffffull) return Context::Segment::Cached;  //xkphys*
+  if(vaddr <= 0xafff'ffff'ffff'ffffull) return Context::Segment::Unused;
+  if(vaddr <= 0xb000'0000'ffff'ffffull) return Context::Segment::Cached;  //xkphys*
+  if(vaddr <= 0xb7ff'ffff'ffff'ffffull) return Context::Segment::Unused;
+  if(vaddr <= 0xb800'0000'ffff'ffffull) return Context::Segment::Cached;  //xkphys*
+  if(vaddr <= 0xbfff'ffff'ffff'ffffull) return Context::Segment::Unused;
+  if(vaddr <= 0xc000'00ff'7fff'ffffull) return Context::Segment::Mapped;  //xkseg
+  if(vaddr <= 0xffff'ffff'7fff'ffffull) return Context::Segment::Unused;
+  if(vaddr <= 0xffff'ffff'9fff'ffffull) return Context::Segment::Cached;  //ckseg0
+  if(vaddr <= 0xffff'ffff'bfff'ffffull) return Context::Segment::Direct;  //ckseg1
+  if(vaddr <= 0xffff'ffff'dfff'ffffull) return Context::Segment::Mapped;  //ckseg2
+  if(vaddr <= 0xffff'ffff'ffff'ffffull) return Context::Segment::Mapped;  //ckseg3
   unreachable;
 }
 
-auto CPU::supervisorSegment64(u64 address) const -> Context::Segment {
-  if(address <= 0x0000'00ff'ffff'ffffull) return Context::Segment::Mapped;  //xsuseg
-  if(address <= 0x3fff'ffff'ffff'ffffull) return Context::Segment::Unused;
-  if(address <= 0x4000'00ff'ffff'ffffull) return Context::Segment::Mapped;  //xsseg
-  if(address <= 0xffff'ffff'bfff'ffffull) return Context::Segment::Unused;
-  if(address <= 0xffff'ffff'dfff'ffffull) return Context::Segment::Mapped;  //csseg
-  if(address <= 0xffff'ffff'ffff'ffffull) return Context::Segment::Unused;
+auto CPU::supervisorSegment64(u64 vaddr) const -> Context::Segment {
+  if(vaddr <= 0x0000'00ff'ffff'ffffull) return Context::Segment::Mapped;  //xsuseg
+  if(vaddr <= 0x3fff'ffff'ffff'ffffull) return Context::Segment::Unused;
+  if(vaddr <= 0x4000'00ff'ffff'ffffull) return Context::Segment::Mapped;  //xsseg
+  if(vaddr <= 0xffff'ffff'bfff'ffffull) return Context::Segment::Unused;
+  if(vaddr <= 0xffff'ffff'dfff'ffffull) return Context::Segment::Mapped;  //csseg
+  if(vaddr <= 0xffff'ffff'ffff'ffffull) return Context::Segment::Unused;
   unreachable;
 }
 
-auto CPU::userSegment64(u64 address) const -> Context::Segment {
-  if(address <= 0x0000'00ff'ffff'ffffull) return Context::Segment::Mapped;  //xuseg
-  if(address <= 0xffff'ffff'ffff'ffffull) return Context::Segment::Unused;
+auto CPU::userSegment64(u64 vaddr) const -> Context::Segment {
+  if(vaddr <= 0x0000'00ff'ffff'ffffull) return Context::Segment::Mapped;  //xuseg
+  if(vaddr <= 0xffff'ffff'ffff'ffffull) return Context::Segment::Unused;
   unreachable;
 }
 
 //
 
-auto CPU::segment(u64 address) -> Context::Segment {
-  auto segment = context.segment[address >> 29 & 7];
+auto CPU::segment(u64 vaddr) -> Context::Segment {
+  auto segment = context.segment[vaddr >> 29 & 7];
   if(likely(context.bits == 32))
     return (Context::Segment)segment;
   switch(segment) {
   case Context::Segment::Kernel64:
-    return kernelSegment64(address);
+    return kernelSegment64(vaddr);
   case Context::Segment::Supervisor64:
-    return supervisorSegment64(address);
+    return supervisorSegment64(vaddr);
   case Context::Segment::User64:
-    return userSegment64(address);
+    return userSegment64(vaddr);
   }
   unreachable;
 }
 
-auto CPU::devirtualize(u64 address) -> maybe<u64> {
-  switch(segment(address)) {
+auto CPU::devirtualize(u64 vaddr) -> maybe<u64> {
+  switch(segment(vaddr)) {
   case Context::Segment::Unused:
-    addressException(address);
+    addressException(vaddr);
     exception.addressLoad();
     return nothing;
   case Context::Segment::Mapped:
-    if(auto match = tlb.load(address)) return match.address & context.physMask;
-    tlb.exception(address);
+    if(auto match = tlb.load(vaddr)) return match.address & context.physMask;
+    tlb.exception(vaddr);
     return nothing;
   case Context::Segment::Cached:
   case Context::Segment::Direct:
-    return address & context.physMask;
+    return vaddr & context.physMask;
   }
   unreachable;
 }
 
-auto CPU::fetch(u64 address) -> u32 {
-  switch(segment(address)) {
+auto CPU::fetch(u64 vaddr) -> u32 {
+  switch(segment(vaddr)) {
   case Context::Segment::Unused:
     step(1);
-    addressException(address);
+    addressException(vaddr);
     exception.addressLoad();
     return 0;  //nop
   case Context::Segment::Mapped:
-    if(auto match = tlb.load(address)) {
+    if(auto match = tlb.load(vaddr)) {
       if(match.cache) return icache.fetch(match.address & context.physMask);
       step(1);
       return bus.read<Word>(match.address & context.physMask);
     }
     step(1);
-    tlb.exception(address);
+    tlb.exception(vaddr);
     return 0;  //nop
   case Context::Segment::Cached:
-    return icache.fetch(address & context.physMask);
+    return icache.fetch(vaddr & context.physMask);
   case Context::Segment::Direct:
     step(1);
-    return bus.read<Word>(address & context.physMask);
+    return bus.read<Word>(vaddr & context.physMask);
   }
 
   unreachable;
 }
 
 template<u32 Size>
-auto CPU::read(u64 address) -> maybe<u64> {
+auto CPU::read(u64 vaddr) -> maybe<u64> {
   if constexpr(Accuracy::CPU::AddressErrors) {
-    if(unlikely(address & Size - 1)) {
+    if(unlikely(vaddr & Size - 1)) {
       step(1);
-      addressException(address);
+      addressException(vaddr);
       exception.addressLoad();
       return nothing;
     }
-    if (context.bits == 32 && unlikely((s32)address != address)) {
+    if (context.bits == 32 && unlikely((s32)vaddr != vaddr)) {
       step(1);
-      addressException(address);
+      addressException(vaddr);
       exception.addressLoad();
       return nothing;      
     }
   }
 
-  switch(segment(address)) {
+  switch(segment(vaddr)) {
   case Context::Segment::Unused:
     step(1);
-    addressException(address);
+    addressException(vaddr);
     exception.addressLoad();
     return nothing;
   case Context::Segment::Mapped:
-    if(auto match = tlb.load(address)) {
+    if(auto match = tlb.load(vaddr)) {
       if(match.cache) return dcache.read<Size>(match.address & context.physMask);
       step(1);
       return bus.read<Size>(match.address & context.physMask);
     }
     step(1);
-    tlb.exception(address);
+    tlb.exception(vaddr);
     return nothing;
   case Context::Segment::Cached:
-    return dcache.read<Size>(address & context.physMask);
+    return dcache.read<Size>(vaddr & context.physMask);
   case Context::Segment::Direct:
     step(1);
-    return bus.read<Size>(address & context.physMask);
+    return bus.read<Size>(vaddr & context.physMask);
   }
 
   unreachable;
 }
 
 template<u32 Size>
-auto CPU::write(u64 address, u64 data) -> bool {
+auto CPU::write(u64 vaddr, u64 data) -> bool {
   if constexpr(Accuracy::CPU::AddressErrors) {
-    if(unlikely(address & Size - 1)) {
+    if(unlikely(vaddr & Size - 1)) {
       step(1);
-      addressException(address);
+      addressException(vaddr);
       exception.addressStore();
       return false;
     }
-    if (context.bits == 32 && unlikely((s32)address != address)) {
+    if (context.bits == 32 && unlikely((s32)vaddr != vaddr)) {
       step(1);
-      addressException(address);
+      addressException(vaddr);
       exception.addressStore();
       return false;
     }
   }
 
-  switch(segment(address)) {
+  switch(segment(vaddr)) {
   case Context::Segment::Unused:
     step(1);
-    addressException(address);
+    addressException(vaddr);
     exception.addressStore();
     return false;
   case Context::Segment::Mapped:
-    if(auto match = tlb.store(address)) {
+    if(auto match = tlb.store(vaddr)) {
       if(match.cache) return dcache.write<Size>(match.address & context.physMask, data), true;
       step(1);
       return bus.write<Size>(match.address & context.physMask, data), true;
     }
     step(1);
-    tlb.exception(address);
+    tlb.exception(vaddr);
     return false;
   case Context::Segment::Cached:
-    return dcache.write<Size>(address & context.physMask, data), true;
+    return dcache.write<Size>(vaddr & context.physMask, data), true;
   case Context::Segment::Direct:
     step(1);
-    return bus.write<Size>(address & context.physMask, data), true;
+    return bus.write<Size>(vaddr & context.physMask, data), true;
   }
 
   unreachable;
 }
 
-auto CPU::addressException(u64 address) -> void {
-  scc.badVirtualAddress = address;
-  scc.context.badVirtualAddress = address >> 13;
-  scc.xcontext.badVirtualAddress = address >> 13;
-  scc.xcontext.region = address >> 62;
+auto CPU::addressException(u64 vaddr) -> void {
+  scc.badVirtualAddress = vaddr;
+  scc.context.badVirtualAddress = vaddr >> 13;
+  scc.xcontext.badVirtualAddress = vaddr >> 13;
+  scc.xcontext.region = vaddr >> 62;
 }

--- a/ares/n64/cpu/serialization.cpp
+++ b/ares/n64/cpu/serialization.cpp
@@ -8,6 +8,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(branch.state);
 
   s(context.endian);
+  s(context.physMask);
   s(context.mode);
   s(context.bits);
   s(context.segment);

--- a/ares/n64/cpu/tlb.cpp
+++ b/ares/n64/cpu/tlb.cpp
@@ -2,7 +2,8 @@
 auto CPU::TLB::load(u64 vaddr) -> Match {
   for(auto& entry : this->entry) {
     if(!entry.globals && entry.addressSpaceID != self.scc.tlb.addressSpaceID) continue;
-    if((u32)(vaddr & entry.addressMaskHi) != (u32)entry.virtualAddress) continue;
+    if((vaddr & entry.addressMaskHi) != entry.virtualAddress) continue;
+    if(vaddr >> 62 != entry.region) continue;
     bool lo = vaddr & entry.addressSelect;
     if(!entry.valid[lo]) {
       self.addressException(vaddr);
@@ -23,7 +24,8 @@ auto CPU::TLB::load(u64 vaddr) -> Match {
 auto CPU::TLB::store(u64 vaddr) -> Match {
   for(auto& entry : this->entry) {
     if(!entry.globals && entry.addressSpaceID != self.scc.tlb.addressSpaceID) continue;
-    if((u32)(vaddr & entry.addressMaskHi) != (u32)entry.virtualAddress) continue;
+    if((vaddr & entry.addressMaskHi) != entry.virtualAddress) continue;
+    if(vaddr >> 62 != entry.region) continue;
     bool lo = vaddr & entry.addressSelect;
     if(!entry.valid[lo]) {
       self.addressException(vaddr);

--- a/ares/n64/cpu/tlb.cpp
+++ b/ares/n64/cpu/tlb.cpp
@@ -1,58 +1,58 @@
 //the N64 TLB is 32-bit only: only the 64-bit XTLB exception vector is used.
 
-auto CPU::TLB::load(u32 address) -> Match {
+auto CPU::TLB::load(u32 vaddr) -> Match {
   for(auto& entry : this->entry) {
     if(!entry.globals && entry.addressSpaceID != self.scc.tlb.addressSpaceID) continue;
-    if((u32)(address & entry.addressMaskHi) != (u32)entry.virtualAddress) continue;
-    bool lo = address & entry.addressSelect;
+    if((u32)(vaddr & entry.addressMaskHi) != (u32)entry.virtualAddress) continue;
+    bool lo = vaddr & entry.addressSelect;
     if(!entry.valid[lo]) {
-      exception(address);
-      self.debugger.tlbLoadInvalid(address);
+      exception(vaddr);
+      self.debugger.tlbLoadInvalid(vaddr);
       self.exception.tlbLoadInvalid();
       return {false};
     }
-    physicalAddress = entry.physicalAddress[lo] + (address & entry.addressMaskLo);
-    self.debugger.tlbLoad(address, physicalAddress);
+    physicalAddress = entry.physicalAddress[lo] + (vaddr & entry.addressMaskLo);
+    self.debugger.tlbLoad(vaddr, physicalAddress);
     return {true, entry.cacheAlgorithm[lo] != 2, physicalAddress};
   }
-  exception(address);
-  self.debugger.tlbLoadMiss(address);
+  exception(vaddr);
+  self.debugger.tlbLoadMiss(vaddr);
   self.exception.tlbLoadMiss();
   return {false};
 }
 
-auto CPU::TLB::store(u32 address) -> Match {
+auto CPU::TLB::store(u32 vaddr) -> Match {
   for(auto& entry : this->entry) {
     if(!entry.globals && entry.addressSpaceID != self.scc.tlb.addressSpaceID) continue;
-    if((u32)(address & entry.addressMaskHi) != (u32)entry.virtualAddress) continue;
-    bool lo = address & entry.addressSelect;
+    if((u32)(vaddr & entry.addressMaskHi) != (u32)entry.virtualAddress) continue;
+    bool lo = vaddr & entry.addressSelect;
     if(!entry.valid[lo]) {
-      exception(address);
-      self.debugger.tlbStoreInvalid(address);
+      exception(vaddr);
+      self.debugger.tlbStoreInvalid(vaddr);
       self.exception.tlbStoreInvalid();
       return {false};
     }
     if(!entry.dirty[lo]) {
-      exception(address);
-      self.debugger.tlbModification(address);
+      exception(vaddr);
+      self.debugger.tlbModification(vaddr);
       self.exception.tlbModification();
       return {false};
     }
-    physicalAddress = entry.physicalAddress[lo] + (address & entry.addressMaskLo);
-    self.debugger.tlbStore(address, physicalAddress);
+    physicalAddress = entry.physicalAddress[lo] + (vaddr & entry.addressMaskLo);
+    self.debugger.tlbStore(vaddr, physicalAddress);
     return {true, entry.cacheAlgorithm[lo] != 2, physicalAddress};
   }
-  exception(address);
-  self.debugger.tlbStoreMiss(address);
+  exception(vaddr);
+  self.debugger.tlbStoreMiss(vaddr);
   self.exception.tlbStoreMiss();
   return {false};
 }
 
-auto CPU::TLB::exception(u32 address) -> void {
-  self.scc.badVirtualAddress = address;
-  self.scc.tlb.virtualAddress.bit(13,39) = address >> 13;
-  self.scc.context.badVirtualAddress = address >> 13;
-  self.scc.xcontext.badVirtualAddress = address >> 13;
+auto CPU::TLB::exception(u32 vaddr) -> void {
+  self.scc.badVirtualAddress = vaddr;
+  self.scc.tlb.virtualAddress.bit(13,39) = vaddr >> 13;
+  self.scc.context.badVirtualAddress = vaddr >> 13;
+  self.scc.xcontext.badVirtualAddress = vaddr >> 13;
   self.scc.xcontext.region = 0;
 }
 

--- a/ares/n64/cpu/tlb.cpp
+++ b/ares/n64/cpu/tlb.cpp
@@ -1,12 +1,11 @@
-//the N64 TLB is 32-bit only: only the 64-bit XTLB exception vector is used.
 
-auto CPU::TLB::load(u32 vaddr) -> Match {
+auto CPU::TLB::load(u64 vaddr) -> Match {
   for(auto& entry : this->entry) {
     if(!entry.globals && entry.addressSpaceID != self.scc.tlb.addressSpaceID) continue;
     if((u32)(vaddr & entry.addressMaskHi) != (u32)entry.virtualAddress) continue;
     bool lo = vaddr & entry.addressSelect;
     if(!entry.valid[lo]) {
-      exception(vaddr);
+      self.addressException(vaddr);
       self.debugger.tlbLoadInvalid(vaddr);
       self.exception.tlbLoadInvalid();
       return {false};
@@ -15,25 +14,25 @@ auto CPU::TLB::load(u32 vaddr) -> Match {
     self.debugger.tlbLoad(vaddr, physicalAddress);
     return {true, entry.cacheAlgorithm[lo] != 2, physicalAddress};
   }
-  exception(vaddr);
+  self.addressException(vaddr);
   self.debugger.tlbLoadMiss(vaddr);
   self.exception.tlbLoadMiss();
   return {false};
 }
 
-auto CPU::TLB::store(u32 vaddr) -> Match {
+auto CPU::TLB::store(u64 vaddr) -> Match {
   for(auto& entry : this->entry) {
     if(!entry.globals && entry.addressSpaceID != self.scc.tlb.addressSpaceID) continue;
     if((u32)(vaddr & entry.addressMaskHi) != (u32)entry.virtualAddress) continue;
     bool lo = vaddr & entry.addressSelect;
     if(!entry.valid[lo]) {
-      exception(vaddr);
+      self.addressException(vaddr);
       self.debugger.tlbStoreInvalid(vaddr);
       self.exception.tlbStoreInvalid();
       return {false};
     }
     if(!entry.dirty[lo]) {
-      exception(vaddr);
+      self.addressException(vaddr);
       self.debugger.tlbModification(vaddr);
       self.exception.tlbModification();
       return {false};
@@ -42,18 +41,10 @@ auto CPU::TLB::store(u32 vaddr) -> Match {
     self.debugger.tlbStore(vaddr, physicalAddress);
     return {true, entry.cacheAlgorithm[lo] != 2, physicalAddress};
   }
-  exception(vaddr);
+  self.addressException(vaddr);
   self.debugger.tlbStoreMiss(vaddr);
   self.exception.tlbStoreMiss();
   return {false};
-}
-
-auto CPU::TLB::exception(u32 vaddr) -> void {
-  self.scc.badVirtualAddress = vaddr;
-  self.scc.tlb.virtualAddress.bit(13,39) = vaddr >> 13;
-  self.scc.context.badVirtualAddress = vaddr >> 13;
-  self.scc.xcontext.badVirtualAddress = vaddr >> 13;
-  self.scc.xcontext.region = 0;
 }
 
 auto CPU::TLB::Entry::synchronize() -> void {


### PR DESCRIPTION
This is a rarely used part of the CPU. All commercial games are practically 32-bit only with the O32 ABI (just some assembly routines used 64-bit instructions). Modern homebrew developed with libdragon uses the N32 ABI, which maps int64_t to 64-bit registers so it allows to use the full power of the CPU; *still*, pointers are 32-bits because there is no reason to waste memory with 64-bit pointers.

Nonetheless, thanks to n64-systemtest testsuite, we implemented to full 64-bit memory addressing with TLB capability. The only known ROM to require these features is the [N64 Linux port by clbr](https://github.com/clbr/n64bootloader).