### PR TITLE
n64: implement basic behavior of freeze bit

### DIFF
--- a/ares/n64/rdp/rdp.hpp
+++ b/ares/n64/rdp/rdp.hpp
@@ -67,6 +67,7 @@ struct RDP : Thread, Memory::IO<RDP> {
   //io.cpp
   auto readWord(u32 address) -> u32;
   auto writeWord(u32 address, u32 data) -> void;
+  auto flushCommands() -> void;
 
   //serialization.cpp
   auto serialize(serializer&) -> void;


### PR DESCRIPTION
The exact behavior of the freeze bit hasn't been investigate yet, but
at the very least it stops the RDP command engine. This PR does a
basic approximation of it, pending more in-depth tests.

Fixes Banjo-Tooie.