### PR TITLE
Fix fds loading

### DIFF
--- a/desktop-ui/emulator/famicom-disk-system.cpp
+++ b/desktop-ui/emulator/famicom-disk-system.cpp
@@ -11,7 +11,7 @@ struct FamicomDiskSystem : Emulator {
 
 FamicomDiskSystem::FamicomDiskSystem() {
   manufacturer = "Nintendo";
-  name = "Famicom Disk System";
+  name = "Famicom Disk";
 
   firmware.append({"BIOS", "Japan"});
 

--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -551,7 +551,7 @@ auto Nintendo64::analyze(vector<u8>& data) -> string {
   if(id == "NVC") {mempak = true;}                                       //Virtual Chess 64
   if(id == "NVR") {mempak = true;}                                       //Virtual Pool 64
   if(id == "NWV") {mempak = true; rumble = true;}                        //WCW: Backstage Assault
-  if(id == "NWV") {mempak = true; rumble = true;}                        //WCW: Mayhem
+  if(id == "NWM") {mempak = true; rumble = true;}                        //WCW: Mayhem
   if(id == "NW3") {mempak = true; rumble = true;}                        //WCW: Nitro
   if(id == "NWN") {mempak = true; rumble = true;}                        //WCW vs. nWo - World Tour
   if(id == "NWW") {mempak = true; rumble = true;}                        //WWF: War Zone


### PR DESCRIPTION
Auto detection depends on emulator name matching mia media name. From mia's perspective, it is returning a famicom disk, so it makes sense to leave this as is (and would have required a lot more changes). Although "Famicom Disk System" sounds a little better for an emulator, "Famicom Disk" should be good enough for now. Otherwise I guess we would need to maintain some type of map between media type and emulator name. I looked at other emulator names and media and it looks like all match up, so this was the path of least resistance for getting *.fds games to auto load.