### PR TITLE
match emulator name with expected mia media definition to fix auto-detection of fds

### DIFF
--- a/ares/fc/fds/fds.cpp
+++ b/ares/fc/fds/fds.cpp
@@ -10,7 +10,7 @@ FDS fds;
 
 auto FDS::load(Node::Object parent) -> void {
   port = parent->append<Node::Port>("Disk Slot");
-  port->setFamily("Famicom Disk");
+  port->setFamily("Famicom Disk System");
   port->setType("Floppy Disk");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(port); });
@@ -35,7 +35,7 @@ auto FDS::unload() -> void {
 }
 
 auto FDS::allocate(Node::Port parent) -> Node::Peripheral {
-  return node = parent->append<Node::Peripheral>("Famicom Disk");
+  return node = parent->append<Node::Peripheral>("Famicom Disk System");
 }
 
 auto FDS::connect() -> void {

--- a/desktop-ui/emulator/famicom-disk-system.cpp
+++ b/desktop-ui/emulator/famicom-disk-system.cpp
@@ -11,7 +11,7 @@ struct FamicomDiskSystem : Emulator {
 
 FamicomDiskSystem::FamicomDiskSystem() {
   manufacturer = "Nintendo";
-  name = "Famicom Disk";
+  name = "Famicom Disk System";
 
   firmware.append({"BIOS", "Japan"});
 
@@ -66,7 +66,7 @@ auto FamicomDiskSystem::load(Menu menu) -> void {
 }
 
 auto FamicomDiskSystem::load() -> bool {
-  game = mia::Medium::create("Famicom Disk");
+  game = mia::Medium::create("Famicom Disk System");
   if(!game->load(Emulator::load(game, configuration.game))) return false;
 
   bios = mia::Medium::create("Famicom");
@@ -115,7 +115,7 @@ auto FamicomDiskSystem::save() -> bool {
 auto FamicomDiskSystem::pak(ares::Node::Object node) -> shared_pointer<vfs::directory> {
   if(node->name() == "Famicom") return system->pak;
   if(node->name() == "Famicom Cartridge") return bios->pak;
-  if(node->name() == "Famicom Disk") return game->pak;
+  if(node->name() == "Famicom Disk System") return game->pak;
   return {};
 }
 

--- a/desktop-ui/emulator/famicom-disk-system.cpp
+++ b/desktop-ui/emulator/famicom-disk-system.cpp
@@ -11,7 +11,7 @@ struct FamicomDiskSystem : Emulator {
 
 FamicomDiskSystem::FamicomDiskSystem() {
   manufacturer = "Nintendo";
-  name = "Famicom Disk System";
+  name = "Famicom Disk";
 
   firmware.append({"BIOS", "Japan"});
 

--- a/mia/medium/famicom-disk-system.cpp
+++ b/mia/medium/famicom-disk-system.cpp
@@ -1,0 +1,138 @@
+struct FamicomDiskSystem : FloppyDisk {
+  auto name() -> string override { return "Famicom Disk System"; }
+  auto extensions() -> vector<string> override { return {"fds"}; }
+  auto load(string location) -> bool override;
+  auto save(string location) -> bool override;
+  auto analyze() -> string;
+  auto transform(array_view<u8> input) -> vector<u8>;
+};
+
+auto FamicomDiskSystem::load(string location) -> bool {
+  if(directory::exists(location)) {
+    this->location = location;
+    this->manifest = analyze();
+
+    pak = new vfs::directory;
+    pak->setAttribute("title", Medium::name(location));
+    pak->append("manifest.bml", manifest);
+    for(auto& filename : directory::files(location, "disk?*.side?*")) {
+      pak->append(filename, file::read({location, filename}));
+    }
+  }
+
+  if(file::exists(location)) {
+    this->location = location;
+    this->manifest = analyze();
+
+    pak = new vfs::directory;
+    pak->setAttribute("title", Medium::name(location));
+    pak->append("manifest.bml", manifest);
+
+    vector<u8> input = FloppyDisk::read(location);
+    array_view<u8> view{input};
+    if(view.size() % 65500 == 16) view += 16;  //skip iNES / fwNES header
+    u32 index = 0;
+    while(auto output = transform(view)) {
+      string name;
+      name.append("disk", (char)('1' + index / 2), ".");
+      name.append("side", (char)('A' + index % 2));
+      pak->append(name, output);
+      view += 65500;
+      index++;
+    }
+  }
+
+  if(!pak) return false;
+
+  Pak::load("disk1.sideA", ".d1a");
+  Pak::load("disk1.sideB", ".d1b");
+  Pak::load("disk2.sideA", ".d2a");
+  Pak::load("disk2.sideB", ".d2b");
+
+  return true;
+}
+
+auto FamicomDiskSystem::save(string location) -> bool {
+  auto document = BML::unserialize(manifest);
+
+  Pak::save("disk1.sideA", ".d1a");
+  Pak::save("disk1.sideB", ".d1b");
+  Pak::save("disk2.sideA", ".d2a");
+  Pak::save("disk2.sideB", ".d2b");
+
+  return true;
+}
+
+auto FamicomDiskSystem::analyze() -> string {
+  string s;
+  s += "game\n";
+  s +={"  name:  ", Medium::name(location), "\n"};
+  s +={"  title: ", Medium::name(location), "\n"};
+  return s;
+}
+
+auto FamicomDiskSystem::transform(array_view<u8> input) -> vector<u8> {
+  if(input.size() < 65500) return {};
+
+  array_view<u8> data{input.data(), 65500};
+  if(data[0x00] != 0x01) return {};
+  if(data[0x38] != 0x02) return {};
+  if(data[0x3a] != 0x03) return {};
+  if(data[0x4a] != 0x04) return {};
+
+  vector<u8> output;
+  u16 crc16 = 0;
+  auto hash = [&](u8 byte) {
+    for(u32 bit : range(8)) {
+      bool carry = crc16 & 1;
+      crc16 = crc16 >> 1 | bool(byte & 1 << bit) << 15;
+      if(carry) crc16 ^= 0x8408;
+    }
+  };
+  auto write = [&](u8 byte) {
+    hash(byte);
+    output.append(byte);
+  };
+  auto flush = [&] {
+    hash(0x00);
+    hash(0x00);
+    output.append(crc16 >> 0);
+    output.append(crc16 >> 8);
+    crc16 = 0;
+  };
+
+  //block 1
+  for(u32 n : range(0xe00)) write(0x00);  //pregap
+  write(0x80);
+  for(u32 n : range(0x38)) write(*data++);
+  flush();
+
+  //block 2
+  for(u32 n : range(0x80)) write(0x00);  //gap
+  write(0x80);
+  for(u32 n : range(0x02)) write(*data++);
+  flush();
+
+  while(true) {
+    if(data[0x00] != 0x03 || data.size() < 0x11) break;
+    u16 size = data[0x0d] << 0 | data[0x0e] << 8;
+    if(data[0x10] != 0x04 || data.size() < 0x11 + size) break;
+
+    //block 3
+    for(u32 n : range(0x80)) write(0x00);  //gap
+    write(0x80);
+    for(u32 n : range(0x10)) write(*data++);
+    flush();
+
+    //block 4
+    for(u32 n : range(0x80)) write(0x00);  //gap
+    write(0x80);
+    for(u32 n : range(1 + size)) write(*data++);
+    flush();
+  }
+
+  //note: actual maximum capacity of a Famicom Disk is currently unknown
+  while(output.size() < 0x12000) output.append(0x00);  //expand if too small
+  output.resize(0x12000);  //shrink if too large
+  return output;
+}

--- a/mia/medium/medium.cpp
+++ b/mia/medium/medium.cpp
@@ -3,7 +3,7 @@ namespace Media {
   #include "atari-2600.cpp"
   #include "colecovision.cpp"
   #include "famicom.cpp"
-  #include "famicom-disk.cpp"
+  #include "famicom-disk-system.cpp"
   #include "game-boy.cpp"
   #include "game-boy-color.cpp"
   #include "game-boy-advance.cpp"
@@ -43,7 +43,7 @@ auto Medium::create(string name) -> shared_pointer<Pak> {
   if(name == "Atari 2600") return new Media::Atari2600;
   if(name == "ColecoVision") return new Media::ColecoVision;
   if(name == "Famicom") return new Media::Famicom;
-  if(name == "Famicom Disk") return new Media::FamicomDisk;
+  if(name == "Famicom Disk System") return new Media::FamicomDiskSystem;
   if(name == "Game Boy") return new Media::GameBoy;
   if(name == "Game Boy Color") return new Media::GameBoyColor;
   if(name == "Game Boy Advance") return new Media::GameBoyAdvance;

--- a/mia/mia.cpp
+++ b/mia/mia.cpp
@@ -49,7 +49,7 @@ auto construct() -> void {
   media.append("BS Memory");
   media.append("ColecoVision");
   media.append("Famicom");
-  media.append("Famicom Disk");
+  media.append("Famicom Disk System");
   media.append("Game Boy");
   media.append("Game Boy Color");
   media.append("Game Boy Advance");


### PR DESCRIPTION
Auto detection depends on emulator name matching mia media name. From mia's perspective, it is returning a famicom disk, so it makes sense to leave this as is (and would have required a lot more changes). Although "Famicom Disk System" sounds a little better for an emulator, "Famicom Disk" should be good enough for now. Otherwise I guess we would need to maintain some type of map between media type and emulator name. I looked at other emulator names and media and it looks like all match up, so this was the path of least resistance for getting *.fds games to auto load.