### PR TITLE
n64: fix AI IRQ

### DIFF
--- a/ares/n64/ai/ai.cpp
+++ b/ares/n64/ai/ai.cpp
@@ -30,22 +30,24 @@ auto AI::main() -> void {
 }
 
 auto AI::sample() -> void {
-  if(io.dmaCount == 0) return stream->frame(0.0, 0.0);
+  if(!io.dmaEnable || io.dmaCount == 0) return stream->frame(0.0, 0.0);
 
-  io.dmaAddress[0].bit(13,23) += io.dmaAddressCarry;
-  auto data  = rdram.ram.read<Word>(io.dmaAddress[0]);
-  auto left  = s16(data >> 16);
-  auto right = s16(data >>  0);
-  stream->frame(left / 32768.0, right / 32768.0);
+  if(io.dmaLength[0]) {
+    io.dmaAddress[0].bit(13,23) += io.dmaAddressCarry;
+    auto data  = rdram.ram.read<Word>(io.dmaAddress[0]);
+    auto left  = s16(data >> 16);
+    auto right = s16(data >>  0);
+    stream->frame(left / 32768.0, right / 32768.0);
 
-  io.dmaAddress[0].bit(0,12) += 4;
-  io.dmaAddressCarry          = io.dmaAddress[0].bit(0,12) == 0;
-  io.dmaLength[0]            -= 4;
+    io.dmaAddress[0].bit(0,12) += 4;
+    io.dmaAddressCarry          = io.dmaAddress[0].bit(0,12) == 0;
+    io.dmaLength[0]            -= 4;
+  }
   if(!io.dmaLength[0]) {
-    mi.raise(MI::IRQ::AI);
     if(--io.dmaCount) {
       io.dmaAddress[0] = io.dmaAddress[1];
       io.dmaLength [0] = io.dmaLength [1];
+      mi.raise(MI::IRQ::AI);
     }
   }
 }

--- a/ares/n64/ai/io.cpp
+++ b/ares/n64/ai/io.cpp
@@ -12,6 +12,7 @@ auto AI::readWord(u32 address) -> u32 {
     data.bit( 0) = io.dmaCount > 1;
     data.bit(20) = 1;
     data.bit(24) = 1;
+    data.bit(25) = io.dmaEnable;
     data.bit(30) = io.dmaCount > 0;
     data.bit(31) = io.dmaCount > 1;
   }
@@ -34,7 +35,8 @@ auto AI::writeWord(u32 address, u32 data_) -> void {
   if(address == 1) {
     //AI_LENGTH
     n18 length = data.bit(0,17) & ~7;
-    if(io.dmaCount < 2 && length) {
+    if(io.dmaCount < 2) {
+      if(io.dmaCount == 0) mi.raise(MI::IRQ::AI);
       io.dmaLength[io.dmaCount] = length;
       io.dmaCount++;
     }


### PR DESCRIPTION
The AI IRQ should be generated when a buffer starts playing, not when
it finishes playing, as verified by hardware tests.

Fixes the audio in Hey Pikachu and possibly other games.