### PR TITLE
sfc: fix old refactor typo that broke bg4 in the pixel renderer

### DIFF
--- a/ares/sfc/ppu/ppu.hpp
+++ b/ares/sfc/ppu/ppu.hpp
@@ -537,7 +537,7 @@ struct PPU : PPUBase::Implementation, PPUcounter {
 
   //unserialized:
     u32* line = nullptr;
-  } dac{*this, bg1, bg2, bg3, bg3, obj, window, cgram};
+  } dac{*this, bg1, bg2, bg3, bg4, obj, window, cgram};
 };
 
 extern PPU ppuImpl;


### PR DESCRIPTION
Caused missing menu windows in Final Fantasy IV and probably many other titles