### PR TITLE
m68000: fix memory read order for A/SBCD, ADD/SUBX

### DIFF
--- a/ares/component/processor/m68000/instructions.cpp
+++ b/ares/component/processor/m68000/instructions.cpp
@@ -1,7 +1,7 @@
 auto M68000::instructionABCD(EffectiveAddress from, EffectiveAddress with) -> void {
   if(from.mode == DataRegisterDirect) idle(2);
-  auto target = read<Byte, Hold, Fast>(with);
   auto source = read<Byte>(from);
+  auto target = read<Byte, Hold, Fast>(with);
   auto result = source + target + r.x;
   bool c = false;
   bool v = false;
@@ -98,8 +98,8 @@ template<u32 Size> auto M68000::instructionADDX(EffectiveAddress from, Effective
   if constexpr(Size == Long) {
     if(from.mode == DataRegisterDirect) idle(4);
   }
-  auto target = read<Size, Hold, Fast>(with);
   auto source = read<Size>(from);
+  auto target = read<Size, Hold, Fast>(with);
   auto result = ADD<Size, Extend>(source, target);
   prefetch();
   write<Size>(with, result);
@@ -1134,8 +1134,8 @@ auto M68000::instructionRTS() -> void {
 
 auto M68000::instructionSBCD(EffectiveAddress from, EffectiveAddress with) -> void {
   if(from.mode == DataRegisterDirect) idle(2);
-  auto target = read<Byte, Hold, Fast>(with);
   auto source = read<Byte>(from);
+  auto target = read<Byte, Hold, Fast>(with);
   auto result = target - source - r.x;
   bool c = false;
   bool v = false;
@@ -1256,8 +1256,8 @@ template<u32 Size> auto M68000::instructionSUBX(EffectiveAddress from, Effective
   if constexpr(Size == Long) {
     if(from.mode == DataRegisterDirect) idle(4);
   }
-  auto target = read<Size, Hold, Fast>(with);
   auto source = read<Size>(from);
+  auto target = read<Size, Hold, Fast>(with);
   auto result = SUB<Size, Extend>(source, target);
   prefetch();
   write<Size>(with, result);


### PR DESCRIPTION
This is especially important when both operands reference the same
register, as the first predecrement should affect the second read.

Discovered by running these tests:
https://github.com/TomHarte/CLK/tree/master/OSBindings/Mac/Clock%20SignalTests/68000%20Comparative%20Tests