### PR TITLE
Add support for the Japanese HPD-200 Paddle

### DIFF
--- a/ares/ms/controller/controller.cpp
+++ b/ares/ms/controller/controller.cpp
@@ -5,5 +5,6 @@ namespace ares::MasterSystem {
 #include "port.cpp"
 #include "gamepad/gamepad.cpp"
 #include "light-phaser/light-phaser.cpp"
+#include "paddle/paddle.cpp"
 
 }

--- a/ares/ms/controller/controller.hpp
+++ b/ares/ms/controller/controller.hpp
@@ -26,3 +26,4 @@ struct Controller {
 #include "port.hpp"
 #include "gamepad/gamepad.hpp"
 #include "light-phaser/light-phaser.hpp"
+#include "paddle/paddle.hpp"

--- a/ares/ms/controller/paddle/paddle.cpp
+++ b/ares/ms/controller/paddle/paddle.cpp
@@ -1,0 +1,40 @@
+Paddle::Paddle(Node::Port parent) {
+  node = parent->append<Node::Peripheral>("Paddle");
+
+  button = node->append<Node::Input::Button>("Button");
+  axis   = node->append<Node::Input::Axis>  ("X-Axis");
+
+  // 18kHz - As measured on real hardware
+  Thread::create(18000, {&Paddle::main, this});
+}
+
+Paddle::~Paddle() {
+  Thread::destroy();
+}
+
+auto Paddle::main() -> void {
+  secondNibble = !secondNibble;
+
+  Thread::step(1);
+  Thread::synchronize(cpu);
+}
+
+auto Paddle::read() -> n7 {
+  platform->input(button);
+  platform->input(axis);
+
+  n7 data;
+  if (secondNibble) {
+    data.bit(0,3) = value.bit(4,7);
+  } else {
+    // scale {-32768 ... +32767} to {0 ... 255 }
+    value = (axis->value() + 32768.0) * 255.0 / 65535.0;
+    data.bit(0,3) = value.bit(0,3);
+  }
+
+  data.bit(4) = !button->value();
+  data.bit(5) = secondNibble;
+  data.bit(6) = 1;
+
+  return data;
+}

--- a/ares/ms/controller/paddle/paddle.hpp
+++ b/ares/ms/controller/paddle/paddle.hpp
@@ -1,0 +1,14 @@
+struct Paddle : Controller, Thread {
+  Node::Input::Axis axis;
+  Node::Input::Button button;
+
+  Paddle(Node::Port);
+  ~Paddle();
+
+  auto main() -> void;
+  auto read() -> n7 override;
+
+private:
+  n8 value;
+  b1 secondNibble;
+};

--- a/ares/ms/controller/port.cpp
+++ b/ares/ms/controller/port.cpp
@@ -10,7 +10,7 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setType("Controller");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
-  port->setSupported({"Gamepad", "Light Phaser"});
+  port->setSupported({"Gamepad", "Light Phaser", "Paddle"});
 }
 
 auto ControllerPort::unload() -> void {
@@ -21,6 +21,7 @@ auto ControllerPort::unload() -> void {
 auto ControllerPort::allocate(string name) -> Node::Peripheral {
   if(name == "Gamepad") device = new Gamepad(port);
   if(name == "Light Phaser") device = new LightPhaser(port);
+  if(name == "Paddle") device = new Paddle(port);
   if(device) return device->node;
   return {};
 }

--- a/desktop-ui/emulator/master-system.cpp
+++ b/desktop-ui/emulator/master-system.cpp
@@ -37,6 +37,13 @@ MasterSystem::MasterSystem() {
     device.digital("2",     virtualPorts[id].pad.east);
     port.append(device); }
 
+  { InputDevice device{"Paddle"};
+    device.analog ("L-Left",  virtualPorts[id].pad.lstick_left);
+    device.analog ("L-Right", virtualPorts[id].pad.lstick_right);
+    device.analog ("X-Axis",  virtualPorts[id].pad.lstick_left, virtualPorts[id].pad.lstick_right);
+    device.digital("Button",  virtualPorts[id].pad.south);
+    port.append(device); }
+
     ports.append(port);
   }
 }


### PR DESCRIPTION
This makes games requiring a Paddle, such as Megumi Rescue, playable with an analog stick, or using USB adapters
supporting the HPD-200 Paddle.

"Prefer Japan" should be selected in tools->Boot Options before load otherwise some game may expect the "Export Paddle" which is not compatible.