### PR TITLE
N64 Setting Request: disable video interface post-processing

### DIFF
--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -21,6 +21,7 @@ auto option(string name, string value) -> bool {
   if(name == "Quality" && value == "HD" ) vulkan.internalUpscale = 2;
   if(name == "Quality" && value == "UHD") vulkan.internalUpscale = 4;
   if(name == "Supersampling") vulkan.supersampleScanout = value.boolean();
+  if(name == "Disable Video Interface Processing") vulkan.disableVideoInterfaceProcessing = value.boolean();
   if(vulkan.internalUpscale == 1) vulkan.supersampleScanout = false;
   vulkan.outputUpscale = vulkan.supersampleScanout ? 1 : vulkan.internalUpscale;
   #endif

--- a/ares/n64/vulkan/vulkan.cpp
+++ b/ares/n64/vulkan/vulkan.cpp
@@ -147,6 +147,9 @@ auto Vulkan::scanoutAsync(bool field) -> bool {
   ::RDP::ScanoutOptions options;
   options.downscale_steps = supersampleScanout ? 16 : 0;
   options.persist_frame_on_invalid_input = true;  //this is a compatibility hack, but I'm not sure what for ...
+  if(disableVideoInterfaceProcessing) {
+    options.vi = {false, false, false, false, false, false};
+  }
 
   if(implementation->scanout.fence) {
     implementation->scanout.fence->wait();

--- a/ares/n64/vulkan/vulkan.hpp
+++ b/ares/n64/vulkan/vulkan.hpp
@@ -18,6 +18,7 @@ struct Vulkan {
   Implementation* implementation = nullptr;
 
   bool enable = true;
+  bool disableVideoInterfaceProcessing = false;
   u32  internalUpscale = 1;  //1, 2, 4, 8
   bool supersampleScanout = false;
   u32  outputUpscale = supersampleScanout ? 1 : internalUpscale;

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -59,6 +59,7 @@ auto Nintendo64::load() -> bool {
   ares::Nintendo64::option("Quality", settings.video.quality);
   ares::Nintendo64::option("Supersampling", settings.video.supersampling);
   ares::Nintendo64::option("Enable Vulkan", settings.video.enableVulkan);
+  ares::Nintendo64::option("Disable Video Interface Processing", settings.video.disableVideoInterfaceProcessing);
 
   auto region = Emulator::region();
   if(!ares::Nintendo64::load(root, {"[Nintendo] Nintendo 64 (", region, ")"})) return false;

--- a/desktop-ui/emulator/nintendo-64dd.cpp
+++ b/desktop-ui/emulator/nintendo-64dd.cpp
@@ -59,6 +59,7 @@ auto Nintendo64DD::load() -> bool {
   ares::Nintendo64::option("Quality", settings.video.quality);
   ares::Nintendo64::option("Supersampling", settings.video.supersampling);
   ares::Nintendo64::option("Enable Vulkan", settings.video.enableVulkan);
+  ares::Nintendo64::option("Disable Video Interface Processing", settings.video.disableVideoInterfaceProcessing);
 
   auto region = Emulator::region();
   if(!ares::Nintendo64::load(root, {"[Nintendo] Nintendo 64 (", region, ")"})) return false;

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -72,6 +72,7 @@ auto Settings::process(bool load) -> void {
   bind(string,  "Video/Quality", video.quality);
   bind(boolean, "Video/Supersampling", video.supersampling);
   bind(boolean, "Video/EnableVulkan", video.enableVulkan);
+  bind(boolean, "Video/DisableVideoInterfaceProcessing", video.disableVideoInterfaceProcessing);
 
   bind(string,  "Audio/Driver", audio.driver);
   bind(string,  "Audio/Device", audio.device);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -31,6 +31,7 @@ struct Settings : Markup::Node {
     string quality = "SD";
     bool supersampling = false;
     bool enableVulkan = true;
+    bool disableVideoInterfaceProcessing = false;
   } video;
 
   struct Audio {
@@ -126,6 +127,9 @@ struct VideoSettings : VerticalLayout {
   HorizontalLayout enableVulkanLayout{this, Size{~0, 0}};
     CheckLabel enableVulkanOption{&enableVulkanLayout, Size{0, 0}, 5};
     Label enableVulkanHint{&enableVulkanLayout, Size{~0, 0}};  
+  HorizontalLayout disableVideoInterfaceProcessingLayout{this, Size{~0, 0}, 5};
+    CheckLabel disableVideoInterfaceProcessingOption{&disableVideoInterfaceProcessingLayout, Size{0, 0}, 5};
+    Label disableVideoInterfaceProcessingHint{&disableVideoInterfaceProcessingLayout, Size{0, 0}};
   HorizontalLayout renderQualityLayout{this, Size{~0, 0}, 5};
     RadioLabel renderQualitySD{&renderQualityLayout, Size{0, 0}};
     RadioLabel renderQualityHD{&renderQualityLayout, Size{0, 0}};

--- a/desktop-ui/settings/video.cpp
+++ b/desktop-ui/settings/video.cpp
@@ -73,10 +73,16 @@ auto VideoSettings::construct() -> void {
     renderQualitySD.setEnabled(settings.video.enableVulkan);
     renderQualityHD.setEnabled(settings.video.enableVulkan);
     renderQualityUHD.setEnabled(settings.video.enableVulkan);
+    disableVideoInterfaceProcessingOption.setEnabled(settings.video.enableVulkan);
   });
   enableVulkanLayout.setAlignment(1).setPadding(12_sx, 0);
   enableVulkanHint.setText("Enables Vulkan Hardware rendering").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
-  
+  disableVideoInterfaceProcessingOption.setText("Disable Video Interface Processing").setChecked(settings.video.disableVideoInterfaceProcessing).onToggle([&] {
+    settings.video.disableVideoInterfaceProcessing = disableVideoInterfaceProcessingOption.checked();
+    if(emulator) emulator->setBoolean("Disable Video Interface Processing", settings.video.disableVideoInterfaceProcessing);
+  });
+  disableVideoInterfaceProcessingLayout.setAlignment(1).setPadding(12_sx, 0);
+  disableVideoInterfaceProcessingHint.setText("Disables Video Interface post processing to render image from VRAM directly").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
   renderQualitySD.setText("SD Quality").onActivate([&] {
     settings.video.quality = "SD";
     renderSupersamplingOption.setChecked(false).setEnabled(false);
@@ -107,5 +113,6 @@ auto VideoSettings::construct() -> void {
   renderQualityLayout.setCollapsible(true).setVisible(false);
   renderSupersamplingLayout.setCollapsible(true).setVisible(false);
   renderSettingsHint.setCollapsible(true).setVisible(false);
+  disableVideoInterfaceProcessingLayout.setCollapsible(true).setVisible(false);
   #endif
 }


### PR DESCRIPTION
#### Feature Request
N64 video setting to disable video interface post processing in the Vulkan renderer.

ParaLLEl exposes options to enable/disable VI passes. Serveral frontends, e.g. [m64p](https://m64p.github.io/), expose these settings to the end user. A matter of personal preference or use-case, there are even N64 hardware modifications which implement something similiar: [ultraHDMI](https://www.retrorgb.com/ultrahdmi.html).

Additionally, the current software renderer doesn't seem to implement some of the VI passes. Users may opt to use it over the Vulkan renderer only because the option to disable VI passes isn't available.

I don't want to pollute the settings, but I have a feeling this feature would be appreciated by more than myself.