### PR TITLE
n64: precise rsp block invalidation

### DIFF
--- a/ares/n64/rsp/dma.cpp
+++ b/ares/n64/rsp/dma.cpp
@@ -12,11 +12,12 @@ auto RSP::dmaTransferStep() -> void {
   auto& region = !dma.current.pbusRegion ? dmem : imem;
 
   if(dma.busy.read) {
+    if constexpr(Accuracy::RSP::Recompiler) {
+      if(dma.current.pbusRegion) {
+        recompiler.invalidate(dma.current.pbusAddress, dma.current.length + 8);
+      }
+    }
     for(u32 i = 0; i <= dma.current.length; i += 8) {
-        if constexpr(Accuracy::RSP::Recompiler) {
-            if(dma.current.pbusRegion) recompiler.invalidate(dma.current.pbusAddress);
-        }
-
         u64 data = rdram.ram.read<Dual>(dma.current.dramAddress);
         region.write<Dual>(dma.current.pbusAddress, data);
         dma.current.dramAddress += 8;

--- a/ares/n64/rsp/rsp.hpp
+++ b/ares/n64/rsp/rsp.hpp
@@ -334,31 +334,31 @@ struct RSP : Thread, Memory::IO<RSP> {
       }
 
       u8* code;
+      u12 size;
     };
 
-    struct Pool {
-      Block* blocks[1024];
-    };
-
-    struct PoolHashPair {
-      auto operator==(const PoolHashPair& source) const -> bool { return hashcode == source.hashcode; }
-      auto operator< (const PoolHashPair& source) const -> bool { return hashcode <  source.hashcode; }
+    struct BlockHashPair {
+      auto operator==(const BlockHashPair& source) const -> bool { return hashcode == source.hashcode; }
+      auto operator< (const BlockHashPair& source) const -> bool { return hashcode <  source.hashcode; }
       auto hash() const -> u32 { return hashcode; }
 
-      Pool* pool;
-      u32 hashcode;
+      Block* block;
+      u64 hashcode;
     };
 
     auto reset() -> void {
-      for(auto n : range(16)) context[n] = nullptr;
-      for(auto n : range(16)) pools[n].reset();
+      context.fill();
+      blocks.reset();
+      dirty = 0;
     }
 
-    auto invalidate(u32 address) -> void {
-      context[address >> 8] = nullptr;
+    auto invalidate(u12 address, u12 size = 1) -> void {
+      dirty |= mask(address, size);
     }
 
-    auto pool(u12 address) -> Pool*;
+    auto measure(u12 address) -> u12;
+    auto hash(u12 address, u12 size) -> u64;
+
     auto block(u12 address) -> Block*;
 
     auto emit(u12 address) -> Block*;
@@ -370,9 +370,22 @@ struct RSP : Thread, Memory::IO<RSP> {
     auto emitLWC2(u32 instruction) -> bool;
     auto emitSWC2(u32 instruction) -> bool;
 
+    auto isTerminal(u32 instruction) -> bool;
+
+    static auto mask(u12 address, u12 size) -> u64 {
+      //1 bit per 64 bytes
+      u6 s = address >> 6;
+      u6 e = address + size - 1 >> 6;
+      u64 smask = ~0ull << s;
+      u64 emask = ~0ull >> 63 - e;
+      //handle wraparound
+      return s <= e ? smask & emask : smask | emask;
+    }
+
     bump_allocator allocator;
-    Pool* context[16];
-    set<PoolHashPair> pools[16];
+    array<Block*[1024]> context;
+    hashset<BlockHashPair> blocks;
+    u64 dirty;
   } recompiler{*this};
 
   struct Disassembler {

--- a/nall/recompiler/generic/generic.hpp
+++ b/nall/recompiler/generic/generic.hpp
@@ -8,9 +8,11 @@ namespace nall::recompiler {
     sljit_label* epilogue = nullptr;
 
     generic(bump_allocator& alloc) : allocator(alloc) {}
+    ~generic() { resetCompiler(); }
 
-    auto beginFunction(int args) {
+    auto beginFunction(int args) -> void {
       assert(args <= 3);
+      resetCompiler();
       compiler = sljit_create_compiler(nullptr, &allocator);
 
       sljit_s32 options = 0;
@@ -27,21 +29,25 @@ namespace nall::recompiler {
 
     auto endFunction() -> u8* {
       u8* code = (u8*)sljit_generate_code(compiler);
-      sljit_free_compiler(compiler);
-      compiler = nullptr;
-      epilogue = nullptr;
+      resetCompiler();
       return code;
     }
 
-    auto testJumpEpilog() {
+    auto resetCompiler() -> void {
+      if(compiler) sljit_free_compiler(compiler);
+      compiler = nullptr;
+      epilogue = nullptr;
+    }
+
+    auto testJumpEpilog() -> void {
       sljit_set_label(sljit_emit_cmp(compiler, SLJIT_NOT_EQUAL | SLJIT_32, SLJIT_RETURN_REG, 0, SLJIT_IMM, 0), epilogue);
     }
 
-    auto jumpEpilog() {
+    auto jumpEpilog() -> void {
       sljit_set_label(sljit_emit_jump(compiler, SLJIT_JUMP), epilogue);
     }
 
-    auto setLabel(sljit_jump* jump) {
+    auto setLabel(sljit_jump* jump) -> void {
       sljit_set_label(jump, sljit_emit_label(compiler));
     }
 


### PR DESCRIPTION
- The primary lookup table is direct addressed
- The secondary lookup table is indexed by hash of code block contents
- IMEM invalidation is tracked at 64-byte granularity and used to
  evict primary lookup table entries
- The secondary lookup table is only pruned on a full code cache flush
- Only executed instructions are hashed, so the code cache no longer
  experiences unbounded growth
- Code blocks can now wrap around the end of IMEM
- generic::recompiler now supports aborting recompilation (required by
  by an earlier version of this change)

This change allows Resident Evil 2 to boot again and should be performance neutral.