### PR TITLE
ms: Add support for the Sports Pad

### DIFF
--- a/ares/ms/controller/controller.cpp
+++ b/ares/ms/controller/controller.cpp
@@ -6,5 +6,6 @@ namespace ares::MasterSystem {
 #include "gamepad/gamepad.cpp"
 #include "light-phaser/light-phaser.cpp"
 #include "paddle/paddle.cpp"
+#include "sports-pad/sports-pad.cpp"
 
 }

--- a/ares/ms/controller/controller.hpp
+++ b/ares/ms/controller/controller.hpp
@@ -20,7 +20,12 @@ struct Controller {
   virtual ~Controller() = default;
 
   virtual auto read() -> n7 { return 0x7f; }
-  virtual auto write(n8 data) -> void {}
+
+  // 0: trDirection
+  // 1: thDirection
+  // 2: trLevel
+  // 3: thLevel
+  virtual auto write(n4 data) -> void {}
 };
 
 #include "port.hpp"

--- a/ares/ms/controller/controller.hpp
+++ b/ares/ms/controller/controller.hpp
@@ -32,3 +32,4 @@ struct Controller {
 #include "gamepad/gamepad.hpp"
 #include "light-phaser/light-phaser.hpp"
 #include "paddle/paddle.hpp"
+#include "sports-pad/sports-pad.hpp"

--- a/ares/ms/controller/port.cpp
+++ b/ares/ms/controller/port.cpp
@@ -10,7 +10,7 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setType("Controller");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
-  port->setSupported({"Gamepad", "Light Phaser", "Paddle"});
+  port->setSupported({"Gamepad", "Light Phaser", "Paddle", "Sports Pad"});
 }
 
 auto ControllerPort::unload() -> void {
@@ -22,6 +22,7 @@ auto ControllerPort::allocate(string name) -> Node::Peripheral {
   if(name == "Gamepad") device = new Gamepad(port);
   if(name == "Light Phaser") device = new LightPhaser(port);
   if(name == "Paddle") device = new Paddle(port);
+  if(name == "Sports Pad") device = new SportsPad(port);
   if(device) return device->node;
   return {};
 }

--- a/ares/ms/controller/sports-pad/sports-pad.cpp
+++ b/ares/ms/controller/sports-pad/sports-pad.cpp
@@ -1,0 +1,98 @@
+SportsPad::SportsPad(Node::Port parent) {
+  node = parent->append<Node::Peripheral>("Sports Pad");
+
+  x   = node->append<Node::Input::Axis>  ("X");
+  y   = node->append<Node::Input::Axis>  ("Y");
+  one = node->append<Node::Input::Button>("1");
+  two = node->append<Node::Input::Button>("2");
+
+  Thread::create(1'000'000, {&SportsPad::main, this});
+}
+
+SportsPad::~SportsPad() {
+  Thread::destroy();
+}
+
+auto SportsPad::main() -> void {
+  // Timeout is reset when TH falls low.
+  // Sampling occurs when TH was kept low
+  // for more than 60us.
+  if (!th && (timeout > 0)) {
+      timeout--;
+
+      if (timeout == 0) {
+          index = 0;
+
+          platform->input(x);
+          platform->input(y);
+
+          i16 ax = -x->value();
+          i16 ay = -y->value();
+
+          if (ax > maxspeed) {
+            ax = maxspeed;
+          } else if (ax < -maxspeed) {
+            ax = -maxspeed;
+          }
+
+          if (ay > maxspeed) {
+            ay = maxspeed;
+          } else if (ay < -maxspeed) {
+            ay = -maxspeed;
+          }
+
+          status[0] = ax.bit(4,7);
+          status[1] = ax.bit(0,3);
+          status[2] = ay.bit(4,7);
+          status[3] = ay.bit(0,3);
+      }
+  }
+  Thread::step(1);
+  Thread::synchronize(cpu);
+}
+
+auto SportsPad::read() -> n7 {
+  platform->input(one);
+  platform->input(two);
+
+  n7 data;
+
+  data.bit(0,3) = status[index];
+  data.bit(4) = !one->value();
+  data.bit(5) = !two->value();
+  data.bit(6) = 1;
+
+  return data;
+}
+
+auto SportsPad::write(n4 data) -> void {
+
+  // Standard read sequence is:
+  //
+  //  1. TH low,  wait 80us, read nibble 1
+  //  2. TH high, wait 40us, read nibble 2
+  //  3. TH low,  wait 40us, read nibble 3
+  //  2. TH high, wait 40us, read nibble 4
+  //
+  // The longer wait at step 1 is used for
+  // synchronisation. In this implementation,
+  // the nibble index resets after 60us.
+
+  // Falling edge of TH
+  if (th && !data.bit(3)) {
+    timeout = 60;
+    index++;
+  }
+
+  // Rising edge of TH
+  if (!th && data.bit(3)) {
+    index++;
+  }
+
+  if (index > 3) {
+      index = 0;
+  }
+
+  th = data.bit(3);
+}
+

--- a/ares/ms/controller/sports-pad/sports-pad.hpp
+++ b/ares/ms/controller/sports-pad/sports-pad.hpp
@@ -1,0 +1,25 @@
+struct SportsPad : Controller, Thread {
+  Node::Input::Axis   x;
+  Node::Input::Axis   y;
+  Node::Input::Button one;
+  Node::Input::Button two;
+
+  SportsPad(Node::Port);
+  ~SportsPad();
+
+  auto main() -> void;
+  auto read() -> n7 override;
+  auto write(n4 data) -> void override;
+
+private:
+  // In theory values ranging from -128 to +127 are
+  // possible, but on real hardware, when polling the
+  // sports pad at 60 hz and giving it a really intense
+  // work out, the maximum observed was +/- 60.
+  s8 maxspeed = 60;
+
+  n32 timeout;
+  n4  status[4];
+  n2  index = 0;
+  n1  th = 1;
+};

--- a/ares/ms/cpu/memory.cpp
+++ b/ares/ms/cpu/memory.cpp
@@ -240,6 +240,17 @@ auto CPU::out(n16 address, n8 data) -> void {
 
     if(!thLevel1 && controllerPort1.thLevel) vdp.hcounterLatch();
     if(!thLevel2 && controllerPort2.thLevel) vdp.hcounterLatch();
+
+    n4 writeData;
+    writeData.bit(0,1) = data.bit(0,1); // Port 1 TR and TH direction
+    writeData.bit(2) = data.bit(4);
+    writeData.bit(3) = data.bit(5);
+    controllerPort1.write(writeData);
+
+    writeData.bit(0,1) = data.bit(2,3); // Port 2 TR and TH direction
+    writeData.bit(2) = data.bit(6);
+    writeData.bit(3) = data.bit(7);
+    controllerPort2.write(data);
   }
 
   else if((address & 0xc0) == 0x40) {

--- a/desktop-ui/emulator/master-system.cpp
+++ b/desktop-ui/emulator/master-system.cpp
@@ -44,6 +44,13 @@ MasterSystem::MasterSystem() {
     device.digital("Button",  virtualPorts[id].pad.south);
     port.append(device); }
 
+  { InputDevice device{"Sports Pad"};
+    device.relative("X", virtualPorts[id].mouse.x);
+    device.relative("Y", virtualPorts[id].mouse.y);
+    device.digital ("1", virtualPorts[id].mouse.left);
+    device.digital ("2", virtualPorts[id].mouse.right);
+    port.append(device); }
+
     ports.append(port);
   }
 }


### PR DESCRIPTION
This adds support for the Sports Pad, a trackball controller for Master System. Input
is done using a Mouse or a trackball (best).

Tested with Sports Pad Soccer and a homebrew test ROM.