### PR TITLE
msx: Fix joystick port 2 implementation

### DIFF
--- a/ares/component/audio/ay38910/ay38910.cpp
+++ b/ares/component/audio/ay38910/ay38910.cpp
@@ -196,9 +196,11 @@ auto AY38910::write(n8 data) -> void {
     envelope.output    = !envelope.attacking ? 15 : 0;
     break;
   case 14:
+    portA.data = data;
     writeIO(0, data);
     break;
   case 15:
+    portB.data = data;
     writeIO(1, data);
     break;
   }

--- a/ares/msx/controller/controller.cpp
+++ b/ares/msx/controller/controller.cpp
@@ -3,6 +3,7 @@
 namespace ares::MSX {
 
 #include "port.cpp"
+#include "mux.cpp"
 #include "gamepad/gamepad.cpp"
 
 }

--- a/ares/msx/controller/controller.hpp
+++ b/ares/msx/controller/controller.hpp
@@ -8,4 +8,5 @@ struct Controller {
 };
 
 #include "port.hpp"
+#include "mux.hpp"
 #include "gamepad/gamepad.hpp"

--- a/ares/msx/controller/mux.cpp
+++ b/ares/msx/controller/mux.cpp
@@ -1,0 +1,9 @@
+ControllerMux controllerMux;
+
+ControllerMux::ControllerMux(void) {
+  port_selected = 0;
+}
+
+auto ControllerMux::select(n1 port) -> void {
+  port_selected = port;
+}

--- a/ares/msx/controller/mux.hpp
+++ b/ares/msx/controller/mux.hpp
@@ -1,0 +1,15 @@
+struct ControllerMux {
+  ControllerMux(void);
+  auto select(n1 port) -> void;
+  auto read() -> n6 {
+    if(port_selected == 0) {
+      return controllerPort1.read();
+    } else {
+      return controllerPort2.read();
+    }
+  };
+
+  b1 port_selected;
+};
+
+extern ControllerMux controllerMux;


### PR DESCRIPTION
On MSX, both joysticks are read through a common port (PSG port 14). Which joystick is being accessed is selected through bit 6 in PSG port 15. In other words, the ports inputs are multiplexed.

This pull request adds a simple concept of controller multiplexer which the PSG IO code can call whenever port 14 is read.
    
PSG port 15 also controls the level and direction of some joystick pins, but those are not multiplexed. This pull request corrects how writes to port 15 are handled and organizes output bits in a predefined order so controller implementation do not need to know which port they are connected to. This paves the way for more advanced peripherals controlled through those outputs, such as the Taito Arkanoid Vaus Paddle.

Reference documentation: https://www.msx.org/wiki/PSG_Registers#PSG_I.2FO_Parallel_Port_Registers
Diagnostic ROM to test the two joystick : https://nightfoxandco.com/?page_id=787
