### PR TITLE
n64: improve exceptions for invalid instructions in cop1/cop2

### DIFF
--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -12,6 +12,7 @@ CPU cpu;
 #include "interpreter-ipu.cpp"
 #include "interpreter-scc.cpp"
 #include "interpreter-fpu.cpp"
+#include "interpreter-cop2.cpp"
 #include "recompiler.cpp"
 #include "debugger.cpp"
 #include "serialization.cpp"
@@ -132,6 +133,7 @@ auto CPU::power(bool reset) -> void {
   scc = {};
   for(auto& r : fpu.r) r.u64 = 0;
   fpu.csr = {};
+  cop2 = {};
   fesetround(FE_TONEAREST);
   context.setMode();
 

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -287,6 +287,7 @@ struct CPU : Thread {
     auto systemCall() -> void;
     auto breakpoint() -> void;
     auto reservedInstruction() -> void;
+    auto reservedInstructionCop2() -> void;
     auto coprocessor0() -> void;
     auto coprocessor1() -> void;
     auto coprocessor2() -> void;
@@ -725,6 +726,20 @@ struct CPU : Thread {
   auto MTC1(cr64& rt, u8 fs) -> void;
   auto SDC1(u8 ft, cr64& rs, s16 imm) -> void;
   auto SWC1(u8 ft, cr64& rs, s16 imm) -> void;
+  auto COP1INVALID() -> void;
+
+  //interpreter-cop2.cpp
+  struct COP2 {
+    u64 latch;
+  } cop2;
+
+  auto MFC2(r64& rt, u8 rd) -> void;
+  auto DMFC2(r64& rt, u8 rd) -> void;
+  auto CFC2(r64& rt, u8 rd) -> void;
+  auto MTC2(cr64& rt, u8 rd) -> void;
+  auto DMTC2(cr64& rt, u8 rd) -> void;
+  auto CTC2(cr64& rt, u8 rd) -> void;
+  auto COP2INVALID() -> void;
 
   //decoder.cpp
   auto decoderEXECUTE() -> void;
@@ -732,8 +747,8 @@ struct CPU : Thread {
   auto decoderREGIMM() -> void;
   auto decoderSCC() -> void;
   auto decoderFPU() -> void;
+  auto decoderCOP2() -> void;
 
-  auto COP2() -> void;
   auto COP3() -> void;
   auto INVALID() -> void;
 
@@ -795,6 +810,7 @@ struct CPU : Thread {
     auto emitREGIMM(u32 instruction) -> bool;
     auto emitSCC(u32 instruction) -> bool;
     auto emitFPU(u32 instruction) -> bool;
+    auto emitCOP2(u32 instruction) -> bool;
 
     bump_allocator allocator;
     Pool* pools[1 << 21];  //2_MiB * sizeof(void*) == 16_MiB

--- a/ares/n64/cpu/exceptions.cpp
+++ b/ares/n64/cpu/exceptions.cpp
@@ -29,24 +29,25 @@ auto CPU::Exception::trigger(u32 code, u32 coprocessor, bool tlbMiss) -> void {
   self.context.setMode();
 }
 
-auto CPU::Exception::interrupt()           -> void { trigger( 0); }
-auto CPU::Exception::tlbModification()     -> void { trigger( 1); }
-auto CPU::Exception::tlbLoadInvalid()      -> void { trigger( 2, 0, 0); }
-auto CPU::Exception::tlbLoadMiss()         -> void { trigger( 2, 0, 1); }
-auto CPU::Exception::tlbStoreInvalid()     -> void { trigger( 3, 0, 0); }
-auto CPU::Exception::tlbStoreMiss()        -> void { trigger( 3, 0, 1); }
-auto CPU::Exception::addressLoad()         -> void { trigger( 4); }
-auto CPU::Exception::addressStore()        -> void { trigger( 5); }
-auto CPU::Exception::busInstruction()      -> void { trigger( 6); }
-auto CPU::Exception::busData()             -> void { trigger( 7); }
-auto CPU::Exception::systemCall()          -> void { trigger( 8); }
-auto CPU::Exception::breakpoint()          -> void { trigger( 9); }
-auto CPU::Exception::reservedInstruction() -> void { trigger(10); }
-auto CPU::Exception::coprocessor0()        -> void { trigger(11, 0); }
-auto CPU::Exception::coprocessor1()        -> void { trigger(11, 1); }
-auto CPU::Exception::coprocessor2()        -> void { trigger(11, 2); }
-auto CPU::Exception::coprocessor3()        -> void { trigger(11, 3); }
-auto CPU::Exception::arithmeticOverflow()  -> void { trigger(12); }
-auto CPU::Exception::trap()                -> void { trigger(13); }
-auto CPU::Exception::floatingPoint()       -> void { trigger(15); }
-auto CPU::Exception::watchAddress()        -> void { trigger(23); }
+auto CPU::Exception::interrupt()               -> void { trigger( 0); }
+auto CPU::Exception::tlbModification()         -> void { trigger( 1); }
+auto CPU::Exception::tlbLoadInvalid()          -> void { trigger( 2, 0, 0); }
+auto CPU::Exception::tlbLoadMiss()             -> void { trigger( 2, 0, 1); }
+auto CPU::Exception::tlbStoreInvalid()         -> void { trigger( 3, 0, 0); }
+auto CPU::Exception::tlbStoreMiss()            -> void { trigger( 3, 0, 1); }
+auto CPU::Exception::addressLoad()             -> void { trigger( 4); }
+auto CPU::Exception::addressStore()            -> void { trigger( 5); }
+auto CPU::Exception::busInstruction()          -> void { trigger( 6); }
+auto CPU::Exception::busData()                 -> void { trigger( 7); }
+auto CPU::Exception::systemCall()              -> void { trigger( 8); }
+auto CPU::Exception::breakpoint()              -> void { trigger( 9); }
+auto CPU::Exception::reservedInstruction()     -> void { trigger(10); }
+auto CPU::Exception::reservedInstructionCop2() -> void { trigger(10, 2); }
+auto CPU::Exception::coprocessor0()            -> void { trigger(11, 0); }
+auto CPU::Exception::coprocessor1()            -> void { trigger(11, 1); }
+auto CPU::Exception::coprocessor2()            -> void { trigger(11, 2); }
+auto CPU::Exception::coprocessor3()            -> void { trigger(11, 3); }
+auto CPU::Exception::arithmeticOverflow()      -> void { trigger(12); }
+auto CPU::Exception::trap()                    -> void { trigger(13); }
+auto CPU::Exception::floatingPoint()           -> void { trigger(15); }
+auto CPU::Exception::watchAddress()            -> void { trigger(23); }

--- a/ares/n64/cpu/interpreter-cop2.cpp
+++ b/ares/n64/cpu/interpreter-cop2.cpp
@@ -1,0 +1,35 @@
+
+auto CPU::MFC2(r64& rt, u8 rd) -> void {
+  if(!scc.status.enable.coprocessor2) return exception.coprocessor2();
+  rt.u64 = s32(cop2.latch);
+}
+
+auto CPU::DMFC2(r64& rt, u8 rd) -> void {
+  if(!scc.status.enable.coprocessor2) return exception.coprocessor2();
+  rt.u64 = cop2.latch;
+}
+
+auto CPU::CFC2(r64& rt, u8 rd) -> void {
+  if(!scc.status.enable.coprocessor2) return exception.coprocessor2();
+  rt.u64 = s32(cop2.latch);
+}
+
+auto CPU::MTC2(cr64& rt, u8 rd) -> void {
+  if(!scc.status.enable.coprocessor2) return exception.coprocessor2();
+  cop2.latch = rt.u64;
+}
+
+auto CPU::DMTC2(cr64& rt, u8 rd) -> void {
+  if(!scc.status.enable.coprocessor2) return exception.coprocessor2();
+  cop2.latch = rt.u64;
+}
+
+auto CPU::CTC2(cr64& rt, u8 rd) -> void {
+  if(!scc.status.enable.coprocessor2) return exception.coprocessor2();
+  cop2.latch = rt.u64;
+}
+
+auto CPU::COP2INVALID() -> void {
+  if(!scc.status.enable.coprocessor2) return exception.coprocessor2();
+  exception.reservedInstructionCop2();
+}

--- a/ares/n64/cpu/interpreter-fpu.cpp
+++ b/ares/n64/cpu/interpreter-fpu.cpp
@@ -583,6 +583,11 @@ auto CPU::SWC1(u8 ft, cr64& rs, s16 imm) -> void {
   write<Word>(rs.u64 + imm, FT(u32));
 }
 
+auto CPU::COP1INVALID() -> void {
+  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  exception.floatingPoint();
+}
+
 #undef CF
 #undef FD
 #undef FS

--- a/ares/n64/cpu/interpreter.cpp
+++ b/ares/n64/cpu/interpreter.cpp
@@ -38,7 +38,7 @@ auto CPU::decoderEXECUTE() -> void {
   op(0x0f, LUI, RT, IMMu16);
   jp(0x10, SCC);
   jp(0x11, FPU);
-  br(0x12, COP2);
+  jp(0x12, COP2);
   br(0x13, COP3);
   br(0x14, BEQL, RS, RT, IMMi16);
   br(0x15, BNEL, RS, RT, IMMi16);
@@ -70,19 +70,19 @@ auto CPU::decoderEXECUTE() -> void {
   op(0x2f, CACHE, OP >> 16 & 31, RS, IMMi16);
   op(0x30, LL, RT, RS, IMMi16);
   op(0x31, LWC1, FT, RS, IMMi16);
-  br(0x32, COP2);  //LWC2
+  jp(0x32, COP2);  //LWC2
   br(0x33, COP3);  //LWC3
   op(0x34, LLD, RT, RS, IMMi16);
   op(0x35, LDC1, FT, RS, IMMi16);
-  br(0x36, COP2);  //LDC2
+  jp(0x36, COP2);  //LDC2
   op(0x37, LD, RT, RS, IMMi16);
   op(0x38, SC, RT, RS, IMMi16);
   op(0x39, SWC1, FT, RS, IMMi16);
-  br(0x3a, COP2);  //SWC2
+  jp(0x3a, COP2);  //SWC2
   br(0x3b, COP3);  //SWC3
   op(0x3c, SCD, RT, RS, IMMi16);
   op(0x3d, SDC1, FT, RS, IMMi16);
-  br(0x3e, COP2);  //SDC2
+  jp(0x3e, COP2);  //SDC2
   op(0x3f, SD, RT, RS, IMMi16);
   }
 }
@@ -229,11 +229,11 @@ auto CPU::decoderFPU() -> void {
   op(0x00, MFC1, RT, FS);
   op(0x01, DMFC1, RT, FS);
   op(0x02, CFC1, RT, RDn);
-  br(0x03, INVALID);
+  br(0x03, COP1INVALID);
   op(0x04, MTC1, RT, FS);
   op(0x05, DMTC1, RT, FS);
   op(0x06, CTC1, RT, RDn);
-  br(0x07, INVALID);
+  br(0x07, COP1INVALID);
   br(0x08, BC1, OP >> 16 & 1, OP >> 17 & 1, IMMi16);
   br(0x09, INVALID);
   br(0x0a, INVALID);
@@ -337,12 +337,20 @@ auto CPU::decoderFPU() -> void {
   //undefined instructions do not throw a reserved instruction exception
 }
 
-auto CPU::COP2() -> void {
-  exception.coprocessor2();
+auto CPU::decoderCOP2() -> void {
+  switch(OP >> 21 & 0x1f) {
+  op(0x00, MFC2, RT, RDn);
+  op(0x01, DMFC2, RT, RDn);
+  op(0x02, CFC2, RT, RDn);
+  op(0x04, MTC2, RT, RDn);
+  op(0x05, DMTC2, RT, RDn);
+  op(0x06, CTC2, RT, RDn);
+  }
+  COP2INVALID();
 }
 
 auto CPU::COP3() -> void {
-  exception.coprocessor3();
+  exception.reservedInstruction();
 }
 
 auto CPU::INVALID() -> void {

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -204,8 +204,7 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //COP2
   case 0x12: {
-    call(&CPU::COP2);
-    return 1;
+    return emitCOP2(instruction);
   }
 
   //COP3
@@ -454,7 +453,7 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //LWC2
   case 0x32: {
-    call(&CPU::COP2);
+    call(&CPU::COP2INVALID);
     return 1;
   }
 
@@ -484,7 +483,7 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //LDC2
   case 0x36: {
-    call(&CPU::COP2);
+    call(&CPU::COP2INVALID);
     return 1;
   }
 
@@ -517,7 +516,7 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //SWC2
   case 0x3a: {
-    call(&CPU::COP2);
+    call(&CPU::COP2INVALID);
     return 1;
   }
 
@@ -547,7 +546,7 @@ auto CPU::Recompiler::emitEXECUTE(u32 instruction) -> bool {
 
   //SDC2
   case 0x3e: {
-    call(&CPU::COP2);
+    call(&CPU::COP2INVALID);
     return 1;
   }
 
@@ -1305,7 +1304,7 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
 
   //INVALID
   case 0x03: {
-    call(&CPU::INVALID);
+    call(&CPU::COP1INVALID);
     return 1;
   }
 
@@ -1335,7 +1334,7 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
 
   //INVALID
   case 0x07: {
-    call(&CPU::INVALID);
+    call(&CPU::COP1INVALID);
     return 1;
   }
 
@@ -1976,6 +1975,73 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
 
   }
 
+  return 0;
+}
+
+auto CPU::Recompiler::emitCOP2(u32 instruction) -> bool {
+  switch(instruction >> 21 & 0x1f) {
+
+  //MFC2 Rt,Rd
+  case 0x00: {
+    lea(reg(1), Rt);
+    mov32(reg(2), imm(Rdn));
+    call(&CPU::MFC2);
+    return 0;
+  }
+
+  //DMFC2 Rt,Rd
+  case 0x01: {
+    lea(reg(1), Rt);
+    mov32(reg(2), imm(Rdn));
+    call(&CPU::DMFC2);
+    return 0;
+  }
+
+  //CFC2 Rt,Rd
+  case 0x02: {
+    lea(reg(1), Rt);
+    mov32(reg(2), imm(Rdn));
+    call(&CPU::CFC2);
+    return 0;
+  }
+
+  //INVALID
+  case 0x03: {
+    call(&CPU::COP2INVALID);
+    return 1;
+  }
+
+  //MTC0 Rt,Rd
+  case 0x04: {
+    lea(reg(1), Rt);
+    mov32(reg(2), imm(Rdn));
+    call(&CPU::MTC2);
+    return 0;
+  }
+
+  //DMTC2 Rt,Rd
+  case 0x05: {
+    lea(reg(1), Rt);
+    mov32(reg(2), imm(Rdn));
+    call(&CPU::DMTC2);
+    return 0;
+  }
+
+  //CTC2 Rt,Rd
+  case 0x06: {
+    lea(reg(1), Rt);
+    mov32(reg(2), imm(Rdn));
+    call(&CPU::CTC2);
+    return 0;
+  }
+
+  //INVALID
+  case 0x07 ... 0x0f: {
+    call(&CPU::COP2INVALID);
+    return 1;
+  }
+
+  }
   return 0;
 }
 

--- a/ares/n64/cpu/serialization.cpp
+++ b/ares/n64/cpu/serialization.cpp
@@ -138,6 +138,8 @@ auto CPU::serialize(serializer& s) -> void {
   s(fpu.csr.compare);
   s(fpu.csr.flushed);
 
+  s(cop2.latch);
+
   if constexpr(Accuracy::CPU::Recompiler) {
     recompiler.reset();
   }


### PR DESCRIPTION
Also implement MFC2/MTC2 and friends which seems to exist at some
level (though they just access a latch).

Fixes new set of tests in n64-systemtest.