### PR TITLE
nall: fix assignment operators

### DIFF
--- a/nall/any.hpp
+++ b/nall/any.hpp
@@ -52,12 +52,14 @@ struct any {
   }
 
   auto operator=(const any& source) -> any& {
+    if(this == &source) return *this;
     if(container) { delete container; container = nullptr; }
     if(source.container) container = source.container->copy();
     return *this;
   }
 
   auto operator=(any&& source) -> any& {
+    if(this == &source) return *this;
     if(container) delete container;
     container = source.container;
     source.container = nullptr;

--- a/nall/database/odbc.hpp
+++ b/nall/database/odbc.hpp
@@ -19,6 +19,7 @@ struct ODBC {
     Statement(Statement&& source) { operator=(move(source)); }
 
     auto operator=(Statement&& source) -> Statement& {
+      if(this == &source) return *this;
       _statement = source._statement;
       _output = source._output;
       _values = move(source._values);
@@ -108,6 +109,8 @@ struct ODBC {
     }
 
     auto operator=(Query&& source) -> Query& {
+      if(this == &source) return *this;
+      if(statement()) SQLFreeHandle(SQL_HANDLE_STMT, _statement);
       Statement::operator=(move(source));
       _bindings = move(source._bindings);
       _result = source._result;

--- a/nall/database/sqlite3.hpp
+++ b/nall/database/sqlite3.hpp
@@ -19,6 +19,7 @@ struct SQLite3 {
     Statement(Statement&& source) { operator=(move(source)); }
 
     auto operator=(Statement&& source) -> Statement& {
+      if(this == &source) return *this;
       _statement = source._statement;
       _response = source._response;
       _output = source._output;
@@ -98,6 +99,8 @@ struct SQLite3 {
     }
 
     auto operator=(Query&& source) -> Query& {
+      if(this == &source) return *this;
+      sqlite3_finalize(statement());
       _statement = source._statement;
       _input = source._input;
       source._statement = nullptr;

--- a/nall/file-buffer.hpp
+++ b/nall/file-buffer.hpp
@@ -34,6 +34,9 @@ struct file_buffer {
   ~file_buffer() { close(); }
 
   auto operator=(file_buffer&& source) -> file_buffer& {
+    if(this == &source) return *this;
+    close();
+
     buffer = source.buffer;
     bufferOffset = source.bufferOffset;
     bufferDirty = source.bufferDirty;

--- a/nall/file-map.hpp
+++ b/nall/file-map.hpp
@@ -55,6 +55,9 @@ private:
 
 public:
   auto operator=(file_map&& source) -> file_map& {
+    if(this == &source) return *this;
+    close();
+
     _open = source._open;
     _data = source._data;
     _size = source._size;
@@ -147,6 +150,9 @@ public:
 
 public:
   auto operator=(file_map&& source) -> file_map& {
+    if(this == &source) return *this;
+    close();
+
     _open = source._open;
     _data = source._data;
     _size = source._size;

--- a/nall/hashset.hpp
+++ b/nall/hashset.hpp
@@ -21,6 +21,7 @@ struct hashset {
   ~hashset() { reset(); }
 
   auto operator=(const hashset& source) -> hashset& {
+    if(this == &source) return *this;
     reset();
     if(source.pool) {
       for(u32 n : range(source.count)) {
@@ -31,6 +32,7 @@ struct hashset {
   }
 
   auto operator=(hashset&& source) -> hashset& {
+    if(this == &source) return *this;
     reset();
     pool = source.pool;
     length = source.length;

--- a/nall/queue/st.hpp
+++ b/nall/queue/st.hpp
@@ -100,6 +100,7 @@ struct queue {
 
   auto operator=(queue&& source) -> queue& {
     if(this == &source) return *this;
+    delete[] _data;
     _data = source._data;
     _capacity = source._capacity;
     _size = source._size;

--- a/nall/serializer.hpp
+++ b/nall/serializer.hpp
@@ -98,6 +98,7 @@ struct serializer {
   }
 
   auto operator=(const serializer& s) -> serializer& {
+    if(this == &s) return *this;
     if(_data) delete[] _data;
 
     _mode = s._mode;
@@ -110,6 +111,7 @@ struct serializer {
   }
 
   auto operator=(serializer&& s) -> serializer& {
+    if(this == &s) return *this;
     if(_data) delete[] _data;
 
     _mode = s._mode;

--- a/nall/set.hpp
+++ b/nall/set.hpp
@@ -44,6 +44,7 @@ template<typename T> struct set {
 
   auto operator=(set&& source) -> set& {
     if(this == &source) return *this;
+    reset();
     root = source.root;
     nodes = source.nodes;
     source.root = nullptr;

--- a/nall/string/view.hpp
+++ b/nall/string/view.hpp
@@ -55,6 +55,7 @@ inline string_view::~string_view() {
 
 inline auto string_view::operator=(const string_view& source) -> type& {
   if(this == &source) return *this;
+  if(_string) delete _string;
   _string = nullptr;
   _data = source._data;
   _size = source._size;
@@ -63,6 +64,7 @@ inline auto string_view::operator=(const string_view& source) -> type& {
 
 inline auto string_view::operator=(string_view&& source) -> type& {
   if(this == &source) return *this;
+  if(_string) delete _string;
   _string = source._string;
   _data = source._data;
   _size = source._size;

--- a/nall/thread.hpp
+++ b/nall/thread.hpp
@@ -96,6 +96,7 @@ struct thread {
   ~thread() { close(); }
 
   auto operator=(thread&& source) -> thread& {
+    if(this == &source) return *this;
     close();
     handle = source.handle;
     source.handle = 0;

--- a/nall/variant.hpp
+++ b/nall/variant.hpp
@@ -112,12 +112,14 @@ template<typename... P> struct variant final {  //final as destructor is not vir
   }
 
   auto& operator=(const variant& source) {
+    if(this == &source) return *this;
     reset();
     if(assigned = source.assigned) variant_copy<P...>(1, source.assigned, (void*)data, (void*)source.data);
     return *this;
   }
 
   auto& operator=(variant&& source) {
+    if(this == &source) return *this;
     reset();
     if(assigned = source.assigned) variant_move<P...>(1, source.assigned, (void*)data, (void*)source.data);
     source.assigned = 0;

--- a/nall/vector/assign.hpp
+++ b/nall/vector/assign.hpp
@@ -4,6 +4,7 @@ namespace nall {
 
 template<typename T> auto vector<T>::operator=(const vector<T>& source) -> vector<T>& {
   if(this == &source) return *this;
+  reset();
   _pool = memory::allocate<T>(source._size);
   _size = source._size;
   _left = 0;
@@ -14,6 +15,7 @@ template<typename T> auto vector<T>::operator=(const vector<T>& source) -> vecto
 
 template<typename T> auto vector<T>::operator=(vector<T>&& source) -> vector<T>& {
   if(this == &source) return *this;
+  reset();
   _pool = source._pool;
   _size = source._size;
   _left = source._left;


### PR DESCRIPTION
Almost all of the assignment operators in nall leaked resources, failed
to handle self assignment, or both.