### PR TITLE
Correct types for screen.hpp

### DIFF
--- a/ares/ares/node/video/screen.hpp
+++ b/ares/ares/node/video/screen.hpp
@@ -82,10 +82,10 @@ protected:
   u32  _rotation = 0;  //counter-clockwise (90 = left, 270 = right)
 
   function<n64 (n32)> _color;
-  unique_pointer<u32> _inputA;
-  unique_pointer<u32> _inputB;
-  unique_pointer<u32> _output;
-  unique_pointer<u32> _rotate;
+  unique_pointer<u32[]> _inputA;
+  unique_pointer<u32[]> _inputB;
+  unique_pointer<u32[]> _output;
+  unique_pointer<u32[]> _rotate;
   unique_pointer<u32[]> _palette;
   vector<Node::Video::Sprite> _sprites;
 


### PR DESCRIPTION
Fixes some memory leaks due to delete being used instead of delete[]