### PR TITLE
nall: make posix impl of thread::join idempotent

### DIFF
--- a/nall/thread.hpp
+++ b/nall/thread.hpp
@@ -28,8 +28,14 @@ struct thread {
   auto operator=(const thread&) -> thread& = delete;
 
   thread() = default;
-  thread(thread&&) = default;
-  auto operator=(thread&&) -> thread& = default;
+  thread(thread&& source) { operator=(move(source)); }
+
+  auto operator=(thread&& source) -> thread& {
+    if(this == &source) return *this;
+    handle = source.handle;
+    source.handle = 0;
+    return *this;
+  }
 
   auto join() -> void;
 
@@ -54,7 +60,10 @@ inline auto _threadCallback(void* parameter) -> void* {
 }
 
 inline auto thread::join() -> void {
-  pthread_join(handle, nullptr);
+  if(handle) {
+    pthread_join(handle, nullptr);
+    handle = 0;
+  }
 }
 
 inline auto thread::create(const function<void (uintptr)>& callback, uintptr parameter, u32 stacksize) -> thread {


### PR DESCRIPTION
ares uses nall::thread with the assumption that calling join() multiple
times on the same thread will have no harmful effects. This was true of
the Windows implementation but not of the POSIX one.

This should address #567