### PR TITLE
n64, ps1: stop video thread immediately on unload

### DIFF
--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -97,6 +97,7 @@ auto System::load(Node::System& root, string name) -> bool {
 auto System::unload() -> void {
   if(!node) return;
   save();
+  if(vi.screen) vi.screen->quit(); //stop video thread
   #if defined(VULKAN)
   vulkan.unload();
   #endif

--- a/ares/n64/vi/vi.cpp
+++ b/ares/n64/vi/vi.cpp
@@ -55,7 +55,6 @@ auto VI::load(Node::Object parent) -> void {
 
 auto VI::unload() -> void {
   debugger = {};
-  screen->quit();
   node->remove(screen);
   screen.reset();
   node.reset();

--- a/ares/ps1/gpu/gpu.cpp
+++ b/ares/ps1/gpu/gpu.cpp
@@ -62,7 +62,6 @@ auto GPU::unload() -> void {
   debugger = {};
   vram.reset();
   overscan.reset();
-  screen->quit();
   node->remove(screen);
   screen.reset();
   node.reset();

--- a/ares/ps1/system/system.cpp
+++ b/ares/ps1/system/system.cpp
@@ -87,6 +87,7 @@ auto System::load(Node::System& root, string name) -> bool {
 auto System::unload() -> void {
   if(!node) return;
   save();
+  if(gpu.screen) gpu.screen->quit(); //stop video thread
   memory.unload();
   cpu.unload();
   gpu.unload();


### PR DESCRIPTION
The N64 and PS1 cores set custom Screen:refresh() callbacks that run on
the video thread and have meaningful dependencies on core state. It's
not safe to unload components from beneath them, so the video thread
should be stopped before any unloading occurs.

Fixes #688 