### PR TITLE
ms: Implement megadrive 3 and 6 buttons pads

### DIFF
--- a/ares/ms/controller/controller.cpp
+++ b/ares/ms/controller/controller.cpp
@@ -7,5 +7,7 @@ namespace ares::MasterSystem {
 #include "light-phaser/light-phaser.cpp"
 #include "paddle/paddle.cpp"
 #include "sports-pad/sports-pad.cpp"
+#include "md-control-pad/md-control-pad.cpp"
+#include "md-fighting-pad/md-fighting-pad.cpp"
 
 }

--- a/ares/ms/controller/controller.hpp
+++ b/ares/ms/controller/controller.hpp
@@ -33,3 +33,5 @@ struct Controller {
 #include "light-phaser/light-phaser.hpp"
 #include "paddle/paddle.hpp"
 #include "sports-pad/sports-pad.hpp"
+#include "md-control-pad/md-control-pad.hpp"
+#include "md-fighting-pad/md-fighting-pad.hpp"

--- a/ares/ms/controller/md-control-pad/md-control-pad.cpp
+++ b/ares/ms/controller/md-control-pad/md-control-pad.cpp
@@ -1,0 +1,61 @@
+MdControlPad::MdControlPad(Node::Port parent) {
+  node = parent->append<Node::Peripheral>("MD Control Pad");
+
+  up    = node->append<Node::Input::Button>("Up");
+  down  = node->append<Node::Input::Button>("Down");
+  left  = node->append<Node::Input::Button>("Left");
+  right = node->append<Node::Input::Button>("Right");
+  a     = node->append<Node::Input::Button>("A");
+  b     = node->append<Node::Input::Button>("B");
+  c     = node->append<Node::Input::Button>("C");
+  start = node->append<Node::Input::Button>("Start");
+}
+
+auto MdControlPad::read() -> n7 {
+  platform->input(up);
+  platform->input(down);
+  platform->input(left);
+  platform->input(right);
+  platform->input(a);
+  platform->input(b);
+  platform->input(c);
+  platform->input(start);
+
+  if(!(up->value() & down->value())) {
+    yHold = 0, upLatch = up->value(), downLatch = down->value();
+  } else if(!yHold) {
+    yHold = 1, swap(upLatch, downLatch);
+  }
+
+  if(!(left->value() & right->value())) {
+    xHold = 0, leftLatch = left->value(), rightLatch = right->value();
+  } else if(!xHold) {
+    xHold = 1, swap(leftLatch, rightLatch);
+  }
+
+  n7 data;
+
+  if (th == 0) {
+    data.bit(0) = upLatch;
+    data.bit(1) = downLatch;
+    data.bit(2,3) = ~0;
+    data.bit(4) = a->value();
+    data.bit(5) = start->value();
+  } else {
+    data.bit(0) = upLatch;
+    data.bit(1) = downLatch;
+    data.bit(2) = leftLatch;
+    data.bit(3) = rightLatch;
+    data.bit(4) = b->value();
+    data.bit(5) = c->value();
+  }
+
+  data = ~data;
+  data.bit(6) = th;
+
+  return data;
+}
+
+auto MdControlPad::write(n4 data) -> void {
+  th = data.bit(3);
+}

--- a/ares/ms/controller/md-control-pad/md-control-pad.hpp
+++ b/ares/ms/controller/md-control-pad/md-control-pad.hpp
@@ -1,0 +1,24 @@
+struct MdControlPad : Controller {
+  Node::Input::Button up;
+  Node::Input::Button down;
+  Node::Input::Button left;
+  Node::Input::Button right;
+  Node::Input::Button a;
+  Node::Input::Button b;
+  Node::Input::Button c;
+  Node::Input::Button start;
+
+  MdControlPad(Node::Port);
+
+  auto read() -> n7 override;
+  auto write(n4 data) -> void override;
+
+private:
+  n1 yHold;
+  n1 upLatch;
+  n1 downLatch;
+  n1 xHold;
+  n1 leftLatch;
+  n1 rightLatch;
+  n1 th;
+};

--- a/ares/ms/controller/md-fighting-pad/md-fighting-pad.cpp
+++ b/ares/ms/controller/md-fighting-pad/md-fighting-pad.cpp
@@ -1,0 +1,110 @@
+MdFightingPad::MdFightingPad(Node::Port parent) {
+  node = parent->append<Node::Peripheral>("MD Fighting Pad");
+
+  up    = node->append<Node::Input::Button>("Up");
+  down  = node->append<Node::Input::Button>("Down");
+  left  = node->append<Node::Input::Button>("Left");
+  right = node->append<Node::Input::Button>("Right");
+  a     = node->append<Node::Input::Button>("A");
+  b     = node->append<Node::Input::Button>("B");
+  c     = node->append<Node::Input::Button>("C");
+  x     = node->append<Node::Input::Button>("X");
+  y     = node->append<Node::Input::Button>("Y");
+  z     = node->append<Node::Input::Button>("Z");
+  mode  = node->append<Node::Input::Button>("Mode");
+  start = node->append<Node::Input::Button>("Start");
+
+  Thread::create(1'000'000, {&MdFightingPad::main, this});
+}
+
+MdFightingPad::~MdFightingPad() {
+  Thread::destroy();
+}
+
+auto MdFightingPad::main() -> void {
+  if(timeout) {
+    timeout--;
+  } else {
+    counter = 0;
+  }
+  Thread::step(1);
+  Thread::synchronize(cpu);
+}
+
+auto MdFightingPad::read() -> n7 {
+  platform->input(up);
+  platform->input(down);
+  platform->input(left);
+  platform->input(right);
+  platform->input(a);
+  platform->input(b);
+  platform->input(c);
+  platform->input(x);
+  platform->input(y);
+  platform->input(z);
+  platform->input(mode);
+  platform->input(start);
+
+  if(!(up->value() & down->value())) {
+    yHold = 0, upLatch = up->value(), downLatch = down->value();
+  } else if(!yHold) {
+    yHold = 1, swap(upLatch, downLatch);
+  }
+
+  if(!(left->value() & right->value())) {
+    xHold = 0, leftLatch = left->value(), rightLatch = right->value();
+  } else if(!xHold) {
+    xHold = 1, swap(leftLatch, rightLatch);
+  }
+
+  n7 data;
+
+  if(select == 0) {
+    if(counter == 0 || counter == 1 || counter == 4) {
+      data.bit(0) = upLatch;
+      data.bit(1) = downLatch;
+      data.bit(2,3) = ~0;
+    }
+
+    if(counter == 2) {
+      data.bit(0,3) = ~0;  //controller type detection
+    }
+
+    if(counter == 3) {
+      data.bit(0,3) = 0;
+    }
+
+    data.bit(4) = a->value();
+    data.bit(5) = start->value();
+  } else {
+    if(counter == 0 || counter == 1 || counter == 2 || counter == 4) {
+      data.bit(0) = upLatch;
+      data.bit(1) = downLatch;
+      data.bit(2) = leftLatch;
+      data.bit(3) = rightLatch;
+      data.bit(4) = b->value();
+      data.bit(5) = c->value();
+    }
+
+    if(counter == 3) {
+      data.bit(0) = z->value();
+      data.bit(1) = y->value();
+      data.bit(2) = x->value();
+      data.bit(3) = mode->value();
+      data.bit(4,5) = 0;
+    }
+  }
+  data = ~data;
+  data.bit(6) = select;
+
+  return data;
+}
+
+auto MdFightingPad::write(n4 data) -> void {
+  if(!select && data.bit(3)) {  //0->1 transition
+    if(++counter == 5) counter = 0;
+  }
+
+  select = data.bit(3);
+  timeout = 1600;  //~1.6ms
+}

--- a/ares/ms/controller/md-fighting-pad/md-fighting-pad.hpp
+++ b/ares/ms/controller/md-fighting-pad/md-fighting-pad.hpp
@@ -1,0 +1,32 @@
+struct MdFightingPad : Controller, Thread {
+  Node::Input::Button up;
+  Node::Input::Button down;
+  Node::Input::Button left;
+  Node::Input::Button right;
+  Node::Input::Button a;
+  Node::Input::Button b;
+  Node::Input::Button c;
+  Node::Input::Button x;
+  Node::Input::Button y;
+  Node::Input::Button z;
+  Node::Input::Button mode;
+  Node::Input::Button start;
+
+  MdFightingPad(Node::Port);
+  ~MdFightingPad();
+  auto main() -> void;
+  auto read() -> n7 override;
+  auto write(n4 data) -> void override;
+
+private:
+  n1  select = 1;
+  n3  counter;
+  n32 timeout;
+
+  b1  yHold;
+  b1  upLatch;
+  b1  downLatch;
+  b1  xHold;
+  b1  leftLatch;
+  b1  rightLatch;
+};

--- a/ares/ms/controller/port.cpp
+++ b/ares/ms/controller/port.cpp
@@ -10,7 +10,7 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setType("Controller");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
-  port->setSupported({"Gamepad", "Light Phaser", "Paddle", "Sports Pad"});
+  port->setSupported({"Gamepad", "Light Phaser", "Paddle", "Sports Pad", "MD Control Pad", "MD Fighting Pad"});
 }
 
 auto ControllerPort::unload() -> void {
@@ -23,6 +23,8 @@ auto ControllerPort::allocate(string name) -> Node::Peripheral {
   if(name == "Light Phaser") device = new LightPhaser(port);
   if(name == "Paddle") device = new Paddle(port);
   if(name == "Sports Pad") device = new SportsPad(port);
+  if(name == "MD Control Pad") device = new MdControlPad(port);
+  if(name == "MD Fighting Pad") device = new MdFightingPad(port);
   if(device) return device->node;
   return {};
 }

--- a/desktop-ui/emulator/master-system.cpp
+++ b/desktop-ui/emulator/master-system.cpp
@@ -51,6 +51,32 @@ MasterSystem::MasterSystem() {
     device.digital ("2", virtualPorts[id].mouse.right);
     port.append(device); }
 
+  { InputDevice device{"MD Control Pad"};
+    device.digital("Up",    virtualPorts[id].pad.up);
+    device.digital("Down",  virtualPorts[id].pad.down);
+    device.digital("Left",  virtualPorts[id].pad.left);
+    device.digital("Right", virtualPorts[id].pad.right);
+    device.digital("A",     virtualPorts[id].pad.west);
+    device.digital("B",     virtualPorts[id].pad.south);
+    device.digital("C",     virtualPorts[id].pad.east);
+    device.digital("Start", virtualPorts[id].pad.start);
+    port.append(device); }
+
+  { InputDevice device{"MD Fighting Pad"};
+    device.digital("Up",    virtualPorts[id].pad.up);
+    device.digital("Down",  virtualPorts[id].pad.down);
+    device.digital("Left",  virtualPorts[id].pad.left);
+    device.digital("Right", virtualPorts[id].pad.right);
+    device.digital("A",     virtualPorts[id].pad.west);
+    device.digital("B",     virtualPorts[id].pad.south);
+    device.digital("C",     virtualPorts[id].pad.east);
+    device.digital("X",     virtualPorts[id].pad.l_bumper);
+    device.digital("Y",     virtualPorts[id].pad.north);
+    device.digital("Z",     virtualPorts[id].pad.r_bumper);
+    device.digital("Mode",  virtualPorts[id].pad.select);
+    device.digital("Start", virtualPorts[id].pad.start);
+    port.append(device); }
+
     ports.append(port);
   }
 }


### PR DESCRIPTION
Master system ports are compatible with megadrive controllers and
those can be used directly to play many original master system
games.

However MD controllers can be fully supported (i.e all buttons
working) if the game software is programmed to do so.

While really only useful on real hardware, there are game patches to
enable the Start button on MD controllers. But it's also possible
to make patches that use additional buttons or code full support
for Megadrive controllers in a homebrew title.