### PR TITLE
desktop-ui: Document command-line options and add --help

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,27 @@ Build Output
 
 There is a single binary produced at the end of compilation which can be found in `desktop-ui/out`. On OS's besides Linux, the `Database` & `Shader` directories are copied over here as well. On Linux, running `make install` after compilation will copy these directories and binary into suitable locations (see desktop-ui/GNUmakefile for details). Alternatively, these directories can be copied from `ares/Shaders/*` and `mia/Database/*`.
 
+
+Command-line options
+--------------------
+
+When started from the command-line, ares accepts a few options.
+
+```
+Usage: ./ares [options] game
+
+  --help                 Displays available options and exit
+  --fullscreen           Start in full screen mode
+  --system system        Specify the system name
+```
+
+The --system option is useful when the system type cannot be auto-detected.
+--fullscreen will only have an effect if a game is also passed in argument.
+
+Example:
+`ares --system MSX examples.rom --fullscreen`
+
+
 High-level Components
 ---------------------
 

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -67,18 +67,18 @@ auto nall::main(Arguments arguments) -> void {
   Emulator::construct();
 
   if(arguments.take("--help")) {
-	print("Usage: ares [OPTIONS]... game\n\n");
-	print("Options:\n");
-	print("  --help               Displays available options and exit\n");
-	print("  --fullscreen         Start in full screen mode\n");
-	print("  --system name        Specifiy the system name\n");
-	print("\n");
-	print("Available Systems:\n");
-	print("  ");
-	for(auto& emulator : emulators) {
-		print(emulator->name, ", ");
-	}
-	print("\n");
+    print("Usage: ares [OPTIONS]... game\n\n");
+    print("Options:\n");
+    print("  --help               Displays available options and exit\n");
+    print("  --fullscreen         Start in full screen mode\n");
+    print("  --system name        Specifiy the system name\n");
+    print("\n");
+    print("Available Systems:\n");
+    print("  ");
+    for(auto& emulator : emulators) {
+      print(emulator->name, ", ");
+    }
+    print("\n");
     return;
   }
 

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -65,6 +65,23 @@ auto nall::main(Arguments arguments) -> void {
 
   inputManager.create();
   Emulator::construct();
+
+  if(arguments.take("--help")) {
+	print("Usage: ares [OPTIONS]... game\n\n");
+	print("Options:\n");
+	print("  --help               Displays available options and exit\n");
+	print("  --fullscreen         Start in full screen mode\n");
+	print("  --system name        Specifiy the system name\n");
+	print("\n");
+	print("Available Systems:\n");
+	print("  ");
+	for(auto& emulator : emulators) {
+		print(emulator->name, ", ");
+	}
+	print("\n");
+    return;
+  }
+
   settings.load();
   Instances::presentation.construct();
   Instances::settingsWindow.construct();


### PR DESCRIPTION
Ideally I think one should not need to read the source code to learn that ares accepts command-line options and what those options are.

I wish I had known earlier that I could pass --system MSX when loading a ROM directly, it would have saved me a lot of time. I had tried --help, but it just opened the application window...