### PR TITLE
build: Add a clean target to the top level Makefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,4 +3,7 @@ all: desktop
 desktop:
 	$(MAKE) -C desktop-ui
 
-.PHONY: all desktop
+clean:
+	$(MAKE) -C desktop-ui clean
+
+.PHONY: all desktop clean


### PR DESCRIPTION
Pull request #690 simplified the build instructions, however typing `make clean` in the top level directory as instructed does not work.

This adds a clean target to the top makefile so that this also works.