### PR TITLE
build: detect when gcc is an alias for clang

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -88,6 +88,11 @@ ifeq ($(compiler),)
   else
     compiler := g++
   endif
+  # detect clang-as-gcc
+  compiler.version := $(shell $(compiler) --version)
+  ifeq ($(findstring clang,$(compiler.version)),clang)
+    compiler := clang++
+  endif
 endif
 
 # architecture detection


### PR DESCRIPTION
Detect build environments where 'g++' is just an alias for 'clang++'.
Example: MSYS2's Clang64 environment. This avoids the need to manually
override compiler detection.