### PR TITLE
nall: always pass by reference to make_string()

### DIFF
--- a/nall/string/cast.hpp
+++ b/nall/string/cast.hpp
@@ -183,16 +183,6 @@ template<u32 Bits> struct stringify<Real<Bits>> {
 //arrays
 
 template<> struct stringify<vector<u8>> {
-  stringify(vector<u8> source) {
-    _text.resize(source.size());
-    memory::copy(_text.data(), source.data(), source.size());
-  }
-  auto data() const -> const char* { return _text.data(); }
-  auto size() const -> u32 { return _text.size(); }
-  vector<char> _text;
-};
-
-template<> struct stringify<const vector<u8>&> {
   stringify(const vector<u8>& source) {
     _text.resize(source.size());
     memory::copy(_text.data(), source.data(), source.size());
@@ -205,7 +195,7 @@ template<> struct stringify<const vector<u8>&> {
 //char arrays
 
 template<> struct stringify<char*> {
-  stringify(char* source) : _data(source ? source : "") {}
+  stringify(const char* source) : _data(source ? source : "") {}
   auto data() const -> const char* { return _data; }
   auto size() const -> u32 { return strlen(_data); }
   const char* _data;
@@ -227,21 +217,7 @@ template<> struct stringify<string> {
   const string& _text;
 };
 
-template<> struct stringify<const string&> {
-  stringify(const string& source) : _text(source) {}
-  auto data() const -> const char* { return _text.data(); }
-  auto size() const -> u32 { return _text.size(); }
-  const string& _text;
-};
-
 template<> struct stringify<string_view> {
-  stringify(const string_view& source) : _view(source) {}
-  auto data() const -> const char* { return _view.data(); }
-  auto size() const -> u32 { return _view.size(); }
-  const string_view& _view;
-};
-
-template<> struct stringify<const string_view&> {
   stringify(const string_view& source) : _view(source) {}
   auto data() const -> const char* { return _view.data(); }
   auto size() const -> u32 { return _view.size(); }
@@ -255,21 +231,7 @@ template<> struct stringify<array_view<u8>> {
   const array_view<u8>& _view;
 };
 
-template<> struct stringify<const array_view<u8>&> {
-  stringify(const array_view<u8>& source) : _view(source) {}
-  auto data() const -> const char* { return _view.data<const char>(); }
-  auto size() const -> u32 { return _view.size(); }
-  const array_view<u8>& _view;
-};
-
 template<> struct stringify<string_pascal> {
-  stringify(const string_pascal& source) : _text(source) {}
-  auto data() const -> const char* { return _text.data(); }
-  auto size() const -> u32 { return _text.size(); }
-  const string_pascal& _text;
-};
-
-template<> struct stringify<const string_pascal&> {
   stringify(const string_pascal& source) : _text(source) {}
   auto data() const -> const char* { return _text.data(); }
   auto size() const -> u32 { return _text.size(); }
@@ -295,8 +257,8 @@ template<typename T> struct stringify<T*> {
 
 //
 
-template<typename T> inline auto make_string(T value) -> stringify<T> {
-  return stringify<T>(forward<T>(value));
+template<typename T> inline auto make_string(const T& value) {
+  return stringify<std::decay_t<T>>(value);
 }
 
 }


### PR DESCRIPTION
Many specializations of stringify store a reference to the wrapped
value. Therefore, passing arguments to make_string() by value can be
disastrous if the compiler does not perform copy elision and stringify
stores a reference to a variable that goes out of scope when
make_string() returns.