### PR TITLE
md: Add support for the Mega Mouse

### DIFF
--- a/ares/md/controller/controller.cpp
+++ b/ares/md/controller/controller.cpp
@@ -5,5 +5,6 @@ namespace ares::MegaDrive {
 #include "port.cpp"
 #include "control-pad/control-pad.cpp"
 #include "fighting-pad/fighting-pad.cpp"
+#include "mega-mouse/mega-mouse.cpp"
 
 }

--- a/ares/md/controller/controller.hpp
+++ b/ares/md/controller/controller.hpp
@@ -26,3 +26,4 @@ struct Controller {
 #include "port.hpp"
 #include "control-pad/control-pad.hpp"
 #include "fighting-pad/fighting-pad.hpp"
+#include "mega-mouse/mega-mouse.hpp"

--- a/ares/md/controller/mega-mouse/mega-mouse.cpp
+++ b/ares/md/controller/mega-mouse/mega-mouse.cpp
@@ -1,0 +1,147 @@
+MegaMouse::MegaMouse(Node::Port parent) {
+  node = parent->append<Node::Peripheral>("Mega Mouse");
+
+  x      = node->append<Node::Input::Axis>("X");
+  y      = node->append<Node::Input::Axis>("Y");
+  left   = node->append<Node::Input::Button>("Left");
+  right  = node->append<Node::Input::Button>("Right");
+  middle = node->append<Node::Input::Button>("Middle");
+  start  = node->append<Node::Input::Button>("Start");
+
+  status[0] = 0x0; // TH high
+  status[1] = 0xB; // TH low
+  status[2] = 0xF; // 1st nibble
+  status[3] = 0xF; // 2nd
+  // status[4..9]  // 3rd .. 8th nibbles
+
+  // Is is said that some games do not do the hanshake correctly
+  // and rely heavily on timing, so we try to mimick the real
+  // timis closely.
+
+  // One game has a programming error where it polls for TL low
+  // instead of TL high for one of the nibbles so it falls rights
+  // through and works by chance. With a 1MHz clock here, vertical
+  // cursor motion was intermittent. So 2MHz is used.
+  double timerfreq = 2'000'000;
+
+  // time between falling edge of clock (TR) and
+  // handshake on TL.
+  //
+  // For first nibble, the measured time is min. 12us, max 34us
+  // For folling nibbles are available in 12-14 us.
+  t_handshake = 14 * timerfreq / 1000000;
+
+  // data changes a bit before the TL handshake occurs,
+  // precisely 4.8us before. But for some games, 4.8 does not
+  // work correclty and it helps to have the data update sooner. So
+  // 10 is used here.
+  t_data = 10 * timerfreq / 1000000;
+
+  Thread::create(timerfreq, {&MegaMouse::main, this});
+  Thread::synchronize(cpu);
+}
+
+MegaMouse::~MegaMouse() {
+  Thread::destroy();
+}
+
+auto MegaMouse::main() -> void {
+  // process clocking after building the data to
+  // cause at least some lag. In real life, it takes
+  // about 10us to the mouse to react and change TL
+  // to reflect TR...
+  if (timeout)
+  {
+    timeout--;
+
+    if (timeout == t_data) {
+      index++;
+      if (index > 9) {
+        index = 1;
+      }
+    }
+    if (timeout == 0) {
+      tl = tr;
+    }
+  }
+  Thread::step(1);
+  Thread::synchronize(cpu);
+}
+
+auto MegaMouse::readData() -> n8 {
+  n8 data;
+
+  if (th) {
+    // When TH is high, the mouse drives a constant on the data pins.
+    data.bit(0,3) = status[0];
+  }
+  else {
+    // When TH is low, output is clocked
+    data.bit(0,3) = status[index];
+  }
+
+  data.bit(4) = tl;
+  data.bit(5) = tr;
+  data.bit(6) = th;
+  data.bit(7) = latch;
+
+  return data;
+}
+
+auto MegaMouse::writeData(n8 data) -> void {
+  // Falling TH
+  if (!data.bit(6) && th) {
+    // When TH falls low, make sure the second nibble is driven. The
+    // index is otherwise controlled by clocking on TR.
+    index = 1;
+
+    platform->input(x);
+    platform->input(y);
+    platform->input(left);
+    platform->input(right);
+    platform->input(middle);
+    platform->input(start);
+
+    // Button byte
+    status[4] = 0;
+    status[5].bit(0) = left->value();
+    status[5].bit(1) = right->value();
+    status[5].bit(2) = middle->value();
+    status[5].bit(3) = start->value();
+
+    i16 ax = x->value();
+    i16 ay = -y->value();
+
+    if (ax > maxspeed) {
+      ax = maxspeed;
+    } else if (ax < -maxspeed) {
+      ax = -maxspeed;
+    }
+
+    if (ay > maxspeed) {
+      ay = maxspeed;
+    } else if (ay < -maxspeed) {
+      ay = -maxspeed;
+    }
+
+    // X byte
+    status[4].bit(0) = ax.bit(8);
+    status[6] = ax.bit(4,7);
+    status[7] = ax.bit(0,3);
+
+    // Y byte
+    status[4].bit(1) = ay.bit(8);
+    status[8] = ay.bit(4,7);
+    status[9] = ay.bit(0,3);
+  }
+
+  // Clock in is TR. The mouse reacts and ACKs by updating TL,
+  // but not instantly.
+  tr = data.bit(5);
+  if (tr != tl) {
+     timeout = t_handshake;
+  }
+
+  latch = data.bit(7);
+  th = data.bit(6);
+}

--- a/ares/md/controller/mega-mouse/mega-mouse.hpp
+++ b/ares/md/controller/mega-mouse/mega-mouse.hpp
@@ -1,0 +1,28 @@
+struct MegaMouse : Controller, Thread {
+  Node::Input::Axis   x;
+  Node::Input::Axis   y;
+  Node::Input::Button left;
+  Node::Input::Button right;
+  Node::Input::Button middle;
+  Node::Input::Button start;
+
+  MegaMouse(Node::Port);
+  ~MegaMouse();
+
+  auto main() -> void;
+  auto readData() -> n8 override;
+  auto writeData(n8 data) -> void override;
+
+private:
+  n1  th = 1;
+  n1  tr = 1;
+  n1  tl = 1;
+  n1  latch;
+  n8  index = 0;
+  n4  status[10];
+  s16 maxspeed = 255;
+  n32 timeout = 0;
+
+  n32 t_data;
+  n32 t_handshake;
+};

--- a/ares/md/controller/port.cpp
+++ b/ares/md/controller/port.cpp
@@ -13,7 +13,7 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setAllocate([&](auto name) { return allocate(name); });
   port->setDisconnect([&] { return disconnect(); });
 
-  port->setSupported({"Control Pad", "Fighting Pad"});
+  port->setSupported({"Control Pad", "Fighting Pad", "Mega Mouse"});
 }
 
 auto ControllerPort::unload() -> void {
@@ -24,6 +24,7 @@ auto ControllerPort::unload() -> void {
 auto ControllerPort::allocate(string name) -> Node::Peripheral {
   if(name == "Control Pad" ) device = new ControlPad(port);
   if(name == "Fighting Pad") device = new FightingPad(port);
+  if(name == "Mega Mouse") device = new MegaMouse(port);
   if(device) return device->node;
   return {};
 }

--- a/desktop-ui/emulator/mega-drive.cpp
+++ b/desktop-ui/emulator/mega-drive.cpp
@@ -41,6 +41,15 @@ MegaDrive::MegaDrive() {
     device.digital("Start", virtualPorts[id].pad.start);
     port.append(device); }
 
+  { InputDevice device{"Mega Mouse"};
+    device.relative("X",      virtualPorts[id].mouse.x);
+    device.relative("Y",      virtualPorts[id].mouse.y);
+    device.digital ("Left",   virtualPorts[id].mouse.left);
+    device.digital ("Right",  virtualPorts[id].mouse.right);
+    device.digital ("Middle", virtualPorts[id].mouse.middle);
+    device.digital ("Start",  virtualPorts[id].mouse.extra);
+    port.append(device); }
+
     ports.append(port);
   }
 }

--- a/desktop-ui/input/input.cpp
+++ b/desktop-ui/input/input.cpp
@@ -462,6 +462,7 @@ VirtualMouse::VirtualMouse() {
   InputDevice::digital ("Left",   left);
   InputDevice::digital ("Middle", middle);
   InputDevice::digital ("Right",  right);
+  InputDevice::digital ("Extra",  extra);
 }
 
 //

--- a/desktop-ui/input/input.hpp
+++ b/desktop-ui/input/input.hpp
@@ -172,6 +172,7 @@ struct VirtualMouse : InputDevice {
   InputDigital  left;
   InputDigital  middle;
   InputDigital  right;
+  InputDigital  extra;
 };
 
 struct VirtualPort {


### PR DESCRIPTION
This pull request adds support for the Sega Mega Mouse, supported by a few Megadrive and Mega CD games.
The MegaMouse has 4 buttons and reports movement using 9 bits per axis. Some games support hotswapping, but most need a reset after selecting the Mega Mouse from the menu.

Data is transmitted using 4 bit nibbles and a clock handshake using the TR and TL lines, but many games have bugs or incorrect implementations which results in precise timing was required to get this working. The timings used here have been updated until it worked with all the games I had to test. It could still not work with some games...