### PR TITLE
n64: PIF fix for invalid commands/timeouts and suppport for disconnecting controllers

### DIFF
--- a/ares/n64/controller/port.cpp
+++ b/ares/n64/controller/port.cpp
@@ -25,6 +25,7 @@ auto ControllerPort::save() -> void {
 }
 
 auto ControllerPort::allocate(string name) -> Node::Peripheral {
+  device = {};
   if(name == "Gamepad") device = new Gamepad(port);
   if(name == "Mouse"  ) device = new Mouse(port);
   if(device) return device->node;

--- a/ares/n64/pif/pif.cpp
+++ b/ares/n64/pif/pif.cpp
@@ -210,8 +210,11 @@ auto PIF::scan() -> void {
     if(over) {
       ram.write<Byte>(recvOffset, 0x40 | recv & 0x3f);
     }
-    for(u32 index : range(recv)) {
-      ram.write<Byte>(offset++, output[index]);
+
+    if (valid) {
+      for(u32 index : range(recv)) {
+        ram.write<Byte>(offset++, output[index]);
+      }
     }
     channel++;
   }

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -402,6 +402,8 @@ auto Presentation::loadEmulator() -> void {
       peripheralItem.onActivate([=] {
         auto port = peripheralItem.attribute<ares::Node::Port>("port");
         port->disconnect();
+        port->allocate(peripheralItem.text());
+        port->connect();
       });
       peripheralGroup.append(peripheralItem);
     }


### PR DESCRIPTION
When sending invalid or proprietary commands to a standard controller, the controller returns "invalid". In those case, the PIF RAM intended to hold the received data should be left as-is. This fixes the raphnet N64 adapter manager ROM which sends proprietary commands to detect adapters and rely on the receive buffer to be left intact if no answer is received. (before this fix, it would wrongly report an adapter in all ports, even though Gamepad was selected)

Also, when controller type Nothing was selected, it turns out that Gamepad instances were still connected to the ports. So the manager ROM would still show "N64 controller" in all ports instead of "Not connected" as it should and now does.