### PR TITLE
MD: Z80+FM fixes

### DIFF
--- a/ares/component/audio/ym2612/ym2612.cpp
+++ b/ares/component/audio/ym2612/ym2612.cpp
@@ -124,7 +124,7 @@ auto YM2612::clock() -> array<i16[2]> {
 
   if(++envelope.divider == 3) {
     envelope.divider = 0;
-    envelope.clock++;
+    if(!++envelope.clock) ++envelope.clock; // 12-bit counter: 1..4095 - zero-value is skipped (confirmed behavior)
   }
 
   for(auto& channel : channels) {

--- a/ares/component/audio/ym2612/ym2612.hpp
+++ b/ares/component/audio/ym2612/ym2612.hpp
@@ -36,7 +36,7 @@ protected:
   } dac;
 
   struct Envelope {
-    n32 clock = 0;
+    n12 clock = 0;
     n32 divider = 0;
   } envelope;
 

--- a/ares/component/processor/z80/instructions.cpp
+++ b/ares/component/processor/z80/instructions.cpp
@@ -351,7 +351,7 @@ auto Z80::instructionLD_a_inn() -> void { Q = 0;
 
 auto Z80::instructionLD_a_irr(n16& x) -> void { Q = 0;
   WZ = x;
-  A = read(displace(WZ));
+  A = read(x);
   WZ++;
 }
 
@@ -370,13 +370,13 @@ auto Z80::instructionLD_inn_rr(n16& x) -> void { Q = 0;
 
 auto Z80::instructionLD_irr_a(n16& x) -> void { Q = 0;
   WZ = x;
-  write(displace(WZ), A);
+  write(x, A);
   WZL++;
   WZH = A;
 }
 
 auto Z80::instructionLD_irr_n(n16& x) -> void { Q = 0;
-  auto addr = displace(x);
+  auto addr = displace(x,5-3); // special case: reduced wait cycles due to timing overlap
   write(addr, operand());
 }
 
@@ -574,7 +574,6 @@ auto Z80::instructionRES_o_r(n3 bit, n8& x) -> void { Q = 1;
 }
 
 auto Z80::instructionRET() -> void { Q = 0;
-  wait(1);
   WZ = pop();
   PC = WZ;
 }

--- a/ares/component/processor/z80/memory.cpp
+++ b/ares/component/processor/z80/memory.cpp
@@ -27,10 +27,10 @@ auto Z80::pop() -> n16 {
   return data | read(SP++) << 8;
 }
 
-auto Z80::displace(n16& x) -> n16 {
+auto Z80::displace(n16& x, u32 wclocks) -> n16 {
   if(&x != &ix.word && &x != &iy.word) return x;
   auto d = operand();
-  wait(5);
+  wait(wclocks);
   WZ = x + (i8)d;
   return WZ;
 }

--- a/ares/component/processor/z80/z80.cpp
+++ b/ares/component/processor/z80/z80.cpp
@@ -31,7 +31,18 @@ auto Z80::power(MOSFET mosfet) -> void {
   HALT = 0;
   IFF1 = 0;
   IFF2 = 0;
-  IM = 1;
+  IM = 0;
+}
+
+auto Z80::reset() -> void {
+  prefix = Prefix::hl;
+  ir.word = 0x0000;
+  WZ = PC = 0x0000;
+  EI = 0;
+  HALT = 0;
+  IFF1 = 0;
+  IFF2 = 0;
+  IM = 0;
 }
 
 auto Z80::irq(bool maskable, n16 pc, n8 extbus) -> bool {

--- a/ares/component/processor/z80/z80.hpp
+++ b/ares/component/processor/z80/z80.hpp
@@ -33,7 +33,7 @@ struct Z80 {
   auto operands() -> n16;
   auto push(n16) -> void;
   auto pop() -> n16;
-  auto displace(n16&) -> n16;
+  auto displace(n16&, u32 wclocks = 5) -> n16;
   auto read(n16 address) -> n8;
   auto write(n16 address, n8 data) -> void;
   auto in(n16 address) -> n8;

--- a/ares/component/processor/z80/z80.hpp
+++ b/ares/component/processor/z80/z80.hpp
@@ -22,6 +22,7 @@ struct Z80 {
 
   //z80.cpp
   auto power(MOSFET = MOSFET::NMOS) -> void;
+  auto reset() -> void;
 
   auto irq(bool maskable, n16 vector = 0x0000, n8 extbus = 0xff) -> bool;
   auto parity(n8) const -> bool;

--- a/ares/md/apu/apu.cpp
+++ b/ares/md/apu/apu.cpp
@@ -69,10 +69,13 @@ auto APU::power(bool reset) -> void {
   Z80::power();
   Thread::create(system.frequency() / 15.0, {&APU::main, this});
   if(!reset) {
+    Z80::power();
     ram.fill();
     state.resLine = 0;
     state.busreqLine = 0;
     state.busreqLatch = 0;
+  } else {
+    Z80::reset();
   }
   state.nmiLine = 0;
   state.intLine = 0;
@@ -81,7 +84,7 @@ auto APU::power(bool reset) -> void {
 }
 
 auto APU::restart() -> void {
-  Z80::power();
+  Z80::reset();
   Thread::restart({&APU::main, this});
   state.nmiLine = 0;
   state.intLine = 0;


### PR DESCRIPTION
1. Various YM2612 fixes and cleanup (see commit msg for finer details). SSG-EG fixed according to test ROMs provided by Nemesis. Also fixes some LFO and clock-related issues (#625 is fixed). Other FM audio issues for MD should be reevaluated.
2. Caught a couple Z80 instructions with incorrect timings (I was not doing a deep dive). Notably LD (IX+d),n / LD (IY+d),n was over by 3 cycles because it's a bit of an oddball. Fixes #445 & #247, and probably others which rely on tight Z80 timing.
3. Proper reinit of registers on Z80 Reset wasn't being done correctly, so now it is (also, corrected state to IM 0 at power-on). Fixed for MD, but I did not check on other cores using Z80.