### PR TITLE
YM2612 envelope fix

### DIFF
--- a/ares/ares/ares.hpp
+++ b/ares/ares/ares.hpp
@@ -47,7 +47,7 @@ namespace ares {
 
   //incremented only when serialization format changes
   static const u32    SerializerSignature = 0x31545342;  //"BST1" (little-endian)
-  static const string SerializerVersion   = "129";
+  static const string SerializerVersion   = "129.1";
 
   namespace VFS {
     using Pak = shared_pointer<vfs::directory>;

--- a/ares/component/audio/ym2612/io.cpp
+++ b/ares/component/audio/ym2612/io.cpp
@@ -68,10 +68,10 @@ auto YM2612::writeData(n8 data) -> void {
     if(index == 3 || index == 7) break;
     if(index >= 4) index--;
 
-    channels[index][0].trigger(data.bit(4));
-    channels[index][1].trigger(data.bit(5));
-    channels[index][2].trigger(data.bit(6));
-    channels[index][3].trigger(data.bit(7));
+    channels[index][0].keyLine = data.bit(4);
+    channels[index][1].keyLine = data.bit(5);
+    channels[index][2].keyLine = data.bit(6);
+    channels[index][3].keyLine = data.bit(7);
 
     break;
   }

--- a/ares/component/audio/ym2612/serialization.cpp
+++ b/ares/component/audio/ym2612/serialization.cpp
@@ -42,6 +42,7 @@ auto YM2612::Channel::serialize(serializer& s) -> void {
 
 auto YM2612::Channel::Operator::serialize(serializer& s) -> void {
   s(keyOn);
+  s(keyLine);
   s(lfoEnable);
   s(detune);
   s(multiple);

--- a/ares/component/audio/ym2612/ym2612.hpp
+++ b/ares/component/audio/ym2612/ym2612.hpp
@@ -91,7 +91,7 @@ protected:
       Operator(Channel& channel) : channel(channel), ym2612(channel.ym2612) {}
 
       //channel.cpp
-      auto trigger(bool) -> void;
+      auto updateKeyState(bool) -> void;
 
       auto runEnvelope() -> void;
       auto runPhase() -> void;
@@ -105,6 +105,7 @@ protected:
       auto serialize(serializer&) -> void;
 
       n1 keyOn = 0;
+      n1 keyLine = 0;
       n1 lfoEnable = 0;
       n3 detune = 0;
       n4 multiple = 0;


### PR DESCRIPTION
Fixed envelope generator logic to avoid stalls on phase transitions. This is needed in cases where certain phases are intentionally skipped. Key press logic was also modified to update with the envelope synchronously for the same reason.