### PR TITLE
build: qualify std::move/forward calls

### DIFF
--- a/ares/ares/debug/debug.hpp
+++ b/ares/ares/debug/debug.hpp
@@ -4,19 +4,19 @@ struct Debug {
   auto reset() -> void;
 
   template<typename... P> auto unhandled(P&&... p) -> void {
-    return _unhandled({forward<P>(p)...});
+    return _unhandled({std::forward<P>(p)...});
   }
 
   template<typename... P> auto unimplemented(P&&... p) -> void {
-    return _unimplemented({forward<P>(p)...});
+    return _unimplemented({std::forward<P>(p)...});
   }
 
   template<typename... P> auto unusual(P&&... p) -> void {
-    return _unusual({forward<P>(p)...});
+    return _unusual({std::forward<P>(p)...});
   }
 
   template<typename... P> auto unverified(P&&... p) -> void {
-    return _unverified({forward<P>(p)...});
+    return _unverified({std::forward<P>(p)...});
   }
 
 private:

--- a/ares/ares/node/audio/stream.hpp
+++ b/ares/ares/node/audio/stream.hpp
@@ -25,7 +25,7 @@ struct Stream : Audio {
   template<typename... P>
   auto frame(P&&... p) -> void {
     if(runAhead()) return;
-    f64 samples[sizeof...(p)] = {forward<P>(p)...};
+    f64 samples[sizeof...(p)] = {std::forward<P>(p)...};
     write(samples);
   }
 

--- a/ares/ares/node/object.hpp
+++ b/ares/ares/node/object.hpp
@@ -33,7 +33,7 @@ struct Object : shared_pointer_this<Object> {
   template<typename T, typename... P>
   auto prepend(P&&... p) -> Node::Object {
     using Type = typename T::type;
-    return prepend(shared_pointer<Type>::create(forward<P>(p)...));
+    return prepend(shared_pointer<Type>::create(std::forward<P>(p)...));
   }
 
   auto append(Node::Object node) -> Node::Object {
@@ -47,7 +47,7 @@ struct Object : shared_pointer_this<Object> {
   template<typename T, typename... P>
   auto append(P&&... p) -> Node::Object {
     using Type = typename T::type;
-    return append(shared_pointer<Type>::create(forward<P>(p)...));
+    return append(shared_pointer<Type>::create(std::forward<P>(p)...));
   }
 
   auto remove(Node::Object node) -> void {

--- a/ares/ares/scheduler/thread.cpp
+++ b/ares/ares/scheduler/thread.cpp
@@ -92,7 +92,7 @@ inline auto Thread::synchronize(Thread& thread, P&&... p) -> void {
     co_switch(thread.handle());
   }
   //convenience: allow synchronizing multiple threads with one function call.
-  if constexpr(sizeof...(p) > 0) synchronize(forward<P>(p)...);
+  if constexpr(sizeof...(p) > 0) synchronize(std::forward<P>(p)...);
 }
 
 inline auto Thread::serialize(serializer& s) -> void {

--- a/ares/component/processor/sh2/disassembler.cpp
+++ b/ares/component/processor/sh2/disassembler.cpp
@@ -1,8 +1,8 @@
 template<typename... P>
 auto SH2::hint(P&&... p) const -> string {
   if(1) return {};
-  if(1) return {"\e[0m\e[37m", forward<P>(p)..., "\e[0m"};
-  return {forward<P>(p)...};
+  if(1) return {"\e[0m\e[37m", std::forward<P>(p)..., "\e[0m"};
+  return {std::forward<P>(p)...};
 }
 
 auto SH2::disassembleInstruction() -> string {

--- a/ares/n64/cpu/disassembler.cpp
+++ b/ares/n64/cpu/disassembler.cpp
@@ -476,6 +476,6 @@ auto CPU::Disassembler::ccrRegisterValue(u32 index) const -> string {
 
 template<typename... P>
 auto CPU::Disassembler::hint(P&&... p) const -> string {
-  if(showColors) return {"\e[0m\e[37m", forward<P>(p)..., "\e[0m"};
-  return {forward<P>(p)...};
+  if(showColors) return {"\e[0m\e[37m", std::forward<P>(p)..., "\e[0m"};
+  return {std::forward<P>(p)...};
 }

--- a/ares/n64/rsp/disassembler.cpp
+++ b/ares/n64/rsp/disassembler.cpp
@@ -525,6 +525,6 @@ auto RSP::Disassembler::ccrRegisterValue(u32 index) const -> string {
 
 template<typename... P>
 auto RSP::Disassembler::hint(P&&... p) const -> string {
-  if(showColors) return {"\e[0m\e[37m", forward<P>(p)..., "\e[0m"};
-  return {forward<P>(p)...};
+  if(showColors) return {"\e[0m\e[37m", std::forward<P>(p)..., "\e[0m"};
+  return {std::forward<P>(p)...};
 }

--- a/ares/ps1/cpu/disassembler.cpp
+++ b/ares/ps1/cpu/disassembler.cpp
@@ -395,6 +395,6 @@ auto CPU::Disassembler::gteControlRegisterValue(u8 index) const -> string {
 
 template<typename... P>
 auto CPU::Disassembler::hint(P&&... p) const -> string {
-  if(showColors) return {"\e[0m\e[37m", forward<P>(p)..., "\e[0m"};
-  return {forward<P>(p)...};
+  if(showColors) return {"\e[0m\e[37m", std::forward<P>(p)..., "\e[0m"};
+  return {std::forward<P>(p)...};
 }

--- a/mia/medium/medium.cpp
+++ b/mia/medium/medium.cpp
@@ -86,7 +86,7 @@ auto Medium::manifestDatabase(string sha256) -> string {
     Database database;
     database.name = name();
     database.list = BML::unserialize(file::read(locate({"Database/", name(), ".bml"})));
-    Media::databases.append(move(database));
+    Media::databases.append(std::move(database));
   }
 
   //search the database for a given sha256 game entry

--- a/mia/pak/pak.cpp
+++ b/mia/pak/pak.cpp
@@ -65,7 +65,7 @@ auto Pak::read(string location, vector<string> match) -> vector<u8> {
   //attempt to apply BPS patch if one was found
   if(patch) {
     if(auto output = Beat::Single::apply(memory, patch)) {
-      memory = move(*output);
+      memory = std::move(*output);
     }
   }
 

--- a/nall/adaptive-array.hpp
+++ b/nall/adaptive-array.hpp
@@ -43,7 +43,7 @@ struct adaptive_array {
   }
 
   auto append(T&& value) -> void {
-    new(_pool.t + _size++) T(move(value));
+    new(_pool.t + _size++) T(std::move(value));
   }
 
   auto begin() { return &_pool.t[0]; }

--- a/nall/algorithm.hpp
+++ b/nall/algorithm.hpp
@@ -12,7 +12,7 @@ template<typename T, typename U> constexpr auto min(const T& t, const U& u) -> T
 }
 
 template<typename T, typename U, typename... P> constexpr auto min(const T& t, const U& u, P&&... p) -> T {
-  return t < u ? min(t, forward<P>(p)...) : min(u, forward<P>(p)...);
+  return t < u ? min(t, std::forward<P>(p)...) : min(u, std::forward<P>(p)...);
 }
 
 template<typename T, typename U> constexpr auto max(const T& t, const U& u) -> T {
@@ -20,7 +20,7 @@ template<typename T, typename U> constexpr auto max(const T& t, const U& u) -> T
 }
 
 template<typename T, typename U, typename... P> constexpr auto max(const T& t, const U& u, P&&... p) -> T {
-  return t > u ? max(t, forward<P>(p)...) : max(u, forward<P>(p)...);
+  return t > u ? max(t, std::forward<P>(p)...) : max(u, std::forward<P>(p)...);
 }
 
 }

--- a/nall/any.hpp
+++ b/nall/any.hpp
@@ -8,7 +8,7 @@ namespace nall {
 struct any {
   any() = default;
   any(const any& source) { operator=(source); }
-  any(any&& source) { operator=(move(source)); }
+  any(any&& source) { operator=(std::move(source)); }
   template<typename T> any(const T& value) { operator=(value); }
   ~any() { reset(); }
 

--- a/nall/database/odbc.hpp
+++ b/nall/database/odbc.hpp
@@ -16,13 +16,13 @@ struct ODBC {
     auto operator=(const Statement& source) -> Statement& = delete;
 
     Statement(SQLHANDLE statement) : _statement(statement) {}
-    Statement(Statement&& source) { operator=(move(source)); }
+    Statement(Statement&& source) { operator=(std::move(source)); }
 
     auto operator=(Statement&& source) -> Statement& {
       if(this == &source) return *this;
       _statement = source._statement;
       _output = source._output;
-      _values = move(source._values);
+      _values = std::move(source._values);
       source._statement = nullptr;
       source._output = 0;
       return *this;
@@ -99,7 +99,7 @@ struct ODBC {
     auto operator=(const Query& source) -> Query& = delete;
 
     Query(SQLHANDLE statement) : Statement(statement) {}
-    Query(Query&& source) : Statement(source._statement) { operator=(move(source)); }
+    Query(Query&& source) : Statement(source._statement) { operator=(std::move(source)); }
 
     ~Query() {
       if(statement()) {
@@ -111,8 +111,8 @@ struct ODBC {
     auto operator=(Query&& source) -> Query& {
       if(this == &source) return *this;
       if(statement()) SQLFreeHandle(SQL_HANDLE_STMT, _statement);
-      Statement::operator=(move(source));
-      _bindings = move(source._bindings);
+      Statement::operator=(std::move(source));
+      _bindings = std::move(source._bindings);
       _result = source._result;
       _input = source._input;
       _stepped = source._stepped;
@@ -281,7 +281,7 @@ struct ODBC {
     _result = SQLPrepareA(_statement, (SQLCHAR*)statement.data(), SQL_NTS);
     if(!success()) return {nullptr};
 
-    bind(query, forward<P>(p)...);
+    bind(query, std::forward<P>(p)...);
     return query;
   }
 
@@ -291,7 +291,7 @@ private:
   auto bind(Query&) -> void {}
   template<typename T, typename... P> auto bind(Query& query, const T& value, P&&... p) -> void {
     query.bind(value);
-    bind(query, forward<P>(p)...);
+    bind(query, std::forward<P>(p)...);
   }
 
   SQLHANDLE _environment = nullptr;

--- a/nall/database/sqlite3.hpp
+++ b/nall/database/sqlite3.hpp
@@ -16,7 +16,7 @@ struct SQLite3 {
     auto operator=(const Statement& source) -> Statement& = delete;
 
     Statement(sqlite3_stmt* statement) : _statement(statement) {}
-    Statement(Statement&& source) { operator=(move(source)); }
+    Statement(Statement&& source) { operator=(std::move(source)); }
 
     auto operator=(Statement&& source) -> Statement& {
       if(this == &source) return *this;
@@ -91,7 +91,7 @@ struct SQLite3 {
     auto operator=(const Query& source) -> Query& = delete;
 
     Query(sqlite3_stmt* statement) : Statement(statement) {}
-    Query(Query&& source) : Statement(source._statement) { operator=(move(source)); }
+    Query(Query&& source) : Statement(source._statement) { operator=(std::move(source)); }
 
     ~Query() {
       sqlite3_finalize(statement());
@@ -195,7 +195,7 @@ struct SQLite3 {
     }
 
     Query query{_statement};
-    bind(query, forward<P>(p)...);
+    bind(query, std::forward<P>(p)...);
     return query;
   }
 
@@ -211,7 +211,7 @@ protected:
   auto bind(Query&) -> void {}
   template<typename T, typename... P> auto bind(Query& query, const T& value, P&&... p) -> void {
     query.bind(value);
-    bind(query, forward<P>(p)...);
+    bind(query, std::forward<P>(p)...);
   }
 
   bool _debug = false;

--- a/nall/elliptic-curve/ed25519.hpp
+++ b/nall/elliptic-curve/ed25519.hpp
@@ -57,17 +57,17 @@ private:
 
   template<typename... P> auto input(Hash::SHA512& hash, u256 value, P&&... p) const -> void {
     for(u32 byte : range(32)) hash.input(u8(value >> byte * 8));
-    input(hash, forward<P>(p)...);
+    input(hash, std::forward<P>(p)...);
   }
 
   template<typename... P> auto input(Hash::SHA512& hash, array_view<u8> value, P&&... p) const -> void {
     hash.input(value);
-    input(hash, forward<P>(p)...);
+    input(hash, std::forward<P>(p)...);
   }
 
   template<typename... P> auto hash(P&&... p) const -> u512 {
     Hash::SHA512 hash;
-    input(hash, forward<P>(p)...);
+    input(hash, std::forward<P>(p)...);
     u512 result;
     for(auto byte : reverse(hash.output())) result = result << 8 | byte;
     return result;

--- a/nall/file-buffer.hpp
+++ b/nall/file-buffer.hpp
@@ -29,7 +29,7 @@ struct file_buffer {
   file_buffer() = default;
   file_buffer(const string& filename, u32 mode) { open(filename, mode); }
 
-  file_buffer(file_buffer&& source) { operator=(move(source)); }
+  file_buffer(file_buffer&& source) { operator=(std::move(source)); }
 
   ~file_buffer() { close(); }
 
@@ -125,7 +125,7 @@ struct file_buffer {
   }
 
   template<typename... P> auto print(P&&... p) -> void {
-    string s{forward<P>(p)...};
+    string s{std::forward<P>(p)...};
     for(auto& byte : s) write(byte);
   }
 

--- a/nall/file-map.hpp
+++ b/nall/file-map.hpp
@@ -29,7 +29,7 @@ struct file_map {
   auto operator=(const file_map&) = delete;
 
   file_map() = default;
-  file_map(file_map&& source) { operator=(move(source)); }
+  file_map(file_map&& source) { operator=(std::move(source)); }
   file_map(const string& filename, u32 mode) { open(filename, mode); }
 
   ~file_map() { close(); }

--- a/nall/function.hpp
+++ b/nall/function.hpp
@@ -26,7 +26,7 @@ template<typename R, typename... P> struct function<auto (P...) -> R> {
   ~function() { if(callback) delete callback; }
 
   explicit operator bool() const { return callback; }
-  auto operator()(P... p) const -> R { return (*callback)(forward<P>(p)...); }
+  auto operator()(P... p) const -> R { return (*callback)(std::forward<P>(p)...); }
   auto reset() -> void { if(callback) { delete callback; callback = nullptr; } }
 
   auto operator=(const function& source) -> function& {
@@ -54,7 +54,7 @@ private:
 
   struct global : container {
     auto (*function)(P...) -> R;
-    auto operator()(P... p) const -> R { return function(forward<P>(p)...); }
+    auto operator()(P... p) const -> R { return function(std::forward<P>(p)...); }
     auto copy() const -> container* { return new global(function); }
     global(auto (*function)(P...) -> R) : function(function) {}
   };
@@ -62,14 +62,14 @@ private:
   template<typename C> struct member : container {
     auto (C::*function)(P...) -> R;
     C* object;
-    auto operator()(P... p) const -> R { return (object->*function)(forward<P>(p)...); }
+    auto operator()(P... p) const -> R { return (object->*function)(std::forward<P>(p)...); }
     auto copy() const -> container* { return new member(function, object); }
     member(auto (C::*function)(P...) -> R, C* object) : function(function), object(object) {}
   };
 
   template<typename L> struct lambda : container {
     mutable L object;
-    auto operator()(P... p) const -> R { return object(forward<P>(p)...); }
+    auto operator()(P... p) const -> R { return object(std::forward<P>(p)...); }
     auto copy() const -> container* { return new lambda(object); }
     lambda(const L& object) : object(object) {}
   };

--- a/nall/hashset.hpp
+++ b/nall/hashset.hpp
@@ -17,7 +17,7 @@ struct hashset {
   hashset() = default;
   hashset(u32 length) : length(bit::round(length)) {}
   hashset(const hashset& source) { operator=(source); }
-  hashset(hashset&& source) { operator=(move(source)); }
+  hashset(hashset&& source) { operator=(std::move(source)); }
   ~hashset() { reset(); }
 
   auto operator=(const hashset& source) -> hashset& {

--- a/nall/image/core.hpp
+++ b/nall/image/core.hpp
@@ -7,7 +7,7 @@ inline image::image(const image& source) {
 }
 
 inline image::image(image&& source) {
-  operator=(forward<image>(source));
+  operator=(std::forward<image>(source));
 }
 
 inline image::image(bool endian, u32 depth, u64 alphaMask, u64 redMask, u64 greenMask, u64 blueMask) {

--- a/nall/image/multifactor.hpp
+++ b/nall/image/multifactor.hpp
@@ -7,7 +7,7 @@ inline multiFactorImage::multiFactorImage(const multiFactorImage& source) {
 }
 
 inline multiFactorImage::multiFactorImage(multiFactorImage&& source) {
-  operator=(forward<multiFactorImage>(source));
+  operator=(std::forward<multiFactorImage>(source));
 }
 
 inline multiFactorImage::multiFactorImage(const image& lowDPI, const image& highDPI) {
@@ -20,7 +20,7 @@ inline multiFactorImage::multiFactorImage(const image& source) {
 }
 
 inline multiFactorImage::multiFactorImage(image&& source) {
-    operator=(forward<multiFactorImage>(source));
+    operator=(std::forward<multiFactorImage>(source));
 }
 
 inline multiFactorImage::multiFactorImage() {

--- a/nall/image/utility.hpp
+++ b/nall/image/utility.hpp
@@ -173,7 +173,7 @@ inline auto image::transform(bool outputEndian, u32 outputDepth, u64 outputAlpha
     }
   }
 
-  operator=(move(output));
+  operator=(std::move(output));
 }
 
 }

--- a/nall/instance.hpp
+++ b/nall/instance.hpp
@@ -16,7 +16,7 @@ struct Instance {
   auto construct(P&&... p) {
     if(constructed) return;
     constructed = true;
-    new((void*)(&instance.object)) T(forward<P>(p)...);
+    new((void*)(&instance.object)) T(std::forward<P>(p)...);
   }
 
   auto destruct() -> void {

--- a/nall/locale.hpp
+++ b/nall/locale.hpp
@@ -42,7 +42,7 @@ struct Locale {
 
   template<typename... P>
   auto operator()(string ns, string input, P&&... p) const -> string {
-    vector<string> arguments{forward<P>(p)...};
+    vector<string> arguments{std::forward<P>(p)...};
     if(selected) {
       for(auto node : selected().document) {
         if(node.name() == "namespace" && node.text() == ns) {
@@ -66,12 +66,12 @@ struct Locale {
 
     template<typename... P>
     auto operator()(string input, P&&... p) const -> string {
-      return _locale(_namespace, input, forward<P>(p)...);
+      return _locale(_namespace, input, std::forward<P>(p)...);
     }
 
     template<typename... P>
     auto tr(string input, P&&... p) const -> string {
-      return _locale(_namespace, input, forward<P>(p)...);
+      return _locale(_namespace, input, std::forward<P>(p)...);
     }
 
   private:

--- a/nall/maybe.hpp
+++ b/nall/maybe.hpp
@@ -13,14 +13,14 @@ struct maybe {
   maybe() {}
   maybe(nothing_t) {}
   maybe(const T& source) { operator=(source); }
-  maybe(T&& source) { operator=(move(source)); }
+  maybe(T&& source) { operator=(std::move(source)); }
   maybe(const maybe& source) { operator=(source); }
-  maybe(maybe&& source) { operator=(move(source)); }
+  maybe(maybe&& source) { operator=(std::move(source)); }
   ~maybe() { reset(); }
 
   auto operator=(nothing_t) -> maybe& { reset(); return *this; }
   auto operator=(const T& source) -> maybe& { reset(); _valid = true; new(&_value.t) T(source); return *this; }
-  auto operator=(T&& source) -> maybe& { reset(); _valid = true; new(&_value.t) T(move(source)); return *this; }
+  auto operator=(T&& source) -> maybe& { reset(); _valid = true; new(&_value.t) T(std::move(source)); return *this; }
 
   auto operator=(const maybe& source) -> maybe& {
     if(this == &source) return *this;
@@ -32,7 +32,7 @@ struct maybe {
   auto operator=(maybe&& source) -> maybe& {
     if(this == &source) return *this;
     reset();
-    if(_valid = source._valid) new(&_value.t) T(move(source.get()));
+    if(_valid = source._valid) new(&_value.t) T(std::move(source.get()));
     return *this;
   }
 

--- a/nall/memory.hpp
+++ b/nall/memory.hpp
@@ -168,7 +168,7 @@ template<typename T> auto fill(void* target, u32 capacity, const T& value) -> T*
 
 template<typename T, typename U, typename... P> auto assign(T* target, const U& value, P&&... p) -> void {
   *target++ = value;
-  assign(target, forward<P>(p)...);
+  assign(target, std::forward<P>(p)...);
 }
 
 template<u32 size, typename T> auto readl(const void* source) -> T {

--- a/nall/merge-sort.hpp
+++ b/nall/merge-sort.hpp
@@ -29,12 +29,12 @@ template<typename T, typename Comparator> auto sort(T list[], u32 size, const Co
     //insertion sort requires a copy (via move construction)
     #if defined(NALL_MERGE_SORT_INSERTION)
     for(s32 i = 1, j; i < size; i++) {
-      T copy(move(list[i]));
+      T copy(std::move(list[i]));
       for(j = i - 1; j >= 0; j--) {
         if(!lessthan(copy, list[j])) break;
-        list[j + 1] = move(list[j]);
+        list[j + 1] = std::move(list[j]);
       }
-      list[j + 1] = move(copy);
+      list[j + 1] = std::move(copy);
     }
     //selection sort requires a swap
     #elif defined(NALL_MERGE_SORT_SELECTION)
@@ -60,16 +60,16 @@ template<typename T, typename Comparator> auto sort(T list[], u32 size, const Co
   u32 offset = 0, left = 0, right = middle;
   while(left < middle && right < size) {
     if(!lessthan(list[right], list[left])) {
-      new(buffer + offset++) T(move(list[left++]));
+      new(buffer + offset++) T(std::move(list[left++]));
     } else {
-      new(buffer + offset++) T(move(list[right++]));
+      new(buffer + offset++) T(std::move(list[right++]));
     }
   }
-  while(left < middle) new(buffer + offset++) T(move(list[left++]));
-  while(right < size ) new(buffer + offset++) T(move(list[right++]));
+  while(left < middle) new(buffer + offset++) T(std::move(list[left++]));
+  while(right < size ) new(buffer + offset++) T(std::move(list[right++]));
 
   for(u32 i = 0; i < size; i++) {
-    list[i] = move(buffer[i]);
+    list[i] = std::move(buffer[i]);
     buffer[i].~T();
   }
   memory::free(buffer);

--- a/nall/queue/st.hpp
+++ b/nall/queue/st.hpp
@@ -83,7 +83,7 @@ template<typename T>
 struct queue {
   queue() = default;
   queue(const queue& source) { operator=(source); }
-  queue(queue&& source) { operator=(move(source)); }
+  queue(queue&& source) { operator=(std::move(source)); }
   ~queue() { reset(); }
 
   auto operator=(const queue& source) -> queue& {

--- a/nall/recompiler/amd64/emitter.hpp
+++ b/nall/recompiler/amd64/emitter.hpp
@@ -7,7 +7,7 @@ struct emitter {
   template<typename... P>
   alwaysinline auto byte(u8 data, P&&... p) {
     span.write(data);
-    byte(forward<P>(p)...);
+    byte(std::forward<P>(p)...);
   }
 
   alwaysinline auto word(u16 data) {

--- a/nall/run.hpp
+++ b/nall/run.hpp
@@ -36,7 +36,7 @@ template<typename... P> inline auto execute(const string& name, P&&... p) -> exe
   if(pid == 0) {
     const char* argv[1 + sizeof...(p) + 1];
     const char** argp = argv;
-    vector<string> argl(forward<P>(p)...);
+    vector<string> argl(std::forward<P>(p)...);
     *argp++ = (const char*)name;
     for(auto& arg : argl) *argp++ = (const char*)arg;
     *argp++ = nullptr;
@@ -92,7 +92,7 @@ template<typename... P> inline auto invoke(const string& name, P&&... p) -> void
   if(pid == 0) {
     const char* argv[1 + sizeof...(p) + 1];
     const char** argp = argv;
-    vector<string> argl(forward<P>(p)...);
+    vector<string> argl(std::forward<P>(p)...);
     *argp++ = (const char*)name;
     for(auto& arg : argl) *argp++ = (const char*)arg;
     *argp++ = nullptr;
@@ -111,7 +111,7 @@ template<typename... P> inline auto invoke(const string& name, P&&... p) -> void
 #elif defined(PLATFORM_WINDOWS)
 
 template<typename... P> inline auto execute(const string& name, P&&... p) -> execute_result_t {
-  vector<string> argl(name, forward<P>(p)...);
+  vector<string> argl(name, std::forward<P>(p)...);
   for(auto& arg : argl) if(arg.find(" ")) arg = {"\"", arg, "\""};
   string arguments = argl.merge(" ");
 
@@ -193,7 +193,7 @@ template<typename... P> inline auto execute(const string& name, P&&... p) -> exe
 }
 
 template<typename... P> inline auto invoke(const string& name, P&&... p) -> void {
-  vector<string> argl(forward<P>(p)...);
+  vector<string> argl(std::forward<P>(p)...);
   for(auto& arg : argl) if(arg.find(" ")) arg = {"\"", arg, "\""};
   string arguments = argl.merge(" ");
   string directory = Path::program().replace("/", "\\");

--- a/nall/serializer.hpp
+++ b/nall/serializer.hpp
@@ -124,7 +124,7 @@ struct serializer {
   }
 
   serializer(const serializer& s) { operator=(s); }
-  serializer(serializer&& s) { operator=(move(s)); }
+  serializer(serializer&& s) { operator=(std::move(s)); }
 
   serializer() {
     setWriting();

--- a/nall/set.hpp
+++ b/nall/set.hpp
@@ -30,7 +30,7 @@ template<typename T> struct set {
 
   set() = default;
   set(const set& source) { operator=(source); }
-  set(set&& source) { operator=(move(source)); }
+  set(set&& source) { operator=(std::move(source)); }
   set(std::initializer_list<T> list) { for(auto& value : list) insert(value); }
   ~set() { reset(); }
 
@@ -80,7 +80,7 @@ template<typename T> struct set {
 
   template<typename... P> auto insert(const T& value, P&&... p) -> bool {
     bool result = insert(value);
-    insert(forward<P>(p)...) | result;
+    insert(std::forward<P>(p)...) | result;
     return result;
   }
 
@@ -94,7 +94,7 @@ template<typename T> struct set {
 
   template<typename... P> auto remove(const T& value, P&&... p) -> bool {
     bool result = remove(value);
-    return remove(forward<P>(p)...) | result;
+    return remove(std::forward<P>(p)...) | result;
   }
 
   struct base_iterator {

--- a/nall/shared-pointer.hpp
+++ b/nall/shared-pointer.hpp
@@ -27,7 +27,7 @@ struct shared_pointer_this_base{};
 template<typename T>
 struct shared_pointer {
   template<typename... P> static auto create(P&&... p) {
-    return shared_pointer<T>{new T{forward<P>(p)...}};
+    return shared_pointer<T>{new T{std::forward<P>(p)...}};
   }
 
   using type = T;
@@ -57,7 +57,7 @@ struct shared_pointer {
   }
 
   shared_pointer(shared_pointer&& source) {
-    operator=(move(source));
+    operator=(std::move(source));
   }
 
   template<typename U, typename = enable_if_t<is_compatible<U>::value>>
@@ -67,7 +67,7 @@ struct shared_pointer {
 
   template<typename U, typename = enable_if_t<is_compatible<U>::value>>
   shared_pointer(shared_pointer<U>&& source) {
-    operator=<U>(move(source));
+    operator=<U>(std::move(source));
   }
 
   template<typename U, typename = enable_if_t<is_compatible<U>::value>>
@@ -279,13 +279,13 @@ struct shared_pointer_this : shared_pointer_this_base {
 
 template<typename T, typename... P>
 auto shared_pointer_make(P&&... p) -> shared_pointer<T> {
-  return shared_pointer<T>{new T{forward<P>(p)...}};
+  return shared_pointer<T>{new T{std::forward<P>(p)...}};
 }
 
 template<typename T>
 struct shared_pointer_new : shared_pointer<T> {
   shared_pointer_new(const shared_pointer<T>& source) : shared_pointer<T>(source) {}
-  template<typename... P> shared_pointer_new(P&&... p) : shared_pointer<T>(new T(forward<P>(p)...)) {}
+  template<typename... P> shared_pointer_new(P&&... p) : shared_pointer<T>(new T(std::forward<P>(p)...)) {}
 };
 
 }

--- a/nall/string.hpp
+++ b/nall/string.hpp
@@ -141,7 +141,7 @@ public:
   string();
   string(string& source) : string() { operator=(source); }
   string(const string& source) : string() { operator=(source); }
-  string(string&& source) : string() { operator=(move(source)); }
+  string(string&& source) : string() { operator=(std::move(source)); }
   template<typename T = char> auto get() -> T*;
   template<typename T = char> auto data() const -> const T*;
   template<typename T = char> auto size() const -> u32 { return _size / sizeof(T); }
@@ -153,7 +153,7 @@ public:
   auto operator=(string&&) -> type&;
 
   template<typename T, typename... P> string(T&& s, P&&... p) : string() {
-    append(forward<T>(s), forward<P>(p)...);
+    append(std::forward<T>(s), std::forward<P>(p)...);
   }
   ~string() { reset(); }
 
@@ -304,12 +304,12 @@ template<> struct vector<string> : vector_base<string> {
 
   vector(const vector& source) { vector_base::operator=(source); }
   vector(vector& source) { vector_base::operator=(source); }
-  vector(vector&& source) { vector_base::operator=(move(source)); }
-  template<typename... P> vector(P&&... p) { append(forward<P>(p)...); }
+  vector(vector&& source) { vector_base::operator=(std::move(source)); }
+  template<typename... P> vector(P&&... p) { append(std::forward<P>(p)...); }
 
   auto operator=(const vector& source) -> type& { return vector_base::operator=(source), *this; }
   auto operator=(vector& source) -> type& { return vector_base::operator=(source), *this; }
-  auto operator=(vector&& source) -> type& { return vector_base::operator=(move(source)), *this; }
+  auto operator=(vector&& source) -> type& { return vector_base::operator=(std::move(source)), *this; }
 
   //vector.hpp
   template<typename... P> auto append(const string&, P&&...) -> type&;
@@ -329,7 +329,7 @@ template<> struct vector<string> : vector_base<string> {
 struct string_format : vector<string> {
   using type = string_format;
 
-  template<typename... P> string_format(P&&... p) { reserve(sizeof...(p)); append(forward<P>(p)...); }
+  template<typename... P> string_format(P&&... p) { reserve(sizeof...(p)); append(std::forward<P>(p)...); }
   template<typename T, typename... P> auto append(const T&, P&&... p) -> type&;
   auto append() -> type&;
 };

--- a/nall/string/core.hpp
+++ b/nall/string/core.hpp
@@ -30,16 +30,16 @@ inline auto string::operator()(u32 position, char fallback) const -> char {
 
 template<typename... P> inline auto string::assign(P&&... p) -> string& {
   resize(0);
-  return append(forward<P>(p)...);
+  return append(std::forward<P>(p)...);
 }
 
 template<typename T, typename... P> inline auto string::prepend(const T& value, P&&... p) -> string& {
-  if constexpr(sizeof...(p)) prepend(forward<P>(p)...);
+  if constexpr(sizeof...(p)) prepend(std::forward<P>(p)...);
   return _prepend(make_string(value));
 }
 
 template<typename... P> inline auto string::prepend(const nall::string_format& value, P&&... p) -> string& {
-  if constexpr(sizeof...(p)) prepend(forward<P>(p)...);
+  if constexpr(sizeof...(p)) prepend(std::forward<P>(p)...);
   return format(value);
 }
 
@@ -52,13 +52,13 @@ template<typename T> inline auto string::_prepend(const stringify<T>& source) ->
 
 template<typename T, typename... P> inline auto string::append(const T& value, P&&... p) -> string& {
   _append(make_string(value));
-  if constexpr(sizeof...(p) > 0) append(forward<P>(p)...);
+  if constexpr(sizeof...(p) > 0) append(std::forward<P>(p)...);
   return *this;
 }
 
 template<typename... P> inline auto string::append(const nall::string_format& value, P&&... p) -> string& {
   format(value);
-  if constexpr(sizeof...(p)) append(forward<P>(p)...);
+  if constexpr(sizeof...(p)) append(std::forward<P>(p)...);
   return *this;
 }
 

--- a/nall/string/format.hpp
+++ b/nall/string/format.hpp
@@ -61,7 +61,7 @@ inline auto string::format(const nall::string_format& params) -> type& {
 
 template<typename T, typename... P> inline auto string_format::append(const T& value, P&&... p) -> string_format& {
   vector<string>::append(value);
-  return append(forward<P>(p)...);
+  return append(std::forward<P>(p)...);
 }
 
 inline auto string_format::append() -> string_format& {
@@ -69,13 +69,13 @@ inline auto string_format::append() -> string_format& {
 }
 
 template<typename... P> inline auto print(P&&... p) -> void {
-  string s{forward<P>(p)...};
+  string s{std::forward<P>(p)...};
   fwrite(s.data(), 1, s.size(), stdout);
   fflush(stdout);
 }
 
 template<typename... P> inline auto print(FILE* fp, P&&... p) -> void {
-  string s{forward<P>(p)...};
+  string s{std::forward<P>(p)...};
   fwrite(s.data(), 1, s.size(), fp);
   if(fp == stdout || fp == stderr) fflush(fp);
 }

--- a/nall/string/pascal.hpp
+++ b/nall/string/pascal.hpp
@@ -25,7 +25,7 @@ struct string_pascal {
   }
 
   string_pascal(const string_pascal& source) { operator=(source); }
-  string_pascal(string_pascal&& source) { operator=(move(source)); }
+  string_pascal(string_pascal&& source) { operator=(std::move(source)); }
 
   ~string_pascal() {
     if(_data) memory::free(_data);

--- a/nall/string/vector.hpp
+++ b/nall/string/vector.hpp
@@ -4,7 +4,7 @@ namespace nall {
 
 template<typename... P> inline auto vector<string>::append(const string& data, P&&... p) -> type& {
   vector_base::append(data);
-  append(forward<P>(p)...);
+  append(std::forward<P>(p)...);
   return *this;
 }
 

--- a/nall/string/view.hpp
+++ b/nall/string/view.hpp
@@ -44,7 +44,7 @@ inline string_view::string_view(const string& source) {
 
 template<typename... P>
 inline string_view::string_view(P&&... p) {
-  _string = new string{forward<P>(p)...};
+  _string = new string{std::forward<P>(p)...};
   _data = _string->data();
   _size = _string->size();
 }

--- a/nall/terminal.hpp
+++ b/nall/terminal.hpp
@@ -16,48 +16,48 @@ inline auto escapable() -> bool {
 namespace color {
 
 template<typename... P> inline auto black(P&&... p) -> string {
-  if(!escapable()) return string{forward<P>(p)...};
-  return {"\e[30m", string{forward<P>(p)...}, "\e[0m"};
+  if(!escapable()) return string{std::forward<P>(p)...};
+  return {"\e[30m", string{std::forward<P>(p)...}, "\e[0m"};
 }
 
 template<typename... P> inline auto blue(P&&... p) -> string {
-  if(!escapable()) return string{forward<P>(p)...};
-  return {"\e[94m", string{forward<P>(p)...}, "\e[0m"};
+  if(!escapable()) return string{std::forward<P>(p)...};
+  return {"\e[94m", string{std::forward<P>(p)...}, "\e[0m"};
 }
 
 template<typename... P> inline auto green(P&&... p) -> string {
-  if(!escapable()) return string{forward<P>(p)...};
-  return {"\e[92m", string{forward<P>(p)...}, "\e[0m"};
+  if(!escapable()) return string{std::forward<P>(p)...};
+  return {"\e[92m", string{std::forward<P>(p)...}, "\e[0m"};
 }
 
 template<typename... P> inline auto cyan(P&&... p) -> string {
-  if(!escapable()) return string{forward<P>(p)...};
-  return {"\e[96m", string{forward<P>(p)...}, "\e[0m"};
+  if(!escapable()) return string{std::forward<P>(p)...};
+  return {"\e[96m", string{std::forward<P>(p)...}, "\e[0m"};
 }
 
 template<typename... P> inline auto red(P&&... p) -> string {
-  if(!escapable()) return string{forward<P>(p)...};
-  return {"\e[91m", string{forward<P>(p)...}, "\e[0m"};
+  if(!escapable()) return string{std::forward<P>(p)...};
+  return {"\e[91m", string{std::forward<P>(p)...}, "\e[0m"};
 }
 
 template<typename... P> inline auto magenta(P&&... p) -> string {
-  if(!escapable()) return string{forward<P>(p)...};
-  return {"\e[95m", string{forward<P>(p)...}, "\e[0m"};
+  if(!escapable()) return string{std::forward<P>(p)...};
+  return {"\e[95m", string{std::forward<P>(p)...}, "\e[0m"};
 }
 
 template<typename... P> inline auto yellow(P&&... p) -> string {
-  if(!escapable()) return string{forward<P>(p)...};
-  return {"\e[93m", string{forward<P>(p)...}, "\e[0m"};
+  if(!escapable()) return string{std::forward<P>(p)...};
+  return {"\e[93m", string{std::forward<P>(p)...}, "\e[0m"};
 }
 
 template<typename... P> inline auto white(P&&... p) -> string {
-  if(!escapable()) return string{forward<P>(p)...};
-  return {"\e[97m", string{forward<P>(p)...}, "\e[0m"};
+  if(!escapable()) return string{std::forward<P>(p)...};
+  return {"\e[97m", string{std::forward<P>(p)...}, "\e[0m"};
 }
 
 template<typename... P> inline auto gray(P&&... p) -> string {
-  if(!escapable()) return string{forward<P>(p)...};
-  return {"\e[37m", string{forward<P>(p)...}, "\e[0m"};
+  if(!escapable()) return string{std::forward<P>(p)...};
+  return {"\e[37m", string{std::forward<P>(p)...}, "\e[0m"};
 }
 
 }

--- a/nall/thread.hpp
+++ b/nall/thread.hpp
@@ -28,7 +28,7 @@ struct thread {
   auto operator=(const thread&) -> thread& = delete;
 
   thread() = default;
-  thread(thread&& source) { operator=(move(source)); }
+  thread(thread&& source) { operator=(std::move(source)); }
 
   auto operator=(thread&& source) -> thread& {
     if(this == &source) return *this;
@@ -100,7 +100,7 @@ struct thread {
   auto operator=(const thread&) -> thread& = delete;
 
   thread() = default;
-  thread(thread&& source) { operator=(move(source)); }
+  thread(thread&& source) { operator=(std::move(source)); }
 
   ~thread() { close(); }
 

--- a/nall/traits.hpp
+++ b/nall/traits.hpp
@@ -17,7 +17,6 @@ namespace nall {
   using std::false_type;
   using std::is_floating_point;
   using std::is_floating_point_v;
-  using std::forward;
   using std::initializer_list;
   using std::is_array;
   using std::is_array_v;
@@ -34,7 +33,6 @@ namespace nall {
   using std::is_signed_v;
   using std::is_unsigned;
   using std::is_unsigned_v;
-  using std::move;
   using std::nullptr_t;
   using std::remove_extent;
   using std::remove_extent_t;

--- a/nall/unique-pointer.hpp
+++ b/nall/unique-pointer.hpp
@@ -5,7 +5,7 @@ namespace nall {
 template<typename T>
 struct unique_pointer {
   template<typename... P> static auto create(P&&... p) {
-    return unique_pointer<T>{new T{forward<P>(p)...}};
+    return unique_pointer<T>{new T{std::forward<P>(p)...}};
   }
 
   using type = T;

--- a/nall/variant.hpp
+++ b/nall/variant.hpp
@@ -33,14 +33,14 @@ template<typename T> struct variant_copy<T> {
 
 template<typename T, typename... P> struct variant_move {
   constexpr variant_move(u32 index, u32 assigned, void* target, void* source) {
-    if(index == assigned) new(target) T(move(*((T*)source)));
+    if(index == assigned) new(target) T(std::move(*((T*)source)));
     else variant_move<P...>(index + 1, assigned, target, source);
   }
 };
 
 template<typename T> struct variant_move<T> {
   constexpr variant_move(u32 index, u32 assigned, void* target, void* source) {
-    if(index == assigned) new(target) T(move(*((T*)source)));
+    if(index == assigned) new(target) T(std::move(*((T*)source)));
   }
 };
 
@@ -74,9 +74,9 @@ template<typename F, typename T> struct variant_equals<F, T> {
 template<typename... P> struct variant final {  //final as destructor is not virtual
   variant() : assigned(0) {}
   variant(const variant& source) { operator=(source); }
-  variant(variant&& source) { operator=(move(source)); }
+  variant(variant&& source) { operator=(std::move(source)); }
   template<typename T> variant(const T& value) { operator=(value); }
-  template<typename T> variant(T&& value) { operator=(move(value)); }
+  template<typename T> variant(T&& value) { operator=(std::move(value)); }
   ~variant() { reset(); }
 
   explicit operator bool() const { return assigned; }
@@ -137,7 +137,7 @@ template<typename... P> struct variant final {  //final as destructor is not vir
   template<typename T> auto& operator=(T&& value) {
     static_assert(variant_index<1, T, P...>::index, "type not in variant");
     reset();
-    new((void*)&data) T(move(value));
+    new((void*)&data) T(std::move(value));
     assigned = variant_index<1, T, P...>::index;
     return *this;
   }

--- a/nall/vector.hpp
+++ b/nall/vector.hpp
@@ -99,9 +99,9 @@ struct vector_base {
   auto removeByValue(const T& value) -> bool;
 
   auto takeLeft() -> T;
-  auto takeFirst() -> T { return move(takeLeft()); }
+  auto takeFirst() -> T { return std::move(takeLeft()); }
   auto takeRight() -> T;
-  auto takeLast() -> T { return move(takeRight()); }
+  auto takeLast() -> T { return std::move(takeRight()); }
   auto take(u64 offset) -> T;
 
   //iterator.hpp

--- a/nall/vector/core.hpp
+++ b/nall/vector/core.hpp
@@ -12,7 +12,7 @@ template<typename T> vector<T>::vector(const vector<T>& source) {
 }
 
 template<typename T> vector<T>::vector(vector<T>&& source) {
-  operator=(move(source));
+  operator=(std::move(source));
 }
 
 template<typename T> vector<T>::~vector() {

--- a/nall/vector/memory.hpp
+++ b/nall/vector/memory.hpp
@@ -48,7 +48,7 @@ template<typename T> auto vector<T>::reserveLeft(u64 capacity) -> bool {
 
   u64 left = bit::round(capacity);
   auto pool = memory::allocate<T>(left + _right) + (left - _size);
-  for(u64 n : range(_size)) new(pool + n) T(move(_pool[n]));
+  for(u64 n : range(_size)) new(pool + n) T(std::move(_pool[n]));
   memory::free(_pool - _left);
 
   _pool = pool;
@@ -62,7 +62,7 @@ template<typename T> auto vector<T>::reserveRight(u64 capacity) -> bool {
 
   u64 right = bit::round(capacity);
   auto pool = memory::allocate<T>(_left + right) + _left;
-  for(u64 n : range(_size)) new(pool + n) T(move(_pool[n]));
+  for(u64 n : range(_size)) new(pool + n) T(std::move(_pool[n]));
   memory::free(_pool - _left);
 
   _pool = pool;

--- a/nall/vector/modify.hpp
+++ b/nall/vector/modify.hpp
@@ -11,7 +11,7 @@ template<typename T> auto vector<T>::prepend(const T& value) -> void {
 
 template<typename T> auto vector<T>::prepend(T&& value) -> void {
   reserveLeft(size() + 1);
-  new(--_pool) T(move(value));
+  new(--_pool) T(std::move(value));
   _left--;
   _size++;
 }
@@ -27,7 +27,7 @@ template<typename T> auto vector<T>::prepend(const vector<T>& values) -> void {
 template<typename T> auto vector<T>::prepend(vector<T>&& values) -> void {
   reserveLeft(size() + values.size());
   _pool -= values.size();
-  for(u64 n : range(values)) new(_pool + n) T(move(values[n]));
+  for(u64 n : range(values)) new(_pool + n) T(std::move(values[n]));
   _left -= values.size();
   _size += values.size();
 }
@@ -43,7 +43,7 @@ template<typename T> auto vector<T>::append(const T& value) -> void {
 
 template<typename T> auto vector<T>::append(T&& value) -> void {
   reserveRight(size() + 1);
-  new(_pool + _size) T(move(value));
+  new(_pool + _size) T(std::move(value));
   _right--;
   _size++;
 }
@@ -57,7 +57,7 @@ template<typename T> auto vector<T>::append(const vector<T>& values) -> void {
 
 template<typename T> auto vector<T>::append(vector<T>&& values) -> void {
   reserveRight(size() + values.size());
-  for(u64 n : range(values.size())) new(_pool + _size + n) T(move(values[n]));
+  for(u64 n : range(values.size())) new(_pool + _size + n) T(std::move(values[n]));
   _right -= values.size();
   _size += values.size();
 }
@@ -70,7 +70,7 @@ template<typename T> auto vector<T>::insert(u64 offset, const T& value) -> void 
   reserveRight(size() + 1);
   _size++;
   for(s64 n = size() - 1; n > offset; n--) {
-    _pool[n] = move(_pool[n - 1]);
+    _pool[n] = std::move(_pool[n - 1]);
   }
   new(_pool + offset) T(value);
 }
@@ -93,7 +93,7 @@ template<typename T> auto vector<T>::remove(u64 offset, u64 length) -> void {
 
   for(u64 n = offset; n < size(); n++) {
     if(n + length < size()) {
-      _pool[n] = move(_pool[n + length]);
+      _pool[n] = std::move(_pool[n + length]);
     } else {
       _pool[n].~T();
     }
@@ -114,13 +114,13 @@ template<typename T> auto vector<T>::removeByValue(const T& value) -> bool {
 //
 
 template<typename T> auto vector<T>::takeLeft() -> T {
-  T value = move(_pool[0]);
+  T value = std::move(_pool[0]);
   removeLeft();
   return value;
 }
 
 template<typename T> auto vector<T>::takeRight() -> T {
-  T value = move(_pool[size() - 1]);
+  T value = std::move(_pool[size() - 1]);
   removeRight();
   return value;
 }
@@ -129,7 +129,7 @@ template<typename T> auto vector<T>::take(u64 offset) -> T {
   if(offset == 0) return takeLeft();
   if(offset == size() - 1) return takeRight();
 
-  T value = move(_pool[offset]);
+  T value = std::move(_pool[offset]);
   remove(offset);
   return value;
 }

--- a/nall/vector/utility.hpp
+++ b/nall/vector/utility.hpp
@@ -13,7 +13,7 @@ template<typename T> auto vector<T>::sort(const function<bool (const T& lhs, con
 template<typename T> auto vector<T>::reverse() -> void {
   vector<T> reversed;
   for(u64 n : range(size())) reversed.prepend(_pool[n]);
-  operator=(move(reversed));
+  operator=(std::move(reversed));
 }
 
 template<typename T> auto vector<T>::find(const function<bool (const T& lhs)>& comparator) -> maybe<u64> {


### PR DESCRIPTION
clang 15 emits a warning if std::move or std::forward are called without a namespace qualifier.
https://reviews.llvm.org/D119670