### PR TITLE
sh2: fix pc-relative moves in branch delay slots

### DIFF
--- a/ares/component/processor/sh2/instructions.cpp
+++ b/ares/component/processor/sh2/instructions.cpp
@@ -503,18 +503,21 @@ auto SH2::MOVI(u32 i, u32 n) -> void {
 }
 
 //MOV.W @(disp,PC),Rn
-auto SH2::MOVWI(u32 d, u32 n) -> void {
-  R[n] = (s16)readWord(PC + d * 2);
+noinline auto SH2::MOVWI(u32 d, u32 n) -> void {
+  u32 pc = inDelaySlot() ? PPC - 2 : PC;
+  R[n] = (s16)readWord(pc + d * 2);
 }
 
 //MOV.L @(disp,PC),Rn
-auto SH2::MOVLI(u32 d, u32 n) -> void {
-  R[n] = readLong((PC & ~3) + d * 4);
+noinline auto SH2::MOVLI(u32 d, u32 n) -> void {
+  u32 pc = inDelaySlot() ? PPC - 2 : PC;
+  R[n] = readLong((pc & ~3) + d * 4);
 }
 
 //MOVA @(disp,PC),R0
-auto SH2::MOVA(u32 d) -> void {
-  R[0] = (PC & ~3) + d * 4 - inDelaySlot() * 2;
+noinline auto SH2::MOVA(u32 d) -> void {
+  u32 pc = inDelaySlot() ? PPC - 2 : PC;
+  R[0] = (pc & ~3) + d * 4;
 }
 
 //MOVT Rn

--- a/ares/component/processor/sh2/recompiler.cpp
+++ b/ares/component/processor/sh2/recompiler.cpp
@@ -611,7 +611,13 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.W @(disp,PC),Rn
   case 0x90 ... 0x9f: {
-    add32(reg(1), PC, imm(d8*2));
+    auto delay = cmp32_jump(PPM, imm(0), flag_ne);
+    mov32(reg(0), PC);
+    auto tail = jump();
+    setLabel(delay);
+    sub32(reg(0), PPC, imm(2));
+    setLabel(tail);
+    add32(reg(1), reg(0), imm(d8*2));
     call(readWord);
     mov32_s16(reg(0), reg(0));
     mov32(Rn, reg(0));
@@ -637,8 +643,14 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOV.L @(disp,PC),Rn
   case 0xd0 ... 0xdf: {
-    and32(reg(1), PC, imm(~3));
-    add32(reg(1), reg(1), imm(d8*4));
+    auto delay = cmp32_jump(PPM, imm(0), flag_ne);
+    mov32(reg(0), PC);
+    auto tail = jump();
+    setLabel(delay);
+    sub32(reg(0), PPC, imm(2));
+    setLabel(tail);
+    and32(reg(0), reg(0), imm(~3));
+    add32(reg(1), reg(0), imm(d8*4));
     call(readLong);
     mov32(Rn, reg(0));
     return 0;
@@ -816,12 +828,15 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //MOVA @(disp,PC),R0
   case 0xc7: {
-    and32(reg(0), PC, imm(~3));
+    auto delay = cmp32_jump(PPM, imm(0), flag_ne);
+    mov32(reg(0), PC);
+    auto tail = jump();
+    setLabel(delay);
+    sub32(reg(0), PPC, imm(2));
+    setLabel(tail);
+    and32(reg(0), reg(0), imm(~3));
     add32(reg(0), reg(0), imm(d8*4));
     mov32(R0, reg(0));
-    auto skip = cmp32_jump(PPM, imm(0), flag_eq);
-    sub32(R0, R0, imm(2));
-    setLabel(skip);
     return 0;
   }
 

--- a/ares/md/m32x/sh7604.cpp
+++ b/ares/md/m32x/sh7604.cpp
@@ -53,7 +53,7 @@ auto M32X::SH7604::step(u32 clocks) -> void {
 
 auto M32X::SH7604::power(bool reset) -> void {
   Thread::create(23'000'000, {&M32X::SH7604::main, this});
-  recompiler.min_cycles = 22;
+  recompiler.min_cycles = 19;
   SH2::power(reset);
   irq = {};
   irq.vres.enable = 1;


### PR DESCRIPTION
- sh2: fix pc-relative moves in branch delay slots
- 32x: reduce recompiler min_cycles 22 -> 19

Together these fix #727 