### PR TITLE
m32x: sync sh2 processors under certain conditions

### DIFF
--- a/ares/component/processor/sh2/instruction.cpp
+++ b/ares/component/processor/sh2/instruction.cpp
@@ -34,10 +34,12 @@ auto SH2::instruction() -> void {
 
     // Recompiled blocks may be very small, negating the impact
     // minimum cycle counts ensure that the recompiler is a net positive
+    auto min_cycles = recompiler.min_cycles;
     do {
       auto block = recompiler.block(PC - 4);
       block->execute(*this);
     } while (CCR <= recompiler.min_cycles);
+    recompiler.min_cycles = min_cycles;
 
     step(CCR);
     CCR = 0;

--- a/ares/component/processor/sh2/instruction.cpp
+++ b/ares/component/processor/sh2/instruction.cpp
@@ -34,12 +34,10 @@ auto SH2::instruction() -> void {
 
     // Recompiled blocks may be very small, negating the impact
     // minimum cycle counts ensure that the recompiler is a net positive
-    auto min_cycles = recompiler.min_cycles;
     do {
       auto block = recompiler.block(PC - 4);
       block->execute(*this);
-    } while (CCR <= recompiler.min_cycles);
-    recompiler.min_cycles = min_cycles;
+    } while (CCR < cyclesUntilSync);
 
     step(CCR);
     CCR = 0;

--- a/ares/component/processor/sh2/sh2.cpp
+++ b/ares/component/processor/sh2/sh2.cpp
@@ -45,6 +45,7 @@ auto SH2::power(bool reset) -> void {
   ET = 0;
   ID = 0;
   exceptions = !reset ? ResetCold : ResetWarm;
+  cyclesUntilSync = 0;
 
   cache = {*this};
   intc = {*this};

--- a/ares/component/processor/sh2/sh2.hpp
+++ b/ares/component/processor/sh2/sh2.hpp
@@ -246,6 +246,9 @@ struct SH2 {
   };
   u32 exceptions = 0;  //delayed exception flags
 
+  s32 cyclesUntilSync = 0;
+  s32 minCyclesBetweenSyncs = 0;
+
   struct Recompiler : recompiler::generic {
     SH2& self;
     Recompiler(SH2& self) : self(self), generic(allocator) {}
@@ -276,7 +279,6 @@ struct SH2 {
 
     bump_allocator allocator;
     Pool* pools[1 << 24];
-    int min_cycles = 0;
   } recompiler{*this};
 
   #include "sh7604/sh7604.hpp"

--- a/ares/component/processor/sh2/sh7604/bus.cpp
+++ b/ares/component/processor/sh2/sh7604/bus.cpp
@@ -137,6 +137,9 @@ template<u32 Origin> auto SH2::writeByte(u32 address, u32 data) -> void {
   }
 
   case Area::Uncached: {
+    if constexpr(Accuracy::Recompiler) {
+      recompiler.min_cycles = 0;
+    }
     return busWriteByte(address & 0x1fff'ffff, data);
   }
 
@@ -185,6 +188,9 @@ template<u32 Origin> auto SH2::writeWord(u32 address, u32 data) -> void {
   }
 
   case Area::Uncached: {
+    if constexpr(Accuracy::Recompiler) {
+      recompiler.min_cycles = 0;
+    }
     return busWriteWord(address & 0x1fff'fffe, data);
   }
 
@@ -231,6 +237,9 @@ template<u32 Origin> auto SH2::writeLong(u32 address, u32 data) -> void {
   }
 
   case Area::Uncached: {
+    if constexpr(Accuracy::Recompiler) {
+      recompiler.min_cycles = 0;
+    }
     return busWriteLong(address & 0x1fff'fffc, data);
   }
 

--- a/ares/component/processor/sh2/sh7604/bus.cpp
+++ b/ares/component/processor/sh2/sh7604/bus.cpp
@@ -137,9 +137,7 @@ template<u32 Origin> auto SH2::writeByte(u32 address, u32 data) -> void {
   }
 
   case Area::Uncached: {
-    if constexpr(Accuracy::Recompiler) {
-      recompiler.min_cycles = 0;
-    }
+    cyclesUntilSync = 0;
     return busWriteByte(address & 0x1fff'ffff, data);
   }
 
@@ -188,9 +186,7 @@ template<u32 Origin> auto SH2::writeWord(u32 address, u32 data) -> void {
   }
 
   case Area::Uncached: {
-    if constexpr(Accuracy::Recompiler) {
-      recompiler.min_cycles = 0;
-    }
+    cyclesUntilSync = 0;
     return busWriteWord(address & 0x1fff'fffe, data);
   }
 
@@ -237,9 +233,7 @@ template<u32 Origin> auto SH2::writeLong(u32 address, u32 data) -> void {
   }
 
   case Area::Uncached: {
-    if constexpr(Accuracy::Recompiler) {
-      recompiler.min_cycles = 0;
-    }
+    cyclesUntilSync = 0;
     return busWriteLong(address & 0x1fff'fffc, data);
   }
 

--- a/ares/md/m32x/sh7604.cpp
+++ b/ares/md/m32x/sh7604.cpp
@@ -48,7 +48,8 @@ auto M32X::SH7604::main() -> void {
 
 auto M32X::SH7604::step(u32 clocks) -> void {
   Thread::step(clocks);
-  Thread::synchronize(cpu);
+  if(m32x.shm.active()) Thread::synchronize(m32x.shs, cpu);
+  if(m32x.shs.active()) Thread::synchronize(m32x.shm, cpu);
 }
 
 auto M32X::SH7604::power(bool reset) -> void {


### PR DESCRIPTION
Replace recompiler.min_cycles with a threshold used by both the interpreter and the recompiler to determine when to sync. This threshold is temporarily reset (forcing a sync) in response to SH2 uncached writes, which can indicate cross-processor communication. Additionally, we now sync between SH2 processors against each other as well as the M68k.

This was originally motivated by a regression in Kolibri that vanished as of #766. Instead, it fixes FIFA Soccer 96, which regressed at the same time.