### PR TITLE
n64: add RDP crash support

### DIFF
--- a/ares/n64/rdp/io.cpp
+++ b/ares/n64/rdp/io.cpp
@@ -20,7 +20,7 @@ auto RDP::readWord(u32 address) -> u32 {
   if(address == 3) {
     //DPC_STATUS
     data.bit( 0) = command.source;
-    data.bit( 1) = command.freeze;
+    data.bit( 1) = command.freeze || command.crashed;
     data.bit( 2) = command.flush;
     data.bit( 3) = command.startGclk;
     data.bit( 4) = command.tmemBusy > 0;
@@ -174,7 +174,7 @@ auto RDP::IO::writeWord(u32 address, u32 data_) -> void {
 }
 
 auto RDP::flushCommands() -> void {
-  if(command.freeze) return;
+  if(command.freeze || command.crashed) return;
   command.pipeBusy = 1;
   command.startGclk = 1;
   if(command.end > command.current) render();

--- a/ares/n64/rdp/rdp.cpp
+++ b/ares/n64/rdp/rdp.cpp
@@ -43,6 +43,11 @@ auto RDP::unload() -> void {
   #endif
 }
 
+auto RDP::crash(const char *reason) -> void {
+  command.crashed = 1;
+  debug(unusual, "[RDP] software triggered a hardware bug; RDP crashed and will stop responding. Reason: ", reason);
+}
+
 auto RDP::main() -> void {
   step(system.frequency());
 }

--- a/ares/n64/rdp/rdp.hpp
+++ b/ares/n64/rdp/rdp.hpp
@@ -23,6 +23,7 @@ struct RDP : Thread, Memory::IO<RDP> {
   auto main() -> void;
   auto step(u32 clocks) -> void;
   auto power(bool reset) -> void;
+  auto crash(const char *reason) -> void;
 
   //render.cpp
   auto render() -> void;
@@ -82,6 +83,7 @@ struct RDP : Thread, Memory::IO<RDP> {
     n24 tmemBusy;
     n1  source;  //0 = RDRAM, 1 = DMEM
     n1  freeze;
+    n1  crashed;
     n1  flush;
     n1  startValid;
     n1  endValid;

--- a/ares/n64/rdp/render.cpp
+++ b/ares/n64/rdp/render.cpp
@@ -54,7 +54,11 @@ auto RDP::render() -> void {
   rdp->set_current(command.current);
   rdp->set_end(command.end);
   rdp->set_status(command.source ? DP_STATUS_XBUS_DMA : 0);
-  rdp->process_command_list();
+  try {
+    rdp->process_command_list();
+  } catch(emu_fatalerror &e) {
+    crash(e.what());
+  }
   command.current = rdp->get_current();
   return;
   #else


### PR DESCRIPTION
There a handful of sequences of invalid commands that can cause the RDP to crash (it will stop processing commands until hard reboot). Mame RDP already knows about them and reacts by throwing an exception, that currently kills Ares because it is not caught.

This commit lets Ares actually emulate the crashed RDP by basically freezing its command processor. A log is also emitted on console.

This is useful to homebrew developers that can do mistakes while coding.