### PR TITLE
GNUmakefile: add error message for incompatible GNU make

### DIFF
--- a/ares/n64/GNUmakefile
+++ b/ares/n64/GNUmakefile
@@ -37,6 +37,9 @@ $(object.path)/ares-n64-rsp.o:        $(ares.path)/n64/rsp/rsp.cpp
 $(object.path)/ares-n64-rdp.o:        $(ares.path)/n64/rdp/rdp.cpp
 
 ifeq ($(vulkan),true)
+  ifeq ($(filter shortest-stem,${.FEATURES}),)
+    $(error Compiling Ares N64 Vulkan backend requires GNU Make 3.82 or later)
+  endif
   ares.objects += ares-n64-vulkan
   $(object.path)/ares-n64-vulkan.o: $(ares.path)/n64/vulkan/vulkan.cpp
   PARALLEL_RDP_IMPLEMENTATION := $(ares.path)/n64/vulkan/parallel-rdp


### PR DESCRIPTION
While testing parallel-RDP on macOS via MoltenVK, I found out that a special syntax used in the N64 Makefile to compile parallel-RDP requires a version of GNU make which is newer than the one that comes with macOS. To avoid confusion, just error out for now.