### PR TITLE
n64: add RDP crash support to Vulkan backend

### DIFF
--- a/COMMIT
+++ b/COMMIT
@@ -1,1 +1,1 @@
-e6cf0e5ca257135acbcacfbdacd7cd3fdf3fb408
+0f7cc6c3a13494a575dbbb977ff4424743b688d7

--- a/ares/n64/rdp/render.cpp
+++ b/ares/n64/rdp/render.cpp
@@ -46,7 +46,11 @@ static const vector<string> commandNames = {
 
 auto RDP::render() -> void {
   #if defined(VULKAN)
-  if(vulkan.enable && vulkan.render()) return;
+  if(vulkan.enable && vulkan.render()) {
+    const char *msg = vulkan.crashed();
+    if(msg) crash(msg);
+    return;
+  }
   #endif
 
   #if defined(MAME_RDP)

--- a/ares/n64/vulkan/vulkan.hpp
+++ b/ares/n64/vulkan/vulkan.hpp
@@ -13,6 +13,7 @@ struct Vulkan {
   auto mapScanoutRead(const u8*& rgba, u32& width, u32& height) -> void;
   auto unmapScanoutRead() -> void;
   auto endScanout() -> void;
+  auto crashed() -> const char*;
 
   struct Implementation;
   Implementation* implementation = nullptr;

--- a/parallel-rdp/rdp_device.cpp
+++ b/parallel-rdp/rdp_device.cpp
@@ -227,6 +227,11 @@ bool CommandProcessor::device_is_supported() const
 	return is_supported;
 }
 
+void CommandProcessor::set_validation_interface(ValidationInterface *iface)
+{
+	renderer.set_validation_interface(iface);
+}
+
 void CommandProcessor::clear_hidden_rdram()
 {
 	clear_buffer(*hidden_rdram, 0x03030303);

--- a/parallel-rdp/rdp_device.hpp
+++ b/parallel-rdp/rdp_device.hpp
@@ -124,6 +124,8 @@ public:
 
 	~CommandProcessor();
 
+	void set_validation_interface(ValidationInterface *iface);
+
 	bool device_is_supported() const;
 
 	// Synchronization.
@@ -210,10 +212,10 @@ private:
 	std::unique_ptr<ShaderBank> shader_bank;
 #endif
 
-	CommandRing ring;
-
-	VideoInterface vi;
+	// Tear-down order is important here.
 	Renderer renderer;
+	VideoInterface vi;
+	CommandRing ring;
 
 	void clear_hidden_rdram();
 	void clear_tmem();

--- a/parallel-rdp/shaders/update_upscaled_domain_resolve.comp
+++ b/parallel-rdp/shaders/update_upscaled_domain_resolve.comp
@@ -93,9 +93,6 @@ layout(set = 0, binding = 4) readonly buffer RDRAMHiddenUpscaling
 
 void copy_rdram_8(uint index)
 {
-    index &= RDRAM_MASK_8;
-    index ^= 3u;
-
     uint r = 0u;
     for (int i = 0; i < NUM_SAMPLES; i++)
     {
@@ -106,18 +103,6 @@ void copy_rdram_8(uint index)
     r = (r + (NUM_SAMPLES >> 1)) / NUM_SAMPLES;
     vram_reference8.elems[index] = uint8_t(r);
     vram8.elems[index] = uint8_t(r);
-
-    if (RDRAM_UNSCALED_WRITE_MASK)
-    {
-        // Need this memory barrier to ensure the mask readback does not read
-        // an invalid value from RDRAM. If the mask is seen, the valid RDRAM value is
-        // also coherent.
-        memoryBarrierBuffer();
-        vram8.elems[index + RDRAM_SIZE] = mem_u8(0xff);
-    }
-
-    // Don't bother writing back hidden VRAM. It is not visible to host anyways, and coverage is meaningless when it's filtered.
-    // If host later decides to modify the CPU memory, then the hidden VRAM values become complete bogus either way.
 }
 
 uvec4 decode_rgba5551(uint word)
@@ -138,9 +123,6 @@ const uint bayer_dither_lut[16] = uint[](
 
 void copy_rdram_16(uint index, uint x, uint y)
 {
-    index &= RDRAM_MASK_16;
-    index ^= 1u;
-
     uvec4 rgba = uvec4(0u);
     for (int i = 0; i < NUM_SAMPLES; i++)
     {
@@ -161,18 +143,6 @@ void copy_rdram_16(uint index, uint x, uint y)
     uint encoded = encode_rgba5551(rgba);
     vram16.elems[index] = uint16_t(encoded);
     vram_reference16.elems[index] = uint16_t(encoded);
-
-    if (RDRAM_UNSCALED_WRITE_MASK)
-    {
-        // Need this memory barrier to ensure the mask readback does not read
-        // an invalid value from RDRAM. If the mask is seen, the valid RDRAM value is
-        // also coherent.
-        memoryBarrierBuffer();
-        vram16.elems[index + (RDRAM_SIZE >> 1u)] = mem_u16(0xffff);
-    }
-
-    // Don't bother writing back hidden VRAM. It is not visible to host anyways, and coverage is meaningless when it's filtered.
-    // If host later decides to modify the CPU memory, then the hidden VRAM values become complete bogus either way.
 }
 
 void copy_rdram_16_single_sample(uint index)
@@ -180,23 +150,9 @@ void copy_rdram_16_single_sample(uint index)
     // Copies the first sample. We cannot meaningfully filter depth samples.
     // The first sample should overlap exactly with the single-sampled version.
     // Coverage clipping might slightly change the result, but shouldn't be different enough to break things.
-    index &= RDRAM_MASK_16;
-    index ^= 1u;
     uint upscaled_word = uint(vram_upscaled16.elems[index]);
     vram16.elems[index] = uint16_t(upscaled_word);
     vram_reference16.elems[index] = uint16_t(upscaled_word);
-
-    if (RDRAM_UNSCALED_WRITE_MASK)
-    {
-        // Need this memory barrier to ensure the mask readback does not read
-        // an invalid value from RDRAM. If the mask is seen, the valid RDRAM value is
-        // also coherent.
-        memoryBarrierBuffer();
-        vram16.elems[index + (RDRAM_SIZE >> 1u)] = mem_u16(0xffff);
-    }
-
-    // Don't bother writing back hidden VRAM. It is not visible to host anyways, and coverage is meaningless when it's filtered.
-    // If host later decides to modify the CPU memory, then the hidden VRAM values become complete bogus either way.
 }
 
 uvec4 decode_rgba8(uint word)
@@ -211,8 +167,6 @@ uint encode_rgba8(uvec4 color)
 
 void copy_rdram_32(uint index)
 {
-    index &= RDRAM_MASK_32;
-
     uvec4 rgba = uvec4(0u);
     for (int i = 0; i < NUM_SAMPLES; i++)
     {
@@ -224,33 +178,24 @@ void copy_rdram_32(uint index)
     uint encoded = encode_rgba8(rgba);
     vram32.elems[index] = encoded;
     vram_reference32.elems[index] = encoded;
-
-    if (RDRAM_UNSCALED_WRITE_MASK)
-    {
-        // Need this memory barrier to ensure the mask readback does not read
-        // an invalid value from RDRAM. If the mask is seen, the valid RDRAM value is
-        // also coherent.
-        memoryBarrierBuffer();
-        vram32.elems[index + (RDRAM_SIZE >> 2u)] = ~0u;
-    }
-
-    // Don't bother writing back hidden VRAM. It is not visible to host anyways, and coverage is meaningless when it's filtered.
-    // If host later decides to modify the CPU memory, then the hidden VRAM values become complete bogus either way.
 }
 
 void main()
 {
     uvec2 coord = gl_GlobalInvocationID.xy;
-    if (coord.x >= registers.width)
-        return;
-
     uint index = coord.y * registers.width + coord.x;
     uint depth_index = index + registers.fb_depth_addr;
     uint color_index = index + registers.fb_addr;
 
     uvec2 mask_coord = coord >> 2u;
     uint mask_index = mask_coord.x + mask_coord.y * ((registers.width + 3) >> 2u);
-    uint write_mask = vram_upscaled32.elems[NUM_SAMPLES * (RDRAM_SIZE >> 2) + mask_index];
+
+    uint write_mask;
+    if (coord.x < registers.width)
+        write_mask = vram_upscaled32.elems[NUM_SAMPLES * (RDRAM_SIZE >> 2) + mask_index];
+    else
+        write_mask = 0u;
+
     uint shamt = 2u * ((coord.x & 3u) + 4u * (coord.y & 3u));
     write_mask = write_mask >> shamt;
     bool color_write_mask = (write_mask & 1u) != 0u;
@@ -261,19 +206,72 @@ void main()
         switch (FB_SIZE_LOG2)
         {
         case 0:
+            color_index &= RDRAM_MASK_8;
+            color_index ^= 3u;
             copy_rdram_8(color_index);
             break;
 
         case 1:
+            color_index &= RDRAM_MASK_16;
+            color_index ^= 1u;
             copy_rdram_16(color_index, coord.x, coord.y);
             break;
 
         case 2:
+            color_index &= RDRAM_MASK_32;
             copy_rdram_32(color_index);
             break;
         }
     }
 
-    if (!COLOR_DEPTH_ALIAS && depth_write_mask)
-        copy_rdram_16_single_sample(depth_index);
+    // Metal portability: Memory barriers must happen in uniform control flow.
+    if (RDRAM_UNSCALED_WRITE_MASK)
+    {
+        // Need this memory barrier to ensure the mask readback does not read
+        // an invalid value from RDRAM. If the mask is seen, the valid RDRAM value is
+        // also coherent.
+        memoryBarrierBuffer();
+
+        if (color_write_mask)
+        {
+            switch (FB_SIZE_LOG2)
+            {
+                case 0:
+                    vram8.elems[color_index + RDRAM_SIZE] = mem_u8(0xff);
+                    break;
+
+                case 1:
+                    vram16.elems[color_index + (RDRAM_SIZE >> 1)] = mem_u16(0xffff);
+                    break;
+
+                case 2:
+                    vram32.elems[color_index + (RDRAM_SIZE >> 2)] = ~0u;
+                    break;
+            }
+        }
+    }
+
+    // Don't bother writing back hidden VRAM. It is not visible to host anyways, and coverage is meaningless when it's filtered.
+    // If host later decides to modify the CPU memory, then the hidden VRAM values become complete bogus either way.
+
+    if (!COLOR_DEPTH_ALIAS)
+    {
+        if (depth_write_mask)
+        {
+            depth_index &= RDRAM_MASK_16;
+            depth_index ^= 1u;
+            copy_rdram_16_single_sample(depth_index);
+        }
+
+        // Metal portability: Memory barriers must happen in uniform control flow.
+        if (RDRAM_UNSCALED_WRITE_MASK)
+        {
+            // Need this memory barrier to ensure the mask readback does not read
+            // an invalid value from RDRAM. If the mask is seen, the valid RDRAM value is
+            // also coherent.
+            memoryBarrierBuffer();
+            if (depth_write_mask)
+                vram16.elems[depth_index + (RDRAM_SIZE >> 1u)] = mem_u16(0xffff);
+        }
+    }
 }

--- a/parallel-rdp/video_interface.hpp
+++ b/parallel-rdp/video_interface.hpp
@@ -218,7 +218,7 @@ private:
 	                                const Registers &registers,
 	                                unsigned scaling_factor) const;
 	Vulkan::ImageHandle scale_stage(Vulkan::CommandBuffer &cmd,
-	                                Vulkan::Image &divot_image,
+	                                const Vulkan::Image *divot_image,
 	                                Registers registers,
 	                                const HorizontalInfoLines &lines,
 	                                unsigned scaling_factor,

--- a/vulkan/buffer_pool.cpp
+++ b/vulkan/buffer_pool.cpp
@@ -24,8 +24,6 @@
 #include "device.hpp"
 #include <utility>
 
-using namespace std;
-
 namespace Vulkan
 {
 void BufferPool::init(Device *device_, VkDeviceSize block_size_,
@@ -106,11 +104,11 @@ BufferBlock BufferPool::request_block(VkDeviceSize minimum_size)
 {
 	if ((minimum_size > block_size) || blocks.empty())
 	{
-		return allocate_block(max(block_size, minimum_size));
+		return allocate_block(std::max(block_size, minimum_size));
 	}
 	else
 	{
-		auto back = move(blocks.back());
+		auto back = std::move(blocks.back());
 		blocks.pop_back();
 
 		back.mapped = static_cast<uint8_t *>(device->map_host_buffer(*back.cpu, MEMORY_ACCESS_WRITE_BIT));
@@ -124,7 +122,7 @@ void BufferPool::recycle_block(BufferBlock &block)
 	VK_ASSERT(block.size == block_size);
 
 	if (blocks.size() < max_retained_blocks)
-		blocks.push_back(move(block));
+		blocks.push_back(std::move(block));
 	else
 		block = {};
 }

--- a/vulkan/command_buffer.cpp
+++ b/vulkan/command_buffer.cpp
@@ -36,7 +36,6 @@
 #include <sstream>
 #endif
 
-using namespace std;
 using namespace Util;
 
 namespace Vulkan
@@ -534,9 +533,9 @@ void CommandBuffer::generate_mipmap(const Image &image)
 	for (unsigned i = 1; i < create_info.levels; i++)
 	{
 		VkOffset3D src_size = size;
-		size.x = max(size.x >> 1, 1);
-		size.y = max(size.y >> 1, 1);
-		size.z = max(size.z >> 1, 1);
+		size.x = std::max(size.x >> 1, 1);
+		size.y = std::max(size.y >> 1, 1);
+		size.z = std::max(size.z >> 1, 1);
 
 		blit_image(image, image,
 		           origin, size, origin, src_size, i, i - 1, 0, 0, create_info.layers, VK_FILTER_LINEAR);
@@ -631,10 +630,10 @@ void CommandBuffer::init_viewport_scissor(const RenderPassInfo &info, const Fram
 	uint32_t fb_width = fb->get_width();
 	uint32_t fb_height = fb->get_height();
 
-	rect.offset.x = min(fb_width, uint32_t(rect.offset.x));
-	rect.offset.y = min(fb_height, uint32_t(rect.offset.y));
-	rect.extent.width = min(fb_width - rect.offset.x, rect.extent.width);
-	rect.extent.height = min(fb_height - rect.offset.y, rect.extent.height);
+	rect.offset.x = std::min(fb_width, uint32_t(rect.offset.x));
+	rect.offset.y = std::min(fb_height, uint32_t(rect.offset.y));
+	rect.extent.width = std::min(fb_width - rect.offset.x, rect.extent.width);
+	rect.extent.height = std::min(fb_height - rect.offset.y, rect.extent.height);
 
 	if (surface_transform_swaps_xy(current_framebuffer_surface_transform))
 		rect2d_swap_xy(rect);

--- a/vulkan/context.hpp
+++ b/vulkan/context.hpp
@@ -70,6 +70,7 @@ struct DeviceFeatures
 	bool supports_external = false;
 	bool supports_image_format_list = false;
 	bool supports_shader_float_control = false;
+	bool supports_tooling_info = false;
 
 	// Vulkan 1.1 core
 	VkPhysicalDeviceFeatures enabled_features = {};
@@ -151,8 +152,7 @@ public:
 	                              ContextCreationFlags flags = 0);
 	bool init_from_instance_and_device(VkInstance instance, VkPhysicalDevice gpu, VkDevice device, VkQueue queue, uint32_t queue_family);
 	bool init_device_from_instance(VkInstance instance, VkPhysicalDevice gpu, VkSurfaceKHR surface, const char **required_device_extensions,
-	                               unsigned num_required_device_extensions, const char **required_device_layers,
-	                               unsigned num_required_device_layers, const VkPhysicalDeviceFeatures *required_features,
+	                               unsigned num_required_device_extensions, const VkPhysicalDeviceFeatures *required_features,
 	                               ContextCreationFlags flags = 0);
 
 	Context() = default;
@@ -268,8 +268,7 @@ private:
 
 	bool create_instance(const char **instance_ext, uint32_t instance_ext_count);
 	bool create_device(VkPhysicalDevice gpu, VkSurfaceKHR surface, const char **required_device_extensions,
-	                   unsigned num_required_device_extensions, const char **required_device_layers,
-	                   unsigned num_required_device_layers, const VkPhysicalDeviceFeatures *required_features,
+	                   unsigned num_required_device_extensions, const VkPhysicalDeviceFeatures *required_features,
 	                   ContextCreationFlags flags);
 
 	bool owned_instance = false;

--- a/vulkan/descriptor_set.cpp
+++ b/vulkan/descriptor_set.cpp
@@ -24,7 +24,6 @@
 #include "device.hpp"
 #include <vector>
 
-using namespace std;
 using namespace Util;
 
 namespace Vulkan
@@ -54,7 +53,7 @@ DescriptorSetAllocator::DescriptorSetAllocator(Hash hash, Device *device_, const
 	VkDescriptorSetLayoutCreateInfo info = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
 	VkDescriptorSetLayoutBindingFlagsCreateInfoEXT flags = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT };
 	VkSampler vk_immutable_samplers[VULKAN_NUM_BINDINGS] = {};
-	vector<VkDescriptorSetLayoutBinding> bindings;
+	std::vector<VkDescriptorSetLayoutBinding> bindings;
 	VkDescriptorBindingFlagsEXT binding_flags = 0;
 
 	if (bindless)
@@ -252,7 +251,7 @@ void DescriptorSetAllocator::begin_frame()
 	}
 }
 
-pair<VkDescriptorSet, bool> DescriptorSetAllocator::find(unsigned thread_index, Hash hash)
+std::pair<VkDescriptorSet, bool> DescriptorSetAllocator::find(unsigned thread_index, Hash hash)
 {
 	VK_ASSERT(!bindless);
 
@@ -288,7 +287,7 @@ pair<VkDescriptorSet, bool> DescriptorSetAllocator::find(unsigned thread_index, 
 
 	VkDescriptorSet sets[VULKAN_NUM_SETS_PER_POOL];
 	VkDescriptorSetLayout layouts[VULKAN_NUM_SETS_PER_POOL];
-	fill(begin(layouts), end(layouts), set_layout);
+	std::fill(std::begin(layouts), std::end(layouts), set_layout);
 
 	VkDescriptorSetAllocateInfo alloc = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO };
 	alloc.descriptorPool = pool;

--- a/vulkan/device.cpp
+++ b/vulkan/device.cpp
@@ -60,7 +60,6 @@ static unsigned get_thread_index()
 }
 #endif
 
-using namespace std;
 using namespace Util;
 
 namespace Vulkan
@@ -317,7 +316,7 @@ LinearHostImageHandle Device::create_linear_host_image(const LinearHostImageCrea
 	else
 		gpu_image->set_layout(Layout::General);
 
-	return LinearHostImageHandle(handle_pool.linear_images.allocate(this, move(gpu_image), move(cpu_image), info.stages));
+	return LinearHostImageHandle(handle_pool.linear_images.allocate(this, std::move(gpu_image), std::move(cpu_image), info.stages));
 }
 
 void *Device::map_linear_host_image(const LinearHostImage &image, MemoryAccessFlags access)
@@ -808,6 +807,28 @@ void Device::init_workarounds()
 		workarounds.broken_pipeline_cache_control = true;
 	}
 #endif
+
+	if (ext.supports_tooling_info && vkGetPhysicalDeviceToolPropertiesEXT)
+	{
+		uint32_t count = 0;
+		vkGetPhysicalDeviceToolPropertiesEXT(gpu, &count, nullptr);
+		Util::SmallVector<VkPhysicalDeviceToolPropertiesEXT> tool_props(count);
+		for (auto &t : tool_props)
+			t = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT };
+		vkGetPhysicalDeviceToolPropertiesEXT(gpu, &count, tool_props.data());
+		for (auto &t : tool_props)
+		{
+			LOGI("  Detected attached tool:\n");
+			LOGI("    Name: %s\n", t.name);
+			LOGI("    Description: %s\n", t.description);
+			LOGI("    Version: %s\n", t.version);
+			if ((t.purposes & VK_TOOL_PURPOSE_TRACING_BIT_EXT) != 0)
+			{
+				LOGI("Detected tracing tool, forcing host cached memory types for performance.\n");
+				workarounds.force_host_cached = true;
+			}
+		}
+	}
 }
 
 void Device::set_context(const Context &context)
@@ -1117,7 +1138,7 @@ void Device::submit(CommandBufferHandle &cmd, Fence *fence, unsigned semaphore_c
 	cmd->end_debug_channel();
 
 	LOCK();
-	submit_nolock(move(cmd), fence, semaphore_count, semaphores);
+	submit_nolock(std::move(cmd), fence, semaphore_count, semaphores);
 }
 
 void Device::submit_discard_nolock(CommandBufferHandle &cmd)
@@ -1181,7 +1202,7 @@ void Device::submit_nolock(CommandBufferHandle cmd, Fence *fence, unsigned semap
 	}
 
 	cmd->end();
-	submissions.push_back(move(cmd));
+	submissions.push_back(std::move(cmd));
 
 	InternalFence signalled_fence;
 
@@ -1972,7 +1993,7 @@ CommandBufferHandle Device::request_secondary_command_buffer_for_thread(unsigned
 
 void Device::set_acquire_semaphore(unsigned index, Semaphore acquire)
 {
-	wsi.acquire = move(acquire);
+	wsi.acquire = std::move(acquire);
 	wsi.index = index;
 	wsi.consumed = false;
 
@@ -1985,7 +2006,7 @@ void Device::set_acquire_semaphore(unsigned index, Semaphore acquire)
 
 Semaphore Device::consume_release_semaphore()
 {
-	auto ret = move(wsi.release);
+	auto ret = std::move(wsi.release);
 	wsi.release.reset();
 	return ret;
 }
@@ -2067,12 +2088,12 @@ void Device::init_frame_contexts(unsigned count)
 
 	for (unsigned i = 0; i < count; i++)
 	{
-		auto frame = unique_ptr<PerFrame>(new PerFrame(this, i));
-		per_frame.emplace_back(move(frame));
+		auto frame = std::unique_ptr<PerFrame>(new PerFrame(this, i));
+		per_frame.emplace_back(std::move(frame));
 	}
 }
 
-void Device::init_external_swapchain(const vector<ImageHandle> &swapchain_images)
+void Device::init_external_swapchain(const std::vector<ImageHandle> &swapchain_images)
 {
 	DRAIN_FRAME_LOCK();
 	wsi.swapchain.clear();
@@ -2110,7 +2131,7 @@ void Device::set_swapchain_queue_family_support(uint32_t queue_family_support)
 	wsi.queue_family_support_mask = queue_family_support;
 }
 
-void Device::init_swapchain(const vector<VkImage> &swapchain_images, unsigned width, unsigned height, VkFormat format,
+void Device::init_swapchain(const std::vector<VkImage> &swapchain_images, unsigned width, unsigned height, VkFormat format,
                             VkSurfaceTransformFlagBitsKHR transform, VkImageUsageFlags usage)
 {
 	DRAIN_FRAME_LOCK();
@@ -2173,7 +2194,7 @@ Device::PerFrame::PerFrame(Device *device_, unsigned frame_index_)
 void Device::keep_handle_alive(ImageHandle handle)
 {
 	LOCK();
-	frame().keep_alive_images.push_back(move(handle));
+	frame().keep_alive_images.push_back(std::move(handle));
 }
 
 void Device::free_memory_nolock(const DeviceAllocation &alloc)
@@ -2649,7 +2670,7 @@ void Device::register_time_interval_nolock(std::string tid, QueryPoolHandle star
 		if (start_ts->is_signalled() && end_ts->is_signalled())
 			VK_ASSERT(end_ts->get_timestamp_ticks() >= start_ts->get_timestamp_ticks());
 #endif
-		frame().timestamp_intervals.push_back({ std::move(tid), move(start_ts), move(end_ts), timestamp_tag, std::move(extra) });
+		frame().timestamp_intervals.push_back({ std::move(tid), std::move(start_ts), std::move(end_ts), timestamp_tag, std::move(extra) });
 	}
 }
 
@@ -2870,6 +2891,27 @@ uint32_t Device::find_memory_type(uint32_t required, uint32_t mask) const
 uint32_t Device::find_memory_type(BufferDomain domain, uint32_t mask) const
 {
 	uint32_t prio[3] = {};
+
+	// Optimize for tracing apps by not allocating host memory that is uncached.
+	if (workarounds.force_host_cached)
+	{
+		switch (domain)
+		{
+		case BufferDomain::LinkedDeviceHostPreferDevice:
+			domain = BufferDomain::Device;
+			break;
+
+		case BufferDomain::LinkedDeviceHost:
+		case BufferDomain::Host:
+		case BufferDomain::CachedCoherentHostPreferCoherent:
+			domain = BufferDomain::CachedCoherentHostPreferCached;
+			break;
+
+		default:
+			break;
+		}
+	}
+
 	switch (domain)
 	{
 	case BufferDomain::Device:
@@ -3060,7 +3102,7 @@ public:
 	VkImageView unorm_view = VK_NULL_HANDLE;
 	VkImageView srgb_view = VK_NULL_HANDLE;
 	VkImageViewType default_view_type = VK_IMAGE_VIEW_TYPE_MAX_ENUM;
-	vector<VkImageView> rt_views;
+	std::vector<VkImageView> rt_views;
 	DeviceAllocation allocation;
 	DeviceAllocator *allocator = nullptr;
 	bool owned = true;
@@ -3358,7 +3400,7 @@ ImageViewHandle Device::create_image_view(const ImageViewCreateInfo &create_info
 	{
 		holder.owned = false;
 		ret->set_alt_views(holder.depth_view, holder.stencil_view);
-		ret->set_render_target_views(move(holder.rt_views));
+		ret->set_render_target_views(std::move(holder.rt_views));
 		return ret;
 	}
 	else
@@ -3903,7 +3945,7 @@ ImageHandle Device::create_image_from_staging_buffer(const ImageCreateInfo &crea
 		if (has_view)
 		{
 			handle->get_view().set_alt_views(holder.depth_view, holder.stencil_view);
-			handle->get_view().set_render_target_views(move(holder.rt_views));
+			handle->get_view().set_render_target_views(std::move(holder.rt_views));
 			handle->get_view().set_unorm_view(holder.unorm_view);
 			handle->get_view().set_srgb_view(holder.srgb_view);
 		}
@@ -4607,7 +4649,7 @@ uint64_t Device::allocate_cookie()
 {
 	// Reserve lower bits for "special purposes".
 #ifdef GRANITE_VULKAN_MT
-	return cookie.fetch_add(16, memory_order_relaxed) + 16;
+	return cookie.fetch_add(16, std::memory_order_relaxed) + 16;
 #else
 	cookie += 16;
 	return cookie;
@@ -4777,8 +4819,8 @@ RenderPassInfo Device::get_swapchain_render_pass(SwapchainRenderPass style)
 
 void Device::set_queue_lock(std::function<void()> lock_callback, std::function<void()> unlock_callback)
 {
-	queue_lock_callback = move(lock_callback);
-	queue_unlock_callback = move(unlock_callback);
+	queue_lock_callback = std::move(lock_callback);
+	queue_unlock_callback = std::move(unlock_callback);
 }
 
 void Device::set_name(const Buffer &buffer, const char *name)
@@ -4832,7 +4874,7 @@ void Device::report_checkpoints()
 
 		uint32_t count;
 		table->vkGetQueueCheckpointDataNV(queue_info.queues[i], &count, nullptr);
-		vector<VkCheckpointDataNV> checkpoint_data(count);
+		std::vector<VkCheckpointDataNV> checkpoint_data(count);
 		for (auto &data : checkpoint_data)
 			data.sType = VK_STRUCTURE_TYPE_CHECKPOINT_DATA_NV;
 		table->vkGetQueueCheckpointDataNV(queue_info.queues[i], &count, checkpoint_data.data());

--- a/vulkan/device_fossilize.cpp
+++ b/vulkan/device_fossilize.cpp
@@ -24,8 +24,6 @@
 #include "timer.hpp"
 #include "thread_group.hpp"
 
-using namespace std;
-
 namespace Vulkan
 {
 #if 0

--- a/vulkan/image.cpp
+++ b/vulkan/image.cpp
@@ -24,8 +24,6 @@
 #include "device.hpp"
 #include "buffer.hpp"
 
-using namespace std;
-
 namespace Vulkan
 {
 ImageView::ImageView(Device *device_, VkImageView view_, const ImageViewCreateInfo &info_)
@@ -207,7 +205,7 @@ VkPipelineStageFlags LinearHostImage::get_used_pipeline_stages() const
 }
 
 LinearHostImage::LinearHostImage(Device *device_, ImageHandle gpu_image_, BufferHandle cpu_image_, VkPipelineStageFlags stages_)
-	: device(device_), gpu_image(move(gpu_image_)), cpu_image(move(cpu_image_)), stages(stages_)
+	: device(device_), gpu_image(std::move(gpu_image_)), cpu_image(std::move(cpu_image_)), stages(stages_)
 {
 	if (gpu_image->get_create_info().domain == ImageDomain::LinearHostCached ||
 	    gpu_image->get_create_info().domain == ImageDomain::LinearHost)

--- a/vulkan/memory_allocator.cpp
+++ b/vulkan/memory_allocator.cpp
@@ -31,8 +31,6 @@
 #include <windows.h>
 #endif
 
-using namespace std;
-
 #ifdef GRANITE_VULKAN_MT
 #define ALLOCATOR_LOCK() std::lock_guard<std::mutex> holder__{lock}
 #else

--- a/vulkan/query_pool.cpp
+++ b/vulkan/query_pool.cpp
@@ -24,8 +24,6 @@
 #include "device.hpp"
 #include <utility>
 
-using namespace std;
-
 namespace Vulkan
 {
 static const char *storage_to_str(VkPerformanceCounterStorageKHR storage)
@@ -382,7 +380,7 @@ void QueryPool::add_pool()
 	if (device->get_device_features().host_query_reset_features.hostQueryReset)
 		table.vkResetQueryPoolEXT(device->get_device(), pool.pool, 0, pool.size);
 
-	pools.push_back(move(pool));
+	pools.push_back(std::move(pool));
 }
 
 QueryPoolHandle QueryPool::write_timestamp(VkCommandBuffer cmd, VkPipelineStageFlagBits stage)
@@ -460,7 +458,7 @@ double TimestampInterval::get_time_per_accumulation() const
 		return 0.0;
 }
 
-const string &TimestampInterval::get_tag() const
+const std::string &TimestampInterval::get_tag() const
 {
 	return tag;
 }
@@ -472,8 +470,8 @@ void TimestampInterval::reset()
 	total_frame_iterations = 0;
 }
 
-TimestampInterval::TimestampInterval(string tag_)
-	: tag(move(tag_))
+TimestampInterval::TimestampInterval(std::string tag_)
+	: tag(std::move(tag_))
 {
 }
 

--- a/vulkan/quirks.hpp
+++ b/vulkan/quirks.hpp
@@ -49,5 +49,6 @@ struct ImplementationWorkarounds
 	bool optimize_all_graphics_barrier = false;
 	bool split_binary_timeline_semaphores = false;
 	bool broken_pipeline_cache_control = false;
+	bool force_host_cached = false;
 };
 }

--- a/vulkan/render_pass.cpp
+++ b/vulkan/render_pass.cpp
@@ -27,7 +27,6 @@
 #include <utility>
 #include <cstring>
 
-using namespace std;
 using namespace Util;
 
 #ifdef GRANITE_VULKAN_MT
@@ -121,7 +120,7 @@ RenderPass::RenderPass(Hash hash, Device *device_, const RenderPassInfo &info)
 	: IntrusiveHashMapEnabled<RenderPass>(hash)
 	, device(device_)
 {
-	fill(begin(color_attachments), end(color_attachments), VK_FORMAT_UNDEFINED);
+	std::fill(std::begin(color_attachments), std::end(color_attachments), VK_FORMAT_UNDEFINED);
 
 	VK_ASSERT(info.num_color_attachments || info.depth_stencil);
 
@@ -307,8 +306,8 @@ RenderPass::RenderPass(Hash hash, Device *device_, const RenderPassInfo &info)
 	Util::StackAllocator<VkAttachmentReference, 1024> reference_allocator;
 	Util::StackAllocator<uint32_t, 1024> preserve_allocator;
 
-	vector<VkSubpassDescription> subpasses(num_subpasses);
-	vector<VkSubpassDependency> external_dependencies;
+	std::vector<VkSubpassDescription> subpasses(num_subpasses);
+	std::vector<VkSubpassDependency> external_dependencies;
 	for (unsigned i = 0; i < num_subpasses; i++)
 	{
 		auto *colors = reference_allocator.allocate_cleared(subpass_infos[i].num_color_attachments);
@@ -789,7 +788,7 @@ RenderPass::RenderPass(Hash hash, Device *device_, const RenderPassInfo &info)
 	setup_subpasses(rp_info);
 
 	VkRenderPassMultiviewCreateInfo multiview_info = { VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO };
-	vector<uint32_t> multiview_view_mask;
+	std::vector<uint32_t> multiview_view_mask;
 	if (multiview && device->get_device_features().multiview_features.multiview)
 	{
 		multiview_view_mask.resize(num_subpasses);
@@ -874,14 +873,14 @@ void Framebuffer::compute_dimensions(const RenderPassInfo &info, uint32_t &width
 	for (unsigned i = 0; i < info.num_color_attachments; i++)
 	{
 		VK_ASSERT(info.color_attachments[i]);
-		width = min(width, info.color_attachments[i]->get_view_width());
-		height = min(height, info.color_attachments[i]->get_view_height());
+		width = std::min(width, info.color_attachments[i]->get_view_width());
+		height = std::min(height, info.color_attachments[i]->get_view_height());
 	}
 
 	if (info.depth_stencil)
 	{
-		width = min(width, info.depth_stencil->get_view_width());
-		height = min(height, info.depth_stencil->get_view_height());
+		width = std::min(width, info.depth_stencil->get_view_width());
+		height = std::min(height, info.depth_stencil->get_view_height());
 	}
 }
 

--- a/vulkan/shader.cpp
+++ b/vulkan/shader.cpp
@@ -27,7 +27,6 @@
 using namespace spirv_cross;
 #endif
 
-using namespace std;
 using namespace Util;
 
 namespace Vulkan

--- a/vulkan/texture_format.cpp
+++ b/vulkan/texture_format.cpp
@@ -24,13 +24,11 @@
 #include "format.hpp"
 #include <algorithm>
 
-using namespace std;
-
 namespace Vulkan
 {
 uint32_t TextureFormatLayout::num_miplevels(uint32_t width, uint32_t height, uint32_t depth)
 {
-	uint32_t size = unsigned(max(max(width, height), depth));
+	uint32_t size = unsigned(std::max(std::max(width, height), depth));
 	uint32_t levels = 0;
 	while (size)
 	{
@@ -379,9 +377,9 @@ void TextureFormatLayout::fill_mipinfo(uint32_t width, uint32_t height, uint32_t
 
 		offset += mip_size;
 
-		width = max((width >> 1u), 1u);
-		height = max((height >> 1u), 1u);
-		depth = max((depth >> 1u), 1u);
+		width = std::max((width >> 1u), 1u);
+		height = std::max((height >> 1u), 1u);
+		depth = std::max((depth >> 1u), 1u);
 	}
 
 	required_size = offset;


### PR DESCRIPTION
Like #769, but for Vulkan.

Requires updating parallel-RDP to the latest version, after the support for catching RDP crashes was added.