### PR TITLE
n64: enable parallel-RDP on Mac via MoltenVK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,16 @@ jobs:
         sudo apt-get update -y -qq
         sudo apt-get install libsdl2-dev libgtksourceview2.0-dev libgtk2.0-dev libao-dev libopenal-dev   
     - uses: actions/checkout@v2
+    - name: Install macOS Dependencies
+      if: runner.os == 'macOS'
+      run: |
+        brew install make
+        echo "MAKE=gmake" >> $GITHUB_ENV
+        pushd thirdparty/MoltenVK
+        ./build-moltenvk.sh
+        popd
     - name: Make
-      run: make -j4 -C desktop-ui build=optimized local=false compiler=${{ matrix.platform.compiler }}
+      run: ${MAKE:-make} -j4 -C desktop-ui build=optimized local=false compiler=${{ matrix.platform.compiler }}
     - name: Upload
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,13 @@ jobs:
         ./build-moltenvk.sh
         popd
     - name: Make
+      if: runner.os != 'macOS'
       run: ${MAKE:-make} -j4 -C desktop-ui build=optimized local=false compiler=${{ matrix.platform.compiler }}
+    - name: Make universal app
+      if: runner.os == 'macOS'
+      run: scripts/macos-make-universal.sh
+      env:
+        MAKEFLAGS: -j3
     - name: Upload
       uses: actions/upload-artifact@v2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 obj/
 out/
+obj-amd64/
+obj-arm64/
+out-amd64/
+out-arm64/

--- a/ares/GNUmakefile
+++ b/ares/GNUmakefile
@@ -15,6 +15,10 @@ ares.objects := ares ares-fixed-allocator
 $(object.path)/ares.o: $(ares.path)/ares/ares.cpp
 $(object.path)/ares-fixed-allocator.o: $(ares.path)/ares/memory/fixed-allocator.cpp
 
+ifeq ($(platform),macos)
+  ares.dylibs :=
+endif
+
 ifeq ($(vulkan),true)
   flags += -DVULKAN
 endif

--- a/ares/n64/GNUmakefile
+++ b/ares/n64/GNUmakefile
@@ -40,6 +40,16 @@ ifeq ($(vulkan),true)
   ifeq ($(filter shortest-stem,${.FEATURES}),)
     $(error Compiling Ares N64 Vulkan backend requires GNU Make 3.82 or later)
   endif
+  ifeq ($(platform),macos)
+    molten = $(ares.path)/../thirdparty/MoltenVK/libMoltenVK.dylib
+    ifeq ($(wildcard $(molten)),)  
+      molten = $(shell brew --prefix molten-vk)/lib/libMoltenVK.dylib
+      ifeq ($(wildcard $(molten)),)
+        $(error Compiling Ares N64 Vulkan backend requires MoltenVK. Install it via Homebrew, compile it using thirdparty/MoltenVK/build-moltenvk.sh, or disable with vulkan=false")
+      endif
+    endif
+    ares.dylibs += $(molten)
+  endif
   ares.objects += ares-n64-vulkan
   $(object.path)/ares-n64-vulkan.o: $(ares.path)/n64/vulkan/vulkan.cpp
   PARALLEL_RDP_IMPLEMENTATION := $(ares.path)/n64/vulkan/parallel-rdp

--- a/desktop-ui/GNUmakefile
+++ b/desktop-ui/GNUmakefile
@@ -2,7 +2,7 @@ name := ares
 build := optimized
 threaded := true
 openmp := false
-vulkan := false
+vulkan := true
 mame.rdp := true
 local := true
 lto := false
@@ -10,10 +10,6 @@ flags += -I. -I.. -I../ares -I../thirdparty -DMIA_LIBRARY
 
 nall.path := ../nall
 include $(nall.path)/GNUmakefile
-
-ifneq ($(filter $(platform),windows linux),)
-  vulkan := true
-endif
 
 ifeq ($(arch),amd64)
   ifeq ($(local),true)

--- a/desktop-ui/GNUmakefile
+++ b/desktop-ui/GNUmakefile
@@ -92,7 +92,7 @@ endif
 	cp -R $(ares.path)/Shaders $(output.path)/$(name).app/Contents/Resources/
 	cp -R $(mia.path)/Database $(output.path)/$(name).app/Contents/Resources/	
 	sips -s format icns resource/$(name).png --out $(output.path)/$(name).app/Contents/Resources/$(name).icns
-	codesign --force --deep --sign - $(output.path)/$(name).app
+	codesign --force --deep --options runtime --entitlements resource/$(name).selfsigned.entitlements --sign - $(output.path)/$(name).app
 else ifeq ($(platform),windows)
 	$(call mkdir,$(output.path)/Shaders/)
 	$(call mkdir,$(output.path)/Database/)

--- a/desktop-ui/GNUmakefile
+++ b/desktop-ui/GNUmakefile
@@ -82,9 +82,15 @@ ifeq ($(platform),macos)
 # Apply workaround for buggy linker in Xcode < 11.4.1
 	@$(compiler) -o $(output.path)/macos-fix-jit macos-fix-jit.cpp
 	$(output.path)/macos-fix-jit $(output.path)/$(name)
+	rm -f $(output.path)/macos-fix-jit
 	rm -rf $(output.path)/$(name).app
+	install_name_tool -add_rpath @executable_path/../Frameworks $(output.path)/$(name)
 	mkdir -p $(output.path)/$(name).app/Contents/MacOS/
 	mkdir -p $(output.path)/$(name).app/Contents/Resources/
+	mkdir -p $(output.path)/$(name).app/Contents/Frameworks/
+ifneq ($(ares.dylibs),)
+	cp $(ares.dylibs) $(output.path)/$(name).app/Contents/Frameworks/
+endif
 	mv $(output.path)/$(name) $(output.path)/$(name).app/Contents/MacOS/$(name)
 	cp resource/$(name).plist $(output.path)/$(name).app/Contents/Info.plist
 	cp -R $(ares.path)/Shaders $(output.path)/$(name).app/Contents/Resources/

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -91,7 +91,7 @@ auto Nintendo64::load() -> bool {
 
   ares::Nintendo64::option("Quality", settings.video.quality);
   ares::Nintendo64::option("Supersampling", settings.video.supersampling);
-  ares::Nintendo64::option("Enable Vulkan", settings.video.enableVulkan);
+  ares::Nintendo64::option("Enable GPU acceleration", settings.video.enableVulkan);
   ares::Nintendo64::option("Disable Video Interface Processing", settings.video.disableVideoInterfaceProcessing);
 
   if(!ares::Nintendo64::load(root, {"[Nintendo] ", name, " (", region, ")"})) return false;

--- a/desktop-ui/emulator/nintendo-64dd.cpp
+++ b/desktop-ui/emulator/nintendo-64dd.cpp
@@ -69,7 +69,7 @@ auto Nintendo64DD::load() -> bool {
 
   ares::Nintendo64::option("Quality", settings.video.quality);
   ares::Nintendo64::option("Supersampling", settings.video.supersampling);
-  ares::Nintendo64::option("Enable Vulkan", settings.video.enableVulkan);
+  ares::Nintendo64::option("Enable GPU acceleration", settings.video.enableVulkan);
   ares::Nintendo64::option("Disable Video Interface Processing", settings.video.disableVideoInterfaceProcessing);
 
   if(!ares::Nintendo64::load(root, {"[Nintendo] Nintendo 64DD (", region, ")"})) return false;

--- a/desktop-ui/program/status.cpp
+++ b/desktop-ui/program/status.cpp
@@ -26,4 +26,5 @@ auto Program::updateMessage() -> void {
 
 auto Program::showMessage(const string& text) -> void {
   messages.append({chrono::millisecond(), text});
+  printf("%s\n", (const char*)text);
 }

--- a/desktop-ui/resource/ares.entitlements
+++ b/desktop-ui/resource/ares.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+</dict>
+</plist>

--- a/desktop-ui/resource/ares.selfsigned.entitlements
+++ b/desktop-ui/resource/ares.selfsigned.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/desktop-ui/settings/video.cpp
+++ b/desktop-ui/settings/video.cpp
@@ -65,9 +65,9 @@ auto VideoSettings::construct() -> void {
   renderSettingsLabel.setText("N64 Render Settings").setFont(Font().setBold());
 
   renderQualityLayout.setPadding(12_sx, 0);
-    enableVulkanOption.setText("Enable Vulkan").setChecked(settings.video.enableVulkan).onToggle([&] {
+    enableVulkanOption.setText("Enable GPU acceleration").setChecked(settings.video.enableVulkan).onToggle([&] {
     settings.video.enableVulkan = enableVulkanOption.checked();
-    if(emulator) emulator->setBoolean("Enable Vulkan", settings.video.enableVulkan);
+    if(emulator) emulator->setBoolean("Enable GPU acceleration", settings.video.enableVulkan);
 
     renderSupersamplingOption.setEnabled(settings.video.enableVulkan && settings.video.quality != "SD");
     renderQualitySD.setEnabled(settings.video.enableVulkan);
@@ -76,7 +76,7 @@ auto VideoSettings::construct() -> void {
     disableVideoInterfaceProcessingOption.setEnabled(settings.video.enableVulkan);
   });
   enableVulkanLayout.setAlignment(1).setPadding(12_sx, 0);
-  enableVulkanHint.setText("Enables Vulkan Hardware rendering").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+  enableVulkanHint.setText("Enables Vulkan/Metal Hardware rendering").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
   disableVideoInterfaceProcessingOption.setText("Disable Video Interface Processing").setChecked(settings.video.disableVideoInterfaceProcessing).onToggle([&] {
     settings.video.disableVideoInterfaceProcessing = disableVideoInterfaceProcessingOption.checked();
     if(emulator) emulator->setBoolean("Disable Video Interface Processing", settings.video.disableVideoInterfaceProcessing);

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -95,13 +95,31 @@ ifeq ($(compiler),)
   endif
 endif
 
+machine_str := $(shell $(compiler) -dumpmachine)
+ifneq ($(filter amd64-% x86_64-%,$(machine_str)),)
+  machine := amd64
+else ifneq ($(filter arm64-% aarch64-%,$(machine_str)),)
+  machine := arm64
+endif
+
+# explicit architecture flags to allow for cross-compilation on macos
+ifeq ($(platform),macos)
+  ifeq ($(arch),amd64)
+    flags += -arch x86_64
+    options += -arch x86_64
+  else ifeq ($(arch),arm64)
+    flags += -arch arm64
+    options += -arch arm64
+  endif
+  ifneq ($(machine),$(arch))
+    local = false
+  endif
+endif
+
 # architecture detection
 ifeq ($(arch),)
-  machine := $(shell $(compiler) -dumpmachine)
-  ifneq ($(filter amd64-% x86_64-%,$(machine)),)
-    arch := amd64
-  else ifneq ($(filter arm64-% aarch64-%,$(machine)),)
-    arch := arm64
+  ifneq ($(machine),)
+    arch := $(machine)
   else
     $(error unknown arch, please specify manually.)
   endif

--- a/scripts/macos-make-universal.sh
+++ b/scripts/macos-make-universal.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+if ! command -v lipo >/dev/null; then
+    echo "Command lipo not found; please install XCode"
+    exit 1
+fi
+
+if ! command -v gmake >/dev/null; then
+    echo "Please install make via Homebrew (brew install make)"
+    exit 1
+fi
+
+# Change to parent directory (top-level)
+cd "$(dirname "$0")"/.. || exit 1
+
+echo "Building for amd64..."
+gmake arch=amd64 object.path=obj-amd64 output.path=out-amd64 "$@"
+
+echo "Building for arm64..."
+gmake arch=arm64 object.path=obj-arm64 output.path=out-arm64 "$@"
+
+echo "Assembling universal binary"
+rm -rf desktop-ui/out
+cp -a desktop-ui/out-amd64 desktop-ui/out
+lipo -create -output desktop-ui/out/ares.app/Contents/MacOS/ares \
+    desktop-ui/out-amd64/ares.app/Contents/MacOS/ares \
+    desktop-ui/out-arm64/ares.app/Contents/MacOS/ares
+codesign --force --deep --sign - desktop-ui/out/ares.app

--- a/scripts/macos-make-universal.sh
+++ b/scripts/macos-make-universal.sh
@@ -26,4 +26,12 @@ cp -a desktop-ui/out-amd64 desktop-ui/out
 lipo -create -output desktop-ui/out/ares.app/Contents/MacOS/ares \
     desktop-ui/out-amd64/ares.app/Contents/MacOS/ares \
     desktop-ui/out-arm64/ares.app/Contents/MacOS/ares
-codesign --force --deep --sign - desktop-ui/out/ares.app
+
+if [ "${CERTIFICATE_NAME:-}" == "" ]; then
+    echo "Signing using self-signed"
+    ENTITLEMENTS=desktop-ui/resource/ares.selfsigned.entitlements
+else
+    echo "Signing using certificate: ${CERTIFICATE_NAME}"
+    ENTITLEMENTS=desktop-ui/resource/ares.entitlements
+fi
+codesign --force --deep --options runtime --entitlements "${ENTITLEMENTS}" --sign "${CERTIFICATE_NAME:--}" desktop-ui/out/ares.app

--- a/scripts/update-subtrees.sh
+++ b/scripts/update-subtrees.sh
@@ -5,9 +5,9 @@
 # If you don't have a POSIX-compatible shell on your system, feel free to use
 # this as a reference for what commands to run, rather than running it directly.
 
-# Change to the directory containing this script, or exit with failure
+# Change to the root directory, or exit with failure
 # to prevent git subtree scrawling over some other repo.
-cd "$(dirname "$0")" || exit 1
+cd "$(dirname "$0")"/.. || exit 1
 
 # Merge changes from the upstream parallel-rdp repository.
 git subtree pull --prefix=ares/n64/vulkan/parallel-rdp https://github.com/Themaister/parallel-rdp-standalone.git master --squash

--- a/thirdparty/MoltenVK/.gitignore
+++ b/thirdparty/MoltenVK/.gitignore
@@ -1,0 +1,3 @@
+MoltenVK/
+HEAD
+libMoltenVK.dylib

--- a/thirdparty/MoltenVK/build-moltenvk.sh
+++ b/thirdparty/MoltenVK/build-moltenvk.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ -d "MoltenVK" ]; then
+	git -C MoltenVK pull
+else
+	git clone https://github.com/KhronosGroup/MoltenVK.git
+fi
+pushd MoltenVK
+./fetchDependencies --macos
+make macos MVK_LOG_LEVEL_INFO=0 MVK_LOG_LEVEL_DEBUG=0
+popd
+cp MoltenVK/MoltenVK/dylib/macOS/libMoltenVK.dylib .
+git -C MoltenVK rev-parse HEAD >HEAD


### PR DESCRIPTION
This also updates the build system and the CI to produce universal binaries on Mac (amd64 + arm64).