### PR TITLE
build: ignore -Wdeprecated-non-prototype in zlib

### DIFF
--- a/thirdparty/libchdr/deps/zlib-1.2.11/zconf.h
+++ b/thirdparty/libchdr/deps/zlib-1.2.11/zconf.h
@@ -531,4 +531,10 @@ typedef uLong FAR uLongf;
   #pragma map(inflate_copyright,"INCOPY")
 #endif
 
+#if defined(__clang__)
+#  if __has_warning("-Wdeprecated-non-prototype")
+#    pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
+#  endif
+#endif
+
 #endif /* ZCONF_H */


### PR DESCRIPTION
This warning is enabled by default in clang 15. The issue has already been reported upstream here: https://github.com/madler/zlib/issues/702