### PR TITLE
md: combine banked & linear carts into standard mapper

### DIFF
--- a/ares/md/bus/inline.hpp
+++ b/ares/md/bus/inline.hpp
@@ -13,7 +13,7 @@ inline auto Bus::read(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
 
   if(address >= 0x400000 && address <= 0x7fffff) {
     waitRefreshExternal();
-    if(!cartridge.bootable()) {
+    if(!cartridge.bootable() || !MegaCD()) {
       data = cartridge.read(upper, lower, address, data);
     } else {
       data = mcd.readExternal(upper, lower, address, data);
@@ -22,7 +22,11 @@ inline auto Bus::read(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
   }
 
   if(address >= 0x800000 && address <= 0x9fffff) {
-    data = m32x.readExternal(upper, lower, address, data);
+    if(!Mega32X()) {
+      data = cartridge.read(upper, lower, address, data);
+    } else {
+      data = m32x.readExternal(upper, lower, address, data);
+    }
     return data;
   }
 
@@ -71,7 +75,7 @@ inline auto Bus::write(n1 upper, n1 lower, n24 address, n16 data) -> void {
 
   if(address >= 0x400000 && address <= 0x7fffff) {
     waitRefreshExternal();
-    if(!cartridge.bootable()) {
+    if(!cartridge.bootable() || !MegaCD()) {
       cartridge.write(upper, lower, address, data);
     } else {
       mcd.writeExternal(upper, lower, address, data);
@@ -80,7 +84,11 @@ inline auto Bus::write(n1 upper, n1 lower, n24 address, n16 data) -> void {
   }
 
   if(address >= 0x800000 && address <= 0x9fffff) {
-    m32x.writeExternal(upper, lower, address, data);
+    if(!Mega32X()) {
+      cartridge.write(upper, lower, address, data);
+    } else {
+      m32x.writeExternal(upper, lower, address, data);
+    }
     return;
   }
 

--- a/ares/md/cartridge/board/board.cpp
+++ b/ares/md/cartridge/board/board.cpp
@@ -1,5 +1,6 @@
 namespace Board {
 
+#include "standard.cpp"
 #include "linear.cpp"
 #include "banked.cpp"
 #include "svp.cpp"

--- a/ares/md/cartridge/board/board.hpp
+++ b/ares/md/cartridge/board/board.hpp
@@ -11,8 +11,8 @@ struct Interface {
   virtual auto save() -> void {}
   virtual auto main() -> void;
   virtual auto step(u32 clocks) -> void;
-  virtual auto read(n1 upper, n1 lower, n22 address, n16 data) -> n16 { return data; }
-  virtual auto write(n1 upper, n1 lower, n22 address, n16 data) -> void {}
+  virtual auto read(n1 upper, n1 lower, n24 address, n16 data) -> n16 { return data; }
+  virtual auto write(n1 upper, n1 lower, n24 address, n16 data) -> void {}
   virtual auto readIO(n1 upper, n1 lower, n24 address, n16 data) -> n16 { return data; }
   virtual auto writeIO(n1 upper, n1 lower, n24 address, n16 data) -> void {}
   virtual auto vblank(bool line) -> void {}

--- a/ares/md/cartridge/board/game-genie.cpp
+++ b/ares/md/cartridge/board/game-genie.cpp
@@ -11,7 +11,7 @@ struct GameGenie : Interface {
   auto save() -> void override {
   }
 
-  auto read(n1 upper, n1 lower, n22 address, n16 data) -> n16 override {
+  auto read(n1 upper, n1 lower, n24 address, n16 data) -> n16 override {
     if(enable) {
       for(auto& code : codes) {
         if(code.enable && code.address == address) return data = code.data;
@@ -21,7 +21,7 @@ struct GameGenie : Interface {
     return data = rom[address >> 1];
   }
 
-  auto write(n1 upper, n1 lower, n22 address, n16 data) -> void override {
+  auto write(n1 upper, n1 lower, n24 address, n16 data) -> void override {
     if(enable) {
       if(slot.connected()) return slot.cartridge.write(upper, lower, address, data);
     }

--- a/ares/md/cartridge/board/j-cart.cpp
+++ b/ares/md/cartridge/board/j-cart.cpp
@@ -1,25 +1,25 @@
-struct JCart : Linear {
-  using Linear::Linear;
+struct JCart : Standard {
+  using Standard::Standard;
 
-  auto read(n1 upper, n1 lower, n22 address, n16 data) -> n16 override {
+  auto read(n1 upper, n1 lower, n24 address, n16 data) -> n16 override {
     if(address >= 0x380000) {
       data.bit( 0, 5) = 0b111111;     //controller port 1
       data.bit( 6)    = jcartSelect;  //TH state
       data.bit( 8,13) = 0b111111;     //controller port 2
       data.bit(14)    = 0;            //forced low
     }
-    return Linear::read(upper, lower, address, data);
+    return Standard::read(upper, lower, address, data);
   }
 
-  auto write(n1 upper, n1 lower, n22 address, n16 data) -> void override {
+  auto write(n1 upper, n1 lower, n24 address, n16 data) -> void override {
     if(address >= 0x380000) {
       jcartSelect = data.bit(0);
     }
-    return Linear::write(upper, lower, address, data);
+    return Standard::write(upper, lower, address, data);
   }
 
   auto serialize(serializer& s) -> void override {
-    Linear::serialize(s);
+    Standard::serialize(s);
     s(jcartSelect);
   }
 

--- a/ares/md/cartridge/board/linear.cpp
+++ b/ares/md/cartridge/board/linear.cpp
@@ -29,7 +29,7 @@ struct Linear : Interface {
     }
   }
 
-  auto read(n1 upper, n1 lower, n22 address, n16 data) -> n16 override {
+  auto read(n1 upper, n1 lower, n24 address, n16 data) -> n16 override {
     if(address >= sramAddr && address < sramAddr+sramSize) {
       if(wram && ramEnable) {
         return wram[address >> 1];
@@ -57,7 +57,7 @@ struct Linear : Interface {
     return rom[address >> 1];
   }
 
-  auto write(n1 upper, n1 lower, n22 address, n16 data) -> void override {
+  auto write(n1 upper, n1 lower, n24 address, n16 data) -> void override {
     //emulating ramWritable will break commercial software:
     //it does not appear that many (any?) games actually connect $a130f1.d1 to /WE;
     //hence RAM ends up always being writable, and many games fail to set d1=1

--- a/ares/md/cartridge/board/mega-32x.cpp
+++ b/ares/md/cartridge/board/mega-32x.cpp
@@ -3,12 +3,7 @@ struct Mega32X : Interface {
   unique_pointer<Board::Interface> board;
 
   auto load() -> void override {
-    if(pak->read("program.rom") && pak->read("program.rom")->size() > 0x400000) {
-      board = new Board::Banked(*cartridge);
-    } else {
-      board = new Board::Linear(*cartridge);
-    }
-
+    board = new Board::Standard(*cartridge);
     board->pak = pak;
     board->load();
 
@@ -19,7 +14,7 @@ struct Mega32X : Interface {
     board->save();
   }
 
-  auto read(n1 upper, n1 lower, n22 address, n16 data) -> n16 override {
+  auto read(n1 upper, n1 lower, n24 address, n16 data) -> n16 override {
     if(!m32x.io.adapterEnable) {
       return board->read(upper, lower, address, data);
     }
@@ -35,7 +30,7 @@ struct Mega32X : Interface {
     return data;
   }
 
-  auto write(n1 upper, n1 lower, n22 address, n16 data) -> void override {
+  auto write(n1 upper, n1 lower, n24 address, n16 data) -> void override {
     if(!m32x.io.adapterEnable) {
       return board->write(upper, lower, address, data);
     }

--- a/ares/md/cartridge/board/svp.cpp
+++ b/ares/md/cartridge/board/svp.cpp
@@ -53,7 +53,7 @@ struct SVP : Interface, SSP1601 {
     SSP1601::instruction();
   }
 
-  auto read(n1 upper, n1 lower, n22 address, n16 data) -> n16 override {
+  auto read(n1 upper, n1 lower, n24 address, n16 data) -> n16 override {
     if(address >= 0x000000 && address <= 0x1fffff) {
       data = rom[address >> 1];
     }
@@ -77,7 +77,7 @@ struct SVP : Interface, SSP1601 {
     return data;
   }
 
-  auto write(n1 upper, n1 lower, n22 address, n16 data) -> void override {
+  auto write(n1 upper, n1 lower, n24 address, n16 data) -> void override {
     if(address >= 0x300000 && address <= 0x37ffff) {
       if(upper) dram[address >> 1].byte(1) = data.byte(1);
       if(lower) dram[address >> 1].byte(0) = data.byte(0);

--- a/ares/md/cartridge/cartridge.cpp
+++ b/ares/md/cartridge/cartridge.cpp
@@ -25,12 +25,10 @@ auto Cartridge::connect() -> void {
     board = new Board::SVP(*this);
   } else if(pak->attribute("label") == "Game Genie") {
     board = new Board::GameGenie(*this);
-  } else if(pak->read("program.rom") && pak->read("program.rom")->size() > 0x400000) {
-    board = new Board::Banked(*this);
   } else if(pak->attribute("jcart").boolean()) {
     board = new Board::JCart(*this);
   } else {
-    board = new Board::Linear(*this);
+    board = new Board::Standard(*this);
   }
   board->pak = pak;
   board->load();
@@ -69,11 +67,11 @@ auto Cartridge::power(bool reset) -> void {
   board->power(reset);
 }
 
-auto Cartridge::read(n1 upper, n1 lower, n22 address, n16 data) -> n16 {
+auto Cartridge::read(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
   return board->read(upper, lower, address, data);
 }
 
-auto Cartridge::write(n1 upper, n1 lower, n22 address, n16 data) -> void {
+auto Cartridge::write(n1 upper, n1 lower, n24 address, n16 data) -> void {
   return board->write(upper, lower, address, data);
 }
 

--- a/ares/md/cartridge/cartridge.hpp
+++ b/ares/md/cartridge/cartridge.hpp
@@ -19,8 +19,8 @@ struct Cartridge : Thread {
   auto step(u32 clocks) -> void;
   auto power(bool reset) -> void;
 
-  auto read(n1 upper, n1 lower, n22 address, n16 data) -> n16;
-  auto write(n1 upper, n1 lower, n22 address, n16 data) -> void;
+  auto read(n1 upper, n1 lower, n24 address, n16 data) -> n16;
+  auto write(n1 upper, n1 lower, n24 address, n16 data) -> void;
 
   auto readIO(n1 upper, n1 lower, n24 address, n16 data) -> n16;
   auto writeIO(n1 upper, n1 lower, n24 address, n16 data) -> void;


### PR DESCRIPTION
This merges the features implemented separately in banked & linear carts into a standard cart mapper. This enables support for large flat-mapped (read: unbanked) carts. Fixes #252 & Bad Apple MD.

linear.cpp & banked.cpp are no longer in use but remain if needed for testing/reference.