### PR TITLE
md: connect 32x to cart slot in cd+32x mode

### DIFF
--- a/ares/md/cartridge/board/mega-32x.cpp
+++ b/ares/md/cartridge/board/mega-32x.cpp
@@ -3,7 +3,12 @@ struct Mega32X : Interface {
   unique_pointer<Board::Interface> board;
 
   auto load() -> void override {
-    board = new Board::Standard(*cartridge);
+    if(pak) {
+      board = new Board::Standard(*cartridge);
+    } else {
+      board = new Board::Interface(*cartridge);
+    }
+
     board->pak = pak;
     board->load();
 

--- a/ares/md/cartridge/cartridge.cpp
+++ b/ares/md/cartridge/cartridge.cpp
@@ -62,7 +62,15 @@ auto Cartridge::step(u32 clocks) -> void {
 }
 
 auto Cartridge::power(bool reset) -> void {
-  if(!board) board = new Board::Interface(*this);
+  if(!board) {
+    if(Mega32X()) {
+      board = new Board::Mega32X{*this};
+    } else {
+      board = new Board::Interface(*this);
+    }
+
+    board->load();
+  }
   Thread::create(board->frequency(), {&Cartridge::main, this});
   board->power(reset);
 }


### PR DESCRIPTION
This is required for register reads/writes and h/vblank signals to be handled by the 32x.