### PR TITLE
sh2: store correct pc in exception frame

### DIFF
--- a/ares/component/processor/sh2/exceptions.cpp
+++ b/ares/component/processor/sh2/exceptions.cpp
@@ -34,22 +34,16 @@ auto SH2::push(u32 data) -> void {
 
 auto SH2::interrupt(u8 level, u8 vector) -> void {
   push(SR);
-  push(PC);
+  push(PC - 4);
   jump(readLong(VBR + vector * 4) + 4);
   SR.I = level;
-}
-
-auto SH2::exception(u8 vector) -> void {
-  push(SR);
-  push(PC - 2);
-  jump(readLong(VBR + vector * 4) + 4);
 }
 
 auto SH2::addressErrorCPU() -> void {
   static constexpr u8 vector = 0x09;
   SP &= ~3;  //not accurate; but prevents infinite recursion
   push(SR);
-  push(PC);
+  push(PC - 4);
   jump(readLong(VBR + vector * 4) + 4);
 }
 
@@ -57,7 +51,7 @@ auto SH2::addressErrorDMA() -> void {
   static constexpr u8 vector = 0x0a;
   SP &= ~3;  //not accurate; but prevents infinite recursion
   push(SR);
-  push(PC);
+  push(PC - 4);
   jump(readLong(VBR + vector * 4) + 4);
 }
 
@@ -66,7 +60,7 @@ auto SH2::illegalInstruction() -> void {
   debug(unusual, "[SH2] illegal instruction: 0x", hex(busReadWord(PC - 4), 4L), " @ 0x", hex(PC - 4));
   static constexpr u8 vector = 0x04;
   push(SR);
-  push(PC);
+  push(PC - 4);
   jump(readLong(VBR + vector * 4) + 4);
 }
 
@@ -74,6 +68,6 @@ auto SH2::illegalSlotInstruction() -> void {
   debug(unusual, "[SH2] illegal slot instruction: 0x", hex(busReadWord(PC - 4), 4L));
   static constexpr u8 vector = 0x06;
   push(SR);
-  push(PC - 2);
+  push(PPC - 4);
   jump(readLong(VBR + vector * 4) + 4);
 }

--- a/ares/component/processor/sh2/instructions.cpp
+++ b/ares/component/processor/sh2/instructions.cpp
@@ -605,7 +605,7 @@ auto SH2::ROTR(u32 n) -> void {
 
 //RTE
 auto SH2::RTE() -> void {
-  delaySlot(readLong(SP + 0));
+  delaySlot(readLong(SP + 0) + 4);
   SR  = readLong(SP + 4);
   SP += 8;
 }
@@ -811,7 +811,7 @@ auto SH2::TAS(u32 n) -> void {
 //TRAPA #imm
 auto SH2::TRAPA(u32 i) -> void {
   push(SR);
-  push(PC + 2);
+  push(PC - 2);
   branch(readLong(VBR + i * 4) + 4);
 }
 

--- a/ares/component/processor/sh2/recompiler.cpp
+++ b/ares/component/processor/sh2/recompiler.cpp
@@ -790,7 +790,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
     sub32(reg(1), R15, imm(4));
     mov32(R15, reg(1));
     call(writeL);
-    add32(reg(2), PC, imm(2));
+    sub32(reg(2), PC, imm(2));
     sub32(reg(1), R15, imm(4));
     mov32(R15, reg(1));
     call(writeL);
@@ -1353,6 +1353,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
     mov32(reg(1), R15);
     add32(R15, reg(1), imm(4));
     call(readL);
+    add32(reg(0), reg(0), imm(4));
     mov32(PPC, reg(0));
     mov32(PPM, imm(Branch::Slot));
     mov32(reg(1), R15);

--- a/ares/component/processor/sh2/sh2.hpp
+++ b/ares/component/processor/sh2/sh2.hpp
@@ -29,7 +29,6 @@ struct SH2 {
   auto exceptionHandler() -> void;
   auto push(u32 data) -> void;
   auto interrupt(u8 level, u8 vector) -> void;
-  auto exception(u8 vector) -> void;
   auto addressErrorCPU() -> void;
   auto addressErrorDMA() -> void;
   auto illegalInstruction() -> void;


### PR DESCRIPTION
The value of PC indicates the fourth byte (second instruction) after the current instruction. The value stored when an exception raised does not maintain this four byte offset. Consequently, the RTE instruction must offset the value it reads back by four bytes.

ares was storing the offset value (and not applying one in RTE) and this went unnoticed until an encounter with code that manually sets up an exception frame (in an interrupt handler common to CD 32X games).

This change also fixes the PC stored in the event of an illegal slot exception, which should be the delayed branch target.

This is the last change required to fix #179 