### PR TITLE
n64: fix 1bit precision error in mame RDP

### DIFF
--- a/thirdparty/mame/mame/video/n64.cpp
+++ b/thirdparty/mame/mame/video/n64.cpp
@@ -3185,7 +3185,7 @@ n64_rdp::n64_rdp(n64_state &state, uint32_t* rdram, uint32_t* dmem) : poly_manag
 	m_current = 0;
 	m_status = 0x88;
 
-	m_one.set(0xff, 0xff, 0xff, 0xff);
+	m_one.set(0x100, 0x100, 0x100, 0x100);
 	m_zero.set(0, 0, 0, 0);
 
 	m_tmem = nullptr;


### PR DESCRIPTION
mame RDP initializes the "ONE" combiner slot to 0xFF. Angrylion upstream and parallel RDP both initialize it to 0x100 instead, and tests on real hardware show that they are right.

Test ROM:
[testrom_emu.zip](https://github.com/ares-emulator/ares/files/9690266/testrom_emu.zip)
