### PR TITLE
Aspect ratio correction for MSX, MSX2, Game Gear, and ColecoVision

### DIFF
--- a/ares/cv/vdp/vdp.cpp
+++ b/ares/cv/vdp/vdp.cpp
@@ -15,7 +15,7 @@ auto VDP::load(Node::Object parent) -> void {
   screen->colors(1 << 4, {&VDP::color, this});
   screen->setSize(256, 192);
   screen->setScale(1.0, 1.0);
-  screen->setAspect(1.0, 1.0);
+  screen->setAspect(8.0, 7.0);
   screen->setViewport(0, 0, 256, 192);
 
   TMS9918::load(screen);

--- a/ares/ms/vdp/vdp.cpp
+++ b/ares/ms/vdp/vdp.cpp
@@ -42,7 +42,7 @@ auto VDP::load(Node::Object parent) -> void {
     screen->colors(1 << 12, {&VDP::colorGameGear, this});
     screen->setSize(160, 144);
     screen->setScale(1.0, 1.0);
-    screen->setAspect(8.0, 7.0);
+    screen->setAspect(6.0, 5.0);
     screen->setViewport(0, 0, 256, 240);
 
     interframeBlending = screen->append<Node::Setting::Boolean>("Interframe Blending", true, [&](auto value) {

--- a/ares/ms/vdp/vdp.cpp
+++ b/ares/ms/vdp/vdp.cpp
@@ -42,7 +42,7 @@ auto VDP::load(Node::Object parent) -> void {
     screen->colors(1 << 12, {&VDP::colorGameGear, this});
     screen->setSize(160, 144);
     screen->setScale(1.0, 1.0);
-    screen->setAspect(1.0, 1.0);
+    screen->setAspect(8.0, 7.0);
     screen->setViewport(0, 0, 256, 240);
 
     interframeBlending = screen->append<Node::Setting::Boolean>("Interframe Blending", true, [&](auto value) {

--- a/ares/msx/vdp/vdp.cpp
+++ b/ares/msx/vdp/vdp.cpp
@@ -14,7 +14,7 @@ auto VDP::load(Node::Object parent) -> void {
     screen->colors(1 << 4, {&VDP::colorMSX, this});
     screen->setSize(256, 192);
     screen->setScale(1.0, 1.0);
-    screen->setAspect(1.0, 1.0);
+    screen->setAspect(8.0, 7.0);
     TMS9918::vram.allocate(16_KiB, 0x00);
     TMS9918::load(screen);
   }
@@ -24,7 +24,7 @@ auto VDP::load(Node::Object parent) -> void {
     screen->colors(1 << 9, {&VDP::colorMSX2, this});
     screen->setSize(512, 424);
     screen->setScale(0.5, 0.5);
-    screen->setAspect(1.0, 1.0);
+    screen->setAspect(8.0, 7.0);
     V9938::vram.allocate(128_KiB, 0x00);
     V9938::xram.allocate(64_KiB, 0x00);
     V9938::pram.allocate(16);


### PR DESCRIPTION
Change setAspect for MSX, MSX2, Game Gear, and ColecoVision.

Note: Game Gear has conflicting sources for pixel aspect ratio (8:7 or 6:5) but I believe 6:5 is correct judging from photographs.