### PR TITLE
gb: fix rtc emulation

### DIFF
--- a/ares/gb/cartridge/board/mbc3.cpp
+++ b/ares/gb/cartridge/board/mbc3.cpp
@@ -37,9 +37,6 @@ struct MBC3 : Interface {
   }
 
   auto save() -> void override {
-    Interface::save(ram, "save.ram");
-    Interface::save(rtc, "time.rtc");
-
     if(rtc.size() == 13) {
       rtc[0] = io.rtc.second;
       rtc[1] = io.rtc.minute;
@@ -52,6 +49,9 @@ struct MBC3 : Interface {
         rtc[5 + index] = timestamp.byte(index);
       }
     }
+
+    Interface::save(ram, "save.ram");
+    Interface::save(rtc, "time.rtc");
   }
 
   auto unload() -> void override {
@@ -174,7 +174,9 @@ struct MBC3 : Interface {
   }
 
   auto power() -> void override {
-    io = {};
+    io.rom = {};
+    io.ram = {};
+    //io.rtc registers are initialized by load()
   }
 
   auto serialize(serializer& s) -> void override {

--- a/ares/gb/cartridge/board/tama.cpp
+++ b/ares/gb/cartridge/board/tama.cpp
@@ -47,9 +47,6 @@ struct TAMA : Interface {
   }
 
   auto save() -> void override {
-    Interface::save(ram, "save.ram");
-    Interface::save(rtc, "time.rtc");
-
     if(rtc.size() == 15) {
       rtc[0] = toBCD(io.rtc.year);
       rtc[1] = toBCD(io.rtc.month);
@@ -64,6 +61,9 @@ struct TAMA : Interface {
         rtc[7 + index] = timestamp.byte(index);
       }
     }
+
+    Interface::save(ram, "save.ram");
+    Interface::save(rtc, "time.rtc");
   }
 
   auto unload() -> void override {

--- a/mia/medium/game-boy.cpp
+++ b/mia/medium/game-boy.cpp
@@ -343,7 +343,7 @@ auto GameBoy::analyze(vector<u8>& rom) -> string {
     if(label == "KORO2 KIRBY" && serial == "KKKJ") eepromSize = 256;
   }
 
-  if(mapper == "MBC3" && rtc) rtcSize = 13;
+  if(mapper.beginsWith("MBC3") && rtc) rtcSize = 13;
   if(mapper == "TAMA" && rtc) rtcSize = 15;
 
   string s;


### PR DESCRIPTION
- Detect RTC with MBC30 mapper (Pocket Monsters - Crystal Version)
- Read current time before saving it to disk, not after
- Don't clear RTC in power()