### PR TITLE
debugger: set per-processor trace history depth

### DIFF
--- a/ares/ares/ares.hpp
+++ b/ares/ares/ares.hpp
@@ -12,6 +12,7 @@
 #include <nall/directory.hpp>
 #include <nall/dl.hpp>
 #include <nall/endian.hpp>
+#include <nall/hashset.hpp>
 #include <nall/image.hpp>
 #include <nall/literals.hpp>
 #include <nall/priority-queue.hpp>

--- a/ares/ares/node/debugger/tracer/instruction.hpp
+++ b/ares/ares/node/debugger/tracer/instruction.hpp
@@ -18,6 +18,7 @@ struct Instruction : Tracer {
 
   auto setMask(bool mask) -> void {
     _mask = mask;
+    _masks.reset();
   }
 
   auto setDepth(u32 depth) -> void {
@@ -32,9 +33,10 @@ struct Instruction : Tracer {
     _address = address;
     address >>= _addressMask;  //clip unneeded alignment bits (to reduce _masks size)
 
-    if(_mask && updateMasks()) {
-      if(_masks[address >> 3] & 1 << (address & 7)) return false;  //do not trace twice
-      _masks[address >> 3] |= 1 << (address & 7);
+    if(_mask) {
+      auto mask = _masks.find(address);
+      if(!mask) mask = _masks.insert(address);
+      if(mask->visit(address)) return false;  //do not trace twice
     }
 
     if(_depth) {
@@ -56,10 +58,12 @@ struct Instruction : Tracer {
   //mark an already-executed address as not executed yet for trace masking.
   //call when writing to executable RAM to support self-modifying code.
   auto invalidate(u64 address) -> void {
-    if(unlikely(_mask && updateMasks())) {
+    if(unlikely(_mask)) {
       address &= ~0ull >> (64 - _addressBits);
       address >>= _addressMask;
-      _masks[address >> 3] &= ~(1 << (address & 7));
+
+      auto mask = _masks.find(address);
+      if(mask) mask->unvisit(address);
     }
   }
 
@@ -103,14 +107,27 @@ struct Instruction : Tracer {
   }
 
 protected:
-  auto updateMasks() -> bool {
-    auto size = 1ull << (_addressBits - _addressMask - 3);
-    if(!_mask || !size) return _masks.reset(), false;
-    if(_masks.size() == size) return true;
-    _masks.reset();
-    _masks.resize(size);
-    return true;
-  }
+  struct VisitMask {
+    VisitMask(u64 address) : upper(address >> 6), mask(0) {}
+    auto operator==(const VisitMask& source) const -> bool { return upper == source.upper; }
+    auto hash() const -> u32 { return upper; }
+
+    auto visit(u64 address) -> bool {
+      const u64 bit = 1ull << (address & 0x3f);
+      if(mask & bit) return true;
+      mask |= bit;
+      return false;
+    }
+
+    auto unvisit(u64 address) -> void {
+      const u64 bit = 1ull << (address & 0x3f);
+      mask &= ~bit;
+    }
+
+  private:
+    u64 upper;
+    u64 mask;
+  };
 
   u32  _addressBits = 32;
   u32  _addressMask = 0;
@@ -121,5 +138,5 @@ protected:
   n64 _address = 0;
   n64 _omitted = 0;
   vector<u64> _history;
-  vector<u08> _masks;
+  hashset<VisitMask> _masks;
 };

--- a/ares/ares/node/debugger/tracer/instruction.hpp
+++ b/ares/ares/node/debugger/tracer/instruction.hpp
@@ -24,7 +24,7 @@ struct Instruction : Tracer {
     _depth = depth;
     _history.reset();
     _history.resize(depth);
-    for(auto& history : _history) history = ~0;
+    for(auto& history : _history) history = ~0ull;
   }
 
   auto address(u64 address) -> bool {
@@ -120,6 +120,6 @@ protected:
 //unserialized:
   n64 _address = 0;
   n64 _omitted = 0;
-  vector<u32> _history;
+  vector<u64> _history;
   vector<u08> _masks;
 };

--- a/ares/gba/cpu/debugger.cpp
+++ b/ares/gba/cpu/debugger.cpp
@@ -19,6 +19,7 @@ auto CPU::Debugger::load(Node::Object parent) -> void {
 
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "CPU");
   tracer.instruction->setAddressBits(32);
+  tracer.instruction->setDepth(16);
 
   tracer.interrupt = parent->append<Node::Debugger::Tracer::Notification>("Interrupt", "CPU");
 }

--- a/ares/md/cartridge/board/debugger.cpp
+++ b/ares/md/cartridge/board/debugger.cpp
@@ -1,6 +1,7 @@
 auto SVP::Debugger::load(Node::Object parent) -> void {
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "SVP");
   tracer.instruction->setAddressBits(16);
+  tracer.instruction->setDepth(16);
 
   tracer.interrupt = parent->append<Node::Debugger::Tracer::Notification>("Interrupt", "SVP");
 }

--- a/ares/md/cpu/debugger.cpp
+++ b/ares/md/cpu/debugger.cpp
@@ -10,6 +10,7 @@ auto CPU::Debugger::load(Node::Object parent) -> void {
 
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "CPU");
   tracer.instruction->setAddressBits(24);
+  tracer.instruction->setDepth(8);
 
   tracer.interrupt = parent->append<Node::Debugger::Tracer::Notification>("Interrupt", "CPU");
 }

--- a/ares/md/m32x/debugger.cpp
+++ b/ares/md/m32x/debugger.cpp
@@ -12,6 +12,7 @@ auto M32X::Debugger::load(Node::Object parent) -> void {
 auto M32X::SH7604::Debugger::load(Node::Object parent) -> void {
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", parent->name());
   tracer.instruction->setAddressBits(32, 1);
+  tracer.instruction->setDepth(16);
 
   tracer.interrupt = parent->append<Node::Debugger::Tracer::Notification>("Interrupt", parent->name());
 }

--- a/ares/md/mcd/debugger.cpp
+++ b/ares/md/mcd/debugger.cpp
@@ -28,6 +28,7 @@ auto MCD::Debugger::load(Node::Object parent) -> void {
 
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "MCD");
   tracer.instruction->setAddressBits(24);
+  tracer.instruction->setDepth(16);
 
   tracer.interrupt = parent->append<Node::Debugger::Tracer::Notification>("Interrupt", "MCD");
 }

--- a/ares/n64/cpu/debugger.cpp
+++ b/ares/n64/cpu/debugger.cpp
@@ -1,6 +1,7 @@
 auto CPU::Debugger::load(Node::Object parent) -> void {
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "CPU");
   tracer.instruction->setAddressBits(64, 2);
+  tracer.instruction->setDepth(64);
 
   tracer.exception = parent->append<Node::Debugger::Tracer::Notification>("Exception", "CPU");
   tracer.interrupt = parent->append<Node::Debugger::Tracer::Notification>("Interrupt", "CPU");

--- a/ares/n64/rsp/debugger.cpp
+++ b/ares/n64/rsp/debugger.cpp
@@ -21,6 +21,7 @@ auto RSP::Debugger::load(Node::Object parent) -> void {
 
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "RSP");
   tracer.instruction->setAddressBits(12, 2);
+  tracer.instruction->setDepth(64);
 
   tracer.io = parent->append<Node::Debugger::Tracer::Notification>("I/O", "RSP");
 }

--- a/ares/ng/cpu/debugger.cpp
+++ b/ares/ng/cpu/debugger.cpp
@@ -1,6 +1,7 @@
 auto CPU::Debugger::load(Node::Object parent) -> void {
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "CPU");
   tracer.instruction->setAddressBits(24);
+  tracer.instruction->setDepth(16);
 
   tracer.interrupt = parent->append<Node::Debugger::Tracer::Notification>("Interrupt", "CPU");
 }

--- a/ares/ngp/cpu/debugger.cpp
+++ b/ares/ngp/cpu/debugger.cpp
@@ -10,6 +10,7 @@ auto CPU::Debugger::load(Node::Object parent) -> void {
 
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "CPU");
   tracer.instruction->setAddressBits(24);
+  tracer.instruction->setDepth(8);
 
   tracer.interrupt = parent->append<Node::Debugger::Tracer::Notification>("Interrupt", "CPU");
 

--- a/ares/pce/cpu/debugger.cpp
+++ b/ares/pce/cpu/debugger.cpp
@@ -10,6 +10,7 @@ auto CPU::Debugger::load(Node::Object parent) -> void {
 
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "CPU");
   tracer.instruction->setAddressBits(24);
+  tracer.instruction->setDepth(8);
 
   tracer.interrupt = parent->append<Node::Debugger::Tracer::Notification>("Interrupt", "CPU");
 }

--- a/ares/ps1/cpu/debugger.cpp
+++ b/ares/ps1/cpu/debugger.cpp
@@ -19,6 +19,7 @@ auto CPU::Debugger::load(Node::Object parent) -> void {
 
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "CPU");
   tracer.instruction->setAddressBits(32, 2);
+  tracer.instruction->setDepth(32);
 
   tracer.exception = parent->append<Node::Debugger::Tracer::Notification>("Exception", "CPU");
   tracer.interrupt = parent->append<Node::Debugger::Tracer::Notification>("Interrupt", "CPU");

--- a/ares/sfc/coprocessor/armdsp/debugger.cpp
+++ b/ares/sfc/coprocessor/armdsp/debugger.cpp
@@ -1,6 +1,7 @@
 auto ARMDSP::Debugger::load(Node::Object parent) -> void {
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "ARM");
   tracer.instruction->setAddressBits(32);
+  tracer.instruction->setDepth(16);
 }
 
 auto ARMDSP::Debugger::instruction() -> void {

--- a/ares/sfc/coprocessor/hitachidsp/debugger.cpp
+++ b/ares/sfc/coprocessor/hitachidsp/debugger.cpp
@@ -1,6 +1,7 @@
 auto HitachiDSP::Debugger::load(Node::Object parent) -> void {
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "HIT");
   tracer.instruction->setAddressBits(23);
+  tracer.instruction->setDepth(16);
 }
 
 auto HitachiDSP::Debugger::instruction() -> void {

--- a/ares/sfc/coprocessor/necdsp/debugger.cpp
+++ b/ares/sfc/coprocessor/necdsp/debugger.cpp
@@ -1,6 +1,7 @@
 auto NECDSP::Debugger::load(Node::Object parent) -> void {
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "NEC");
   tracer.instruction->setAddressBits(14);
+  tracer.instruction->setDepth(necdsp.Frequency < 12_MHz ? 8 : 16);
 }
 
 auto NECDSP::Debugger::instruction() -> void {

--- a/ares/sfc/coprocessor/sa1/debugger.cpp
+++ b/ares/sfc/coprocessor/sa1/debugger.cpp
@@ -1,6 +1,7 @@
 auto SA1::Debugger::load(Node::Object parent) -> void {
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "SA1");
   tracer.instruction->setAddressBits(24);
+  tracer.instruction->setDepth(8);
 
   tracer.interrupt = parent->append<Node::Debugger::Tracer::Notification>("Interrupt", "SA1");
 }

--- a/ares/sfc/coprocessor/superfx/debugger.cpp
+++ b/ares/sfc/coprocessor/superfx/debugger.cpp
@@ -1,6 +1,7 @@
 auto SuperFX::Debugger::load(Node::Object parent) -> void {
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "GSU");
   tracer.instruction->setAddressBits(24);
+  tracer.instruction->setDepth(superfx.Frequency < 12_MHz ? 8 : 16);
 }
 
 auto SuperFX::Debugger::instruction() -> void {


### PR DESCRIPTION
The instruction tracer's default history depth (4) is much too low to reliably filter out hot loops in processors clocked above a few megahertz.

Assuming a correlation between processor speed and the path length of code written for that processor, this change sets the history depth to the processor's clock speed in megahertz rounded to the nearest power of two.

This choice is arbitrary, but in practice I've nearly always had to manually adjust the trace depth to values in the 16-64 range when dealing with faster processors, so this seems like a good enough heuristic.

This PR also includes a couple of bugfixes for the instruction tracer.