### PR TITLE
n64: fix 1-bit precision error in mame RDP

### DIFF
--- a/thirdparty/mame/mame/video/n64.cpp
+++ b/thirdparty/mame/mame/video/n64.cpp
@@ -605,7 +605,7 @@ void n64_rdp::set_suba_input_rgb(color_t** input, int32_t code, rdp_span_aux* us
 		case 3:     *input = &userdata->m_prim_color; break;
 		case 4:     *input = &userdata->m_shade_color; break;
 		case 5:     *input = &userdata->m_env_color; break;
-		case 6:     *input = &m_one; break;
+		case 6:     *input = &m_onecc; break;
 		case 7:     *input = &userdata->m_noise_color; break;
 		case 8: case 9: case 10: case 11: case 12: case 13: case 14: case 15:
 		{
@@ -671,7 +671,7 @@ void n64_rdp::set_add_input_rgb(color_t** input, int32_t code, rdp_span_aux* use
 		case 3:     *input = &userdata->m_prim_color; break;
 		case 4:     *input = &userdata->m_shade_color; break;
 		case 5:     *input = &userdata->m_env_color; break;
-		case 6:     *input = &m_one; break;
+		case 6:     *input = &m_onecc; break;
 		case 7:     *input = &m_zero; break;
 	}
 }
@@ -686,7 +686,7 @@ void n64_rdp::set_sub_input_alpha(color_t** input, int32_t code, rdp_span_aux* u
 		case 3:     *input = &userdata->m_prim_alpha; break;
 		case 4:     *input = &userdata->m_shade_alpha; break;
 		case 5:     *input = &userdata->m_env_alpha; break;
-		case 6:     *input = &m_one; break;
+		case 6:     *input = &m_onecc; break;
 		case 7:     *input = &m_zero; break;
 	}
 }
@@ -3186,6 +3186,7 @@ n64_rdp::n64_rdp(n64_state &state, uint32_t* rdram, uint32_t* dmem) : poly_manag
 	m_status = 0x88;
 
 	m_one.set(0xff, 0xff, 0xff, 0xff);
+	m_onecc.set(0x100, 0x100, 0x100, 0x100);
 	m_zero.set(0, 0, 0, 0);
 
 	m_tmem = nullptr;

--- a/thirdparty/mame/mame/video/n64.h
+++ b/thirdparty/mame/mame/video/n64.h
@@ -281,6 +281,7 @@ public:
 	color_t         m_prim_lod_fraction;    /* fixed LOD fraction for this poly */
 
 	color_t         m_one;
+	color_t         m_onecc;
 	color_t         m_zero;
 
 	uint32_t          m_fill_color;


### PR DESCRIPTION
This is another regression introduced to mame RDP wrt upstream angrylion and parallel-RDP. The color combiner slot "ONE" should use the value 0x100 for the color components, not 0xff. Notice that "ONE" in the blender is indeed 0xFF, instead.

This is a test ROM that tests both behaviors.
[testrom_emu.z64.zip](https://github.com/ares-emulator/ares/files/9759949/testrom_emu.z64.zip)

Upstream AL:
https://sourceforge.net/p/angrylions-stuff/code/HEAD/tree/trunk/mylittle-nocomment/n64video.cpp#l305
https://sourceforge.net/p/angrylions-stuff/code/HEAD/tree/trunk/mylittle-nocomment/n64video.cpp#l308
