### PR TITLE
32X audio + other fixes

### DIFF
--- a/ares/ares/ares.hpp
+++ b/ares/ares/ares.hpp
@@ -48,7 +48,7 @@ namespace ares {
 
   //incremented only when serialization format changes
   static const u32    SerializerSignature = 0x31545342;  //"BST1" (little-endian)
-  static const string SerializerVersion   = "130.2";
+  static const string SerializerVersion   = "130.3";
 
   namespace VFS {
     using Pak = shared_pointer<vfs::directory>;

--- a/ares/component/processor/sh2/sh7604/dma.cpp
+++ b/ares/component/processor/sh2/sh7604/dma.cpp
@@ -4,12 +4,16 @@ auto SH2::DMAC::run() -> void {
       if(chcr[c].ar) {
         transfer(c);
       } else if(drcr[c] == 0) {
-        if(dreq) transfer(c);
+        if(dreq[c]) transfer(c);
+        // Note: DACK is not implemented (not used by 32X)
       } else if(drcr[c] == 1) {
         debug(unimplemented, "[SH2] DMA RXI");
       } else if(drcr[c] == 2) {
         debug(unimplemented, "[SH2] DMA TXI");
+      } else {
+        continue;
       }
+      break; // ignoring cycle-steal mode for now
     }
   }
 }

--- a/ares/component/processor/sh2/sh7604/sh7604.hpp
+++ b/ares/component/processor/sh2/sh7604/sh7604.hpp
@@ -159,8 +159,9 @@
       n1 pr;        //priority mode bit
     } dmaor;
 
+    n1 dreq[2];
+
     //internal:
-    n1 dreq;
     n2 pendingIRQ;
   } dmac;
 

--- a/ares/md/cartridge/board/standard.cpp
+++ b/ares/md/cartridge/board/standard.cpp
@@ -59,7 +59,7 @@ struct Standard : Interface {
 
     if(bank > 0x3f) return data;
 
-    n24 offset = bank << 19 | (n19)address;
+    n25 offset = bank << 19 | (n19)address;
     if(offset >= rom.size()*2) return data;
     return rom[offset >> 1];
   }

--- a/ares/md/m32x/io-external.cpp
+++ b/ares/md/m32x/io-external.cpp
@@ -192,8 +192,8 @@ auto M32X::writeExternalIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
       dreq.active = data.bit(2);
       if(!dreq.active) {
         dreq.fifo.flush();
-        shm.dmac.dreq = 0;
-        shs.dmac.dreq = 0;
+        shm.dmac.dreq[0] = 0;
+        shs.dmac.dreq[0] = 0;
       }
     }
   }
@@ -227,8 +227,8 @@ auto M32X::writeExternalIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
     if(dreq.active && !dreq.fifo.full()) {
       dreq.fifo.write(data);
       if(!--dreq.length) dreq.active = 0;
-      shm.dmac.dreq = !dreq.fifo.empty();
-      shs.dmac.dreq = !dreq.fifo.empty();
+      shm.dmac.dreq[0] = !dreq.fifo.empty();
+      shs.dmac.dreq[0] = !dreq.fifo.empty();
     }
   }
 
@@ -257,6 +257,7 @@ auto M32X::writeExternalIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
     }
     if(upper) {
       pwm.timer = data.bit(8,11);
+      pwm.periods = 0;
     }
   }
 

--- a/ares/md/m32x/io-internal.cpp
+++ b/ares/md/m32x/io-internal.cpp
@@ -60,8 +60,8 @@ auto M32X::readInternalIO(n1 upper, n1 lower, n29 address, n16 data) -> n16 {
   //FIFO
   if(address == 0x4012) {
     data = dreq.fifo.read(data);
-    shm.dmac.dreq = !dreq.fifo.empty();
-    shs.dmac.dreq = !dreq.fifo.empty();
+    shm.dmac.dreq[0] = !dreq.fifo.empty();
+    shs.dmac.dreq[0] = !dreq.fifo.empty();
   }
 
   //communication
@@ -229,9 +229,14 @@ auto M32X::writeInternalIO(n1 upper, n1 lower, n29 address, n16 data) -> void {
       if(!pwm.rmode) pwm.rsample = 0;
       pwm.mono    = data.bit(4);
       pwm.dreqIRQ = data.bit(7);
+      if(!pwm.dreqIRQ) {
+        shm.dmac.dreq[1] = 0;
+        shs.dmac.dreq[1] = 0;
+      }
     }
     if(upper) {
       pwm.timer = data.bit(8,11);
+      pwm.periods = 0;
     }
   }
 

--- a/ares/md/m32x/io-internal.cpp
+++ b/ares/md/m32x/io-internal.cpp
@@ -85,20 +85,20 @@ auto M32X::readInternalIO(n1 upper, n1 lower, n29 address, n16 data) -> n16 {
 
   //PWM left channel pulse width
   if(address == 0x4034) {
-    data.bit(14) = pwm.lfifo.empty();
+    data = pwm.lfifoLatch;
     data.bit(15) = pwm.lfifo.full();
   }
 
   //PWM right channel pulse width
   if(address == 0x4036) {
-    data.bit(14) = pwm.rfifo.empty();
+    data = pwm.rfifoLatch;
     data.bit(15) = pwm.rfifo.full();
   }
 
   //PWM mono pulse width
   if(address == 0x4038) {
-    data.bit(14) = pwm.lfifo.empty() && pwm.rfifo.empty();
-    data.bit(15) = pwm.lfifo.full()  || pwm.rfifo.full();
+    data = pwm.mfifoLatch;
+    data.bit(15) = pwm.lfifo.full() || pwm.rfifo.full();
   }
 
   //bitmap mode
@@ -225,6 +225,8 @@ auto M32X::writeInternalIO(n1 upper, n1 lower, n29 address, n16 data) -> void {
     if(lower) {
       pwm.lmode   = data.bit(0,1);
       pwm.rmode   = data.bit(2,3);
+      if(!pwm.lmode) pwm.lsample = 0;
+      if(!pwm.rmode) pwm.rsample = 0;
       pwm.mono    = data.bit(4);
       pwm.dreqIRQ = data.bit(7);
     }
@@ -241,18 +243,21 @@ auto M32X::writeInternalIO(n1 upper, n1 lower, n29 address, n16 data) -> void {
 
   //PWM left channel pulse width
   if(address == 0x4034) {
-    pwm.lfifo.write(data);
+    pwm.lfifoLatch = data;
+    pwm.lfifo.write(pwm.lfifoLatch);
   }
 
   //PWM right channel pulse width
   if(address == 0x4036) {
-    pwm.rfifo.write(data);
+    pwm.rfifoLatch = data;
+    pwm.rfifo.write(pwm.rfifoLatch);
   }
 
   //PWM mono pulse width
   if(address == 0x4038) {
-    pwm.lfifo.write(data);
-    pwm.rfifo.write(data);
+    pwm.mfifoLatch = data;
+    pwm.lfifo.write(pwm.mfifoLatch);
+    pwm.rfifo.write(pwm.mfifoLatch);
   }
 
   //bitmap mode

--- a/ares/md/m32x/m32x.hpp
+++ b/ares/md/m32x/m32x.hpp
@@ -123,6 +123,21 @@ struct M32X {
     //serialization.cpp
     auto serialize(serializer&) -> void;
 
+    struct FIFO {
+      auto empty() const -> bool { return fifo.empty(); }
+      auto full()  const -> bool { return fifo.full();  }
+      auto flush()       -> void { return fifo.flush(); }
+
+      auto read() -> i12 { return last = fifo.read(last); }
+      auto write(i12 data) -> void {
+        if(fifo.full()) read(); // purge oldest sample
+        fifo.write(data);
+      }
+
+      queue<i12[3]> fifo;
+      i12 last;
+    } lfifo, rfifo;
+
     n2  lmode;
     n2  rmode;
     n1  mono;
@@ -134,8 +149,9 @@ struct M32X {
     n32 counter;
     i12 lsample;
     i12 rsample;
-    queue<i12[4096]> lfifo;
-    queue<i12[4096]> rfifo;
+    n16 lfifoLatch;
+    n16 rfifoLatch;
+    n16 mfifoLatch;
   };
 
   //m32x.cpp

--- a/ares/md/m32x/pwm.cpp
+++ b/ares/md/m32x/pwm.cpp
@@ -22,12 +22,12 @@ auto M32X::PWM::main() -> void {
     rfifoLatch.bit(14) = rfifo.empty();
     mfifoLatch.bit(14) = lfifoLatch.bit(14) & rfifoLatch.bit(14);
 
-    if(timer) {
-      if(++periods == timer) {
-        periods = 0;
-        m32x.shm.irq.pwm.active = 1;
-        m32x.shs.irq.pwm.active = 1;
-      }
+    if(periods++ == n4(timer-1)) {
+      periods = 0;
+      m32x.shm.irq.pwm.active = 1;
+      m32x.shs.irq.pwm.active = 1;
+      m32x.shm.dmac.dreq[1] = dreqIRQ;
+      m32x.shs.dmac.dreq[1] = dreqIRQ;
     }
   }
 

--- a/ares/md/m32x/serialization.cpp
+++ b/ares/md/m32x/serialization.cpp
@@ -69,6 +69,11 @@ auto M32X::PWM::serialize(serializer& s) -> void {
   s(counter);
   s(lsample);
   s(rsample);
-  s(lfifo);
-  s(rfifo);
+  s(lfifo.fifo);
+  s(lfifo.last);
+  s(rfifo.fifo);
+  s(rfifo.last);
+  s(lfifoLatch);
+  s(rfifoLatch);
+  s(mfifoLatch);
 }

--- a/ares/md/m32x/sh7604.cpp
+++ b/ares/md/m32x/sh7604.cpp
@@ -44,6 +44,8 @@ auto M32X::SH7604::main() -> void {
   SH2::instruction();
   SH2::intc.run();
   SH2::dmac.run();
+  if(m32x.shm.active()) m32x.shm.dmac.dreq[1] = 0;
+  if(m32x.shs.active()) m32x.shs.dmac.dreq[1] = 0;
   SH2::frt.run();
   SH2::wdt.run();
 }

--- a/ares/md/m32x/vdp.cpp
+++ b/ares/md/m32x/vdp.cpp
@@ -55,10 +55,10 @@ auto M32X::VDP::scanlineMode3(u32 pixels[1280], u32 y) -> void {
   u16 address = fbram[y];
   for(u32 x = 0; x < 320;) {
     u16 word  = fbram[address++ & 0xffff];
-    u8 length = (word >> 8) + 1;
-    u8 color  = (word >> 0);
+    u8 length = word >> 8;
+    u8 color  = word >> 0;
     u16 pixel = cram[color];
-    for(u32 repeat : range(length)) {
+    for(u32 repeat : range(min(length+1, 320-x))) {
       plot(&pixels[x * 4], pixel);
       x++;
     }


### PR DESCRIPTION
1. PWM FIFO has been reworked according to docs. This should eliminate some annoying sound bugs. Also implemented register latching, which should guarantee FIFO bit test passes in Mars Check.
2. Implements SH2 2nd-channel DREQ (PWM DMA) which should satisfy #630. Fixes #737. Also fixes music in #734 but game still crashes going to in-game. Other sound-related issues should be retested.
3. Corrects max length runs in RLE mode while also preventing overrun. Fixes gfx issues in #743.
4. Fixes a reported sound+gfx issue in Bad Apple MD related to large ROM banking. Ares now supports banked ROMs up to 32MB, as intended.