### PR TITLE
fc: fix ram banking on mmc5

### DIFF
--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -193,9 +193,9 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     break;
 
   case   5:
-    s += "  board:  HVC-ELROM\n";
+    s += "  board:  HVC-EWROM\n";
     s += "    chip type=MMC5\n";
-    prgram = 65536;
+    prgram = 32768;
     break;
 
   case   7:


### PR DESCRIPTION
Some improvements to NES / Famicom MMC5 emulation. Changes are:

- Program ROM banking when selecting RAM chip (bit 7 of bank is clear) should only apply to first RAM chip. This fixes #846 and fixes #847.
- Change default in mia to a real configuration
- Some refactoring

Note: as ram banking has changed previous ram saves and savestates of MMC5 games are invalid, and can lead to unexpected behavior or crashes. Please delete them before testing.