### PR TITLE
fc: fix mmc5 expansion sound

### DIFF
--- a/ares/fc/cartridge/board/hvc-exrom.cpp
+++ b/ares/fc/cartridge/board/hvc-exrom.cpp
@@ -222,12 +222,6 @@ struct HVC_ExROM : Interface {  //MMC5
   }
 
   auto readPRG(n32 address, n8 data) -> n8 override {
-    if((address & 0xfffa) == 0xfffa) {
-      inFrame = 0;
-      vcounter = 0;
-      irqLine = 0;
-    }
-
     if((address & 0xfc00) == 0x5800) {
       if(chipRevision != ChipRevision::MMC5A) return data;
       if(cl3.direction == 1) cl3.line = 0;  //!M2


### PR DESCRIPTION
Famicom MMC5 (not the NES variant) provides extra sound output, consisting of two pulse wave channels and a PCM channel. This pr fixes output from the pulse channels, that were previously not working. Fixing these channels also fixes #848.

Also irq and inframe flag are not cleared anymore on readings of nmi vector, as this was producing graphic corruption in some games.