### PR TITLE
n64: improve accuracy of n64 FPU emulation

### DIFF
--- a/ares/n64/cpu/algorithms.cpp
+++ b/ares/n64/cpu/algorithms.cpp
@@ -1,11 +1,7 @@
 template <typename T>
 auto CPU::roundNearest(f32 f) -> T {
 #if defined(ARCHITECTURE_ARM64)
-  u32 rnd = fenv.getRound();
-  fenv.setRound(float_env::toNearest);
-  T d = vrndns_f32(f);
-  fenv.setRound(rnd);
-  return d;
+  return vrndns_f32(f);
 #elif defined(ARCHITECTURE_AMD64)
   __m128 t = _mm_set_ss(f);
   t = _mm_round_ss(t, t, _MM_FROUND_TO_NEAREST_INT);
@@ -18,12 +14,8 @@ auto CPU::roundNearest(f32 f) -> T {
 template <typename T>
 auto CPU::roundNearest(f64 f) -> T {
 #if defined(ARCHITECTURE_ARM64)
-  u32 rnd = fenv.getRound();
-  fenv.setRound(float_env::toNearest);
   float64x1_t vf = {f};
-  T d = vrndn_f64(vf)[0];
-  fenv.setRound(rnd);
-  return d;
+  return vrndn_f64(vf)[0];
 #elif defined(ARCHITECTURE_AMD64)
   __m128d t = _mm_set_sd(f);
   t = _mm_round_sd(t, t, _MM_FROUND_TO_NEAREST_INT);

--- a/ares/n64/cpu/algorithms.cpp
+++ b/ares/n64/cpu/algorithms.cpp
@@ -1,0 +1,142 @@
+template <typename T>
+auto CPU::roundNearest(f32 f) -> T {
+#if defined(ARCHITECTURE_ARM64)
+  u32 rnd = fenv.getRound();
+  fenv.setRound(float_env::toNearest);
+  T d = vrndns_f32(f);
+  fenv.setRound(rnd);
+  return d;
+#elif defined(ARCHITECTURE_AMD64)
+  __m128 t = _mm_set_ss(f);
+  t = _mm_round_ss(t, t, _MM_FROUND_TO_NEAREST_INT);
+  return _mm_cvtss_f32(t);
+#else
+  return lround(f);
+#endif
+}
+
+template <typename T>
+auto CPU::roundNearest(f64 f) -> T {
+#if defined(ARCHITECTURE_ARM64)
+  u32 rnd = fenv.getRound();
+  fenv.setRound(float_env::toNearest);
+  float64x1_t vf = {f};
+  T d = vrndn_f64(vf)[0];
+  fenv.setRound(rnd);
+  return d;
+#elif defined(ARCHITECTURE_AMD64)
+  __m128d t = _mm_set_sd(f);
+  t = _mm_round_sd(t, t, _MM_FROUND_TO_NEAREST_INT);
+  return _mm_cvtsd_f64(t);
+#else
+  return llround(f);
+#endif
+}
+
+template <typename T>
+auto CPU::roundCeil(f32 f) -> T {
+#if defined(ARCHITECTURE_AMD64)
+  __m128 t = _mm_set_ss(f);
+  t = _mm_round_ss(t, t, _MM_FROUND_TO_POS_INF);
+  return _mm_cvtss_f32(t);
+#else
+  return ceil(f);
+#endif
+}
+
+template <typename T>
+auto CPU::roundCeil(f64 f) -> T {
+#if defined(ARCHITECTURE_AMD64)
+  __m128d t = _mm_set_sd(f);
+  t = _mm_round_sd(t, t, _MM_FROUND_TO_POS_INF);
+  return _mm_cvtsd_f64(t);
+#else
+  return ceil(f);
+#endif
+}
+
+template<typename T>
+auto CPU::roundCurrent(f32 f) -> T {
+#if defined(ARCHITECTURE_AMD64)
+  auto t = _mm_set_ss(f);
+  t = _mm_round_ss(t, t, _MM_FROUND_CUR_DIRECTION);
+  return _mm_cvtss_f32(t);
+#else
+  return lrint(f);
+#endif
+}
+
+template<typename T>
+auto CPU::roundCurrent(f64 f) -> T {
+#if defined(ARCHITECTURE_AMD64)
+  auto t = _mm_set_sd(f);
+  t = _mm_round_sd(t, t, _MM_FROUND_CUR_DIRECTION);
+  return _mm_cvtsd_f64(t);
+#else
+  return llrint(f);
+#endif
+}
+
+template <typename T>
+auto CPU::roundFloor(f32 f) -> T {
+#if defined(ARCHITECTURE_AMD64)
+  __m128 t = _mm_set_ss(f);
+  t = _mm_round_ss(t, t, _MM_FROUND_TO_NEG_INF);
+  return _mm_cvtss_f32(t);
+#else
+  return floor(f);
+#endif
+}
+
+template <typename T>
+auto CPU::roundFloor(f64 f) -> T {
+#if defined(ARCHITECTURE_AMD64)
+  __m128d t = _mm_set_sd(f);
+  t = _mm_round_sd(t, t, _MM_FROUND_TO_NEG_INF);
+  return _mm_cvtsd_f64(t);
+#else
+  return floor(f);
+#endif
+}
+
+template <typename T>
+auto CPU::roundTrunc(f32 f) -> T {
+#if defined(ARCHITECTURE_AMD64)
+  __m128 t = _mm_set_ss(f);
+  t = _mm_round_ss(t, t, _MM_FROUND_TO_ZERO);
+  return _mm_cvtss_f32(t);
+#else
+  return trunc(f);
+#endif
+}
+
+template <typename T>
+auto CPU::roundTrunc(f64 f) -> T {
+#if defined(ARCHITECTURE_AMD64)
+  __m128d t = _mm_set_sd(f);
+  t = _mm_round_sd(t, t, _MM_FROUND_TO_ZERO);
+  return _mm_cvtsd_f64(t);
+#else
+  return trunc(f);
+#endif
+}
+
+auto CPU::squareRoot(f32 f) -> f32 {
+#if defined(ARCHITECTURE_AMD64)
+  __m128 t = _mm_set_ss(f);
+  t = _mm_sqrt_ss(t);
+  return _mm_cvtss_f32(t);
+#else
+  return sqrt(f);
+#endif
+}
+
+auto CPU::squareRoot(f64 f) -> f64 {
+#if defined(ARCHITECTURE_AMD64)
+  __m128d t = _mm_set_sd(f);
+  t = _mm_sqrt_sd(t, t);
+  return _mm_cvtsd_f64(t);
+#else
+  return sqrt(f);
+#endif
+}

--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -8,6 +8,7 @@ CPU cpu;
 #include "tlb.cpp"
 #include "memory.cpp"
 #include "exceptions.cpp"
+#include "algorithms.cpp"
 #include "interpreter.cpp"
 #include "interpreter-ipu.cpp"
 #include "interpreter-scc.cpp"

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -649,6 +649,7 @@ struct CPU : Thread {
   auto fpeOverflow() -> bool;
   auto fpeInvalidOperation() -> bool;
   auto fpeUnimplemented() -> bool;
+  auto fpuCheckStart() -> bool;
   auto fpuCheckInput(f32& f) -> bool;
   auto fpuCheckInput(f64& f) -> bool;
   auto fpuCheckOutput(f32& f) -> bool;

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -632,7 +632,7 @@ struct CPU : Thread {
         n1 unimplementedOperation = 0;
       } cause;
       n1 compare = 0;
-      n1 flushed = 0;
+      n1 flushSubnormals = 0;
     } csr;
   } fpu;
 
@@ -649,6 +649,11 @@ struct CPU : Thread {
   auto fpeOverflow() -> bool;
   auto fpeInvalidOperation() -> bool;
   auto fpeUnimplemented() -> bool;
+  auto fpuCheckInput(f32& f) -> bool;
+  auto fpuCheckInput(f64& f) -> bool;
+  auto fpuCheckOutput(f32& f) -> bool;
+  auto fpuCheckOutput(f64& f) -> bool;
+  auto fpuClearCause() -> void;
 
   auto BC1(bool value, bool likely, s16 imm) -> void;
   auto CFC1(r64& rt, u8 rd) -> void;

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -700,10 +700,12 @@ struct CPU : Thread {
   auto FC_ULT_D(u8 fs, u8 ft) -> void;
   auto FC_UN_S(u8 fs, u8 ft) -> void;
   auto FC_UN_D(u8 fs, u8 ft) -> void;
+  auto FCVT_S_S(u8 fd, u8 fs) -> void;
   auto FCVT_S_D(u8 fd, u8 fs) -> void;
   auto FCVT_S_W(u8 fd, u8 fs) -> void;
   auto FCVT_S_L(u8 fd, u8 fs) -> void;
   auto FCVT_D_S(u8 fd, u8 fs) -> void;
+  auto FCVT_D_D(u8 fd, u8 fs) -> void;
   auto FCVT_D_W(u8 fd, u8 fs) -> void;
   auto FCVT_D_L(u8 fd, u8 fs) -> void;
   auto FCVT_L_S(u8 fd, u8 fs) -> void;

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -656,6 +656,8 @@ struct CPU : Thread {
   auto fpuClearCause() -> void;
   template<typename DST, typename SF>
   auto fpuCheckInputConv(SF& f) -> bool;
+  template <typename T> auto roundeven(f32 f) -> T;
+  template <typename T> auto roundeven(f64 f) -> T;
 
   auto BC1(bool value, bool likely, s16 imm) -> void;
   auto CFC1(r64& rt, u8 rd) -> void;

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -662,6 +662,8 @@ struct CPU : Thread {
   auto BC1(bool value, bool likely, s16 imm) -> void;
   auto CFC1(r64& rt, u8 rd) -> void;
   auto CTC1(cr64& rt, u8 rd) -> void;
+  auto DCFC1(r64& rt, u8 rd) -> void;
+  auto DCTC1(cr64& rt, u8 rd) -> void;
   auto DMFC1(r64& rt, u8 fs) -> void;
   auto DMTC1(cr64& rt, u8 fs) -> void;
   auto FABS_S(u8 fd, u8 fs) -> void;

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -344,6 +344,20 @@ struct CPU : Thread {
     u64 pc;  //program counter
   } ipu;
 
+  //algorithms.cpp
+  template<typename T> auto roundNearest(f32 f) -> T;
+  template<typename T> auto roundNearest(f64 f) -> T;
+  template<typename T> auto roundCeil(f32 f) -> T;
+  template<typename T> auto roundCeil(f64 f) -> T;
+  template<typename T> auto roundCurrent(f32 f) -> T;
+  template<typename T> auto roundCurrent(f64 f) -> T;
+  template<typename T> auto roundFloor(f32 f) -> T;
+  template<typename T> auto roundFloor(f64 f) -> T;
+  template<typename T> auto roundTrunc(f32 f) -> T;
+  template<typename T> auto roundTrunc(f64 f) -> T;
+  auto squareRoot(f32 f) -> f32;
+  auto squareRoot(f64 f) -> f64;
+
   //interpreter-ipu.cpp
   auto ADD(r64& rd, cr64& rs, cr64& rt) -> void;
   auto ADDI(r64& rt, cr64& rs, s16 imm) -> void;
@@ -657,8 +671,6 @@ struct CPU : Thread {
   auto fpuClearCause() -> void;
   template<typename DST, typename SF>
   auto fpuCheckInputConv(SF& f) -> bool;
-  template <typename T> auto roundeven(f32 f) -> T;
-  template <typename T> auto roundeven(f64 f) -> T;
 
   auto BC1(bool value, bool likely, s16 imm) -> void;
   auto CFC1(r64& rt, u8 rd) -> void;

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -654,6 +654,8 @@ struct CPU : Thread {
   auto fpuCheckOutput(f32& f) -> bool;
   auto fpuCheckOutput(f64& f) -> bool;
   auto fpuClearCause() -> void;
+  template<typename DST, typename SF>
+  auto fpuCheckInputConv(SF& f) -> bool;
 
   auto BC1(bool value, bool likely, s16 imm) -> void;
   auto CFC1(r64& rt, u8 rd) -> void;
@@ -666,8 +668,12 @@ struct CPU : Thread {
   auto FADD_D(u8 fd, u8 fs, u8 ft) -> void;
   auto FCEIL_L_S(u8 fd, u8 fs) -> void;
   auto FCEIL_L_D(u8 fd, u8 fs) -> void;
+  auto FCEIL_L_W(u8 fd, u8 fs) -> void;
+  auto FCEIL_L_L(u8 fd, u8 fs) -> void;
   auto FCEIL_W_S(u8 fd, u8 fs) -> void;
   auto FCEIL_W_D(u8 fd, u8 fs) -> void;
+  auto FCEIL_W_W(u8 fd, u8 fs) -> void;
+  auto FCEIL_W_L(u8 fd, u8 fs) -> void;
   auto FC_EQ_S(u8 fs, u8 ft) -> void;
   auto FC_EQ_D(u8 fs, u8 ft) -> void;
   auto FC_F_S(u8 fs, u8 ft) -> void;
@@ -710,14 +716,22 @@ struct CPU : Thread {
   auto FCVT_D_L(u8 fd, u8 fs) -> void;
   auto FCVT_L_S(u8 fd, u8 fs) -> void;
   auto FCVT_L_D(u8 fd, u8 fs) -> void;
+  auto FCVT_L_W(u8 fd, u8 fs) -> void;
+  auto FCVT_L_L(u8 fd, u8 fs) -> void;
   auto FCVT_W_S(u8 fd, u8 fs) -> void;
   auto FCVT_W_D(u8 fd, u8 fs) -> void;
+  auto FCVT_W_W(u8 fd, u8 fs) -> void;
+  auto FCVT_W_L(u8 fd, u8 fs) -> void;
   auto FDIV_S(u8 fd, u8 fs, u8 ft) -> void;
   auto FDIV_D(u8 fd, u8 fs, u8 ft) -> void;
   auto FFLOOR_L_S(u8 fd, u8 fs) -> void;
   auto FFLOOR_L_D(u8 fd, u8 fs) -> void;
+  auto FFLOOR_L_W(u8 fd, u8 fs) -> void;
+  auto FFLOOR_L_L(u8 fd, u8 fs) -> void;
   auto FFLOOR_W_S(u8 fd, u8 fs) -> void;
   auto FFLOOR_W_D(u8 fd, u8 fs) -> void;
+  auto FFLOOR_W_W(u8 fd, u8 fs) -> void;
+  auto FFLOOR_W_L(u8 fd, u8 fs) -> void;
   auto FMOV_S(u8 fd, u8 fs) -> void;
   auto FMOV_D(u8 fd, u8 fs) -> void;
   auto FMUL_S(u8 fd, u8 fs, u8 ft) -> void;
@@ -726,16 +740,24 @@ struct CPU : Thread {
   auto FNEG_D(u8 fd, u8 fs) -> void;
   auto FROUND_L_S(u8 fd, u8 fs) -> void;
   auto FROUND_L_D(u8 fd, u8 fs) -> void;
+  auto FROUND_L_W(u8 fd, u8 fs) -> void;
+  auto FROUND_L_L(u8 fd, u8 fs) -> void;
   auto FROUND_W_S(u8 fd, u8 fs) -> void;
   auto FROUND_W_D(u8 fd, u8 fs) -> void;
+  auto FROUND_W_W(u8 fd, u8 fs) -> void;
+  auto FROUND_W_L(u8 fd, u8 fs) -> void;
   auto FSQRT_S(u8 fd, u8 fs) -> void;
   auto FSQRT_D(u8 fd, u8 fs) -> void;
   auto FSUB_S(u8 fd, u8 fs, u8 ft) -> void;
   auto FSUB_D(u8 fd, u8 fs, u8 ft) -> void;
   auto FTRUNC_L_S(u8 fd, u8 fs) -> void;
   auto FTRUNC_L_D(u8 fd, u8 fs) -> void;
+  auto FTRUNC_L_W(u8 fd, u8 fs) -> void;
+  auto FTRUNC_L_L(u8 fd, u8 fs) -> void;
   auto FTRUNC_W_S(u8 fd, u8 fs) -> void;
   auto FTRUNC_W_D(u8 fd, u8 fs) -> void;
+  auto FTRUNC_W_W(u8 fd, u8 fs) -> void;
+  auto FTRUNC_W_L(u8 fd, u8 fs) -> void;
   auto LDC1(u8 ft, cr64& rs, s16 imm) -> void;
   auto LWC1(u8 ft, cr64& rs, s16 imm) -> void;
   auto MFC1(r64& rt, u8 fs) -> void;
@@ -743,6 +765,7 @@ struct CPU : Thread {
   auto SDC1(u8 ft, cr64& rs, s16 imm) -> void;
   auto SWC1(u8 ft, cr64& rs, s16 imm) -> void;
   auto COP1INVALID() -> void;
+  auto COP1UNIMPLEMENTED() -> void;
 
   //interpreter-cop2.cpp
   struct COP2 {

--- a/ares/n64/cpu/interpreter-fpu.cpp
+++ b/ares/n64/cpu/interpreter-fpu.cpp
@@ -1019,6 +1019,9 @@ auto CPU::FTRUNC_W_L(u8 fd, u8 fs) -> void { COP1UNIMPLEMENTED(); }
 auto CPU::FCEIL_W_L(u8 fd, u8 fs) -> void { COP1UNIMPLEMENTED(); }
 auto CPU::FFLOOR_W_L(u8 fd, u8 fs) -> void { COP1UNIMPLEMENTED(); }
 
+auto CPU::DCFC1(r64& rt, u8 rd) -> void { COP1UNIMPLEMENTED(); }
+auto CPU::DCTC1(cr64& rt, u8 rd) -> void { COP1UNIMPLEMENTED(); }
+
 #undef CF
 #undef FD
 #undef FS

--- a/ares/n64/cpu/interpreter-fpu.cpp
+++ b/ares/n64/cpu/interpreter-fpu.cpp
@@ -218,6 +218,12 @@ auto qnan(f64 f) -> bool {
   return f64repr(f).bit(51); 
 }
 
+auto CPU::fpuCheckStart() -> bool {
+  if(!scc.status.enable.coprocessor1) return exception.coprocessor1(), false;
+  fpu.csr.cause = {0};
+  return true;
+}
+
 auto CPU::fpuCheckInput(f32& f) -> bool {
   switch (fpclassify(f)) {
   case FP_SUBNORMAL:
@@ -332,7 +338,7 @@ auto CPU::fpuCheckInputConv<s64>(f64& f) -> bool {
 #define FT(type) fgr<type>(ft)
 
 auto CPU::BC1(bool value, bool likely, s16 imm) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   if(CF == value) branch.take(ipu.pc + 4 + (imm << 2));
   else if(likely) branch.discard();
   else branch.notTaken();
@@ -359,7 +365,7 @@ auto CPU::DMTC1(cr64& rt, u8 fs) -> void {
 }
 
 auto CPU::FABS_S(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32);
   if(!fpuCheckInput(ffs)) return;
   auto ffd = fabs(ffs);
@@ -368,7 +374,7 @@ auto CPU::FABS_S(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FABS_D(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64);
   if(!fpuCheckInput(ffs)) return;
   auto ffd = fabs(ffs);
@@ -377,7 +383,7 @@ auto CPU::FABS_D(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FADD_S(u8 fd, u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   f32 ffs = FS(f32), fft = FT(f32);
   if(!fpuCheckInput(ffs)) return;
   if(!fpuCheckInput(fft)) return;
@@ -387,7 +393,7 @@ auto CPU::FADD_S(u8 fd, u8 fs, u8 ft) -> void {
 }
 
 auto CPU::FADD_D(u8 fd, u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64), fft = FT(f64);
   if(!fpuCheckInput(ffs)) return;
   if(!fpuCheckInput(fft)) return;
@@ -397,7 +403,7 @@ auto CPU::FADD_D(u8 fd, u8 fs, u8 ft) -> void {
 }
 
 auto CPU::FCEIL_L_S(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32);
   if(!fpuCheckInputConv<s64>(ffs)) return;
   auto ffd = CHECK_FPE(s64, ceil(ffs));
@@ -405,7 +411,7 @@ auto CPU::FCEIL_L_S(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FCEIL_L_D(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64);
   if(!fpuCheckInputConv<s64>(ffs)) return;
   auto ffd = CHECK_FPE(s64, ceil(ffs));
@@ -413,7 +419,7 @@ auto CPU::FCEIL_L_D(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FCEIL_W_S(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32);
   if(!fpuCheckInputConv<s32>(ffs)) return;
   auto ffd = CHECK_FPE(s32, ceil(ffs));
@@ -421,7 +427,7 @@ auto CPU::FCEIL_W_S(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FCEIL_W_D(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64);
   if(!fpuCheckInputConv<s32>(ffs)) return;
   auto ffd = CHECK_FPE(s32, ceil(ffs));
@@ -441,162 +447,162 @@ auto CPU::FCEIL_W_D(u8 fd, u8 fs) -> void {
 #define UNORDERED(type, value) XORDERED(type, value, 1)
 
 auto CPU::FC_EQ_S(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   UNORDERED(f32, 0); CF = FS(f32) == FT(f32);
 }
 
 auto CPU::FC_EQ_D(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   UNORDERED(f64, 0); CF = FS(f64) == FT(f64);
 }
 
 auto CPU::FC_F_S(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   UNORDERED(f32, 0); CF = 0;
 }
 
 auto CPU::FC_F_D(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   UNORDERED(f64, 0); CF = 0;
 }
 
 auto CPU::FC_LE_S(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   ORDERED(f32, 0); CF = FS(f32) <= FT(f32);
 }
 
 auto CPU::FC_LE_D(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   ORDERED(f64, 0); CF = FS(f64) <= FT(f64);
 }
 
 auto CPU::FC_LT_S(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   ORDERED(f32, 0); CF = FS(f32) < FT(f32);
 }
 
 auto CPU::FC_LT_D(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   ORDERED(f64, 0); CF = FS(f64) < FT(f64);
 }
 
 auto CPU::FC_NGE_S(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   ORDERED(f32, 1); CF = FS(f32) < FT(f32);
 }
 
 auto CPU::FC_NGE_D(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   ORDERED(f64, 1); CF = FS(f64) < FT(f64);
 }
 
 auto CPU::FC_NGL_S(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   ORDERED(f32, 1); CF = FS(f32) == FT(f32);
 }
 
 auto CPU::FC_NGL_D(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   ORDERED(f64, 1); CF = FS(f64) == FT(f64);
 }
 
 auto CPU::FC_NGLE_S(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   ORDERED(f32, 1); CF = 0;
 }
 
 auto CPU::FC_NGLE_D(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   ORDERED(f64, 1); CF = 0;
 }
 
 auto CPU::FC_NGT_S(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   ORDERED(f32, 1); CF = FS(f32) <= FT(f32);
 }
 
 auto CPU::FC_NGT_D(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   ORDERED(f64, 1); CF = FS(f64) <= FT(f64);
 }
 
 auto CPU::FC_OLE_S(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   UNORDERED(f32, 0); CF = FS(f32) <= FT(f32);
 }
 
 auto CPU::FC_OLE_D(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   UNORDERED(f64, 0); CF = FS(f64) <= FT(f64);
 }
 
 auto CPU::FC_OLT_S(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   UNORDERED(f32, 0); CF = FS(f32) < FT(f32);
 }
 
 auto CPU::FC_OLT_D(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   UNORDERED(f64, 0); CF = FS(f64) < FT(f64);
 }
 
 auto CPU::FC_SEQ_S(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   ORDERED(f32, 0); CF = FS(f32) == FT(f32);
 }
 
 auto CPU::FC_SEQ_D(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   ORDERED(f64, 0); CF = FS(f64) == FT(f64);
 }
 
 auto CPU::FC_SF_S(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   ORDERED(f32, 0); CF = 0;
 }
 
 auto CPU::FC_SF_D(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   ORDERED(f64, 0); CF = 0;
 }
 
 auto CPU::FC_UEQ_S(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   UNORDERED(f32, 1); CF = FS(f32) == FT(f32);
 }
 
 auto CPU::FC_UEQ_D(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   UNORDERED(f64, 1); CF = FS(f64) == FT(f64);
 }
 
 auto CPU::FC_ULE_S(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   UNORDERED(f32, 1); CF = FS(f32) <= FT(f32);
 }
 
 auto CPU::FC_ULE_D(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   UNORDERED(f64, 1); CF = FS(f64) <= FT(f64);
 }
 
 auto CPU::FC_ULT_S(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   UNORDERED(f32, 1); CF = FS(f32) < FT(f32);
 }
 
 auto CPU::FC_ULT_D(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   UNORDERED(f64, 1); CF = FS(f64) < FT(f64);
 }
 
 auto CPU::FC_UN_S(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   UNORDERED(f32, 1); CF = 0;
 }
 
 auto CPU::FC_UN_D(u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   UNORDERED(f64, 1); CF = 0;
 }
 
@@ -604,12 +610,12 @@ auto CPU::FC_UN_D(u8 fs, u8 ft) -> void {
 #undef UNORDERED
 
 auto CPU::FCVT_S_S(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   if(fpeUnimplemented()) return exception.floatingPoint();
 }
 
 auto CPU::FCVT_S_D(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64);
   if(!fpu.csr.flushSubnormals && ffs > 0 && ffs < FLT_MIN && fpeUnimplemented()) return exception.floatingPoint();
   if(!fpuCheckInput(ffs)) return;
@@ -619,7 +625,7 @@ auto CPU::FCVT_S_D(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FCVT_S_W(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(s32);
   auto ffd = CHECK_FPE(f32, ffs);
   if(!fpuCheckOutput(ffd)) return;
@@ -627,7 +633,7 @@ auto CPU::FCVT_S_W(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FCVT_S_L(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(s64);
   if (ffs >= (s64)0x0080'0000'0000'0000ull || ffs <= (s64)0xff80'0000'0000'0000ull) {
     if (fpeUnimplemented()) return exception.floatingPoint();
@@ -639,7 +645,7 @@ auto CPU::FCVT_S_L(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FCVT_D_S(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32);
   if(!fpuCheckInput(ffs)) return;
   auto ffd = CHECK_FPE(f64, ffs);
@@ -648,12 +654,12 @@ auto CPU::FCVT_D_S(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FCVT_D_D(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   if(fpeUnimplemented()) return exception.floatingPoint();
 }
 
 auto CPU::FCVT_D_W(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(s32);
   auto ffd = CHECK_FPE(f64, (f64)ffs);
   if(!fpuCheckOutput(ffd)) return;
@@ -661,7 +667,7 @@ auto CPU::FCVT_D_W(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FCVT_D_L(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(s64);
   if (ffs >= (s64)0x0080'0000'0000'0000ull || ffs <= (s64)0xff80'0000'0000'0000ull) {
     if (fpeUnimplemented()) return exception.floatingPoint();
@@ -673,7 +679,7 @@ auto CPU::FCVT_D_L(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FCVT_L_S(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32);
   if(!fpuCheckInputConv<s64>(ffs)) return;
   auto ffd = CHECK_FPE(s64, llrint(ffs));
@@ -681,7 +687,7 @@ auto CPU::FCVT_L_S(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FCVT_L_D(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64);
   if(!fpuCheckInputConv<s64>(ffs)) return;
   auto ffd = CHECK_FPE(s64, llrint(ffs));
@@ -689,7 +695,7 @@ auto CPU::FCVT_L_D(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FCVT_W_S(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32);
   if(!fpuCheckInputConv<s32>(ffs)) return;
   auto ffd = CHECK_FPE(s32, lrint(ffs));
@@ -697,7 +703,7 @@ auto CPU::FCVT_W_S(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FCVT_W_D(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64);
   if(!fpuCheckInputConv<s32>(ffs)) return;
   auto ffd = CHECK_FPE(s32, lrint(ffs));
@@ -705,7 +711,7 @@ auto CPU::FCVT_W_D(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FDIV_S(u8 fd, u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32), fft = FT(f32);
   if(!fpuCheckInput(ffs)) return;
   if(!fpuCheckInput(fft)) return;
@@ -715,7 +721,7 @@ auto CPU::FDIV_S(u8 fd, u8 fs, u8 ft) -> void {
 }
 
 auto CPU::FDIV_D(u8 fd, u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64), fft = FT(f64);
   if(!fpuCheckInput(ffs)) return;
   if(!fpuCheckInput(fft)) return;
@@ -725,7 +731,7 @@ auto CPU::FDIV_D(u8 fd, u8 fs, u8 ft) -> void {
 }
 
 auto CPU::FFLOOR_L_S(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32);
   if(!fpuCheckInputConv<s64>(ffs)) return;
   auto ffd = CHECK_FPE(s64, floor(ffs));
@@ -733,7 +739,7 @@ auto CPU::FFLOOR_L_S(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FFLOOR_L_D(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64);
   if(!fpuCheckInputConv<s64>(ffs)) return;
   auto ffd = CHECK_FPE(s64, floor(ffs));
@@ -741,7 +747,7 @@ auto CPU::FFLOOR_L_D(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FFLOOR_W_S(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32);
   if(!fpuCheckInputConv<s32>(ffs)) return;
   auto ffd = CHECK_FPE(s32, floor(ffs));
@@ -749,7 +755,7 @@ auto CPU::FFLOOR_W_S(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FFLOOR_W_D(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64);
   if(!fpuCheckInputConv<s32>(ffs)) return;
   auto ffd = CHECK_FPE(s32, floor(ffs));
@@ -757,17 +763,17 @@ auto CPU::FFLOOR_W_D(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FMOV_S(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   FD(f32) = FS(f32);
 }
 
 auto CPU::FMOV_D(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   FD(f64) = FS(f64);
 }
 
 auto CPU::FMUL_S(u8 fd, u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32), fft = FT(f32);
   if(!fpuCheckInput(ffs)) return;
   if(!fpuCheckInput(fft)) return;
@@ -777,7 +783,7 @@ auto CPU::FMUL_S(u8 fd, u8 fs, u8 ft) -> void {
 }
 
 auto CPU::FMUL_D(u8 fd, u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64), fft = FT(f64);
   if(!fpuCheckInput(ffs)) return;
   if(!fpuCheckInput(fft)) return;
@@ -787,7 +793,7 @@ auto CPU::FMUL_D(u8 fd, u8 fs, u8 ft) -> void {
 }
 
 auto CPU::FNEG_S(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32);
   if(!fpuCheckInput(ffs)) return;
   auto ffd = CHECK_FPE(f32, -ffs);
@@ -796,7 +802,7 @@ auto CPU::FNEG_S(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FNEG_D(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64);
   if(!fpuCheckInput(ffs)) return;
   auto ffd = CHECK_FPE(f64, -ffs);
@@ -848,7 +854,7 @@ auto CPU::roundeven(f64 f) -> T {
 }
 
 auto CPU::FROUND_L_S(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32);
   if(!fpuCheckInputConv<s64>(ffs)) return;
   auto ffd = CHECK_FPE(s64, roundeven<s64>(ffs));
@@ -857,7 +863,7 @@ auto CPU::FROUND_L_S(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FROUND_L_D(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64);
   if(!fpuCheckInputConv<s64>(ffs)) return;
   auto ffd = CHECK_FPE(s64, roundeven<s64>(ffs));
@@ -866,7 +872,7 @@ auto CPU::FROUND_L_D(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FROUND_W_S(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32);
   if(!fpuCheckInputConv<s32>(ffs)) return;
   auto ffd = CHECK_FPE(s32, roundeven<s32>(ffs));
@@ -875,7 +881,7 @@ auto CPU::FROUND_W_S(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FROUND_W_D(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64);
   if(!fpuCheckInputConv<s32>(ffs)) return;
   auto ffd = CHECK_FPE(s32, roundeven<s32>(ffs));
@@ -884,7 +890,7 @@ auto CPU::FROUND_W_D(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FSQRT_S(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32);
   if(!fpuCheckInput(ffs)) return;
   auto ffd = CHECK_FPE(f32, sqrt(ffs));
@@ -893,7 +899,7 @@ auto CPU::FSQRT_S(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FSQRT_D(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64);
   if(!fpuCheckInput(ffs)) return;
   auto ffd = CHECK_FPE(f64, sqrt(ffs));
@@ -902,7 +908,7 @@ auto CPU::FSQRT_D(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FSUB_S(u8 fd, u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32), fft = FT(f32);
   if(!fpuCheckInput(ffs)) return;
   if(!fpuCheckInput(fft)) return;
@@ -912,7 +918,7 @@ auto CPU::FSUB_S(u8 fd, u8 fs, u8 ft) -> void {
 }
 
 auto CPU::FSUB_D(u8 fd, u8 fs, u8 ft) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64), fft = FT(f64);
   if(!fpuCheckInput(ffs)) return;
   if(!fpuCheckInput(fft)) return;
@@ -922,7 +928,7 @@ auto CPU::FSUB_D(u8 fd, u8 fs, u8 ft) -> void {
 }
 
 auto CPU::FTRUNC_L_S(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32);
   if(!fpuCheckInputConv<s64>(ffs)) return;
   s64 ffd = ffs < 0 ? ceil(ffs) : floor(ffs);
@@ -931,7 +937,7 @@ auto CPU::FTRUNC_L_S(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FTRUNC_L_D(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64);
   if(!fpuCheckInputConv<s64>(ffs)) return;
   s64 ffd = ffs < 0 ? ceil(ffs) : floor(ffs);
@@ -940,7 +946,7 @@ auto CPU::FTRUNC_L_D(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FTRUNC_W_S(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f32);
   if(!fpuCheckInputConv<s32>(ffs)) return;
   s32 ffd = ffs < 0 ? ceil(ffs) : floor(ffs);
@@ -949,7 +955,7 @@ auto CPU::FTRUNC_W_S(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::FTRUNC_W_D(u8 fd, u8 fs) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   auto ffs = FS(f64);
   if(!fpuCheckInputConv<s32>(ffs)) return;
   s32 ffd = ffs < 0 ? ceil(ffs) : floor(ffs);
@@ -958,12 +964,12 @@ auto CPU::FTRUNC_W_D(u8 fd, u8 fs) -> void {
 }
 
 auto CPU::LDC1(u8 ft, cr64& rs, s16 imm) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   if(auto data = read<Dual>(rs.u64 + imm)) FT(u64) = *data;
 }
 
 auto CPU::LWC1(u8 ft, cr64& rs, s16 imm) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   if(auto data = read<Word>(rs.u64 + imm)) FT(u32) = *data;
 }
 
@@ -978,22 +984,22 @@ auto CPU::MTC1(cr64& rt, u8 fs) -> void {
 }
 
 auto CPU::SDC1(u8 ft, cr64& rs, s16 imm) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   write<Dual>(rs.u64 + imm, FT(u64));
 }
 
 auto CPU::SWC1(u8 ft, cr64& rs, s16 imm) -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   write<Word>(rs.u64 + imm, FT(u32));
 }
 
 auto CPU::COP1INVALID() -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   exception.floatingPoint();
 }
 
 auto CPU::COP1UNIMPLEMENTED() -> void {
-  if(!scc.status.enable.coprocessor1) return exception.coprocessor1();
+  if(!fpuCheckStart()) return;
   if(fpeUnimplemented()) return exception.floatingPoint();
 }
 

--- a/ares/n64/cpu/interpreter-fpu.cpp
+++ b/ares/n64/cpu/interpreter-fpu.cpp
@@ -123,6 +123,14 @@ auto CPU::setControlRegisterFPU(n5 index, n32 data) -> void {
       case 3: fenv.setRound(float_env::downward);   break;
       }
     }
+
+    if(fpu.csr.cause.inexact          && fpu.csr.enable.inexact)          return exception.floatingPoint();
+    if(fpu.csr.cause.underflow        && fpu.csr.enable.underflow)        return exception.floatingPoint();
+    if(fpu.csr.cause.overflow         && fpu.csr.enable.overflow)         return exception.floatingPoint();
+    if(fpu.csr.cause.divisionByZero   && fpu.csr.enable.divisionByZero)   return exception.floatingPoint();
+    if(fpu.csr.cause.invalidOperation && fpu.csr.enable.invalidOperation) return exception.floatingPoint();
+    if(fpu.csr.cause.unimplementedOperation)                              return exception.floatingPoint();
+
   } break;
   }
 }

--- a/ares/n64/cpu/interpreter-fpu.cpp
+++ b/ares/n64/cpu/interpreter-fpu.cpp
@@ -617,7 +617,10 @@ auto CPU::FCVT_S_S(u8 fd, u8 fs) -> void {
 auto CPU::FCVT_S_D(u8 fd, u8 fs) -> void {
   if(!fpuCheckStart()) return;
   auto ffs = FS(f64);
-  if(!fpu.csr.flushSubnormals && ffs > 0 && ffs < FLT_MIN && fpeUnimplemented()) return exception.floatingPoint();
+  if(ffs > 0 && ffs < FLT_MIN) {
+    if(!fpu.csr.flushSubnormals || fpu.csr.enable.inexact || fpu.csr.enable.underflow)
+      if(fpeUnimplemented()) return exception.floatingPoint();
+  }
   if(!fpuCheckInput(ffs)) return;
   auto ffd = CHECK_FPE(f32, (f32)ffs);
   if(!fpuCheckOutput(ffd)) return;

--- a/ares/n64/cpu/interpreter-fpu.cpp
+++ b/ares/n64/cpu/interpreter-fpu.cpp
@@ -195,7 +195,7 @@ auto CPU::checkFPUExceptions() -> bool {
 
 #define CHECK_FPE(type, operation) ({ \
   fenv.clearExcept(); \
-  volatile type res = operation; \
+  type res = [&]() noinline -> type { return operation; }(); \
   if (checkFPUExceptions()) return; \
   (res); \
 })

--- a/ares/n64/cpu/interpreter.cpp
+++ b/ares/n64/cpu/interpreter.cpp
@@ -229,11 +229,11 @@ auto CPU::decoderFPU() -> void {
   op(0x00, MFC1, RT, FS);
   op(0x01, DMFC1, RT, FS);
   op(0x02, CFC1, RT, RDn);
-  br(0x03, COP1INVALID);
+  br(0x03, DCFC1, RT, RDn);
   op(0x04, MTC1, RT, FS);
   op(0x05, DMTC1, RT, FS);
   op(0x06, CTC1, RT, RDn);
-  br(0x07, COP1INVALID);
+  br(0x07, DCTC1, RT, RDn);
   br(0x08, BC1, OP >> 16 & 1, OP >> 17 & 1, IMMi16);
   br(0x09, INVALID);
   br(0x0a, INVALID);

--- a/ares/n64/cpu/interpreter.cpp
+++ b/ares/n64/cpu/interpreter.cpp
@@ -262,6 +262,7 @@ auto CPU::decoderFPU() -> void {
   op(0x0d, FTRUNC_W_S, FD, FS);
   op(0x0e, FCEIL_W_S, FD, FS);
   op(0x0f, FFLOOR_W_S, FD, FS);
+  op(0x20, FCVT_S_S, FD, FS);
   op(0x21, FCVT_D_S, FD, FS);
   op(0x24, FCVT_W_S, FD, FS);
   op(0x25, FCVT_L_S, FD, FS);
@@ -302,6 +303,7 @@ auto CPU::decoderFPU() -> void {
   op(0x0e, FCEIL_W_D, FD, FS);
   op(0x0f, FFLOOR_W_D, FD, FS);
   op(0x20, FCVT_S_D, FD, FS);
+  op(0x21, FCVT_D_D, FD, FS);
   op(0x24, FCVT_W_D, FD, FS);
   op(0x25, FCVT_L_D, FD, FS);
   op(0x30, FC_F_D, FS, FT);

--- a/ares/n64/cpu/interpreter.cpp
+++ b/ares/n64/cpu/interpreter.cpp
@@ -326,14 +326,34 @@ auto CPU::decoderFPU() -> void {
 
   if((OP >> 21 & 31) == 20)
   switch(OP & 0x3f) {
+  op(0x08, FROUND_L_W, FD, FS);
+  op(0x09, FTRUNC_L_W, FD, FS);
+  op(0x0a, FCEIL_L_W, FD, FS);
+  op(0x0b, FFLOOR_L_W, FD, FS);
+  op(0x0c, FROUND_W_W, FD, FS);
+  op(0x0d, FTRUNC_W_W, FD, FS);
+  op(0x0e, FCEIL_W_W, FD, FS);
+  op(0x0f, FFLOOR_W_W, FD, FS);
   op(0x20, FCVT_S_W, FD, FS);
   op(0x21, FCVT_D_W, FD, FS);
+  op(0x24, FCVT_W_W, FD, FS);
+  op(0x25, FCVT_L_W, FD, FS);
   }
 
   if((OP >> 21 & 31) == 21)
   switch(OP & 0x3f) {
+  op(0x08, FROUND_L_L, FD, FS);
+  op(0x09, FTRUNC_L_L, FD, FS);
+  op(0x0a, FCEIL_L_L, FD, FS);
+  op(0x0b, FFLOOR_L_L, FD, FS);
+  op(0x0c, FROUND_W_L, FD, FS);
+  op(0x0d, FTRUNC_W_L, FD, FS);
+  op(0x0e, FCEIL_W_L, FD, FS);
+  op(0x0f, FFLOOR_W_L, FD, FS);
   op(0x20, FCVT_S_L, FD, FS);
   op(0x21, FCVT_D_L, FD, FS);
+  op(0x24, FCVT_W_L, FD, FS);
+  op(0x25, FCVT_L_L, FD, FS);
   }
 
   //undefined instructions do not throw a reserved instruction exception

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -1302,9 +1302,9 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
     return 0;
   }
 
-  //INVALID
+  //DCFC1 Rt,Rd
   case 0x03: {
-    call(&CPU::COP1INVALID);
+    call(&CPU::COP1UNIMPLEMENTED);
     return 1;
   }
 
@@ -1332,9 +1332,9 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
     return 0;
   }
 
-  //INVALID
+  //DCTC1 Rt,Rd
   case 0x07: {
-    call(&CPU::COP1INVALID);
+    call(&CPU::COP1UNIMPLEMENTED);
     return 1;
   }
 
@@ -1953,12 +1953,12 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
   switch(instruction & 0x3f) {    
   case 0x08 ... 0x0f: {
     call(&CPU::COP1UNIMPLEMENTED);
-    return 0;
+    return 1;
   }
 
   case 0x24 ... 0x25: {
     call(&CPU::COP1UNIMPLEMENTED);
-    return 0;
+    return 1;
   }
 
   //FCVT.S.W Fd,Fs
@@ -1983,11 +1983,11 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
   switch(instruction & 0x3f) {
   case 0x08 ... 0x0f: {
     call(&CPU::COP1UNIMPLEMENTED);
-    return 0;
+    return 1;
   }
   case 0x24 ... 0x25: {
     call(&CPU::COP1UNIMPLEMENTED);
-    return 0;
+    return 1;
   }
 
   //FCVT.S.L

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -1490,6 +1490,14 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
     return 0;
   }
 
+  //FCVT.S.S Fd,Fs
+  case 0x20: {
+    mov32(reg(1), imm(Fdn));
+    mov32(reg(2), imm(Fsn));
+    call(&CPU::FCVT_S_S);
+    return 0;
+  }
+
   //FCVT.D.S Fd,Fs
   case 0x21: {
     mov32(reg(1), imm(Fdn));
@@ -1784,6 +1792,14 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
     mov32(reg(1), imm(Fdn));
     mov32(reg(2), imm(Fsn));
     call(&CPU::FCVT_S_D);
+    return 0;
+  }
+
+  //FCVT.D.D Fd,Fs
+  case 0x21: {
+    mov32(reg(1), imm(Fdn));
+    mov32(reg(2), imm(Fsn));
+    call(&CPU::FCVT_D_D);
     return 0;
   }
 

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -1950,7 +1950,16 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
   }
 
   if((instruction >> 21 & 31) == 20)
-  switch(instruction & 0x3f) {
+  switch(instruction & 0x3f) {    
+  case 0x08 ... 0x0f: {
+    call(&CPU::COP1UNIMPLEMENTED);
+    return 0;
+  }
+
+  case 0x24 ... 0x25: {
+    call(&CPU::COP1UNIMPLEMENTED);
+    return 0;
+  }
 
   //FCVT.S.W Fd,Fs
   case 0x20: {
@@ -1972,6 +1981,14 @@ auto CPU::Recompiler::emitFPU(u32 instruction) -> bool {
 
   if((instruction >> 21 & 31) == 21)
   switch(instruction & 0x3f) {
+  case 0x08 ... 0x0f: {
+    call(&CPU::COP1UNIMPLEMENTED);
+    return 0;
+  }
+  case 0x24 ... 0x25: {
+    call(&CPU::COP1UNIMPLEMENTED);
+    return 0;
+  }
 
   //FCVT.S.L
   case 0x20: {

--- a/ares/n64/cpu/serialization.cpp
+++ b/ares/n64/cpu/serialization.cpp
@@ -136,7 +136,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(fpu.csr.cause.invalidOperation);
   s(fpu.csr.cause.unimplementedOperation);
   s(fpu.csr.compare);
-  s(fpu.csr.flushed);
+  s(fpu.csr.flushSubnormals);
 
   s(cop2.latch);
 

--- a/ares/n64/n64.hpp
+++ b/ares/n64/n64.hpp
@@ -3,6 +3,7 @@
 
 #define XXH_INLINE_ALL
 #include <xxhash.h>
+#include <float.h>
 #include <ares/ares.hpp>
 #include <nall/float-env.hpp>
 #include <nall/hashset.hpp>

--- a/nall/float-env.hpp
+++ b/nall/float-env.hpp
@@ -70,6 +70,10 @@ struct float_env {
     setControl();
   }
 
+  auto getRound() -> u32 {
+    return control & roundMask;
+  }
+
   auto testExcept(u32 mask) -> u32 {
     return getStatus() & mask & allExcept;
   }


### PR DESCRIPTION
Thanks to the amazing work in Lemmy's n64-systemtest, this commit series radically improves the accuracy of the FPU emulation. Now it is basically perfect in all its details (all rounding modes, denormal handling, NaNs, infinites, all exception flags, etc.), and this includes all FPU exceptions that are correctly generated on the right opcode with the correct flags. 

This builds upon the previous work we did on FPU exceptions, so it shouldn't impact much commercial games, performance wise.

Notice that the n64-systemtest version which includes FPU tests hasn't been released yet, but we now pass its current working version.