### PR TITLE
fc: correct mmc5 scanline detection behavior

### DIFF
--- a/ares/fc/cartridge/board/hvc-exrom.cpp
+++ b/ares/fc/cartridge/board/hvc-exrom.cpp
@@ -184,8 +184,8 @@ struct HVC_ExROM : Interface {  //MMC5
       irqLine = 0;
       vcounter = 0;
     } else {
-      if(vcounter == irqCoincidence) irqLine = 1;
       vcounter++;
+      if(vcounter == irqCoincidence) irqLine = 1;
     }
   }
 

--- a/ares/fc/cartridge/board/hvc-exrom.cpp
+++ b/ares/fc/cartridge/board/hvc-exrom.cpp
@@ -640,16 +640,17 @@ struct HVC_ExROM : Interface {  //MMC5
 
   auto readCHR(n32 address, n8 data) -> n8 override {
     cycleCounter = 3;
-    characterAccess[0] = characterAccess[1];
-    characterAccess[1] = characterAccess[2];
-    characterAccess[2] = characterAccess[3];
-    characterAccess[3] = address;
 
     //detect two unused nametable fetches at end of each scanline
-    if(characterAccess[0].bit(13) == 0
-    && characterAccess[1].bit(13) == 1
-    && characterAccess[2].bit(13) == 1
-    && characterAccess[3].bit(13) == 1) scanline();
+    if(address & 0x2000) {
+      if(characterAccess != address) {
+        characterMatch = 0;
+      } else {
+        characterMatch++;
+        if(characterMatch >= 2) scanline();
+      }
+      characterAccess = address;
+    }
 
     if(inFrame == false) {
       vsplitFetch = 0;
@@ -744,6 +745,7 @@ struct HVC_ExROM : Interface {  //MMC5
     s(vcounter);
     s(hcounter);
     s(characterAccess);
+    s(characterMatch);
     s(characterActive);
     s(sprite8x16);
     s(exbank);
@@ -803,7 +805,8 @@ struct HVC_ExROM : Interface {  //MMC5
 
   n16 vcounter;
   n16 hcounter;
-  n16 characterAccess[4];
+  n16 characterAccess;
+  n8  characterMatch;
   n1  characterActive;
   n1  sprite8x16;
 


### PR DESCRIPTION
Correct Famicom MMC5 scanline detection behavior:

- Scanline is detected when three (or more) consecutive reads from the same address of ppu ram happens. This new behaviour matches the description in https://www.nesdev.org/wiki/MMC5#Scanline_Detection_and_Scanline_IRQ
- Scanline counter is now incremented before comparing with $5203, this is needed in combination of the above change. It also has the effect of not producing irqs when $5203 is zero, as described in https://www.nesdev.org/wiki/MMC5#IRQ_Scanline_Compare_Value_($5203)

These changes fix scanline sync issues and shaking text on the intro of Metal Slader Glory, and garbage tiles (visible only for a frame) on the intro of Gun Sight / Laser Invasion.

Full MMC5 library tested with no visible issues, so this is (hopefully) the last fix for Famicom MMC5.