### PR TITLE
fc: namco163 expansion audio

### DIFF
--- a/ares/fc/cartridge/board/namco-163.cpp
+++ b/ares/fc/cartridge/board/namco-163.cpp
@@ -1,5 +1,3 @@
-//todo: sound
-
 struct Namco163 : Interface {
   static auto create(string id) -> Interface* {
     if(id == "NAMCO-163") return new Namco163;
@@ -9,15 +7,27 @@ struct Namco163 : Interface {
   Memory::Readable<n8> programROM;
   Memory::Writable<n8> programRAM;
   Memory::Readable<n8> characterROM;
+  Memory::Writable<n8> soundRAM;
+  Node::Audio::Stream stream;
 
   auto load() -> void override {
     Interface::load(programROM, "program.rom");
     Interface::load(programRAM, "save.ram");
     Interface::load(characterROM, "character.rom");
+    soundRAM.allocate(128);
+
+    stream = cartridge.node->append<Node::Audio::Stream>("N163");
+    stream->setChannels(1);
+    stream->setFrequency(u32(system.frequency() + 0.5) / cartridge.rate() / 15);
   }
 
   auto save() -> void override {
     Interface::save(programRAM, "save.ram");
+  }
+
+  auto unload() -> void override {
+    cartridge.node->remove(stream);
+    stream.reset();
   }
 
   auto main() -> void override {
@@ -25,13 +35,50 @@ struct Namco163 : Interface {
     if(irqEnable) {
       if(irqCounter != 0x7fff && ++irqCounter == 0x7fff) irqLine = 1;
     }
+
+    if(++soundDivider == 15) {
+      soundDivider = 0;
+      double output = clockSound();
+      stream->frame(output / 255.0 * 0.25);
+    }
+
     tick();
+  }
+
+  auto clockSound() -> double {
+    if(!soundEnable) return 0;
+
+    n7 address = 0x40 | (7 - soundChannel) << 3;
+    n24 phase = soundRAM[address + 5] << 16 | soundRAM[address + 3] << 8 | soundRAM[address + 1];
+    n18 freq  = soundRAM[address + 4] << 16 | soundRAM[address + 2] << 8 | soundRAM[address + 0];
+    n8 length = 256 - (soundRAM[address + 4] & 0xfc);
+    n8 offset = soundRAM[address + 6];
+    n4 volume = soundRAM[address + 7];
+
+    phase = length ? (phase + freq) % (length << 16) : 0;
+    offset = (phase >> 16) + offset;
+    n4 sample = soundRAM[offset >> 1] >> (offset.bit(0) ? 4 : 0);
+
+    soundOutput[soundChannel] = (sample - 8) * volume;
+    soundRAM[address + 1] = phase >> 0;
+    soundRAM[address + 3] = phase >> 8;
+    soundRAM[address + 5] = phase >> 16;
+
+    n4 channels = soundRAM[0x7f].bit(4,6) + 1;
+    if(++soundChannel == channels) soundChannel = 0;
+
+    double output = 0;
+    for(u32 i : range(channels)) output += soundOutput[i];
+    return output / channels;
   }
 
   auto readPRG(n32 address, n8 data) -> n8 override {
     if(address < 0x4800) return data;
-    if(address < 0x5000) return data;
-    //if(address < 0x5000) return soundRAM.read(soundAddress);
+    if(address < 0x5000) {
+      data = soundRAM.read(soundAddress);
+      if(soundIncrement) soundAddress++;
+      return data;
+    }
 
     if(address < 0x6000) {
       if(address < 0x5800) return irqCounter.bit(0,7);
@@ -62,7 +109,8 @@ struct Namco163 : Interface {
 
     switch(address & 0xf800) {
     case 0x4800:
-      //soundRAM.write(soundAddres, data);
+      soundRAM.write(soundAddress, data);
+      if(soundIncrement) soundAddress++;
       break;
     case 0x5000:
       irqCounter.bit(0,7) = data;
@@ -87,7 +135,7 @@ struct Namco163 : Interface {
     case 0xd800: characterBank[11] = data; break;
     case 0xe000:
       programBank[0] = data.bit(0,5);
-      //soundEnable = !data.bit(6);
+      soundEnable = !data.bit(6);
       break;
     case 0xe800:
       programBank[1] = data.bit(0,5);
@@ -102,8 +150,8 @@ struct Namco163 : Interface {
       ramEnable[1] = data.bit(4,7) == 4 && !data.bit(1);
       ramEnable[2] = data.bit(4,7) == 4 && !data.bit(2);
       ramEnable[3] = data.bit(4,7) == 4 && !data.bit(3);
-      //soundAddress = data.bit(0,6);
-      //soundRepeat = data.bit(7);
+      soundAddress = data.bit(0,6);
+      soundIncrement = data.bit(7);
       break;
     }
   }
@@ -129,10 +177,17 @@ struct Namco163 : Interface {
 
   auto serialize(serializer& s) -> void override {
     s(programRAM);
+    s(soundRAM);
     s(ramEnable);
     s(ciramEnable);
     s(programBank);
     s(characterBank);
+    s(soundOutput);
+    s(soundAddress);
+    s(soundIncrement);
+    s(soundEnable);
+    s(soundChannel);
+    s(soundDivider);
     s(irqCounter);
     s(irqEnable);
     s(irqLine);
@@ -142,6 +197,12 @@ struct Namco163 : Interface {
   n1  ciramEnable[2];
   n6  programBank[3];
   n8  characterBank[12];
+  i16 soundOutput[8];
+  n7  soundAddress;
+  n1  soundIncrement;
+  n1  soundEnable;
+  n3  soundChannel;
+  n4  soundDivider;
   n15 irqCounter;
   n1  irqEnable;
   n1  irqLine;


### PR DESCRIPTION
Famicom Namco163 chip offers up to 8 additional sound channels that play wavetable samples, previously missing in ares.

Namco163 expansion audio is used by the following games:

- Digital Devil Story - Megami Tensei II (Japan)
- Erika to Satoru no Yume Bouken (Japan)
- Final Lap (Japan)
- King of Kings (Japan)
- Mappy Kids (Japan)
- Namco Classic II (Japan)
- Rolling Thunder (Japan)
- Sangokushi - Chuugen no Hasha (Japan)
- Sangokushi II - Haou no Tairiku (Japan)
- Youkai Douchuuki (Japan)

This pr closes #832