### PR TITLE
fc: boost expansion audio output levels

### DIFF
--- a/ares/fc/apu/apu.cpp
+++ b/ares/fc/apu/apu.cpp
@@ -25,7 +25,7 @@ auto APU::load(Node::Object parent) -> void {
     if(amp == 0) {
       pulseDAC[amp] = 0;
     } else {
-      pulseDAC[amp] = 16384.0 * 95.88 / (8128.0 / amp + 100.0);
+      pulseDAC[amp] = 32768.0 * 95.88 / (8128.0 / amp + 100.0);
     }
   }
 
@@ -36,7 +36,7 @@ auto APU::load(Node::Object parent) -> void {
           dmcTriangleNoiseDAC[dmcAmp][triangleAmp][noiseAmp] = 0;
         } else {
           dmcTriangleNoiseDAC[dmcAmp][triangleAmp][noiseAmp]
-          = 16384.0 * 159.79 / (100.0 + 1.0 / (triangleAmp / 8227.0 + noiseAmp / 12241.0 + dmcAmp / 22638.0));
+          = 32768.0 * 159.79 / (100.0 + 1.0 / (triangleAmp / 8227.0 + noiseAmp / 12241.0 + dmcAmp / 22638.0));
         }
       }
     }
@@ -59,8 +59,6 @@ auto APU::main() -> void {
   s32 output = 0;
   output += pulseDAC[pulseOutput];
   output += dmcTriangleNoiseDAC[dmcOutput][triangleOutput][noiseOutput];
-
-  output = (output * 2) - 32768;
 
   stream->frame(sclamp<16>(output) / 32768.0);
 

--- a/ares/fc/apu/apu.hpp
+++ b/ares/fc/apu/apu.hpp
@@ -154,8 +154,8 @@ struct APU : Thread {
   n5 enabledChannels;
 
 //unserialized:
-  i16 pulseDAC[32];
-  i16 dmcTriangleNoiseDAC[128][16][16];
+  u16 pulseDAC[32];
+  u16 dmcTriangleNoiseDAC[128][16][16];
 
   static const n8  lengthCounterTable[32];
   static const n16 dmcPeriodTableNTSC[16];

--- a/ares/fc/apu/apu.hpp
+++ b/ares/fc/apu/apu.hpp
@@ -86,7 +86,7 @@ struct APU : Thread {
     n8  linearLength;
     n1  haltLengthCounter;
     n11 period;
-    n5  stepCounter;
+    n5  stepCounter = 16;
     n8  linearLengthCounter;
     n1  reloadLinear;
   } triangle;

--- a/ares/fc/cartridge/board/konami-vrc6.cpp
+++ b/ares/fc/cartridge/board/konami-vrc6.cpp
@@ -132,7 +132,7 @@ struct KonamiVRC6 : Interface {
     pulse1.clock();
     pulse2.clock();
     sawtooth.clock();
-    f64 output = (pulse1.output + pulse2.output + sawtooth.output) / 61.0 * 0.25;
+    f64 output = (pulse1.output + pulse2.output + sawtooth.output) / 61.0 * 0.5;
     stream->frame(-output);
 
     tick();

--- a/ares/fc/cartridge/board/namco-163.cpp
+++ b/ares/fc/cartridge/board/namco-163.cpp
@@ -39,7 +39,7 @@ struct Namco163 : Interface {
     if(++soundDivider == 15) {
       soundDivider = 0;
       double output = clockSound();
-      stream->frame(output / 255.0 * 0.25);
+      stream->frame(output / 255.0 * 0.5);
     }
 
     tick();

--- a/ares/fc/cartridge/board/sunsoft-5b.cpp
+++ b/ares/fc/cartridge/board/sunsoft-5b.cpp
@@ -45,7 +45,7 @@ struct Sunsoft5B : Interface {
       output += volume[channels[0]];
       output += volume[channels[1]];
       output += volume[channels[2]];
-      stream->frame(output);
+      stream->frame(sclamp<16>(output * 1.5 * 32768.0) / 32768.0);
     }
 
     tick();

--- a/ares/fc/fds/audio.cpp
+++ b/ares/fc/fds/audio.cpp
@@ -106,8 +106,8 @@ auto FDSAudio::updateOutput() -> void {
   static constexpr u32 lookup[4] = {36, 24, 17, 14};
   i32 level = min(carrier.gain, 32) * lookup[masterVolume];
 
-  n8 output = waveform.data[waveform.index] * level / 1152;
-  stream->frame(output / 255.0 * 0.5);
+  n8 output = waveform.data[waveform.index] * level / 561;
+  stream->frame(output / 255.0 * 0.25);
 }
 
 auto FDSAudio::read(n16 address, n8 data) -> n8 {


### PR DESCRIPTION
Corrections on Famicom expansion audio output levels.

Two expansion audio systems don't require changes:
- MMC5: it uses the same DAC as the APU (with already boosted output levels)
- Konami VRC7: it was too loud before compared with the APU, it's fine now with no changes

This should close #869 (the "strange waveform" was discussed on discord)