### PR TITLE
desktop-ui: enable debugging self-signed builds on macOS

### DIFF
--- a/desktop-ui/resource/ares.selfsigned.entitlements
+++ b/desktop-ui/resource/ares.selfsigned.entitlements
@@ -6,5 +6,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.get-task-allow</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
The get-task-allow entitlement is required to enable attaching a debugger to a hardened runtime process.