### PR TITLE
v30mz, ws: emulation fixes

### DIFF
--- a/ares/component/processor/v30mz/instructions-adjust.cpp
+++ b/ares/component/processor/v30mz/instructions-adjust.cpp
@@ -32,8 +32,7 @@ auto V30MZ::instructionAdjustAfterMultiply() -> void {
   wait(16);
   auto imm = fetch<Byte>();
   if(imm == 0) return interrupt(0);
-  //NEC CPUs do not honor the immediate and always use (base) 10
-  AH = AL / 10;
+  AH = AL / imm;
   AL %= imm;
   PSW.P = parity(AL);
   PSW.S = AW & 0x8000;
@@ -43,8 +42,7 @@ auto V30MZ::instructionAdjustAfterMultiply() -> void {
 auto V30MZ::instructionAdjustAfterDivide() -> void {
   wait(6);
   auto imm = fetch<Byte>();
-  //NEC CPUs do not honor the immediate and always use (base) 10
-  AL += AH * 10;
+  AL += AH * imm;
   AH = 0;
   PSW.P = parity(AL);
   PSW.S = AW & 0x8000;

--- a/ares/ws/ppu/io.cpp
+++ b/ares/ws/ppu/io.cpp
@@ -30,7 +30,7 @@ auto PPU::readIO(n16 address) -> n8 {
     break;
 
   case 0x0004:  //SPR_BASE
-    if(depth() == 2) {
+    if(grayscale()) {
       data.bit(0,4) = sprite.oamBase.bit(0,4);
     } else {
       data.bit(0,5) = sprite.oamBase.bit(0,5);
@@ -46,7 +46,7 @@ auto PPU::readIO(n16 address) -> n8 {
     break;
 
   case 0x0007:  //MAP_BASE
-    if(depth() == 2) {
+    if(grayscale()) {
       data.bit(0,2) = screen1.mapBase[1].bit(0,2);
       data.bit(4,6) = screen2.mapBase[1].bit(0,2);
     } else {

--- a/ares/ws/ppu/memory.cpp
+++ b/ares/ws/ppu/memory.cpp
@@ -1,8 +1,7 @@
 auto PPU::fetch(n10 tile, n3 x, n3 y) -> n4 {
   n4 color;
 
-  if(depth() == 2) tile &= 0x1ff;
-  if(depth() == 4) tile &= 0x3ff;
+  tile &= grayscale() ? 0x1ff : 0x3ff;
 
   if(planar() && depth() == 2) {
     n16 data = iram.read16(0x2000 + (tile << 4) + (y << 1));

--- a/ares/ws/ppu/ppu.hpp
+++ b/ares/ws/ppu/ppu.hpp
@@ -29,10 +29,10 @@ struct PPU : Thread, IO {
   auto vcounter() const -> u32 { return io.vcounter; }
   auto field() const -> bool { return io.field; }
 
-  auto planar() const -> bool { return system.mode().bit(0) == 0; }
-  auto packed() const -> bool { return system.mode().bit(0) == 1; }
+  auto planar() const -> bool { return system.mode().bit(0,2) != 7; }
+  auto packed() const -> bool { return system.mode().bit(0,2) == 7; }
   auto depth() const -> u32 { return system.mode().bit(1,2) != 3 ? 2 : 4; }
-  auto grayscale() const -> bool { return system.mode().bit(1,2) == 0; }
+  auto grayscale() const -> bool { return system.mode().bit(2) == 0; }
 
   //ppu.cpp
   auto load(Node::Object) -> void;

--- a/ares/ws/ppu/sprite.cpp
+++ b/ares/ws/ppu/sprite.cpp
@@ -1,6 +1,6 @@
 auto PPU::Sprite::frame() -> void {
   n7 index = first;
-  n16 base = oamBase.bit(0, self.depth() == 2 ? 4 : 5) << 9;
+  n16 base = oamBase.bit(0, self.grayscale() ? 4 : 5) << 9;
   oam[self.field()].flush();
   for(auto object : range(min(128, count))) {
     oam[self.field()].write(iram.read32(base + index++ * 4));

--- a/ares/ws/system/system.hpp
+++ b/ares/ws/system/system.hpp
@@ -75,16 +75,10 @@ struct System : IO {
   auto memory() const -> u32 { return io.mode.bit(2) == 0 ? 16_KiB : 64_KiB; }
 
   //mode:
-  //xx0 => planar tiledata
-  //xx1 => packed tiledata
-  //x0x => 512 tiles
-  //x1x => 1024 tiles
-  //0xx => 16 KiB memory mode
-  //1xx => 64 KiB memory mode
-  //00x => 2bpp, grayscale
-  //01x => 2bpp, color
-  //10x => 2bpp, color
-  //11x => 4bpp, color
+  //0xx => 2bpp, mono, planar tiledata (WSC enhancements locked)
+  //10x => 2bpp, color, planar tiledata (WSC enhancements unlocked)
+  //110 => 4bpp, color, planar tiledata
+  //111 => 4bpp, color, packed tiledata
 
   //system.cpp
   auto game() -> string;


### PR DESCRIPTION
* The NEC V30MZ does not ignore the immediate operand in AAD/AAM calls. This is contrary to NEC V20/V30 behaviour, as well as many existing emulators. It is, broadly speaking, important to remember that the V30MZ is much closer to "an 80186-compatible CPU with much better opcode timings" than "a V20/V30 derivative". A test ROM is provided for this.
* The sprite base location register's access to 0x4000-0x7FFF memory is gated by the color mode bit, not by the 4bpp mode bit. A test ROM is provided for this.
* The PPU can address 1024 tiles in 2bpp color mode, simply by following the consecutive addresses (so 0x2000-0x5FFF total). This has been verified independently.
* The planar(), packed(), depth() and grayscale() functions have been reworked to accurately reflect what the hardware does. This has been verified independently.

https://asie.pl/files/accutest_20221122.zip - Test ROM for the first two scenarios. It's almost midnight, so I could not deliver a test ROM for the other two - I'll have to trust that this has been independently verified, or I can deliver a test ROM later if desired.