### PR TITLE
huc6280: adc/sbc decimal mode fixes

### DIFF
--- a/ares/component/processor/huc6280/algorithms.cpp
+++ b/ares/component/processor/huc6280/algorithms.cpp
@@ -1,17 +1,15 @@
 auto HuC6280::algorithmADC(n8 i) -> n8 {
-  i16 o;
+  i16 o = A + i + C;
   if(!D) {
-    o = A + i + C;
+    C = o.bit(8);
     V = ~(A ^ i) & (A ^ o) & 0x80;
   } else {
     idle();
-    o = (A & 0x0f) + (i & 0x0f) + (C << 0);
-    if(o > 0x09) o += 0x06;
-    C = o > 0x0f;
-    o = (A & 0xf0) + (i & 0xf0) + (C << 4) + (o & 0x0f);
+    n8 l = (A & 0x0f) + (i & 0x0f) + C;
+    if(l > 0x09) o += 0x06;
     if(o > 0x9f) o += 0x60;
+    C = o > 0xff;
   }
-  C = o.bit(8);
   Z = n8(o) == 0;
   N = o.bit(7);
   return o;
@@ -125,19 +123,17 @@ auto HuC6280::algorithmROR(n8 i) -> n8 {
 
 auto HuC6280::algorithmSBC(n8 i) -> n8 {
   i ^= 0xff;
-  i16 o;
+  i16 o = A + i + C;
   if(!D) {
-    o = A + i + C;
+    C = o.bit(8);
     V = ~(A ^ i) & (A ^ o) & 0x80;
   } else {
     idle();
-    o = (A & 0x0f) + (i & 0x0f) + (C << 0);
-    if(o <= 0x0f) o -= 0x06;
-    C = o > 0x0f;
-    o = (A & 0xf0) + (i & 0xf0) + (C << 4) + (o & 0x0f);
+    n8 l = (A & 0x0f) + (i & 0x0f) + C;
+    C = o > 0xff;
     if(o <= 0xff) o -= 0x60;
+    if(l <= 0x0f) o -= 0x06;
   }
-  C = o.bit(8);
   Z = n8(o) == 0;
   N = o.bit(7);
   return o;


### PR DESCRIPTION
This only impacts cases with inputs that are not valid BCD. This change was verified against hardware test roms in the Mednafen repo.