### PR TITLE
n64: fix 32bit / 64bit address space confusion

### DIFF
--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -83,7 +83,7 @@ struct CPU : Thread {
 
     enum Endian : bool { Little, Big };
     enum Mode : u32 { Kernel, Supervisor, User };
-    enum Segment : u32 { Unused, Mapped, Cached, Direct, Kernel64, Supervisor64, User64 };
+    enum Segment : u32 { Unused, Mapped, Cached, Direct, Cached32, Direct32, Kernel64, Supervisor64, User64 };
 
     auto littleEndian() const -> bool { return endian == Endian::Little; }
     auto bigEndian() const -> bool { return endian == Endian::Big; }


### PR DESCRIPTION
context.physMask is only used for TLBs. In directly-mapped memory segments (either cached or uncached), the virtual-to-physical conversion uses a hardcoded mask that depends on the exact address space segment, and is not contextful. In 32-bit, segments only use 29 bits of the virtual address. In 64-bit, some segments (xkphys*) use the full 32 bits.

Besides 64-bit direct-mapped segments correctness, this also fixes the devirtualize function that is used as part of the CACHE/LL/SC opcodes, which were misbehaving when used with a uncached segment (0xa000'0000) in 32-bit mode. This might actually affect also games.