### PR TITLE
nall: define _WIN32_WINNT in makefile

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -199,6 +199,8 @@ endif
 # windows settings
 ifeq ($(platform),windows)
   extension := .exe
+  # target Windows 7
+  flags += -D_WIN32_WINNT=0x0601
   ifeq ($(msvc),true)
     flags += -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS -DNOMINMAX
   endif

--- a/nall/windows/windows.hpp
+++ b/nall/windows/windows.hpp
@@ -9,9 +9,4 @@
 #undef  WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 
-//target Windows 7
-#undef  _WIN32_WINNT
-#define _WIN32_WINNT 0x0601
-#include <sdkddkver.h>
-
 #include <windows.h>


### PR DESCRIPTION
We build third party dependencies that do not include nall, so defining the target Windows version (currently Win7) in a header is unreliable.