### PR TITLE
ares: fix console build option on Windows

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -197,7 +197,13 @@ ifeq ($(platform),windows)
   options += -mthreads -lws2_32 -lole32 -lshell32
   options += $(if $(findstring clang++,$(compiler)),-fuse-ld=lld)
   options += -static
-  options += $(if $(findstring true,$(console)),-mconsole,-mwindows)
+  ifeq ($(console),true)
+    flags += -DSUBSYTEM_CONSOLE
+    options += -mconsole
+  else
+    flags += -DSUBSYTEM_WINDOWS
+    options += -mwindows
+  endif
   ifeq ($(windres),)
     ifeq ($(msvc),true)
       windres := llvm-rc

--- a/nall/main.cpp
+++ b/nall/main.cpp
@@ -39,6 +39,17 @@ auto main(int argc, char** argv) -> int {
 
 }
 
+#if defined(PLATFORM_WINDOWS) && defined(SUBSYTEM_WINDOWS)
+
+auto WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR pCmdLine, int nCmdShow) -> int {
+  //arguments are retrieved later via GetCommandLineW()
+  return nall::main(0, nullptr);
+}
+
+#else
+
 auto main(int argc, char** argv) -> int {
   return nall::main(argc, argv);
 }
+
+#endif


### PR DESCRIPTION
The -mconsole and -mwindows flags don't seem to do much of anything when Clang isn't targeting MinGW. On the other hand, directly overriding the subsystem with a linker flag results in a bunch of unresolved symbols. However, if the right entry point exists (either WinMain or main), some apparent magic goes on under the hood to ensure that everything links as expected, so we can just take advantage of that.