### PR TITLE
ws: debugger/UI additions + emulation bugfixes batch

### DIFF
--- a/ares/component/processor/v30mz/disassembler.cpp
+++ b/ares/component/processor/v30mz/disassembler.cpp
@@ -394,9 +394,9 @@ auto V30MZ::disassembleInstruction(u16 ps, u16 pc) -> string {
   op(0xe2, "loop");
   op(0xe3, "jcwz", relativeByte());
   op(0xe4, "in", "al", immediateByte());
-  op(0xe5, "in", "aw", immediateWord());
+  op(0xe5, "in", "aw", immediateByte());
   op(0xe6, "out", immediateByte(), "al");
-  op(0xe7, "out", immediateWord(), "aw");
+  op(0xe7, "out", immediateByte(), "aw");
   op(0xe8, "call", relativeWord());
   op(0xe9, "jmp", relativeWord());
   op(0xea, "jmp", immediateLong());

--- a/ares/component/processor/v30mz/disassembler.cpp
+++ b/ares/component/processor/v30mz/disassembler.cpp
@@ -379,7 +379,7 @@ auto V30MZ::disassembleInstruction(u16 ps, u16 pc) -> string {
   op(0xd3, group2(), memoryWord(), "cl");
   op(0xd4, "aam", immediateByte());
   op(0xd5, "aad", immediateByte());
-  op(0xd6, "xlat");  //undocumented mirror
+  op(0xd6, "salc");
   op(0xd7, "xlat");
 //op(0xd8);
 //op(0xd9);

--- a/ares/component/processor/v30mz/instruction.cpp
+++ b/ares/component/processor/v30mz/instruction.cpp
@@ -251,8 +251,8 @@ auto V30MZ::instruction() -> void {
   op(0xd3, Group2MemImm<Word>, 3, (u8)CL)
   op(0xd4, AdjustAfterMultiply)
   op(0xd5, AdjustAfterDivide)
-  op(0xd6, Translate, 7)  //xlat (undocumented mirror)
-  op(0xd7, Translate, 4)  //xlat
+  op(0xd6, SetALCarry) //salc
+  op(0xd7, Translate)  //xlat
   op(0xd8, Undefined)
   op(0xd9, Undefined)
   op(0xda, Undefined)

--- a/ares/component/processor/v30mz/instruction.cpp
+++ b/ares/component/processor/v30mz/instruction.cpp
@@ -136,11 +136,11 @@ auto V30MZ::instruction() -> void {
   op(0x60, PushAll)
   op(0x61, PopAll)
   op(0x62, Bound)
-//op(0x63, ...)
-//op(0x64, ...)  repnc
-//op(0x65, ...)  repc
-//op(0x66, ...)  fpo2
-//op(0x67, ...)  fpo2
+  op(0x63, Undefined)
+  op(0x64, Undefined)
+  op(0x65, Undefined)
+  op(0x66, Undefined)
+  op(0x67, Undefined)
   op(0x68, PushImm<Word>)
   op(0x69, MultiplySignedRegMemImm<Word>)
   op(0x6a, PushImm<Byte>)
@@ -253,14 +253,14 @@ auto V30MZ::instruction() -> void {
   op(0xd5, AdjustAfterDivide)
   op(0xd6, Translate, 7)  //xlat (undocumented mirror)
   op(0xd7, Translate, 4)  //xlat
-//op(0xd8, ...)  //fpo1
-//op(0xd9, ...)  //fpo1
-//op(0xda, ...)  //fpo1
-//op(0xdb, ...)  //fpo1
-//op(0xdc, ...)  //fpo1
-//op(0xdd, ...)  //fpo1
-//op(0xde, ...)  //fpo1
-//op(0xdf, ...)  //fpo1
+  op(0xd8, Undefined)
+  op(0xd9, Undefined)
+  op(0xda, Undefined)
+  op(0xdb, Undefined)
+  op(0xdc, Undefined)
+  op(0xdd, Undefined)
+  op(0xde, Undefined)
+  op(0xdf, Undefined)
   op(0xe0, LoopWhile, 0)  //loopnz
   op(0xe1, LoopWhile, 1)  //loopz
   op(0xe2, Loop)

--- a/ares/component/processor/v30mz/instructions-alu.cpp
+++ b/ares/component/processor/v30mz/instructions-alu.cpp
@@ -146,7 +146,7 @@ template<u32 size> auto V30MZ::instructionTestMemReg() -> void {
 }
 
 template<u32 size> auto V30MZ::instructionMultiplySignedRegMemImm() -> void {
-  wait(5);
+  wait(3);
   modRM();
   setRegister<Word>(MULI<Word>(getMemory<Word>(), size == Word ? (s16)fetch<Word>() : (s8)fetch<Byte>()));
 }

--- a/ares/component/processor/v30mz/instructions-group.cpp
+++ b/ares/component/processor/v30mz/instructions-group.cpp
@@ -40,7 +40,7 @@ template<u32 size> auto V30MZ::instructionGroup3MemImm() -> void {
   auto mem = getMemory<size>();
   switch(modrm.reg) {
   case 0: wait(1); AND<size>(mem, fetch<size>()); break;  //TEST
-  case 1: wait(1); AND<size>(mem, fetch<size>()); break;  //TEST (undocumented mirror)
+  case 1: wait(1); break; // undefined (acts as NOP)
   case 2: wait(1); setMemory<size>(NOT<size>(mem)); break;
   case 3: wait(1); setMemory<size>(NEG<size>(mem)); break;
   case 4: wait(3); setAccumulator<size * 2>(MULU<size>(getAccumulator<size>(), mem)); break;

--- a/ares/component/processor/v30mz/instructions-misc.cpp
+++ b/ares/component/processor/v30mz/instructions-misc.cpp
@@ -21,7 +21,7 @@ auto V30MZ::instructionLock() -> void {
 }
 
 auto V30MZ::instructionWait() -> void {
-  wait(1 + 9);
+  wait(10);
 }
 
 auto V30MZ::instructionHalt() -> void {

--- a/ares/component/processor/v30mz/instructions-misc.cpp
+++ b/ares/component/processor/v30mz/instructions-misc.cpp
@@ -21,7 +21,7 @@ auto V30MZ::instructionLock() -> void {
 }
 
 auto V30MZ::instructionWait() -> void {
-  wait(1);
+  wait(1 + 9);
 }
 
 auto V30MZ::instructionHalt() -> void {
@@ -30,6 +30,10 @@ auto V30MZ::instructionHalt() -> void {
 }
 
 auto V30MZ::instructionNop() -> void {
+  wait(1);
+}
+
+auto V30MZ::instructionUndefined() -> void {
   wait(1);
 }
 

--- a/ares/component/processor/v30mz/instructions-misc.cpp
+++ b/ares/component/processor/v30mz/instructions-misc.cpp
@@ -57,8 +57,13 @@ template<u32 size> auto V30MZ::instructionOutDW() -> void {
   out<size>(DW, getAccumulator<size>());
 }
 
-auto V30MZ::instructionTranslate(u8 clocks) -> void {
-  wait(clocks);
+auto V30MZ::instructionSetALCarry() -> void {
+  wait(8);
+  AL = PSW.CY ? 0xFF : 0x00;
+}
+
+auto V30MZ::instructionTranslate() -> void {
+  wait(4);
   AL = read<Byte>(segment(DS0), BW + AL);
 }
 

--- a/ares/component/processor/v30mz/instructions-string.cpp
+++ b/ares/component/processor/v30mz/instructions-string.cpp
@@ -1,5 +1,5 @@
 template<u32 size> auto V30MZ::instructionInString() -> void {
-  wait(5);
+  wait(3);
   if(!repeat() || CW) {
     auto data = in<size>(DW);
     write<size>(DS1, IY, data);
@@ -14,7 +14,7 @@ template<u32 size> auto V30MZ::instructionInString() -> void {
 }
 
 template<u32 size> auto V30MZ::instructionOutString() -> void {
-  wait(6);
+  wait(3);
   if(!repeat() || CW) {
     auto data = read<size>(segment(DS0), IX);
     out<size>(DW, data);

--- a/ares/component/processor/v30mz/v30mz.hpp
+++ b/ares/component/processor/v30mz/v30mz.hpp
@@ -220,6 +220,7 @@ struct V30MZ {
   auto instructionWait() -> void;
   auto instructionHalt() -> void;
   auto instructionNop() -> void;
+  auto instructionUndefined() -> void;
   template<u32> auto instructionIn() -> void;
   template<u32> auto instructionOut() -> void;
   template<u32> auto instructionInDW() -> void;

--- a/ares/component/processor/v30mz/v30mz.hpp
+++ b/ares/component/processor/v30mz/v30mz.hpp
@@ -225,7 +225,8 @@ struct V30MZ {
   template<u32> auto instructionOut() -> void;
   template<u32> auto instructionInDW() -> void;
   template<u32> auto instructionOutDW() -> void;
-  auto instructionTranslate(u8) -> void;
+  auto instructionTranslate() -> void;
+  auto instructionSetALCarry() -> void;
   auto instructionBound() -> void;
 
   //instructions-move.cpp

--- a/ares/ws/GNUmakefile
+++ b/ares/ws/GNUmakefile
@@ -8,6 +8,7 @@ ares.objects += ares-ws-cartridge
 ares.objects += ares-ws-cpu
 ares.objects += ares-ws-ppu
 ares.objects += ares-ws-apu
+ares.objects += ares-ws-serial
 
 $(object.path)/ares-ws-system.o:    $(ares.path)/ws/system/system.cpp
 $(object.path)/ares-ws-memory.o:    $(ares.path)/ws/memory/memory.cpp
@@ -16,3 +17,4 @@ $(object.path)/ares-ws-cartridge.o: $(ares.path)/ws/cartridge/cartridge.cpp
 $(object.path)/ares-ws-cpu.o:       $(ares.path)/ws/cpu/cpu.cpp
 $(object.path)/ares-ws-ppu.o:       $(ares.path)/ws/ppu/ppu.cpp
 $(object.path)/ares-ws-apu.o:       $(ares.path)/ws/apu/apu.cpp
+$(object.path)/ares-ws-serial.o:    $(ares.path)/ws/serial/serial.cpp

--- a/ares/ws/apu/apu.cpp
+++ b/ares/ws/apu/apu.cpp
@@ -74,10 +74,10 @@ auto APU::dacRun() -> void {
   if(channel5.io.enable) right += channel5.output.right * io.headphonesConnected;
 
   if(!io.headphonesConnected) {
-    left = right = sclamp<16>((((left + right) >> io.speakerShift) & 0xFF) << 8);
+    left = right = sclamp<16>((((left + right) >> io.speakerShift) & 0xFF) << 7);
   } else {
-    left = sclamp<16>(left << 5);
-    right = sclamp<16>(right << 5);
+    left = sclip<16>(left << 5);
+    right = sclip<16>(right << 5);
   }
 
   //ASWAN has three volume steps (0%, 50%, 100%); SPHINX and SPHINX2 have four (0%, 33%, 66%, 100%)

--- a/ares/ws/apu/apu.cpp
+++ b/ares/ws/apu/apu.cpp
@@ -33,13 +33,25 @@ auto APU::unload() -> void {
 }
 
 auto APU::main() -> void {
-  if(++state.dmaClock == 0) dma.run();
+  // further verification could always be useful
+
+  // TODO: is the period value (run()) updated before or after the outputs (runOutput())?
   channel1.run();
   channel2.run();
   channel3.run();
+  if(++state.sweepClock == 0) channel3.sweep(); // TODO: which cycle is this, or is it separate?
   channel4.run();
-  if(++state.dacClock == 0) dacRun();
-  if(++state.sweepClock == 0) channel3.sweep();
+
+  // TODO: are voice/noise modes handled on different cycles than tone modes?
+  switch(state.apuClock++) {
+  case 0: if(channel1.io.enable) channel1.runOutput(); break;
+  case 1: if(channel2.io.enable) channel2.runOutput(); break;
+  case 2: if(channel3.io.enable) channel3.runOutput(); break;
+  case 3: if(channel4.io.enable) channel4.runOutput(); break;
+  case 4: if(channel5.io.enable) channel5.runOutput(); break; // TODO: which cycle is this?
+  case 5: dma.run(); break; // TODO: which cycle is this?
+  case 6: dacRun(); break; // TODO: which cycle is this?
+  }
   step(1);
 }
 
@@ -52,12 +64,6 @@ auto APU::sample(u32 channel, n5 index) -> n4 {
 
 auto APU::dacRun() -> void {
   bool outputEnable = io.headphonesConnected ? io.headphonesEnable : io.speakerEnable;
-
-  if(channel1.io.enable) channel1.runOutput();
-  if(channel2.io.enable) channel2.runOutput();
-  if(channel3.io.enable) channel3.runOutput();
-  if(channel4.io.enable) channel4.runOutput();
-  if(channel5.io.enable) channel5.runOutput();
 
   if(!outputEnable) {
     stream->frame(0, 0);
@@ -117,7 +123,7 @@ auto APU::power() -> void {
   io.masterVolume = SoC::ASWAN() ? 2 : 3;
   state = {};
 
-  state.dacClock = 0;
+  state.apuClock = 0;
   state.sweepClock = 0;
 }
 

--- a/ares/ws/apu/apu.cpp
+++ b/ares/ws/apu/apu.cpp
@@ -3,6 +3,7 @@
 namespace ares::WonderSwan {
 
 APU apu;
+#include "debugger.cpp"
 #include "io.cpp"
 #include "dma.cpp"
 #include "channel1.cpp"
@@ -19,9 +20,13 @@ auto APU::load(Node::Object parent) -> void {
   stream->setChannels(2);
   stream->setFrequency(24'000);
   stream->addHighPassFilter(15.915, 1);
+
+  debugger.load(node);
 }
 
 auto APU::unload() -> void {
+  debugger.unload(node);
+
   node->remove(stream);
   stream.reset();
   node.reset();

--- a/ares/ws/apu/apu.cpp
+++ b/ares/ws/apu/apu.cpp
@@ -54,7 +54,7 @@ auto APU::dacRun() -> void {
   if(channel4.io.enable) channel4.runOutput();
   if(channel5.io.enable) channel5.runOutput();
 
-  if (!outputEnable) {
+  if(!outputEnable) {
     stream->frame(0, 0);
     return;
   }

--- a/ares/ws/apu/apu.hpp
+++ b/ares/ws/apu/apu.hpp
@@ -48,6 +48,7 @@ struct APU : Thread, IO {
   struct Channel1 {
     //channel1.cpp
     auto run() -> void;
+    auto runOutput() -> void;
     auto power() -> void;
 
     //serialization.cpp
@@ -74,6 +75,7 @@ struct APU : Thread, IO {
   struct Channel2 {
     //channel2.cpp
     auto run() -> void;
+    auto runOutput() -> void;
     auto power() -> void;
 
     //serialization.cpp
@@ -85,8 +87,10 @@ struct APU : Thread, IO {
       n4  volumeRight;
       n1  enable;
       n1  voice;
-      n2  voiceEnableLeft;
-      n2  voiceEnableRight;
+      n1  voiceEnableLeftHalf;
+      n1  voiceEnableLeftFull;
+      n1  voiceEnableRightHalf;
+      n1  voiceEnableRightFull;
     } io;
 
     struct State {
@@ -104,6 +108,7 @@ struct APU : Thread, IO {
     //channel3.cpp
     auto sweep() -> void;
     auto run() -> void;
+    auto runOutput() -> void;
     auto power() -> void;
 
     //serialization.cpp
@@ -135,6 +140,7 @@ struct APU : Thread, IO {
     //channel4.cpp
     auto noiseSample() -> n4;
     auto run() -> void;
+    auto runOutput() -> void;
     auto power() -> void;
 
     //serialization.cpp
@@ -166,7 +172,7 @@ struct APU : Thread, IO {
 
   struct Channel5 {
     //channel5.cpp
-    auto run() -> void;
+    auto runOutput() -> void;
     auto power() -> void;
 
     //serialization.cpp
@@ -204,6 +210,8 @@ struct APU : Thread, IO {
 
   struct State {
     n13 sweepClock;
+    n7 dacClock;
+    n7 dmaClock;
   } state;
 };
 

--- a/ares/ws/apu/apu.hpp
+++ b/ares/ws/apu/apu.hpp
@@ -19,6 +19,19 @@ struct APU : Thread, IO {
   //serialization.cpp
   auto serialize(serializer&) -> void;
 
+  struct Debugger {
+    APU& self;
+
+    //debugger.cpp
+    auto load(Node::Object) -> void;
+    auto unload(Node::Object) -> void;
+    auto ports() -> string;
+
+    struct Properties {
+      Node::Debugger::Properties ports;
+    } properties;
+  } debugger{*this};
+
   struct DMA {
     //dma.cpp
     auto run() -> void;

--- a/ares/ws/apu/apu.hpp
+++ b/ares/ws/apu/apu.hpp
@@ -223,8 +223,7 @@ struct APU : Thread, IO {
 
   struct State {
     n13 sweepClock;
-    n7 dacClock;
-    n7 dmaClock;
+    n7 apuClock;
   } state;
 };
 

--- a/ares/ws/apu/apu.hpp
+++ b/ares/ws/apu/apu.hpp
@@ -2,7 +2,11 @@ struct APU : Thread, IO {
   Node::Object node;
   Node::Audio::Stream stream;
 
+  bool accurate;
+
   //apu.cpp
+  auto setAccurate(bool value) -> void;
+
   auto load(Node::Object) -> void;
   auto unload() -> void;
 

--- a/ares/ws/apu/channel1.cpp
+++ b/ares/ws/apu/channel1.cpp
@@ -1,10 +1,14 @@
 auto APU::Channel1::run() -> void {
   if(--state.period == io.pitch) {
     state.period = 0;
-    auto sample = apu.sample(1, state.sampleOffset++);
-    output.left  = sample * io.volumeLeft;
-    output.right = sample * io.volumeRight;
+    state.sampleOffset++;
   }
+}
+
+auto APU::Channel1::runOutput() -> void {
+  auto sample = apu.sample(1, state.sampleOffset);
+  output.left  = sample * io.volumeLeft;
+  output.right = sample * io.volumeRight;
 }
 
 auto APU::Channel1::power() -> void {

--- a/ares/ws/apu/channel2.cpp
+++ b/ares/ws/apu/channel2.cpp
@@ -1,11 +1,19 @@
 auto APU::Channel2::run() -> void {
+  if (!io.voice) {
+    if(--state.period == io.pitch) {
+      state.period = 0;
+      state.sampleOffset++;
+    }
+  }
+}
+
+auto APU::Channel2::runOutput() -> void {
   if(io.voice) {
     n8 volume = io.volumeLeft << 4 | io.volumeRight << 0;
-    output.left  = io.voiceEnableLeft  ? volume : (n8)0;
-    output.right = io.voiceEnableRight ? volume : (n8)0;
-  } else if(--state.period == io.pitch) {
-    state.period = 0;
-    auto sample = apu.sample(2, state.sampleOffset++);
+    output.left  = io.voiceEnableLeftFull  ? volume : (n8)(io.voiceEnableLeftHalf  ? (volume >> 1) : 0);
+    output.right = io.voiceEnableRightFull ? volume : (n8)(io.voiceEnableRightHalf ? (volume >> 1) : 0);
+  } else {
+    auto sample = apu.sample(2, state.sampleOffset);
     output.left  = sample * io.volumeLeft;
     output.right = sample * io.volumeRight;
   }

--- a/ares/ws/apu/channel3.cpp
+++ b/ares/ws/apu/channel3.cpp
@@ -8,10 +8,14 @@ auto APU::Channel3::sweep() -> void {
 auto APU::Channel3::run() -> void {
   if(--state.period == io.pitch) {
     state.period = 0;
-    auto sample = apu.sample(3, state.sampleOffset++);
-    output.left  = sample * io.volumeLeft;
-    output.right = sample * io.volumeRight;
+    state.sampleOffset++;
   }
+}
+
+auto APU::Channel3::runOutput() -> void {
+  auto sample = apu.sample(3, state.sampleOffset);
+  output.left  = sample * io.volumeLeft;
+  output.right = sample * io.volumeRight;
 }
 
 auto APU::Channel3::power() -> void {

--- a/ares/ws/apu/channel4.cpp
+++ b/ares/ws/apu/channel4.cpp
@@ -5,10 +5,7 @@ auto APU::Channel4::noiseSample() -> n4 {
 auto APU::Channel4::run() -> void {
   if(--state.period == io.pitch) {
     state.period = 0;
-
-    auto sample = io.noise ? noiseSample() : apu.sample(4, state.sampleOffset++);
-    output.left  = sample * io.volumeLeft;
-    output.right = sample * io.volumeRight;
+    state.sampleOffset++;
 
     if(io.noiseReset) {
       io.noiseReset = 0;
@@ -24,6 +21,12 @@ auto APU::Channel4::run() -> void {
       state.noiseLFSR = state.noiseLFSR << 1 | state.noiseOutput;
     }
   }
+}
+
+auto APU::Channel4::runOutput() -> void {
+  auto sample = io.noise ? noiseSample() : apu.sample(4, state.sampleOffset);
+  output.left  = sample * io.volumeLeft;
+  output.right = sample * io.volumeRight;
 }
 
 auto APU::Channel4::power() -> void {

--- a/ares/ws/apu/channel5.cpp
+++ b/ares/ws/apu/channel5.cpp
@@ -1,4 +1,4 @@
-auto APU::Channel5::run() -> void {
+auto APU::Channel5::runOutput() -> void {
   i11 sample;
   switch(io.scale) {
   case 0: sample = (n8)state.data << 3 - io.volume; break;

--- a/ares/ws/apu/debugger.cpp
+++ b/ares/ws/apu/debugger.cpp
@@ -1,0 +1,96 @@
+auto APU::Debugger::load(Node::Object parent) -> void {
+  properties.ports = parent->append<Node::Debugger::Properties>("Sound I/O");
+  properties.ports->setQuery([&] { return ports(); });
+}
+
+auto APU::Debugger::unload(Node::Object parent) -> void {
+  parent->remove(properties.ports);
+  properties.ports.reset();
+}
+
+auto APU::Debugger::ports() -> string {
+  string output;
+
+  output.append("Headphone Output: ", self.io.headphonesEnable ? "enabled" : "disabled", "\n");
+  output.append("Speaker Output: ", self.io.speakerEnable ? "enabled, " : "disabled, ");
+  if(self.io.speakerShift == 0) output.append("100%");
+  if(self.io.speakerShift == 1) output.append("50%");
+  if(self.io.speakerShift == 2) output.append("25%");
+  if(self.io.speakerShift == 3) output.append("12.5%");
+  output.append("\n");
+  output.append("Wavetable: ", hex(self.io.waveBase << 6, 4L), "\n");
+
+  output.append("Channel 1: ");
+  if(!self.channel1.io.enable) {
+    output.append("disabled");
+  } else {
+    output.append("tone, ", self.channel1.io.pitch, " (", (96000.0 / (2048 - self.channel1.io.pitch)), " Hz), ",
+      self.channel1.io.volumeLeft, "/", self.channel1.io.volumeRight);
+  }
+  output.append("\n");
+
+  output.append("Channel 2: ");
+  if(!self.channel2.io.enable) {
+    output.append("disabled");
+  } else if(self.channel2.io.voice) {
+    output.append("voice, ", (self.channel2.io.volumeRight | ((self.channel2.io.volumeLeft) << 4)), ", ",
+      self.channel2.io.voiceEnableLeftFull  ? "100%" : (self.channel2.io.voiceEnableLeftHalf  ? "50%" : "0"), "/",
+      self.channel2.io.voiceEnableRightFull ? "100%" : (self.channel2.io.voiceEnableRightHalf ? "50%" : "0"));
+  } else {
+    output.append("tone, ", self.channel2.io.pitch, " (", (96000.0 / (2048 - self.channel2.io.pitch)), " Hz), ",
+      self.channel2.io.volumeLeft, "/", self.channel2.io.volumeRight);
+  }
+  output.append("\n");
+
+  output.append("Channel 3: ");
+  if(!self.channel3.io.enable) {
+    output.append("disabled");
+  } else {
+    output.append("tone, ", self.channel3.io.pitch, " (", (96000.0 / (2048 - self.channel3.io.pitch)), " Hz), ",
+      self.channel3.io.volumeLeft, "/", self.channel3.io.volumeRight);
+    if(self.channel3.io.sweep) {
+      output.append(", sweep by ", self.channel3.io.sweepValue, " every ", self.channel3.io.sweepTime);
+    }
+  }
+  output.append("\n");
+
+  output.append("Channel 4: ");
+  if(!self.channel4.io.enable) {
+    output.append("disabled");
+  } else {
+    if(self.channel4.io.noise) {
+      output.append("noise, mode ", (self.channel4.io.noiseMode));
+    } else {
+      output.append("tone, ", self.channel4.io.pitch, " (", (96000.0 / (2048 - self.channel4.io.pitch)), " Hz)");
+    }
+    output.append(", ", self.channel4.io.volumeLeft, "/", self.channel4.io.volumeRight);
+  }
+  if(self.channel4.io.noiseUpdate) output.append(", LFSR active");
+  output.append("\n");
+
+  if(system.color()) {
+    output.append("Hyper Voice: ");
+    if(!self.channel5.io.enable) {
+      output.append("disabled");
+    } else {
+      // TODO: Hyper Voice
+      output.append("enabled");
+    }
+    output.append("\n");
+
+    output.append("Sound DMA: ",
+      self.dma.io.enable ? "enabled" : "disabled", ", ",
+      self.dma.io.loop ? "repeat" : "one-shot", ", ",
+      self.dma.io.target ? "Hyper Voice" : "Channel 2", ", ",
+      self.dma.io.direction ? "reverse" : "forward",
+      "\n");
+    output.append("Sound DMA Rate: ");
+    if(self.dma.io.rate == 0) output.append("4000 Hz\n");
+    if(self.dma.io.rate == 1) output.append("6000 Hz\n");
+    if(self.dma.io.rate == 2) output.append("12000 Hz\n");
+    if(self.dma.io.rate == 3) output.append("24000 Hz\n");
+    output.append("Sound DMA Source: ", hex(self.dma.io.source), " (", self.dma.io.length, " bytes)", "\n");
+  }
+
+  return output;
+}

--- a/ares/ws/apu/dma.cpp
+++ b/ares/ws/apu/dma.cpp
@@ -1,10 +1,10 @@
 auto APU::DMA::run() -> void {
   if(!io.enable) return;
 
-  if(io.rate == 0 && ++state.clock < 768) return;  // 4000hz
-  if(io.rate == 1 && ++state.clock < 512) return;  // 6000hz
-  if(io.rate == 2 && ++state.clock < 256) return;  //12000hz
-  if(io.rate == 3 && ++state.clock < 128) return;  //24000hz
+  if(io.rate == 0 && ++state.clock < 6) return;  // 4000hz
+  if(io.rate == 1 && ++state.clock < 4) return;  // 6000hz
+  if(io.rate == 2 && ++state.clock < 2) return;  //12000hz
+  //24000hz runs always
   state.clock = 0;
 
   n8 data = bus.read(state.source);

--- a/ares/ws/apu/io.cpp
+++ b/ares/ws/apu/io.cpp
@@ -4,14 +4,17 @@ auto APU::readIO(n16 address) -> n8 {
   switch(address) {
 
   case 0x004a ... 0x004c:  //SDMA_SRC
+    if(!system.color()) break;
     data = dma.state.source.byte(address - 0x004a);
     break;
 
   case 0x004e ... 0x0050:  //SDMA_LEN
+    if(!system.color()) break;
     data = dma.state.length.byte(address - 0x004e);
     break;
 
   case 0x0052:  //SDMA_CTRL
+    if(!system.color()) break;
     data.bit(0,1) = dma.io.rate;
     data.bit(2)   = dma.io.unknown;
     data.bit(3)   = dma.io.loop;
@@ -21,6 +24,7 @@ auto APU::readIO(n16 address) -> n8 {
     break;
 
   case 0x006a:  //SND_HYPER_CTRL
+    if(!system.color()) break;
     data.bit(0,1) = channel5.io.volume;
     data.bit(2,3) = channel5.io.scale;
     data.bit(4,6) = channel5.io.speed;
@@ -28,6 +32,7 @@ auto APU::readIO(n16 address) -> n8 {
     break;
 
   case 0x006b:  //SND_HYPER_CHAN_CTRL
+    if(!system.color()) break;
     data.bit(0,3) = channel5.io.unknown;
     data.bit(5)   = channel5.io.leftEnable;
     data.bit(6)   = channel5.io.rightEnable;
@@ -116,6 +121,7 @@ auto APU::readIO(n16 address) -> n8 {
     break;
 
   case 0x0095:  //SND_HYPERVOICE
+    if(!system.color()) break;
     data = channel5.state.data;
     break;
 

--- a/ares/ws/apu/io.cpp
+++ b/ares/ws/apu/io.cpp
@@ -109,8 +109,10 @@ auto APU::readIO(n16 address) -> n8 {
     break;
 
   case 0x0094:  //SND_VOICE_CTRL
-    data.bit(0,1) = channel2.io.voiceEnableRight;
-    data.bit(2,3) = channel2.io.voiceEnableLeft;
+    data.bit(0) = channel2.io.voiceEnableRightHalf;
+    data.bit(1) = channel2.io.voiceEnableRightFull;
+    data.bit(2) = channel2.io.voiceEnableLeftHalf;
+    data.bit(3) = channel2.io.voiceEnableLeftFull;
     break;
 
   case 0x0095:  //SND_HYPERVOICE
@@ -237,8 +239,10 @@ auto APU::writeIO(n16 address, n8 data) -> void {
     break;
 
   case 0x0094:  //SND_VOICE_CTRL
-    channel2.io.voiceEnableRight = data.bit(0,1);
-    channel2.io.voiceEnableLeft  = data.bit(2,3);
+    channel2.io.voiceEnableRightHalf = data.bit(0);
+    channel2.io.voiceEnableRightFull = data.bit(1);
+    channel2.io.voiceEnableLeftHalf  = data.bit(2);
+    channel2.io.voiceEnableLeftFull  = data.bit(3);
     break;
 
   case 0x009e:  //SND_VOLUME

--- a/ares/ws/apu/serialization.cpp
+++ b/ares/ws/apu/serialization.cpp
@@ -15,6 +15,8 @@ auto APU::serialize(serializer& s) -> void {
   s(io.headphonesConnected);
   s(io.masterVolume);
   s(state.sweepClock);
+  s(state.dacClock);
+  s(state.dmaClock);
 }
 
 auto APU::DMA::serialize(serializer& s) -> void {

--- a/ares/ws/apu/serialization.cpp
+++ b/ares/ws/apu/serialization.cpp
@@ -15,8 +15,7 @@ auto APU::serialize(serializer& s) -> void {
   s(io.headphonesConnected);
   s(io.masterVolume);
   s(state.sweepClock);
-  s(state.dacClock);
-  s(state.dmaClock);
+  s(state.apuClock);
 }
 
 auto APU::DMA::serialize(serializer& s) -> void {

--- a/ares/ws/apu/serialization.cpp
+++ b/ares/ws/apu/serialization.cpp
@@ -48,8 +48,10 @@ auto APU::Channel2::serialize(serializer& s) -> void {
   s(io.volumeRight);
   s(io.enable);
   s(io.voice);
-  s(io.voiceEnableLeft);
-  s(io.voiceEnableRight);
+  s(io.voiceEnableLeftHalf);
+  s(io.voiceEnableLeftFull);
+  s(io.voiceEnableRightHalf);
+  s(io.voiceEnableRightFull);
   s(state.period);
   s(state.sampleOffset);
   s(output.left);

--- a/ares/ws/cartridge/cartridge.cpp
+++ b/ares/ws/cartridge/cartridge.cpp
@@ -92,9 +92,7 @@ auto Cartridge::power() -> void {
   eeprom.power();
   rtc.power();
 
-  bus.map(this, 0x00c0, 0x00c8);
-  if(rtc.ram) bus.map(this, 0x00ca, 0x00cb);
-  bus.map(this, 0x00cc, 0x00cd);
+  bus.map(this, 0x00c0, 0x00ff);
 
   io = {};
 }

--- a/ares/ws/cartridge/cartridge.hpp
+++ b/ares/ws/cartridge/cartridge.hpp
@@ -85,10 +85,10 @@ struct Cartridge : Thread, IO {
   } rtc{*this};
 
   struct IO {
-    n8 romBank2 = 0xff;
-    n8 sramBank = 0xff;
-    n8 romBank0 = 0xff;
-    n8 romBank1 = 0xff;
+    n16 romBank2 = 0xffff;
+    n16 sramBank = 0xffff;
+    n16 romBank0 = 0xffff;
+    n16 romBank1 = 0xffff;
     n8 gpoEnable;
     n8 gpoData;
   } io;

--- a/ares/ws/cartridge/cartridge.hpp
+++ b/ares/ws/cartridge/cartridge.hpp
@@ -12,6 +12,11 @@ struct Cartridge : Thread, IO {
     //debugger.cpp
     auto load(Node::Object) -> void;
     auto unload(Node::Object) -> void;
+    auto ports() -> string;
+
+    struct Properties {
+      Node::Debugger::Properties ports;
+    } properties;
 
     struct Memory {
       Node::Debugger::Memory rom;

--- a/ares/ws/cartridge/debugger.cpp
+++ b/ares/ws/cartridge/debugger.cpp
@@ -37,9 +37,11 @@ auto Cartridge::Debugger::load(Node::Object parent) -> void {
 }
 
 auto Cartridge::Debugger::unload(Node::Object parent) -> void {
+  parent->remove(properties.ports);
   parent->remove(memory.rom);
   parent->remove(memory.ram);
   parent->remove(memory.eeprom);
+  properties.ports.reset();
   memory.rom.reset();
   memory.ram.reset();
   memory.eeprom.reset();

--- a/ares/ws/cartridge/debugger.cpp
+++ b/ares/ws/cartridge/debugger.cpp
@@ -55,7 +55,7 @@ auto Cartridge::Debugger::ports() -> string {
   output.append("ROM Bank Linear: ", hex(self.io.romBank2, 4L), "\n");
   output.append("SRAM Bank: ", hex(self.io.sramBank, 4L), "\n");
 
-  // TODO: RTC
+  // TODO: RTC, GPO
 
   return output;
 }

--- a/ares/ws/cartridge/debugger.cpp
+++ b/ares/ws/cartridge/debugger.cpp
@@ -31,6 +31,9 @@ auto Cartridge::Debugger::load(Node::Object parent) -> void {
       self.eeprom.data[address] = data;
     });
   }
+
+  properties.ports = parent->append<Node::Debugger::Properties>("Cartridge I/O");
+  properties.ports->setQuery([&] { return ports(); });
 }
 
 auto Cartridge::Debugger::unload(Node::Object parent) -> void {
@@ -40,4 +43,17 @@ auto Cartridge::Debugger::unload(Node::Object parent) -> void {
   memory.rom.reset();
   memory.ram.reset();
   memory.eeprom.reset();
+}
+
+auto Cartridge::Debugger::ports() -> string {
+  string output;
+
+  output.append("ROM Bank 0: ", hex(self.io.romBank0, 4L), "\n");
+  output.append("ROM Bank 1: ", hex(self.io.romBank1, 4L), "\n");
+  output.append("ROM Bank Linear: ", hex(self.io.romBank2, 4L), "\n");
+  output.append("SRAM Bank: ", hex(self.io.sramBank, 4L), "\n");
+
+  // TODO: RTC
+
+  return output;
 }

--- a/ares/ws/cartridge/io.cpp
+++ b/ares/ws/cartridge/io.cpp
@@ -4,19 +4,35 @@ auto Cartridge::readIO(n16 address) -> n8 {
   switch(address) {
 
   case 0x00c0:  //BANK_ROM2
-    data = io.romBank2;
+  case 0x00cf:
+    data.bit(0,7) = io.romBank2.bit(0,7);
     break;
 
   case 0x00c1:  //BANK_SRAM
-    data = io.sramBank;
+  case 0x00d0:
+    data.bit(0,7) = io.sramBank.bit(0,7);
+    break;
+
+  case 0x00d1:  //BANK_SRAM_HI
+    data.bit(0,7) = io.sramBank.bit(8,15);
     break;
 
   case 0x00c2:  //BANK_ROM0
-    data = io.romBank0;
+  case 0x00d2:
+    data.bit(0,7) = io.romBank0.bit(0,7);
+    break;
+
+  case 0x00d3:  //BANK_ROM0_HI
+    data.bit(0,7) = io.romBank0.bit(8,15);
     break;
 
   case 0x00c3:  //BANK_ROM1
-    data = io.romBank1;
+  case 0x00d4:
+    data.bit(0,7) = io.romBank1.bit(0,7);
+    break;
+
+  case 0x00d5:  //BANK_ROM1_HI
+    data.bit(0,7) = io.romBank1.bit(8,15);
     break;
 
   case 0x00c4:  //EEP_DATALO
@@ -64,19 +80,35 @@ auto Cartridge::writeIO(n16 address, n8 data) -> void {
   switch(address) {
 
   case 0x00c0:  //BANK_ROM2
-    io.romBank2 = data;
+  case 0x00cf:
+    io.romBank2.bit(0,7) = data.bit(0,7);
     break;
 
   case 0x00c1:  //BANK_SRAM
-    io.sramBank = data;
+  case 0x00d0:
+    io.sramBank.bit(0,7) = data.bit(0,7);
+    break;
+
+  case 0x00d1:  //BANK_RO01_HI
+    io.sramBank.bit(8,15) = data.bit(0,7);
     break;
 
   case 0x00c2:  //BANK_ROM0
-    io.romBank0 = data;
+  case 0x00d2:
+    io.romBank0.bit(0,7) = data.bit(0,7);
+    break;
+
+  case 0x00d3:  //BANK_RO01_HI
+    io.romBank0.bit(8,15) = data.bit(0,7);
     break;
 
   case 0x00c3:  //BANK_ROM1
-    io.romBank1 = data;
+  case 0x00d4:
+    io.romBank1.bit(0,7) = data.bit(0,7);
+    break;
+
+  case 0x00d5:  //BANK_ROM1_HI
+    io.romBank1.bit(8,15) = data.bit(0,7);
     break;
 
   case 0x00c4:  //EEP_DATALO
@@ -100,11 +132,11 @@ auto Cartridge::writeIO(n16 address, n8 data) -> void {
     break;
 
   case 0x00ca:  //RTC_CMD
-    rtc.execute(data);
+    if (rtc.ram) rtc.execute(data);
     break;
 
   case 0x00cb:  //RTC_DATA
-    rtc.write(data);
+    if (rtc.ram) rtc.write(data);
     break;
 
   case 0x00cc:  //GPO_EN

--- a/ares/ws/cartridge/memory.cpp
+++ b/ares/ws/cartridge/memory.cpp
@@ -1,7 +1,7 @@
 //20000-fffff
 auto Cartridge::readROM(n20 address) -> n8 {
   if(!rom) return 0x00;
-  n28 offset;
+  n32 offset;
   switch(address.bit(16,19)) {
   case 2:  offset = io.romBank0 << 16 | (n16)address; break;  //20000-2ffff
   case 3:  offset = io.romBank1 << 16 | (n16)address; break;  //30000-3ffff
@@ -16,12 +16,12 @@ auto Cartridge::writeROM(n20 address, n8 data) -> void {
 //10000-1ffff
 auto Cartridge::readRAM(n20 address) -> n8 {
   if(!ram) return 0x00;
-  n24 offset = io.sramBank << 16 | (n16)address;
+  n32 offset = io.sramBank << 16 | (n16)address;
   return ram.read(offset);
 }
 
 auto Cartridge::writeRAM(n20 address, n8 data) -> void {
   if(!ram) return;
-  n24 offset = io.sramBank << 16 | (n16)address;
+  n32 offset = io.sramBank << 16 | (n16)address;
   ram.write(offset, data);
 }

--- a/ares/ws/cartridge/rtc.cpp
+++ b/ares/ws/cartridge/rtc.cpp
@@ -43,11 +43,7 @@ auto Cartridge::RTC::tickSecond() -> void {
 auto Cartridge::RTC::checkAlarm() -> void {
   if(!alarm.bit(5)) return;
 
-  if(hour() == alarmHour && minute() == alarmMinute) {
-    cpu.raise(CPU::Interrupt::Cartridge);
-  } else {
-    cpu.lower(CPU::Interrupt::Cartridge);
-  }
+  cpu.irqLevel(CPU::Interrupt::Cartridge, hour() == alarmHour && minute() == alarmMinute);
 }
 
 auto Cartridge::RTC::status() -> n8 {

--- a/ares/ws/cpu/cpu.cpp
+++ b/ares/ws/cpu/cpu.cpp
@@ -62,6 +62,7 @@ auto CPU::power() -> void {
   }
 
   io = {};
+  keypad.power();
 }
 
 }

--- a/ares/ws/cpu/cpu.cpp
+++ b/ares/ws/cpu/cpu.cpp
@@ -52,7 +52,9 @@ auto CPU::power() -> void {
   Thread::create(3'072'000, {&CPU::main, this});
 
   bus.map(this, 0x00a0);
-  bus.map(this, 0x00b0, 0x00b7);
+  bus.map(this, 0x00b0);
+  bus.map(this, 0x00b2);
+  bus.map(this, 0x00b4, 0x00b7);
 
   if(Model::WonderSwanColor() || Model::SwanCrystal()) {
     bus.map(this, 0x0040, 0x0049);

--- a/ares/ws/cpu/cpu.cpp
+++ b/ares/ws/cpu/cpu.cpp
@@ -40,11 +40,11 @@ auto CPU::write(n20 address, n8 data) -> void {
 }
 
 auto CPU::in(n16 port) -> n8 {
-  return bus.readIO(port);
+  return bus.readIO(port & 0x01ff);
 }
 
 auto CPU::out(n16 port, n8 data) -> void {
-  return bus.writeIO(port, data);
+  return bus.writeIO(port & 0x01ff, data);
 }
 
 auto CPU::power() -> void {
@@ -52,7 +52,7 @@ auto CPU::power() -> void {
   Thread::create(3'072'000, {&CPU::main, this});
 
   bus.map(this, 0x00a0);
-  bus.map(this, 0x00b0, 0x00b6);
+  bus.map(this, 0x00b0, 0x00b7);
 
   if(Model::WonderSwanColor() || Model::SwanCrystal()) {
     bus.map(this, 0x0040, 0x0049);

--- a/ares/ws/cpu/cpu.hpp
+++ b/ares/ws/cpu/cpu.hpp
@@ -86,9 +86,6 @@ struct CPU : V30MZ, Thread, IO {
     n8 interruptBase;
     n8 interruptEnable;
     n8 interruptStatus;
-    n8 serialData;
-    n1 serialBaudRate;  //0 = 9600; 1 = 38400
-    n1 serialEnable;
     n1 nmiOnLowBattery;
   } io;
 };

--- a/ares/ws/cpu/cpu.hpp
+++ b/ares/ws/cpu/cpu.hpp
@@ -81,12 +81,15 @@ struct CPU : V30MZ, Thread, IO {
 
   struct IO {
     n1 cartridgeEnable;
+    n1 cartridgeRomWidth; // 0 = 8-bit; 1 = 16-bit
+    n1 cartridgeRomWait; // 0 = 3 cycles; 1 = 1 cycle
     n8 interruptBase;
     n8 interruptEnable;
     n8 interruptStatus;
     n8 serialData;
     n1 serialBaudRate;  //0 = 9600; 1 = 38400
     n1 serialEnable;
+    n1 nmiOnLowBattery;
   } io;
 };
 

--- a/ares/ws/cpu/cpu.hpp
+++ b/ares/ws/cpu/cpu.hpp
@@ -7,6 +7,7 @@ struct CPU : V30MZ, Thread, IO {
     //debugger.cpp
     auto load(Node::Object) -> void;
     auto unload(Node::Object) -> void;
+    auto ports() -> string;
     auto instruction() -> void;
     auto interrupt(n3) -> void;
 

--- a/ares/ws/cpu/cpu.hpp
+++ b/ares/ws/cpu/cpu.hpp
@@ -52,6 +52,7 @@ struct CPU : V30MZ, Thread, IO {
 
   //interrupt.cpp
   auto poll() -> void;
+  auto irqLevel(n3, bool) -> void;
   auto raise(n3) -> void;
   auto lower(n3) -> void;
 
@@ -76,8 +77,11 @@ struct CPU : V30MZ, Thread, IO {
 
     //keypad.cpp
     auto read() -> n4;
+    auto poll() -> void;
+    auto power() -> void;
 
     n3 matrix;
+    n3 lastPolledMatrix;
   } keypad{*this};
 
   struct IO {

--- a/ares/ws/cpu/debugger.cpp
+++ b/ares/ws/cpu/debugger.cpp
@@ -37,6 +37,8 @@ auto CPU::Debugger::ports() -> string {
     "HblankTimer"
   };
 
+  output.append("SoC Interrupt Base: ", hex(self.io.interruptBase, 2), "\n");
+
   output.append("SoC Interrupts Enabled: ");
   u32 iAdded = 0;
   for(u32 i : range(8)) {
@@ -58,6 +60,12 @@ auto CPU::Debugger::ports() -> string {
   output.append("\n");
 
   output.append("NMI on Low Battery: ", self.io.nmiOnLowBattery ? "enabled" : "disabled", "\n");
+
+  output.append("Cartridge Bus: ",
+    self.io.cartridgeEnable ? "enabled" : "disabled", ", ",
+    self.io.cartridgeRomWidth ? "16-bit" : "8-bit", ", ",
+    self.io.cartridgeRomWait ? "1 wait cycle" : "3 wait cycles",
+    "\n");
 
   return output;
 }

--- a/ares/ws/cpu/debugger.cpp
+++ b/ares/ws/cpu/debugger.cpp
@@ -23,6 +23,45 @@ auto CPU::Debugger::unload(Node::Object parent) -> void {
   tracer.interrupt.reset();
 }
 
+auto CPU::Debugger::ports() -> string {
+  string output;
+
+  static const string irqName[8] = {
+    "SerialSend",
+    "Input",
+    "Cartridge",
+    "SerialReceive",
+    "LineCompare",
+    "VblankTimer",
+    "Vblank",
+    "HblankTimer"
+  };
+
+  output.append("SoC Interrupts Enabled: ");
+  u32 iAdded = 0;
+  for(u32 i : range(8)) {
+    if(self.io.interruptEnable & (1 << i)) {
+      if(iAdded++ > 0) output.append(", ");
+      output.append(irqName[i]);
+    }
+  }
+  output.append("\n");
+
+  output.append("SoC Interrupts Raised: ");
+  iAdded = 0;
+  for(u32 i : range(8)) {
+    if(self.io.interruptStatus & (1 << i)) {
+      if(iAdded++ > 0) output.append(", ");
+      output.append(irqName[i]);
+    }
+  }
+  output.append("\n");
+
+  output.append("NMI on Low Battery: ", self.io.nmiOnLowBattery ? "enabled" : "disabled", "\n");
+
+  return output;
+}
+
 auto CPU::Debugger::instruction() -> void {
   if(likely(!tracer.instruction->enabled())) return;
   if(tracer.instruction->address(n20(self.PS * 16 + self.PC))) {

--- a/ares/ws/cpu/interrupt.cpp
+++ b/ares/ws/cpu/interrupt.cpp
@@ -21,3 +21,8 @@ auto CPU::raise(n3 irq) -> void {
 auto CPU::lower(n3 irq) -> void {
   io.interruptStatus.bit(irq) = 0;
 }
+
+auto CPU::irqLevel(n3 irq, bool value) -> void {
+  if(value) raise(irq);
+  else lower(irq);
+}

--- a/ares/ws/cpu/interrupt.cpp
+++ b/ares/ws/cpu/interrupt.cpp
@@ -8,7 +8,7 @@ auto CPU::poll() -> void {
     if(!PSW.IE) continue;
 
     debugger.interrupt(id);
-    interrupt(io.interruptBase + id);
+    interrupt((io.interruptBase & ~7) | id);
     return;
   }
 }

--- a/ares/ws/cpu/io.cpp
+++ b/ares/ws/cpu/io.cpp
@@ -4,18 +4,22 @@ auto CPU::readIO(n16 address) -> n8 {
   switch(address) {
 
   case 0x0040 ... 0x0042:  //DMA_SRC
+    if(!system.color()) break;
     data = dma.source.byte(address - 0x0040);
     break;
 
   case 0x0044 ... 0x0045:  //DMA_DST
+    if(!system.color()) break;
     data = dma.target.byte(address - 0x0044);
     break;
 
   case 0x0046 ... 0x0047:  //DMA_LEN
+    if(!system.color()) break;
     data = dma.length.byte(address - 0x0046);
     break;
 
   case 0x0048:  //DMA_CTRL
+    if(!system.color()) break;
     data.bit(0) = dma.direction;
     data.bit(7) = dma.enable;
     break;
@@ -63,21 +67,25 @@ auto CPU::writeIO(n16 address, n8 data) -> void {
   switch(address) {
 
   case 0x0040 ... 0x0042:  //DMA_SRC
+    if(!system.color()) break;
     dma.source.byte(address - 0x0040) = data;
     dma.source &= ~1;
     break;
 
   case 0x0044 ... 0x0045:  //DMA_DST
+    if(!system.color()) break;
     dma.target.byte(address - 0x0044) = data;
     dma.target &= ~1;
     break;
 
   case 0x0046 ... 0x0047:  //DMA_LEN
+    if(!system.color()) break;
     dma.length.byte(address - 0x0046) = data;
     dma.length &= ~1;
     break;
 
   case 0x0048:  //DMA_CTRL
+    if(!system.color()) break;
     dma.direction = data.bit(6);
     dma.enable    = data.bit(7);
     if(dma.enable) dma.transfer();

--- a/ares/ws/cpu/io.cpp
+++ b/ares/ws/cpu/io.cpp
@@ -27,7 +27,8 @@ auto CPU::readIO(n16 address) -> n8 {
   case 0x00a0:  //HW_FLAGS
     data.bit(0) = io.cartridgeEnable;
     data.bit(1) = !SoC::ASWAN();
-    data.bit(2) = 1;  //0 = 8-bit bus width; 1 = 16-bit bus width
+    data.bit(2) = io.cartridgeRomWidth;
+    data.bit(3) = io.cartridgeRomWait;
     data.bit(7) = 1;  //1 = built-in self-test passed
     break;
 
@@ -57,6 +58,10 @@ auto CPU::readIO(n16 address) -> n8 {
   case 0x00b5:  //KEYPAD
     data.bit(0,3) = keypad.read();
     data.bit(4,6) = keypad.matrix;
+    break;
+
+  case 0x00b7:  //NMI
+    data.bit(4) = io.nmiOnLowBattery;
     break;
 
   }
@@ -95,8 +100,9 @@ auto CPU::writeIO(n16 address, n8 data) -> void {
     break;
 
   case 0x00a0:  //HW_FLAGS
-    //todo: d2 (bus width) bit is writable; but ... it will do very bad things
     io.cartridgeEnable |= data.bit(0);  //bit can never be unset (boot ROM lockout)
+    io.cartridgeRomWidth = data.bit(2);
+    io.cartridgeRomWait = data.bit(3);
     break;
 
   case 0x00b0:  //INT_BASE
@@ -124,6 +130,10 @@ auto CPU::writeIO(n16 address, n8 data) -> void {
   case 0x00b6:  //INT_ACK
     //acknowledge only edge-sensitive interrupts
     io.interruptStatus &= ~(data & 0b11110010);
+    break;
+
+  case 0x00b7:  //NMI
+    io.nmiOnLowBattery = data.bit(4);
     break;
 
   }

--- a/ares/ws/cpu/io.cpp
+++ b/ares/ws/cpu/io.cpp
@@ -37,18 +37,8 @@ auto CPU::readIO(n16 address) -> n8 {
     data |= SoC::ASWAN() ? 3 : 0;
     break;
 
-  case 0x00b1:  //SER_DATA
-    data = io.serialData;
-    break;
-
   case 0x00b2:  //INT_ENABLE
     data = io.interruptEnable;
-    break;
-
-  case 0x00b3:  //SER_STATUS
-    data.bit(2) = 1;  //hack: always report send buffer as empty
-    data.bit(6) = io.serialBaudRate;
-    data.bit(7) = io.serialEnable;
     break;
 
   case 0x00b4:  //INT_STATUS
@@ -109,18 +99,9 @@ auto CPU::writeIO(n16 address, n8 data) -> void {
     io.interruptBase = SoC::ASWAN() ? data & ~7 : data & ~1;
     break;
 
-  case 0x00b1:  //SER_DATA
-    io.serialData = data;
-    break;
-
   case 0x00b2:  //INT_ENABLE
     //disabling an interrupt that is pending will *not* clear its pending flag
     io.interruptEnable = data;
-    break;
-
-  case 0x00b3:  //SER_STATUS
-    io.serialBaudRate = data.bit(6);
-    io.serialEnable   = data.bit(7);
     break;
 
   case 0x00b5:  //KEYPAD

--- a/ares/ws/cpu/keypad.cpp
+++ b/ares/ws/cpu/keypad.cpp
@@ -63,3 +63,15 @@ auto CPU::Keypad::read() -> n4 {
 
   return data;
 }
+
+auto CPU::Keypad::poll() -> void {
+  n3 polledMatrix = read();
+  if (polledMatrix & ~(lastPolledMatrix)) {
+    cpu.raise(CPU::Interrupt::Input);
+  }
+  lastPolledMatrix = polledMatrix;
+}
+
+auto CPU::Keypad::power() -> void {
+  lastPolledMatrix = read();
+}

--- a/ares/ws/cpu/serialization.cpp
+++ b/ares/ws/cpu/serialization.cpp
@@ -11,7 +11,5 @@ auto CPU::serialize(serializer& s) -> void {
   s(io.interruptBase);
   s(io.interruptEnable);
   s(io.interruptStatus);
-  s(io.serialData);
-  s(io.serialBaudRate);
-  s(io.serialEnable);
+  s(io.nmiOnLowBattery);
 }

--- a/ares/ws/cpu/serialization.cpp
+++ b/ares/ws/cpu/serialization.cpp
@@ -7,6 +7,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(dma.enable);
   s(dma.direction);
   s(keypad.matrix);
+  s(keypad.lastPolledMatrix);
   s(io.cartridgeEnable);
   s(io.interruptBase);
   s(io.interruptEnable);

--- a/ares/ws/memory/memory.cpp
+++ b/ares/ws/memory/memory.cpp
@@ -28,7 +28,9 @@ auto Bus::read(n20 address) -> n8 {
   switch(address.bit(16,19)) { default:
   case 0x0: return iram.read(address);
   case 0x1: return cartridge.readRAM(address);
-  case 0x2 ... 0xf: return cartridge.readROM(address);
+  case 0x2 ... 0xf:
+    if(!cpu.io.cartridgeRomWidth) address &= ~(0x1);
+    return cartridge.readROM(address);
   }
 }
 
@@ -39,7 +41,9 @@ auto Bus::write(n20 address, n8 data) -> void {
   switch(address.bit(16,19)) { default:
   case 0x0: return iram.write(address, data);
   case 0x1: return cartridge.writeRAM(address, data);
-  case 0x2 ... 0xf: return cartridge.writeROM(address, data);
+  case 0x2 ... 0xf:
+    if(!cpu.io.cartridgeRomWidth) address &= ~(0x1);
+    return cartridge.writeROM(address, data);
   }
 }
 

--- a/ares/ws/ppu/debugger.cpp
+++ b/ares/ws/ppu/debugger.cpp
@@ -131,6 +131,9 @@ auto PPU::Debugger::ports() -> string {
   }
 
   output.append("\n");
+  output.append("HBlank Timer: ", self.htimer.counter, "/", self.htimer.frequency, "; ", self.htimer.enable ? "enabled" : "disabled", ", ", self.htimer.repeat ? "repeat" : "one-shot", "\n");
+  output.append("VBlank Timer: ", self.vtimer.counter, "/", self.vtimer.frequency, "; ", self.vtimer.enable ? "enabled" : "disabled", ", ", self.vtimer.repeat ? "repeat" : "one-shot", "\n");
+
   output.append("LCD Timing: ", (self.io.vtotal + 1), " lines/frame (", (12000.0 / (self.io.vtotal + 1)), " Hz), VBP @ line ", self.io.vsync);
   if(self.io.vtotal != self.io.vsync + 3) {
     output.append(" (unexpected)");

--- a/ares/ws/ppu/debugger.cpp
+++ b/ares/ws/ppu/debugger.cpp
@@ -1,0 +1,47 @@
+auto PPU::Debugger::load(Node::Object parent) -> void {
+  graphics.tiles = parent->append<Node::Debugger::Graphics>("Tiles");
+  graphics.tiles->setSize(256, 256);
+  graphics.tiles->setCapture([&]() -> vector<u32> {
+    vector<u32> output;
+    output.resize(256 * 256);
+    for(u32 tileY : range(32)) {
+      if(tileY == 16 && !system.color()) break;
+      for(u32 tileX : range(32)) {
+        n16 address = 0x2000 + ((tileY * 32 + tileX) << 4);
+        if(self.depth() == 4) {
+          for(u32 y : range(8)) {
+            n32 d0 = iram.read32((address + (y << 1)) << 1);
+            for(u32 x : range(8)) {
+              n4 color;
+              if(self.packed()) {
+                color.bit(0, 3) = d0.bit((7 - x) << 2);
+              } else {
+                color.bit(0) = d0.bit( 7 - x);
+                color.bit(1) = d0.bit(15 - x);
+                color.bit(2) = d0.bit(23 - x);
+                color.bit(3) = d0.bit(31 - x);
+              }
+              output[(tileY * 8 + y) * 256 + (tileX * 8 + x)] = color * 0x111111;
+            }
+          }
+        } else {
+          for(u32 y : range(8)) {
+            n16 d0 = iram.read16(address + (y << 1));
+            for(u32 x : range(8)) {
+              n2 color;
+              color.bit(0) = d0.bit( 7 - x);
+              color.bit(1) = d0.bit(15 - x);
+              output[(tileY * 8 + y) * 256 + (tileX * 8 + x)] = color * 0x555555;
+            }
+          }
+        }
+      }
+    }
+    return output;
+  });
+}
+
+auto PPU::Debugger::unload(Node::Object parent) -> void {
+  parent->remove(graphics.tiles);
+  graphics.tiles.reset();
+}

--- a/ares/ws/ppu/debugger.cpp
+++ b/ares/ws/ppu/debugger.cpp
@@ -113,6 +113,8 @@ auto PPU::Debugger::ports() -> string {
     self.sprite.window.x1[1], ", ", self.sprite.window.y1[1], "; ",
     self.sprite.window.enable[1] ? (self.sprite.window.invert[1] ? "inverted" : "enabled") : "disabled",
     "\n");
+  
+  output.append("Line Compare: ", self.io.vcounter, " == ", self.io.vcompare, "\n");
 
   output.append("Shade LUT: ");
   for(u32 i : range(8)) {

--- a/ares/ws/ppu/debugger.cpp
+++ b/ares/ws/ppu/debugger.cpp
@@ -1,4 +1,43 @@
 auto PPU::Debugger::load(Node::Object parent) -> void {
+  graphics.screen1 = parent->append<Node::Debugger::Graphics>("Screen 1");
+  graphics.screen1->setSize(256, 256);
+  graphics.screen1->setCapture([&]() -> vector<u32> {
+    vector<u32> output;
+    output.resize(256 * 256);
+    for(u32 y : range(256)) {
+      for(u32 x : range(256)) {
+        PPU::Output pixel;
+        ppu.screen1.screenPixel(x, y, pixel);
+        if(!pixel.valid) continue;
+        u32 b = pixel.color.bit(0, 3);
+        u32 g = pixel.color.bit(4, 7);
+        u32 r = pixel.color.bit(8,11);
+        output[y * 256 + x] = ((r * 0x11) << 16) | ((g * 0x11) << 8) | (b * 0x11);
+      }
+    }
+    return output;
+  });
+
+  graphics.screen2 = parent->append<Node::Debugger::Graphics>("Screen 2");
+  graphics.screen2->setSize(256, 256);
+  graphics.screen2->setCapture([&]() -> vector<u32> {
+    vector<u32> output;
+    output.resize(256 * 256);
+    for(u32 y : range(256)) {
+      for(u32 x : range(256)) {
+        PPU::Output pixel;
+        ppu.screen2.screenPixel(x, y, pixel);
+        if(!pixel.valid) continue;
+        u32 b = pixel.color.bit(0, 3);
+        u32 g = pixel.color.bit(4, 7);
+        u32 r = pixel.color.bit(8,11);
+        output[y * 256 + x] = ((r * 0x11) << 16) | ((g * 0x11) << 8) | (b * 0x11);
+      }
+    }
+    return output;
+  });
+
+
   graphics.tiles = parent->append<Node::Debugger::Graphics>("Tiles");
   graphics.tiles->setSize(256, 256);
   graphics.tiles->setCapture([&]() -> vector<u32> {
@@ -14,7 +53,7 @@ auto PPU::Debugger::load(Node::Object parent) -> void {
             for(u32 x : range(8)) {
               n4 color;
               if(self.packed()) {
-                color.bit(0, 3) = d0.bit((7 - x) << 2);
+                color.bit(0, 3) = bswap32(d0) >> ((7 - x) << 2);
               } else {
                 color.bit(0) = d0.bit( 7 - x);
                 color.bit(1) = d0.bit(15 - x);
@@ -43,5 +82,9 @@ auto PPU::Debugger::load(Node::Object parent) -> void {
 
 auto PPU::Debugger::unload(Node::Object parent) -> void {
   parent->remove(graphics.tiles);
+  parent->remove(graphics.screen2);
+  parent->remove(graphics.screen1);
   graphics.tiles.reset();
+  graphics.screen2.reset();
+  graphics.screen1.reset();
 }

--- a/ares/ws/ppu/io.cpp
+++ b/ares/ws/ppu/io.cpp
@@ -21,7 +21,6 @@ auto PPU::readIO(n16 address) -> n8 {
     break;
 
   case 0x0002:  //LINE_CUR
-    //todo: unknown if this is vcounter or vcounter%(vtotal+1)
     data = io.vcounter;
     break;
 

--- a/ares/ws/ppu/ppu.cpp
+++ b/ares/ws/ppu/ppu.cpp
@@ -3,6 +3,7 @@
 namespace ares::WonderSwan {
 
 PPU ppu;
+#include "debugger.cpp"
 #include "io.cpp"
 #include "memory.cpp"
 #include "window.cpp"
@@ -160,9 +161,13 @@ auto PPU::load(Node::Object parent) -> void {
 
   updateOrientation();
   updateIcons();
+
+  debugger.load(node);
 }
 
 auto PPU::unload() -> void {
+  debugger.unload(node);
+
   icon = {};
   showIcons.reset();
   orientation.reset();

--- a/ares/ws/ppu/ppu.cpp
+++ b/ares/ws/ppu/ppu.cpp
@@ -14,6 +14,10 @@ PPU ppu;
 #include "color.cpp"
 #include "serialization.cpp"
 
+auto PPU::setAccurate(bool value) -> void {
+  accurate = value;
+}
+
 auto PPU::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("PPU");
 
@@ -195,9 +199,9 @@ auto PPU::main() -> void {
       screen2.pixel(x, y);
       sprite.pixel(x, y);
       dac.pixel(x, y);
-      step(1);
+      if(accurate) step(1);
     }
-    step(32);
+    step((accurate ? 0 : 224) + 32);
   } else {
     step(256);
   }

--- a/ares/ws/ppu/ppu.hpp
+++ b/ares/ws/ppu/ppu.hpp
@@ -42,6 +42,8 @@ struct PPU : Thread, IO {
     auto unload(Node::Object) -> void;
 
     struct Graphics {
+      Node::Debugger::Graphics screen1;
+      Node::Debugger::Graphics screen2;
       Node::Debugger::Graphics tiles;
     } graphics;
   } debugger{*this};
@@ -100,6 +102,7 @@ struct PPU : Thread, IO {
 
     //screen.cpp
     auto scanline(n8 y) -> void;
+    auto screenPixel(n8 x, n8 y, Output& output) -> void;
     auto pixel(n8 x, n8 y) -> void;
     auto power() -> void;
 

--- a/ares/ws/ppu/ppu.hpp
+++ b/ares/ws/ppu/ppu.hpp
@@ -25,6 +25,8 @@ struct PPU : Thread, IO {
     Node::Video::Sprite volumeB3;
   } icon;
 
+  bool accurate;
+
   auto hcounter() const -> u32 { return io.hcounter; }
   auto vcounter() const -> u32 { return io.vcounter; }
   auto field() const -> bool { return io.field; }
@@ -54,6 +56,8 @@ struct PPU : Thread, IO {
   } debugger{*this};
 
   //ppu.cpp
+  auto setAccurate(bool value) -> void;
+
   auto load(Node::Object) -> void;
   auto unload() -> void;
 
@@ -123,7 +127,8 @@ struct PPU : Thread, IO {
     //screen.cpp
     auto scanline(n8 y) -> void;
     auto pixel(n8 x, n8 y) -> void;
-    auto power() -> void;
+    auto power() -> void;  auto setAccurate(bool value) -> void;
+
   } screen1{*this};
 
   struct Screen2 : Screen {

--- a/ares/ws/ppu/ppu.hpp
+++ b/ares/ws/ppu/ppu.hpp
@@ -40,12 +40,17 @@ struct PPU : Thread, IO {
     //debugger.cpp
     auto load(Node::Object) -> void;
     auto unload(Node::Object) -> void;
+    auto ports() -> string;
 
     struct Graphics {
       Node::Debugger::Graphics screen1;
       Node::Debugger::Graphics screen2;
       Node::Debugger::Graphics tiles;
     } graphics;
+
+    struct Properties {
+      Node::Debugger::Properties ports;
+    } properties;
   } debugger{*this};
 
   //ppu.cpp

--- a/ares/ws/ppu/ppu.hpp
+++ b/ares/ws/ppu/ppu.hpp
@@ -34,6 +34,18 @@ struct PPU : Thread, IO {
   auto depth() const -> u32 { return system.mode().bit(1,2) != 3 ? 2 : 4; }
   auto grayscale() const -> bool { return system.mode().bit(2) == 0; }
 
+  struct Debugger {
+    PPU& self;
+
+    //debugger.cpp
+    auto load(Node::Object) -> void;
+    auto unload(Node::Object) -> void;
+
+    struct Graphics {
+      Node::Debugger::Graphics tiles;
+    } graphics;
+  } debugger{*this};
+
   //ppu.cpp
   auto load(Node::Object) -> void;
   auto unload() -> void;

--- a/ares/ws/ppu/screen.cpp
+++ b/ares/ws/ppu/screen.cpp
@@ -14,12 +14,8 @@ auto PPU::Screen2::scanline(n8 y) -> void {
   window.scanline(y);
 }
 
-auto PPU::Screen::pixel(n8 x, n8 y) -> void {
+auto PPU::Screen::screenPixel(n8 x, n8 y, Output& output) -> void {
   output = {};
-  if(!enable[0]) return;
-
-  x += hscroll[0];
-  y += vscroll[0];
 
   n15 address = x.bit(3,7) << 1 | y.bit(3,7) << 6 | mapBase[0] << 11;
   n16 attributes = iram.read16(address);
@@ -34,6 +30,15 @@ auto PPU::Screen::pixel(n8 x, n8 y) -> void {
     output.valid = 1;
     output.color = self.palette(palette, color);
   }
+}
+
+auto PPU::Screen::pixel(n8 x, n8 y) -> void {
+  if(!enable[0]) return;
+
+  x += hscroll[0];
+  y += vscroll[0];
+
+  screenPixel(x, y, output);
 }
 
 auto PPU::Screen1::pixel(n8 x, n8 y) -> void {

--- a/ares/ws/ppu/screen.cpp
+++ b/ares/ws/ppu/screen.cpp
@@ -33,6 +33,7 @@ auto PPU::Screen::screenPixel(n8 x, n8 y, Output& output) -> void {
 }
 
 auto PPU::Screen::pixel(n8 x, n8 y) -> void {
+  output = {};
   if(!enable[0]) return;
 
   x += hscroll[0];

--- a/ares/ws/ppu/timer.cpp
+++ b/ares/ws/ppu/timer.cpp
@@ -1,7 +1,10 @@
-auto PPU::Timer::step() -> bool {
-  if(enable && counter && !--counter) {
-    if(repeat) counter = frequency;
-    return true;
+auto PPU::Timer::step() -> bool { 
+  n16 counterNext = counter - 1;
+  if(enable) {
+    counter = counterNext;
+    if(repeat && !counter) {
+      counter = frequency;
+    }
   }
-  return false;
+  return counterNext == 0;
 }

--- a/ares/ws/serial/debugger.cpp
+++ b/ares/ws/serial/debugger.cpp
@@ -1,0 +1,27 @@
+auto Serial::Debugger::load(Node::Object parent) -> void {
+  properties.ports = parent->append<Node::Debugger::Properties>("Serial I/O");
+  properties.ports->setQuery([&] { return ports(); });
+}
+
+auto Serial::Debugger::unload(Node::Object parent) -> void {
+  parent->remove(properties.ports);
+  properties.ports.reset();
+}
+
+auto Serial::Debugger::ports() -> string {
+  string output;
+
+  output.append("Serial: ");
+  if(self.state.enable) {
+    output.append("enabled, ", self.state.baudRate ? "38400 Hz" : "9600 Hz");
+  } else {
+    output.append("disabled");
+  }
+  output.append("\n");
+
+  output.append("Serial TX in progress: ", self.state.txFull ? "yes" : "no", "\n");
+  output.append("Serial RX available: ", self.state.rxFull ? "yes" : "no", "\n");
+  output.append("Serial RX overrun: ", self.state.rxOverrun ? "yes" : "no", "\n");
+
+  return output;
+}

--- a/ares/ws/serial/serial.cpp
+++ b/ares/ws/serial/serial.cpp
@@ -1,0 +1,87 @@
+#include <ws/ws.hpp>
+
+namespace ares::WonderSwan {
+
+Serial serial;
+#include "serialization.cpp"
+
+auto Serial::main() -> void {
+  step(80);
+  
+  if (!state.enable) return;
+  if (!state.baudRate && ++state.clock < 4) return;
+  state.clock = 0;
+
+  // stub implementation
+  state.txFull = 0;
+  if(!state.txFull) {
+    cpu.raise(CPU::Interrupt::SerialSend);
+  } else {
+    cpu.lower(CPU::Interrupt::SerialSend);
+  }
+  if(state.rxFull) {
+    cpu.raise(CPU::Interrupt::SerialReceive);
+  } else {
+    cpu.lower(CPU::Interrupt::SerialReceive);
+  }
+}
+
+auto Serial::step(u32 clocks) -> void {
+  Thread::step(clocks);
+  Thread::synchronize(cpu);
+}
+
+auto Serial::readIO(n16 address) -> n8 {
+  n8 data;
+
+  switch(address) {
+
+  case 0x00b1:  //SER_DATA
+    data = state.dataRx;
+    state.rxFull = 0;
+    break;
+
+  case 0x00b3:  //SER_STATUS
+    data.bit(0) = state.rxFull;
+    data.bit(1) = state.rxOverrun;
+    data.bit(2) = !state.txFull;
+    data.bit(6) = state.baudRate;
+    data.bit(7) = state.enable;
+    break;
+
+  }
+
+  return data;
+}
+
+auto Serial::writeIO(n16 address, n8 data) -> void {
+  switch(address) {
+
+  case 0x00b1:  //SER_DATA
+    if(!state.txFull) {
+      state.dataTx = data;
+      state.txFull = 1;
+    }
+    break;
+
+  case 0x00b3:  //SER_STATUS
+    state.rxOverrun &= ~data.bit(5);
+    state.baudRate  = data.bit(6);
+    state.enable    = data.bit(7);
+    break;
+
+  }
+
+  return;
+}
+
+auto Serial::power() -> void {
+  Thread::create(3'072'000, {&Serial::main, this});
+
+  bus.map(this, 0x00b1);
+  bus.map(this, 0x00b3);
+
+  state = {};
+}
+
+}

--- a/ares/ws/serial/serial.cpp
+++ b/ares/ws/serial/serial.cpp
@@ -30,16 +30,8 @@ auto Serial::main() -> void {
       state.txFull = 0;
     }
   }
-  if(!state.txFull) {
-    cpu.raise(CPU::Interrupt::SerialSend);
-  } else {
-    cpu.lower(CPU::Interrupt::SerialSend);
-  }
-  if(state.rxFull) {
-    cpu.raise(CPU::Interrupt::SerialReceive);
-  } else {
-    cpu.lower(CPU::Interrupt::SerialReceive);
-  }
+  cpu.irqLevel(CPU::Interrupt::SerialSend, !state.txFull);
+  cpu.irqLevel(CPU::Interrupt::SerialReceive, state.rxFull);
 }
 
 auto Serial::step(u32 clocks) -> void {

--- a/ares/ws/serial/serial.cpp
+++ b/ares/ws/serial/serial.cpp
@@ -9,11 +9,16 @@ auto Serial::main() -> void {
   step(80);
   
   if (!state.enable) return;
-  if (!state.baudRate && ++state.clock < 4) return;
-  state.clock = 0;
+  if (!state.baudRate && ++state.baudClock < 4) return;
+  state.baudClock = 0;
 
   // stub implementation
-  state.txFull = 0;
+  if(state.txFull) {
+    if(++state.txBitClock == 9) {
+      state.txBitClock = 0;
+      state.txFull = 0;
+    }
+  }
   if(!state.txFull) {
     cpu.raise(CPU::Interrupt::SerialSend);
   } else {

--- a/ares/ws/serial/serial.cpp
+++ b/ares/ws/serial/serial.cpp
@@ -3,7 +3,18 @@
 namespace ares::WonderSwan {
 
 Serial serial;
+#include "debugger.cpp"
 #include "serialization.cpp"
+
+auto Serial::load(Node::Object parent) -> void {
+  node = parent->append<Node::Object>("Serial");
+  debugger.load(node);
+}
+
+auto Serial::unload() -> void {
+  debugger.unload(node);
+  node.reset();
+}
 
 auto Serial::main() -> void {
   step(80);

--- a/ares/ws/serial/serial.hpp
+++ b/ares/ws/serial/serial.hpp
@@ -1,0 +1,26 @@
+struct Serial : Thread, IO {
+  //serial.cpp
+  auto main() -> void;
+  auto step(u32 clocks) -> void;
+
+  auto readIO(n16 address) -> n8 override;
+  auto writeIO(n16 address, n8 data) -> void override;
+
+  auto power() -> void;
+
+  //serialization.cpp
+  auto serialize(serializer&) -> void;
+
+  struct State {
+    n8 dataTx;
+    n8 dataRx;
+    n1 baudRate;  //0 = 9600; 1 = 38400
+    n1 enable;
+    n1 rxOverrun;
+    n1 txFull;
+    n1 rxFull;
+    n32 clock;
+  } state;
+};
+
+extern Serial serial;

--- a/ares/ws/serial/serial.hpp
+++ b/ares/ws/serial/serial.hpp
@@ -19,7 +19,9 @@ struct Serial : Thread, IO {
     n1 rxOverrun;
     n1 txFull;
     n1 rxFull;
-    n32 clock;
+    n8 baudClock;
+    n8 txBitClock;
+    n8 rxBitClock;
   } state;
 };
 

--- a/ares/ws/serial/serial.hpp
+++ b/ares/ws/serial/serial.hpp
@@ -1,5 +1,10 @@
 struct Serial : Thread, IO {
+  Node::Object node;
+  
   //serial.cpp
+  auto load(Node::Object) -> void;
+  auto unload() -> void;
+
   auto main() -> void;
   auto step(u32 clocks) -> void;
 
@@ -10,6 +15,19 @@ struct Serial : Thread, IO {
 
   //serialization.cpp
   auto serialize(serializer&) -> void;
+
+  struct Debugger {
+    Serial& self;
+
+    //debugger.cpp
+    auto load(Node::Object) -> void;
+    auto unload(Node::Object) -> void;
+    auto ports() -> string;
+
+    struct Properties {
+      Node::Debugger::Properties ports;
+    } properties;
+  } debugger{*this};
 
   struct State {
     n8 dataTx;

--- a/ares/ws/serial/serialization.cpp
+++ b/ares/ws/serial/serialization.cpp
@@ -6,5 +6,7 @@ auto Serial::serialize(serializer& s) -> void {
   s(state.rxOverrun);
   s(state.txFull);
   s(state.rxFull);
-  s(state.clock);
+  s(state.baudClock);
+  s(state.txBitClock);
+  s(state.rxBitClock);
 }

--- a/ares/ws/serial/serialization.cpp
+++ b/ares/ws/serial/serialization.cpp
@@ -1,0 +1,10 @@
+auto Serial::serialize(serializer& s) -> void {
+  s(state.dataTx);
+  s(state.dataRx);
+  s(state.baudRate);
+  s(state.enable);
+  s(state.rxOverrun);
+  s(state.txFull);
+  s(state.rxFull);
+  s(state.clock);
+}

--- a/ares/ws/system/controls.cpp
+++ b/ares/ws/system/controls.cpp
@@ -45,13 +45,6 @@ auto System::Controls::poll() -> void {
     platform->input(a);
     platform->input(start);
 
-    if(y1->value() || y2->value() || y3->value() || y4->value()
-    || x1->value() || x2->value() || x3->value() || x4->value()
-    || b->value() || a->value() || start->value()
-    ) {
-      cpu.raise(CPU::Interrupt::Input);
-    }
-
     bool volumeValue = volume->value();
     platform->input(volume);
     if(!volumeValue && volume->value()) {
@@ -81,14 +74,9 @@ auto System::Controls::poll() -> void {
     } else if(!xHold) {
       xHold = 1, swap(leftLatch, rightLatch);
     }
-
-    if(up->value() || down->value() || leftLatch || rightLatch
-    || pass->value() || circle->value() || clear->value()
-    || view->value() || escape->value()
-    ) {
-      cpu.raise(CPU::Interrupt::Input);
-    }
   }
+
+  cpu.keypad.poll();
 
   bool powerValue = power->value();
   platform->input(power);

--- a/ares/ws/system/debugger.cpp
+++ b/ares/ws/system/debugger.cpp
@@ -7,9 +7,29 @@ auto System::Debugger::load(Node::Object parent) -> void {
   memory.eeprom->setWrite([&](u32 address, u8 data) -> void {
     self.eeprom.data[address] = data;
   });
+
+  properties.ports = parent->append<Node::Debugger::Properties>("SoC I/O");
+  properties.ports->setQuery([&] { return ports(); });
 }
 
 auto System::Debugger::unload(Node::Object parent) -> void {
+  parent->remove(properties.ports);
   parent->remove(memory.eeprom);
+  properties.ports.reset();
   memory.eeprom.reset();
+}
+
+auto System::Debugger::ports() -> string {
+  string output;
+
+  output.append("System Mode: ");
+  if(system.mode().bit(0,2) >= 7) { output.append("Color, 4bpp packed"); }
+  else if(system.mode().bit(0,2) >= 6) { output.append("Color, 4bpp planar"); }
+  else if(system.mode().bit(0,2) >= 4) { output.append("Color, 2bpp planar"); }
+  else output.append("Mono");
+  output.append("\n");
+
+  output.append(cpu.debugger.ports());
+
+  return output;
 }

--- a/ares/ws/system/io.cpp
+++ b/ares/ws/system/io.cpp
@@ -4,12 +4,10 @@ auto System::readIO(n16 address) -> n8 {
   switch(address) {
 
   case 0x0060:  //DISP_MODE
-    data.bit(0) = io.unknown0;
-    data.bit(1) = io.unknown1;
-    data.bit(3) = io.unknown3;
-    data.bit(5) = io.mode.bit(0);
-    data.bit(6) = io.mode.bit(1);
-    data.bit(7) = io.mode.bit(2);
+    data.bit(0)    = io.unknown0;
+    data.bit(1)    = io.unknown1;
+    data.bit(3)    = io.unknown3;
+    data.bit(5, 7) = io.mode.bit(0, 2);
     break;
 
   case 0x00ba:  //IEEP_DATALO

--- a/ares/ws/system/serialization.cpp
+++ b/ares/ws/system/serialization.cpp
@@ -47,4 +47,5 @@ auto System::serialize(serializer& s, bool synchronize) -> void {
   s(apu);
   s(cartridge);
   s(iram);
+  s(serial);
 }

--- a/ares/ws/system/system.cpp
+++ b/ares/ws/system/system.cpp
@@ -207,6 +207,7 @@ auto System::power(bool reset) -> void {
   ppu.power();
   apu.power();
   cartridge.power();
+  serial.power();
   scheduler.power(cpu);
 
   bus.map(this, 0x0060);

--- a/ares/ws/system/system.cpp
+++ b/ares/ws/system/system.cpp
@@ -16,6 +16,14 @@ auto load(Node::System& node, string name) -> bool {
   return system.load(node, name);
 }
 
+auto option(string name, string value) -> bool {
+  if(name == "Pixel Accuracy") {
+    apu.setAccurate(value.boolean());
+    ppu.setAccurate(value.boolean());
+  }
+  return true;
+}
+
 Scheduler scheduler;
 System system;
 #define Model ares::WonderSwan::Model

--- a/ares/ws/system/system.cpp
+++ b/ares/ws/system/system.cpp
@@ -166,6 +166,7 @@ auto System::load(Node::System& root, string name) -> bool {
   cpu.load(node);
   ppu.load(node);
   apu.load(node);
+  serial.load(node);
   cartridgeSlot.load(node);
   debugger.load(node);
   return true;
@@ -191,6 +192,7 @@ auto System::unload() -> void {
   cpu.unload();
   ppu.unload();
   apu.unload();
+  serial.unload();
   cartridgeSlot.unload();
   headphones.reset();
   pak.reset();

--- a/ares/ws/system/system.hpp
+++ b/ares/ws/system/system.hpp
@@ -73,6 +73,7 @@ struct System : IO {
   auto soc() const -> SoC { return information.soc; }
   auto mode() const -> n3 { return io.mode; }
   auto memory() const -> u32 { return io.mode.bit(2) == 0 ? 16_KiB : 64_KiB; }
+  auto color() const -> bool { return io.mode.bit(2) != 0; }
 
   //mode:
   //0xx => 2bpp, mono, planar tiledata (WSC enhancements locked)

--- a/ares/ws/system/system.hpp
+++ b/ares/ws/system/system.hpp
@@ -62,10 +62,15 @@ struct System : IO {
     //debugger.cpp
     auto load(Node::Object) -> void;
     auto unload(Node::Object) -> void;
+    auto ports() -> string;
 
     struct Memory {
       Node::Debugger::Memory eeprom;
     } memory;
+
+    struct Properties {
+      Node::Debugger::Properties ports;
+    } properties;
   } debugger{*this};
 
   auto name() const -> string { return information.name; }

--- a/ares/ws/ws.hpp
+++ b/ares/ws/ws.hpp
@@ -10,6 +10,7 @@ namespace ares::WonderSwan {
   #include <ares/inline.hpp>
   auto enumerate() -> vector<string>;
   auto load(Node::System& node, string name) -> bool;
+  auto option(string name, string value) -> bool;
 
   enum : u32 { Byte = 1, Word = 2, Long = 4 };
 

--- a/ares/ws/ws.hpp
+++ b/ares/ws/ws.hpp
@@ -33,4 +33,5 @@ namespace ares::WonderSwan {
   #include <ws/cpu/cpu.hpp>
   #include <ws/ppu/ppu.hpp>
   #include <ws/apu/apu.hpp>
+  #include <ws/serial/serial.hpp>
 }

--- a/desktop-ui/emulator/emulators.cpp
+++ b/desktop-ui/emulator/emulators.cpp
@@ -130,6 +130,7 @@ namespace ares::Atari2600 {
 #ifdef CORE_WS
   namespace ares::WonderSwan {
     auto load(Node::System& node, string name) -> bool;
+    auto option(string name, string value) -> bool;
   }
   #include "wonderswan.cpp"
   #include "wonderswan-color.cpp"

--- a/desktop-ui/emulator/pocket-challenge-v2.cpp
+++ b/desktop-ui/emulator/pocket-challenge-v2.cpp
@@ -41,6 +41,8 @@ auto PocketChallengeV2::load() -> bool {
   system = mia::System::create("Pocket Challenge V2");
   if(!system->load()) return false;
 
+  ares::WonderSwan::option("Pixel Accuracy", settings.video.pixelAccuracy);
+
   if(!ares::WonderSwan::load(root, "[Benesse] Pocket Challenge V2")) return false;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {

--- a/desktop-ui/emulator/wonderswan-color.cpp
+++ b/desktop-ui/emulator/wonderswan-color.cpp
@@ -64,6 +64,8 @@ auto WonderSwanColor::load() -> bool {
   system = mia::System::create("WonderSwan Color");
   if(!system->load()) return false;
 
+  ares::WonderSwan::option("Pixel Accuracy", settings.video.pixelAccuracy);
+
   if(!ares::WonderSwan::load(root, "[Bandai] WonderSwan Color")) return false;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {

--- a/desktop-ui/emulator/wonderswan-color.cpp
+++ b/desktop-ui/emulator/wonderswan-color.cpp
@@ -46,6 +46,15 @@ auto WonderSwanColor::load(Menu menu) -> void {
       group.append(item);
     }
   }
+
+  if(auto headphones = root->find<ares::Node::Setting::Boolean>("Headphones")) {
+    MenuCheckItem headphoneItem{&menu};
+    headphoneItem.setText("Headphones").setChecked(headphones->value()).onToggle([=] {
+      if(auto headphones = root->find<ares::Node::Setting::Boolean>("Headphones")) {
+        headphones->setValue(headphoneItem.checked());
+      }
+    });
+  }
 }
 
 auto WonderSwanColor::load() -> bool {

--- a/desktop-ui/emulator/wonderswan.cpp
+++ b/desktop-ui/emulator/wonderswan.cpp
@@ -46,6 +46,15 @@ auto WonderSwan::load(Menu menu) -> void {
       group.append(item);
     }
   }
+
+  if(auto headphones = root->find<ares::Node::Setting::Boolean>("Headphones")) {
+    MenuCheckItem headphoneItem{&menu};
+    headphoneItem.setText("Headphones").setChecked(headphones->value()).onToggle([=] {
+      if(auto headphones = root->find<ares::Node::Setting::Boolean>("Headphones")) {
+        headphones->setValue(headphoneItem.checked());
+      }
+    });
+  }
 }
 
 auto WonderSwan::load() -> bool {

--- a/desktop-ui/emulator/wonderswan.cpp
+++ b/desktop-ui/emulator/wonderswan.cpp
@@ -64,6 +64,8 @@ auto WonderSwan::load() -> bool {
   system = mia::System::create("WonderSwan");
   if(!system->load()) return false;
 
+  ares::WonderSwan::option("Pixel Accuracy", settings.video.pixelAccuracy);
+
   if(!ares::WonderSwan::load(root, "[Bandai] WonderSwan")) return false;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {


### PR DESCRIPTION
tl;dr:

### V30MZ

* Fixed low-hanging CPU timing fruit, based on [WSTimingTest](https://github.com/FluBBaOfWard/WSTimingTest). There's still some tests not passing, most notably jumps.
* Fixed IN/OUT opcode decoding in the CPU tracer.
* Fixed emulation of undocumented opcode 0xD6 (while on NEC V20/V30 CPUs it is a mirror for XLAT, on NEC V30MZ it is actually the undocumented Intel 8086/80186 opcode SALC) as well as 0xF7 subop 1 (V20/V30 has it as a mirror for TEST, but on V30MZ it is simply a NOP).

### WonderSwan (emulation)

* Tweaked APU code to properly treat it as a 24000 Hz digital chip, as opposed to a 3072000 Hz analog chip - this fixes my own [Headphones' Warming Eve](https://demozoo.org/productions/316722/) demo and should overall bring audio accuracy closer to the device's own. It is theoretically possible to get the APU code to give *exact* matching input, as the output procedure is well-understood and the EXT port provides digital PCM samples - however, more research is required to get there. (This improves performance by a solid ~10% due to the significant amount of calculations that can be skipped.)
* Fixed APU channel 2 "half-volume" bits being ignored.
* Tentatively tweaked low-pass filter value based on [GuyPerfect's research](http://perfectkiosk.net/stsws.html#sound_output_procedure).
* Implemented a less stubby serial I/O stub. This properly emits TX/RX interrupts. (This probably also hurts performance a little... you gain some, you lose some.)
* Added support for Bandai 2003's 16-bit banking ports - this is used by exactly zero commercial games, but reverse-engineering has shown that the chip supports this.
* Added stubby support for NMI register 0xB7, as found and documented by FluBBa in the NitroSwan emulator.
* Appropriately gate WSC-mode I/O ports from Mono mode.
* Fixed behavior of the HBlank/VBlank PPU timers when the reload value is 1, but the timer is not enabled. Existing reverse-engineered documentation implies that this won't fire an interrupt, but hardware testing proves that it indeed does.
* Fixed APU internal speaker output logic.
* Added support for "pixel-inaccurate" mode; this makes the PPU step at a per-scanline level, and the APU step at a per-sample level. Improves performance by ~65% on my machine due to avoiding all the context switches.
* Fixed keypad interrupt emulation to match hardware quirks.
* Fixed handling the interrupt base port on WSC.

### WonderSwan (UI)

* Added PPU SCREEN1, SCREEN2 and tiles to the Graphics debug view.
* Added PPU, APU, cartridge, serial and SoC I/O ports to the Properties debug view. This covers most, but not all, of the device's I/O ports...
* Exposed the ability to use internal speaker output in the UI.

The APU changes in particular could use more verification. In total, in "pixel-inaccurate" mode, this should double the core's performance over ares v130.

PS. Can I just say that the Ares codebase is an absolute joy to work with? Seriously, good job to everyone involved.