### PR TITLE
v30mz: emulate PUSH SP bug

### DIFF
--- a/ares/component/processor/v30mz/instructions-exec.cpp
+++ b/ares/component/processor/v30mz/instructions-exec.cpp
@@ -149,7 +149,9 @@ auto V30MZ::instructionLeave() -> void {
 }
 
 auto V30MZ::instructionPushReg(u16& reg) -> void {
-  push(reg);
+  // Emulate the 8086/80186 "PUSH SP" bug.
+  if(&reg == &SP) push(reg - 2);
+  else push(reg);
 }
 
 auto V30MZ::instructionPushSeg(u16& seg) -> void {


### PR DESCRIPTION
Tested on real hardware with [the latest WSTimingTest update](https://github.com/FluBBaOfWard/WSTimingTest), whose POP SP timing test [accidentally tests this behavior](https://github.com/FluBBaOfWard/WSTimingTest/blob/88ca56c239392513680ec3a7bd26b02cfa65a435/tests_op.asm#L370-L374) - see the `add sp, 2` after `pop sp`.