### PR TITLE
fc: support ave nina-001 board

### DIFF
--- a/ares/fc/cartridge/board/ave-nina-001.cpp
+++ b/ares/fc/cartridge/board/ave-nina-001.cpp
@@ -1,0 +1,63 @@
+struct AveNina001 : Interface {
+  static auto create(string id) -> Interface* {
+    if(id == "AVE-NINA-001") return new AveNina001;
+    return nullptr;
+  }
+
+  Memory::Readable<n8> programROM;
+  Memory::Writable<n8> programRAM;
+  Memory::Readable<n8> characterROM;
+
+  auto load() -> void override {
+    Interface::load(programROM, "program.rom");
+    Interface::load(programRAM, "save.ram");
+    Interface::load(characterROM, "character.rom");
+  }
+
+  auto save() -> void override {
+    Interface::save(programRAM, "save.ram");
+  }
+
+  auto readPRG(n32 address, n8 data) -> n8 override {
+    if(address < 0x6000) return data;
+    if(address < 0x8000) return programRAM.read((n13)address);
+    return programROM.read(programBank << 15 | (n15)address);
+  }
+
+  auto writePRG(n32 address, n8 data) -> void override {
+    if(address < 0x6000) return;
+    if(address < 0x8000) {
+      switch(address) {
+      case 0x7ffd: programBank = data.bit(0); break;
+      case 0x7ffe: characterBank[0] = data.bit(0,3); break;
+      case 0x7fff: characterBank[1] = data.bit(0,3); break;
+      }
+      return programRAM.write((n13)address, data);
+    }
+  }
+
+  auto readCHR(n32 address, n8 data) -> n8 override {
+    if(address & 0x2000) return ppu.readCIRAM((n11)address);
+    n4 bank = characterBank[address.bit(12)];
+    return characterROM.read(bank << 12 | (n12)address);
+  }
+
+  auto writeCHR(n32 address, n8 data) -> void override {
+    if(address & 0x2000) return ppu.writeCIRAM((n11)address, data);
+  }
+
+  auto power() -> void override {
+    programBank = 0;
+    characterBank[0] = 0;
+    characterBank[1] = 1;
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(programRAM);
+    s(programBank);
+    s(characterBank);
+  }
+
+  n1 programBank;
+  n4 characterBank[2];
+};

--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -1,5 +1,6 @@
 namespace Board {
 
+#include "ave-nina-001.cpp"
 #include "bandai-74161.cpp"
 #include "bandai-fcg.cpp"
 #include "bandai-karaoke.cpp"
@@ -52,6 +53,7 @@ namespace Board {
 
 auto Interface::create(string board) -> Interface* {
   Interface* p = nullptr;
+  if(!p) p = AveNina001::create(board);
   if(!p) p = Bandai74161::create(board);
   if(!p) p = BandaiFCG::create(board);
   if(!p) p = BandaiKaraoke::create(board);

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -294,8 +294,13 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     break;
 
   case  34:
-    s += "  board:  HVC-BNROM\n";
-    s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
+    if(submapper == 0 && chrrom != 0 || submapper == 1) {
+      s += "  board:  AVE-NINA-001\n";
+      prgram = 8192;
+    } else {
+      s += "  board:  HVC-BNROM\n";
+      s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
+    }
     break;
 
   case  48:


### PR DESCRIPTION
Add support for American Video Entertainment's NINA-001 board which was used only by the unlicensed NES port of Impossible Mission II developed by Novotrade.

iNES mapper 34 is assigned to two unrelated boards, so detection must rely on the NES 2.0 header or use the CHR ROM size as a heuristic.

Fixes #749 