### PR TITLE
v30mz: implement interrupt priority, fix disassembler adding CPU cycle overhead

### DIFF
--- a/ares/component/processor/v30mz/disassembler.cpp
+++ b/ares/component/processor/v30mz/disassembler.cpp
@@ -6,7 +6,7 @@ auto V30MZ::disassembleInstruction(u16 ps, u16 pc) -> string {
   string output, repeat, prefix;
 
   auto read = [&](u32 offset) -> n8 {
-    return V30MZ::read<Byte>(ps, pc + offset);
+    return this->read(ps * 16 + ((pc + offset) & 0xFFFF));
   };
 
   auto modRM = [&](u32 offset = 1) -> u32 {

--- a/ares/component/processor/v30mz/serialization.cpp
+++ b/ares/component/processor/v30mz/serialization.cpp
@@ -28,4 +28,7 @@ auto V30MZ::serialize(serializer& s) -> void {
   s(PFP);
   s(PF);
   s(PSW.data);
+
+  s(queuedInterruptSource);
+  s(queuedInterruptVector);
 }

--- a/ares/component/processor/v30mz/v30mz.hpp
+++ b/ares/component/processor/v30mz/v30mz.hpp
@@ -293,13 +293,16 @@ struct V30MZ {
   u16* const RS[8]{&DS1, &PS, &SS, &DS0, &DS1, &PS, &SS, &DS0};
 
 protected:
-  // TODO: implement interrupt priorities
   enum class InterruptSource : u32 {
+    None = 0,
     CPU = 1, // internal request
     NMI = 2, // external NMI
     INT = 3, // external interrupt request
     SingleStep = 4 // internal request - single step
   };
+
+  n8 queuedInterruptVector;
+  u32 queuedInterruptSource;
 
   // algorithms.cpp
   template<u32> auto ADD (u16, u16, u16) -> u16;
@@ -307,6 +310,7 @@ protected:
 
   // instruction.cpp
   auto interrupt(u8 vector, InterruptSource source) -> bool;
+  auto processInterrupt(void) -> void;
 };
 
 }


### PR DESCRIPTION
Things still don't seem to be entirely right, but they're better - essentially, I don't think CPU instruction timing seems to affect PPU-emitted interrupts. Is there some type of missing cothread synchronization that would prevent this from occuring?