### PR TITLE
Add ability to set shader from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Usage: ./ares [options] game
   --help                 Displays available options and exit
   --fullscreen           Start in full screen mode
   --system system        Specify the system name
+  --shader shader        Specify GLSL shader name to load (requires OpenGL driver)
 ```
 
 The --system option is useful when the system type cannot be auto-detected.

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -59,6 +59,10 @@ auto nall::main(Arguments arguments) -> void {
     program.startSystem = system;
   }
 
+  if(string shader; arguments.take("--shader", shader)) {
+    program.startShader = shader;
+  }
+
   for(auto argument : arguments) {
     if(file::exists(argument)) program.startGameLoad = argument;
   }

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -508,11 +508,37 @@ auto Presentation::loadShaders() -> void {
     }
   }
 
-  if(settings.video.shader == "None") none.setChecked();
-  if(settings.video.shader == "Blur") blur.setChecked();
+  if(program.startShader) {
+    string existingShader = settings.video.shader;
+
+    if(!program.startShader.imatch("None") &&
+       !program.startShader.imatch("Blur")) {
+        settings.video.shader = {location, program.startShader, ".shader/"};
+    } else {
+        settings.video.shader = program.startShader;
+    }
+
+    if(inode::exists(settings.video.shader) ||
+       settings.video.shader.imatch("None") ||
+       settings.video.shader.imatch("Blur")) {
+        ruby::video.setShader(settings.video.shader);
+    } else {
+        hiro::MessageDialog()
+            .setTitle("Warning")
+            .setAlignment(hiro::Alignment::Center)
+            .setText({ "Requested shader not found: ", settings.video.shader , "\nUsing existing defined shader: ", existingShader })
+            .warning();
+        settings.video.shader = existingShader;
+    }
+  }
+
+  if(settings.video.shader.imatch("None")) {none.setChecked(); settings.video.shader = "None";}
+  if(settings.video.shader.imatch("Blur")) {blur.setChecked(); settings.video.shader = "Blur";}
   for(auto item : shaders.objects<MenuRadioItem>()) {
-    if(settings.video.shader == string{location, item.text(), ".shader/"}) {
+    string fullPath = {location, item.text(), ".shader/"};
+    if(settings.video.shader.imatch(fullPath)) {
       item.setChecked();
+      settings.video.shader = fullPath;
     }
   }
 }

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -51,6 +51,7 @@ struct Program : ares::Platform {
   bool startFullScreen = false;
   string startGameLoad;
   string startSystem;
+  string startShader;
 
   vector<ares::Node::Video::Screen> screens;
   vector<ares::Node::Audio::Stream> streams;


### PR DESCRIPTION
This resolves the second part of the request from: https://github.com/ares-emulator/ares/issues/322
The first part has already been resolved (making Ares portable), so this completes this issue now.

There is some extra stuff/changes here so that the specified shader name didn't have to be case sensitive in order to work. This required a few additional updates though so that the proper shader would still be selected in the menu, and the case correct name was written back to the settings.bml file for case-sensitive file systems.