### PR TITLE
Fix for Peter Lemon's SNES CPU reset test

### DIFF
--- a/ares/sfc/ppu-performance/ppu.cpp
+++ b/ares/sfc/ppu-performance/ppu.cpp
@@ -118,7 +118,7 @@ auto PPU::map() -> void {
 auto PPU::power(bool reset) -> void {
   Thread::create(system.cpuFrequency(), {&PPU::main, this});
   PPUcounter::reset();
-  screen->power();
+  if(!reset) screen->power();
 
   ppu1.version = 1, ppu1.mdr = 0x00;
   ppu2.version = 3, ppu2.mdr = 0x00;
@@ -131,15 +131,18 @@ auto PPU::power(bool reset) -> void {
   latch = {};
   io = {};
   mode7 = {};
-  window.power();
-  mosaic.power();
-  bg1.power();
-  bg2.power();
-  bg3.power();
-  bg4.power();
-  obj.power();
-  dac.power();
-
+  
+  if(!reset) {
+    window.power();
+    mosaic.power();
+    bg1.power();
+    bg2.power();
+    bg3.power();
+    bg4.power();
+    obj.power();
+    dac.power();
+  }
+  
   updateVideoMode();
 
   string title;

--- a/ares/sfc/ppu-performance/ppu.cpp
+++ b/ares/sfc/ppu-performance/ppu.cpp
@@ -118,7 +118,7 @@ auto PPU::map() -> void {
 auto PPU::power(bool reset) -> void {
   Thread::create(system.cpuFrequency(), {&PPU::main, this});
   PPUcounter::reset();
-  if(!reset) screen->power();
+  screen->power();
 
   ppu1.version = 1, ppu1.mdr = 0x00;
   ppu2.version = 3, ppu2.mdr = 0x00;

--- a/ares/sfc/ppu/ppu.cpp
+++ b/ares/sfc/ppu/ppu.cpp
@@ -104,7 +104,7 @@ inline auto PPU::step(u32 clocks) -> void {
 auto PPU::power(bool reset) -> void {
   Thread::create(system.cpuFrequency(), {&PPU::main, this});
   PPUcounter::reset();
-  if(!reset)screen->power();
+  screen->power();
 
   if(!reset) random.array({vram.data, sizeof(vram.data)});
 

--- a/ares/sfc/ppu/ppu.cpp
+++ b/ares/sfc/ppu/ppu.cpp
@@ -104,7 +104,7 @@ inline auto PPU::step(u32 clocks) -> void {
 auto PPU::power(bool reset) -> void {
   Thread::create(system.cpuFrequency(), {&PPU::main, this});
   PPUcounter::reset();
-  screen->power();
+  if(!reset)screen->power();
 
   if(!reset) random.array({vram.data, sizeof(vram.data)});
 
@@ -129,8 +129,10 @@ auto PPU::power(bool reset) -> void {
     object.size = 0;
   }
 
-  random.array({cgram, sizeof(cgram)});
-  for(auto& word : cgram) word &= 0x7fff;
+  if(!reset) {
+    random.array({cgram, sizeof(cgram)});
+    for(auto& word : cgram) word &= 0x7fff;
+  }
 
   latch.vram = random();
   latch.oam = random();
@@ -203,7 +205,7 @@ auto PPU::power(bool reset) -> void {
 
   //$2133  SETINI
   io.extbg = random();
-  io.pseudoHires = random();
+  if(!reset) io.pseudoHires = random();
   io.overscan = false;
   io.interlace = false;
 
@@ -213,6 +215,7 @@ auto PPU::power(bool reset) -> void {
   //$213d  OPVCT
   io.vcounter = 0;
 
+if(!reset) {
   mosaic.power();
   bg1.power();
   bg2.power();
@@ -221,6 +224,7 @@ auto PPU::power(bool reset) -> void {
   obj.power();
   window.power();
   dac.power();
+}
 
   updateVideoMode();
 }


### PR DESCRIPTION
This is a fix for a reset test in Peter Lemon's CPU test ROM as defined in Github issue: https://github.com/ares-emulator/ares/issues/427 It addresses both pixel renderer and scanline renderer.

This has been discussed as a BNES issue previously, there has been a fix to a fork of bsnes that addresses this, and a similar fix was committed to BizHawk. The only problem is I can't to attempt to validate this behavior on real hardware (although the test itself _does_ work on real hardware). 

I'm going to open a discussion about this in our Discord to get others input, so it may be best to hold off on merging until others get a chance to chime in on this.