### PR TITLE
build: guard usage of sse4.1 round instructions

### DIFF
--- a/ares/n64/cpu/algorithms.cpp
+++ b/ares/n64/cpu/algorithms.cpp
@@ -2,7 +2,7 @@ template <typename T>
 auto CPU::roundNearest(f32 f) -> T {
 #if defined(ARCHITECTURE_ARM64)
   return vrndns_f32(f);
-#elif defined(ARCHITECTURE_AMD64)
+#elif defined(ARCHITECTURE_AMD64) && ARCHITECTURE_SUPPORTS_SSE4_1
   __m128 t = _mm_set_ss(f);
   t = _mm_round_ss(t, t, _MM_FROUND_TO_NEAREST_INT);
   return _mm_cvtss_f32(t);
@@ -16,7 +16,7 @@ auto CPU::roundNearest(f64 f) -> T {
 #if defined(ARCHITECTURE_ARM64)
   float64x1_t vf = {f};
   return vrndn_f64(vf)[0];
-#elif defined(ARCHITECTURE_AMD64)
+#elif defined(ARCHITECTURE_AMD64) && ARCHITECTURE_SUPPORTS_SSE4_1
   __m128d t = _mm_set_sd(f);
   t = _mm_round_sd(t, t, _MM_FROUND_TO_NEAREST_INT);
   return _mm_cvtsd_f64(t);
@@ -27,7 +27,7 @@ auto CPU::roundNearest(f64 f) -> T {
 
 template <typename T>
 auto CPU::roundCeil(f32 f) -> T {
-#if defined(ARCHITECTURE_AMD64)
+#if defined(ARCHITECTURE_AMD64) && ARCHITECTURE_SUPPORTS_SSE4_1
   __m128 t = _mm_set_ss(f);
   t = _mm_round_ss(t, t, _MM_FROUND_TO_POS_INF);
   return _mm_cvtss_f32(t);
@@ -38,7 +38,7 @@ auto CPU::roundCeil(f32 f) -> T {
 
 template <typename T>
 auto CPU::roundCeil(f64 f) -> T {
-#if defined(ARCHITECTURE_AMD64)
+#if defined(ARCHITECTURE_AMD64) && ARCHITECTURE_SUPPORTS_SSE4_1
   __m128d t = _mm_set_sd(f);
   t = _mm_round_sd(t, t, _MM_FROUND_TO_POS_INF);
   return _mm_cvtsd_f64(t);
@@ -49,7 +49,7 @@ auto CPU::roundCeil(f64 f) -> T {
 
 template<typename T>
 auto CPU::roundCurrent(f32 f) -> T {
-#if defined(ARCHITECTURE_AMD64)
+#if defined(ARCHITECTURE_AMD64) && ARCHITECTURE_SUPPORTS_SSE4_1
   auto t = _mm_set_ss(f);
   t = _mm_round_ss(t, t, _MM_FROUND_CUR_DIRECTION);
   return _mm_cvtss_f32(t);
@@ -60,7 +60,7 @@ auto CPU::roundCurrent(f32 f) -> T {
 
 template<typename T>
 auto CPU::roundCurrent(f64 f) -> T {
-#if defined(ARCHITECTURE_AMD64)
+#if defined(ARCHITECTURE_AMD64) && ARCHITECTURE_SUPPORTS_SSE4_1
   auto t = _mm_set_sd(f);
   t = _mm_round_sd(t, t, _MM_FROUND_CUR_DIRECTION);
   return _mm_cvtsd_f64(t);
@@ -71,7 +71,7 @@ auto CPU::roundCurrent(f64 f) -> T {
 
 template <typename T>
 auto CPU::roundFloor(f32 f) -> T {
-#if defined(ARCHITECTURE_AMD64)
+#if defined(ARCHITECTURE_AMD64) && ARCHITECTURE_SUPPORTS_SSE4_1
   __m128 t = _mm_set_ss(f);
   t = _mm_round_ss(t, t, _MM_FROUND_TO_NEG_INF);
   return _mm_cvtss_f32(t);
@@ -82,7 +82,7 @@ auto CPU::roundFloor(f32 f) -> T {
 
 template <typename T>
 auto CPU::roundFloor(f64 f) -> T {
-#if defined(ARCHITECTURE_AMD64)
+#if defined(ARCHITECTURE_AMD64) && ARCHITECTURE_SUPPORTS_SSE4_1
   __m128d t = _mm_set_sd(f);
   t = _mm_round_sd(t, t, _MM_FROUND_TO_NEG_INF);
   return _mm_cvtsd_f64(t);
@@ -93,7 +93,7 @@ auto CPU::roundFloor(f64 f) -> T {
 
 template <typename T>
 auto CPU::roundTrunc(f32 f) -> T {
-#if defined(ARCHITECTURE_AMD64)
+#if defined(ARCHITECTURE_AMD64) && ARCHITECTURE_SUPPORTS_SSE4_1
   __m128 t = _mm_set_ss(f);
   t = _mm_round_ss(t, t, _MM_FROUND_TO_ZERO);
   return _mm_cvtss_f32(t);
@@ -104,7 +104,7 @@ auto CPU::roundTrunc(f32 f) -> T {
 
 template <typename T>
 auto CPU::roundTrunc(f64 f) -> T {
-#if defined(ARCHITECTURE_AMD64)
+#if defined(ARCHITECTURE_AMD64) && ARCHITECTURE_SUPPORTS_SSE4_1
   __m128d t = _mm_set_sd(f);
   t = _mm_round_sd(t, t, _MM_FROUND_TO_ZERO);
   return _mm_cvtsd_f64(t);


### PR DESCRIPTION
Guard usage of round_ss/sd intrinsics with a preprocessor check just as we do with other SSE4.1 instructions.

Fixes #927