### PR TITLE
ym2610, v9938: fix accidental switch case fallthrough

### DIFF
--- a/ares/component/audio/ym2610/io.cpp
+++ b/ares/component/audio/ym2610/io.cpp
@@ -40,7 +40,9 @@ auto YM2610::writeLower(n8 data) -> void {
   case 0x013: pcmB.startAddress.bit(16, 23) = data; return;
   case 0x014: pcmB.endAddress.bit  ( 8, 15) = data; return;
   case 0x015: pcmB.endAddress.bit  (16, 23) = data; return;
-  case 0x016 ... 0x018: debug(unimplemented, "[YM2610::ADPCMB] Write ", hex(registerAddress), " = ", data);
+  case 0x016 ... 0x018:
+    debug(unimplemented, "[YM2610::ADPCMB] Write ", hex(registerAddress), " = ", data);
+    return;
   case 0x019: pcmB.delta.bit       ( 0,  7) = data; return;
   case 0x01a: pcmB.delta.bit       ( 8, 15) = data; return;
   case 0x01b: pcmB.volume                   = data; return;

--- a/ares/component/processor/z80/z80.cpp
+++ b/ares/component/processor/z80/z80.cpp
@@ -51,7 +51,7 @@ auto Z80::irq(n8 extbus) -> bool {
   R.bit(0,6)++;
 
   switch(IM) {
-  case 1: extbus = 0xff;
+  case 1: extbus = 0xff; [[fallthrough]];
   case 0: {
     WZ = extbus;
     wait(6);

--- a/ares/component/video/v9938/sprite.cpp
+++ b/ares/component/video/v9938/sprite.cpp
@@ -37,6 +37,7 @@ auto V9938::Sprite::setup(n8 voffset) -> void {
 
       objects[valid++] = {x, y, pattern, color};
     }
+    break;
   }
 
   case 0b01000:
@@ -82,6 +83,7 @@ auto V9938::Sprite::setup(n8 voffset) -> void {
 
       objects[valid++] = {x, y, pattern, color, collision, priority};
     }
+    break;
   }
 
   }

--- a/ares/pce/vdp-performance/vdp.cpp
+++ b/ares/pce/vdp-performance/vdp.cpp
@@ -66,9 +66,9 @@ auto VDP::main() -> void {
       for(u32 x : range(vce.width())) {
         u32 color = vce.io.grayscale << 9 | vce.cram.read(vdc0.output[x]);
         switch(clock) {
-        case 4: *line++ = color;
-        case 3: *line++ = color;
-        case 2: *line++ = color;
+        case 4: *line++ = color; [[fallthrough]];
+        case 3: *line++ = color; [[fallthrough]];
+        case 2: *line++ = color; [[fallthrough]];
         case 1: *line++ = color;
         }
       }
@@ -79,9 +79,9 @@ auto VDP::main() -> void {
       for(u32 x : range(vce.width())) {
         u32 color = vce.io.grayscale << 9 | vce.cram.read(vpc.output[x]);
         switch(clock) {
-        case 4: *line++ = color;
-        case 3: *line++ = color;
-        case 2: *line++ = color;
+        case 4: *line++ = color; [[fallthrough]];
+        case 3: *line++ = color; [[fallthrough]];
+        case 2: *line++ = color; [[fallthrough]];
         case 1: *line++ = color;
         }
       }

--- a/ares/pce/vdp/vdp.cpp
+++ b/ares/pce/vdp/vdp.cpp
@@ -87,9 +87,9 @@ auto VDP::main() -> void {
     color = vce.io.grayscale << 9 | vce.cram.read(color);
 
     switch(vce.clock()) {
-    case 4: *output++ = color;
-    case 3: *output++ = color;
-    case 2: *output++ = color;
+    case 4: *output++ = color; [[fallthrough]];
+    case 3: *output++ = color; [[fallthrough]];
+    case 2: *output++ = color; [[fallthrough]];
     case 1: *output++ = color;
     }
 

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -174,6 +174,7 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
 
   default:
     debug(unimplemented, "[famicom] unknown iNES mapper number ", mapper);
+  case   0:
     s += "  board:  HVC-NROM-256\n";
     s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
     break;

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -174,6 +174,7 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
 
   default:
     debug(unimplemented, "[famicom] unknown iNES mapper number ", mapper);
+    [[fallthrough]];
   case   0:
     s += "  board:  HVC-NROM-256\n";
     s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};

--- a/nall/intrinsics.hpp
+++ b/nall/intrinsics.hpp
@@ -25,6 +25,7 @@ namespace nall {
     static constexpr bool GCC       = 0;
     static constexpr bool Microsoft = 0;
   };
+  #pragma clang diagnostic warning "-Wimplicit-fallthrough"
   #pragma clang diagnostic warning "-Wreturn-type"
   #pragma clang diagnostic ignored "-Wunused-result"
   #pragma clang diagnostic ignored "-Wunknown-pragmas"
@@ -43,6 +44,7 @@ namespace nall {
     static constexpr bool GCC       = 1;
     static constexpr bool Microsoft = 0;
   };
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
   #pragma GCC diagnostic warning "-Wreturn-type"
   #pragma GCC diagnostic ignored "-Wunused-result"
   #pragma GCC diagnostic ignored "-Wunknown-pragmas"


### PR DESCRIPTION
Enable switch case fallthrough warnings throughout ares and annotate legitimate fallthrough with the C++17 standard [[fallthrough]] attribute. Fix a couple of ares bugs caught in the process and a minor mia bug that motivated me to turn on the warning in the first place.