### PR TITLE
Radio the scale settings and allow 1x

### DIFF
--- a/ares/a26/tia/tia.cpp
+++ b/ares/a26/tia/tia.cpp
@@ -16,7 +16,7 @@ auto TIA::load(Node::Object parent) -> void {
   screen = node->append<Node::Video::Screen>("Screen", 160, vlines());
   screen->colors(1 << 7, {&TIA::color, this});
   screen->setSize(160, vlines());
-  screen->setScale(2.0, 2.0);
+  screen->setScale(1.0, 1.0);
   screen->setAspect(12.0, 7.0);
   screen->setViewport(0, 0, 160, vlines());
 

--- a/ares/ng/lspc/lspc.cpp
+++ b/ares/ng/lspc/lspc.cpp
@@ -13,10 +13,10 @@ auto LSPC::load(Node::Object parent) -> void {
 
   screen = node->append<Node::Video::Screen>("Screen", 320, 256);
   screen->colors(1 << 17, {&LSPC::color, this});
-  screen->setSize(320, 256);
-  screen->setScale(2.0, 2.0);
+  screen->setSize(304, 240);
+  screen->setScale(1.0, 1.0);
   screen->setAspect(1.0, 1.0);
-  screen->setViewport(8, 8, 320 - 16, 256 - 16);
+  screen->setViewport(8, 8, 304, 240);
 
   vram.allocate(68_KiB >> 1);
   pram.allocate(16_KiB >> 1);

--- a/ares/ng/lspc/lspc.cpp
+++ b/ares/ng/lspc/lspc.cpp
@@ -13,10 +13,15 @@ auto LSPC::load(Node::Object parent) -> void {
 
   screen = node->append<Node::Video::Screen>("Screen", 320, 256);
   screen->colors(1 << 17, {&LSPC::color, this});
-  screen->setSize(304, 240);
+  screen->setSize(320, 256);
   screen->setScale(1.0, 1.0);
   screen->setAspect(1.0, 1.0);
-  screen->setViewport(8, 8, 304, 240);
+
+  overscan = screen->append<Node::Setting::Boolean>("Overscan", true, [&](auto value) {
+    if(value == 0) screen->setSize(304, 224);
+    if(value == 1) screen->setSize(320, 256);
+  });
+  overscan->setDynamic(true);
 
   vram.allocate(68_KiB >> 1);
   pram.allocate(16_KiB >> 1);
@@ -47,6 +52,7 @@ auto LSPC::unload() -> void {
   debugger.unload(node);
   vram.reset();
   pram.reset();
+  overscan.reset();
   screen->quit();
   node->remove(screen);
   screen.reset();
@@ -95,6 +101,8 @@ auto LSPC::main() -> void {
 }
 
 auto LSPC::frame() -> void {
+  if(overscan->value() == 0) screen->setViewport(8, 16, 304, 224);
+  if(overscan->value() == 1) screen->setViewport(0, 0, 320, 256);
   screen->frame();
   scheduler.exit(Event::Frame);
 }

--- a/ares/ng/lspc/lspc.hpp
+++ b/ares/ng/lspc/lspc.hpp
@@ -3,6 +3,7 @@
 struct LSPC : Thread {
   Node::Object node;
   Node::Video::Screen screen;
+  Node::Setting::Boolean overscan;
   Memory::Writable<n16> vram;
   Memory::Writable<n16> pram;
 

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -14,27 +14,33 @@ Presentation::Presentation() {
   systemMenu.setVisible(false);
 
   settingsMenu.setText("Settings");
-  videoSizeMenu.setText("Size").setIcon(Icon::Emblem::Image);
-  //determine the largest multiplier that can be used by the largest monitor found
-  u32 monitorHeight = 1;
-  for(u32 monitor : range(Monitor::count())) {
-    monitorHeight = max(monitorHeight, Monitor::workspace(monitor).height());
-  }
-  //generate size menu
-  u32 multipliers = max(1, monitorHeight / 240);
-  for(u32 multiplier : range(2, multipliers + 1)) {
-    MenuItem item{&videoSizeMenu};
-    item.setText({multiplier, "x (", 240 * multiplier, "p)"});
-    item.onActivate([=] {
-      settings.video.multiplier = multiplier;
-      resizeWindow();
-    });
-  }
-  videoSizeMenu.append(MenuSeparator());
-  MenuItem centerWindow{&videoSizeMenu};
-  centerWindow.setText("Center Window").setIcon(Icon::Place::Settings).onActivate([&] {
-    setAlignment(Alignment::Center);
+  videoScaleMenu.setText("Scale").setIcon(Icon::Emblem::Image);
+  videoScaleOne.setText("1x").onActivate([&] {
+    settings.video.scale = 1;
+    resizeWindow();
   });
+  videoScaleTwo.setText("2x").onActivate([&] {
+    settings.video.scale = 2;
+    resizeWindow();
+  });
+  videoScaleThree.setText("3x").onActivate([&] {
+    settings.video.scale = 3;
+    resizeWindow();
+  });
+  videoScaleFour.setText("4x").onActivate([&] {
+    settings.video.scale = 4;
+    resizeWindow();
+  });
+  videoScaleFive.setText("5x").onActivate([&] {
+    settings.video.scale = 5;
+    resizeWindow();
+  });
+  if(settings.video.scale == 1) videoScaleOne.setChecked();
+  if(settings.video.scale == 2) videoScaleTwo.setChecked();
+  if(settings.video.scale == 3) videoScaleThree.setChecked();
+  if(settings.video.scale == 4) videoScaleFour.setChecked();
+  if(settings.video.scale == 5) videoScaleFive.setChecked();
+
   videoOutputMenu.setText("Output").setIcon(Icon::Emblem::Image);
   videoOutputCenter.setText("Center").onActivate([&] {
     settings.video.output = "Center";
@@ -55,11 +61,10 @@ Presentation::Presentation() {
   videoAdaptiveSizing.setText("Adaptive Sizing").setChecked(settings.video.adaptiveSizing).onToggle([&] {
     if(settings.video.adaptiveSizing = videoAdaptiveSizing.checked()) resizeWindow();
   });
-  videoAutoCentering.setText("Auto Centering").setChecked(settings.video.autoCentering).onToggle([&] {
-    if(settings.video.autoCentering = videoAutoCentering.checked()) resizeWindow();
-  });
+
   videoShaderMenu.setText("Shader").setIcon(Icon::Emblem::Image);
   loadShaders();
+
   bootOptionsMenu.setText("Boot Options").setIcon(Icon::Place::Settings);
   fastBoot.setText("Fast Boot").setChecked(settings.boot.fast).onToggle([&] {
     settings.boot.fast = fastBoot.checked();
@@ -79,6 +84,7 @@ Presentation::Presentation() {
   if(settings.boot.prefer == "NTSC-U") preferNTSCU.setChecked();
   if(settings.boot.prefer == "NTSC-J") preferNTSCJ.setChecked();
   if(settings.boot.prefer == "PAL") preferPAL.setChecked();
+
   muteAudioSetting.setText("Mute Audio").setChecked(settings.audio.mute).onToggle([&] {
     settings.audio.mute = muteAudioSetting.checked();
   });
@@ -91,6 +97,7 @@ Presentation::Presentation() {
     }
     if(visible()) resizeWindow();
   }).doToggle();
+
   videoSettingsAction.setText("Video" ELLIPSIS).setIcon(Icon::Device::Display).onActivate([&] {
     settingsWindow.show("Video");
   });
@@ -245,9 +252,9 @@ auto Presentation::resizeWindow() -> void {
   if(fullScreen()) setFullScreen(false);
   if(maximized()) setMaximized(false);
 
-  u32 multiplier = max(2, settings.video.multiplier);
-  u32 viewportWidth = 320 * multiplier;
-  u32 viewportHeight = 240 * multiplier;
+  u32 scale = settings.video.scale;
+  u32 viewportWidth = 320 * scale;
+  u32 viewportHeight = 240 * scale;
 
   if(emulator && program.screens) {
     auto& node = program.screens.first();
@@ -255,24 +262,13 @@ auto Presentation::resizeWindow() -> void {
     u32 videoHeight = node->height() * node->scaleY();
     if(settings.video.aspectCorrection) videoWidth = videoWidth * node->aspectX() / node->aspectY();
     if(node->rotation() == 90 || node->rotation() == 270) swap(videoWidth, videoHeight);
-
-    u32 multiplierX = viewportWidth / videoWidth;
-    u32 multiplierY = viewportHeight / videoHeight;
-    u32 multiplier = max(1, min(multiplierX, multiplierY));
-
-    viewportWidth = videoWidth * multiplier;
-    viewportHeight = videoHeight * multiplier;
+    viewportWidth = videoWidth * scale;
+    viewportHeight = videoHeight * scale;
   }
 
   u32 statusHeight = showStatusBarSetting.checked() ? StatusHeight : 0;
-
-  if(settings.video.autoCentering) {
-    setGeometry(Alignment::Center, {viewportWidth, viewportHeight + statusHeight});
-  } else {
-    setSize({viewportWidth, viewportHeight + statusHeight});
-  }
-
-  setMinimumSize({256, 240 + statusHeight});
+  setSize({viewportWidth, viewportHeight + statusHeight});
+  setMinimumSize({16, 16 + statusHeight});
 }
 
 auto Presentation::loadEmulators() -> void {

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -268,7 +268,7 @@ auto Presentation::resizeWindow() -> void {
 
   u32 statusHeight = showStatusBarSetting.checked() ? StatusHeight : 0;
   setSize({viewportWidth, viewportHeight + statusHeight});
-  setMinimumSize({16, 16 + statusHeight});
+  setMinimumSize({160, 144 + statusHeight});
 }
 
 auto Presentation::loadEmulators() -> void {

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -13,7 +13,13 @@ struct Presentation : Window {
     Menu loadMenu{&menuBar};
     Menu systemMenu{&menuBar};
     Menu settingsMenu{&menuBar};
-      Menu videoSizeMenu{&settingsMenu};
+      Menu videoScaleMenu{&settingsMenu};
+        MenuRadioItem videoScaleOne{&videoScaleMenu};
+        MenuRadioItem videoScaleTwo{&videoScaleMenu};
+        MenuRadioItem videoScaleThree{&videoScaleMenu};
+        MenuRadioItem videoScaleFour{&videoScaleMenu};
+        MenuRadioItem videoScaleFive{&videoScaleMenu};
+        Group videoScaleGroup{&videoScaleOne, &videoScaleTwo, &videoScaleThree, &videoScaleFour, &videoScaleFive};
       Menu videoOutputMenu{&settingsMenu};
         MenuRadioItem videoOutputCenter{&videoOutputMenu};
         MenuRadioItem videoOutputScale{&videoOutputMenu};
@@ -22,7 +28,6 @@ struct Presentation : Window {
         MenuSeparator videoOutputSeparator{&videoOutputMenu};
         MenuCheckItem videoAspectCorrection{&videoOutputMenu};
         MenuCheckItem videoAdaptiveSizing{&videoOutputMenu};
-        MenuCheckItem videoAutoCentering{&videoOutputMenu};
       Menu videoShaderMenu{&settingsMenu};
       Menu bootOptionsMenu{&settingsMenu};
         MenuCheckItem fastBoot{&bootOptionsMenu};
@@ -32,7 +37,7 @@ struct Presentation : Window {
         MenuRadioItem preferNTSCJ{&bootOptionsMenu};
         MenuRadioItem preferPAL{&bootOptionsMenu};
         Group preferRegionGroup{&preferNTSCU, &preferNTSCJ, &preferPAL};
-      MenuSeparator groupSettingsSeparatpr{&settingsMenu};
+      MenuSeparator groupSettingsSeparator{&settingsMenu};
       MenuCheckItem muteAudioSetting{&settingsMenu};
       MenuCheckItem showStatusBarSetting{&settingsMenu};
       MenuSeparator audioSettingsSeparator{&settingsMenu};

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -54,7 +54,7 @@ auto Settings::process(bool load) -> void {
   bind(boolean, "Video/Blocking", video.blocking);
   bind(boolean, "Video/Flush", video.flush);
   bind(string,  "Video/Shader", video.shader);
-  bind(natural, "Video/Multiplier", video.multiplier);
+  bind(natural, "Video/Scale", video.scale);
   bind(string,  "Video/Output", video.output);
   bind(boolean, "Video/AspectCorrection", video.aspectCorrection);
   bind(boolean, "Video/AdaptiveSizing", video.adaptiveSizing);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -13,7 +13,7 @@ struct Settings : Markup::Node {
     bool blocking = false;
     bool flush = false;
     string shader = "None";
-    u32 multiplier = 2;
+    u32 scale = 2;
     string output = "Scale";
     bool aspectCorrection = true;
     bool adaptiveSizing = true;


### PR DESCRIPTION
1x scaling is nice for recording videos. You can achieve the smallest filesize and it's easier to use the recorder app side by side with the emulator.

This PR allows 1x scaling and makes the scale settings explicit and radio. This also allows you to see the current scale setting whereas you couldn't before. "Auto centering" options were removed in favor of allowing 5x to simply exist without doing anything fancy like removing it based on the monitor.

The words "multiplier" and "size" were also used interchangeably with "scale" in the codebase. This PR also changes everything to "scale" as I believe it's the most common term for video and less generic.