### PR TITLE
ruby: fix wasapi and xaudio2 crashes

### DIFF
--- a/ruby/audio/wasapi.cpp
+++ b/ruby/audio/wasapi.cpp
@@ -20,7 +20,7 @@ struct AudioWASAPI : AudioDriver {
 
   auto create() -> bool override {
     super.setExclusive(false);
-    super.setDevice(hasDevices().first());
+    if(hasDevices()) super.setDevice(hasDevices().first());
     super.setBlocking(false);
     super.setChannels(2);
     super.setFrequency(48000);
@@ -59,6 +59,8 @@ struct AudioWASAPI : AudioDriver {
   auto setLatency(u32 latency) -> bool override { return initialize(); }
 
   auto clear() -> void override {
+    if(!ready()) return;
+
     self.queue.read = 0;
     self.queue.write = 0;
     self.queue.count = 0;

--- a/ruby/audio/xaudio2.cpp
+++ b/ruby/audio/xaudio2.cpp
@@ -8,7 +8,7 @@ struct AudioXAudio2 : AudioDriver, public IXAudio2VoiceCallback {
   ~AudioXAudio2() { destruct(); }
 
   auto create() -> bool override {
-    super.setDevice(hasDevices().first());
+    if(hasDevices()) super.setDevice(hasDevices().first());
     super.setChannels(2);
     super.setFrequency(48000);
     super.setLatency(40);
@@ -41,6 +41,8 @@ struct AudioXAudio2 : AudioDriver, public IXAudio2VoiceCallback {
   auto setLatency(u32 latency) -> bool override { return initialize(); }
 
   auto clear() -> void override {
+    if(!ready()) return;
+
     self.sourceVoice->Stop(0);
     self.sourceVoice->FlushSourceBuffers();  //calls OnBufferEnd for all currently submitted buffers
 
@@ -94,7 +96,7 @@ private:
   vector<Device> devices;
 
   auto construct() -> void {
-    XAudio2Create(&self.xa2Interface, 0 , XAUDIO2_DEFAULT_PROCESSOR);
+    if(FAILED(XAudio2Create(&self.xa2Interface, 0 , XAUDIO2_DEFAULT_PROCESSOR))) return;
 
     u32 deviceCount = 0;
     self.xa2Interface->GetDeviceCount(&deviceCount);


### PR DESCRIPTION
The WASAPI driver should now gracefully handle machines that don't have any available output devices. The XAudio2 driver probably still won't, but more importantly it won't crash machines that don't have a specific DirectX redist from 2008 (!). It needs a rework but for now I'm leaving it a little better than I found it.

Likely would have fixed #371.