### PR TITLE
ruby: fix hang on loading rom from command line

### DIFF
--- a/ruby/audio/wasapi.cpp
+++ b/ruby/audio/wasapi.cpp
@@ -59,14 +59,15 @@ struct AudioWASAPI : AudioDriver {
   auto setLatency(u32 latency) -> bool override { return initialize(); }
 
   auto clear() -> void override {
-    if(!ready()) return;
-
     self.queue.read = 0;
     self.queue.write = 0;
     self.queue.count = 0;
-    self.audioClient->Stop();
-    self.audioClient->Reset();
-    self.audioClient->Start();
+
+    if(self.audioClient) {
+      self.audioClient->Stop();
+      self.audioClient->Reset();
+      self.audioClient->Start();
+    }
   }
 
   auto output(const f64 samples[]) -> void override {

--- a/ruby/audio/xaudio2.cpp
+++ b/ruby/audio/xaudio2.cpp
@@ -41,16 +41,16 @@ struct AudioXAudio2 : AudioDriver, public IXAudio2VoiceCallback {
   auto setLatency(u32 latency) -> bool override { return initialize(); }
 
   auto clear() -> void override {
-    if(!ready()) return;
-
-    self.sourceVoice->Stop(0);
-    self.sourceVoice->FlushSourceBuffers();  //calls OnBufferEnd for all currently submitted buffers
+    if(self.sourceVoice) {
+      self.sourceVoice->Stop(0);
+      self.sourceVoice->FlushSourceBuffers();  //calls OnBufferEnd for all currently submitted buffers
+    }
 
     self.index = 0;
     self.queue = 0;
     for(u32 n : range(Buffers)) self.buffers[n].fill();
 
-    self.sourceVoice->Start(0);
+    if(self.sourceVoice) self.sourceVoice->Start(0);
   }
 
   auto level() -> f64 override {


### PR DESCRIPTION
Fix a regression introduced by my last change. The pattern of checking ready() at the top doesn't work for clear() because it's called from iniatialize(). This was obscured by the fact that other code calls clear() again after initialization *unless* you are loading a ROM directly from the command line.