### PR TITLE
n64: Do not use maximum dead-zone value in scaling

### DIFF
--- a/ares/n64/controller/gamepad/gamepad.cpp
+++ b/ares/n64/controller/gamepad/gamepad.cpp
@@ -198,13 +198,13 @@ auto Gamepad::read() -> n32 {
   if(length <= 85.0) {
     auto lengthAbsoluteX = abs(ax);
     auto lengthAbsoluteY = abs(ay);
-    if(lengthAbsoluteX < 7.0) {
+    if(lengthAbsoluteX <= 7.0) {
       lengthAbsoluteX = 0.0;
     } else {
       lengthAbsoluteX = (lengthAbsoluteX - 7.0) * 85.0 / (85.0 - 7.0) / lengthAbsoluteX;
     }
     ax *= lengthAbsoluteX;
-    if(lengthAbsoluteY < 7.0) {
+    if(lengthAbsoluteY <= 7.0) {
       lengthAbsoluteY = 0.0;
     } else {
       lengthAbsoluteY = (lengthAbsoluteY - 7.0) * 85.0 / (85.0 - 7.0) / lengthAbsoluteY;


### PR DESCRIPTION
The maximum inner dead-zone value should be set to 0 like all other numbers in the dead-zone. This is to avoid problems that can arise when a maximum inner dead-zone is set to zero or a number near zero instead of the current fixed value of 7.0.