### PR TITLE
sfc: fix debugger memory view for cx4, sa1, superfx

### DIFF
--- a/ares/sfc/cartridge/cartridge.cpp
+++ b/ares/sfc/cartridge/cartridge.cpp
@@ -11,7 +11,6 @@ Cartridge& cartridge = cartridgeSlot.cartridge;
 
 auto Cartridge::allocate(Node::Port parent) -> Node::Peripheral {
   node = parent->append<Node::Peripheral>(string{system.name(), " Cartridge"});
-  debugger.load(node);
   return node;
 }
 

--- a/ares/sfc/cartridge/debugger.cpp
+++ b/ares/sfc/cartridge/debugger.cpp
@@ -1,19 +1,23 @@
 auto Cartridge::Debugger::load(Node::Object parent) -> void {
-  memory.rom = parent->append<Node::Debugger::Memory>("Cartridge ROM");
-  memory.rom->setSize(cartridge.rom.size());
-  memory.rom->setRead([&](u32 address) -> u8 {
-    return cartridge.rom.read(address);
-  });
-  memory.rom->setWrite([&](u32 address, u8 data) -> void {
-    return cartridge.rom.program(address, data);
-  });
+  if(cartridge.rom) {
+    memory.rom = parent->append<Node::Debugger::Memory>("Cartridge ROM");
+    memory.rom->setSize(cartridge.rom.size());
+    memory.rom->setRead([&](u32 address) -> u8 {
+      return cartridge.rom.read(address);
+    });
+    memory.rom->setWrite([&](u32 address, u8 data) -> void {
+      return cartridge.rom.program(address, data);
+    });
+  }
 
-  memory.ram = parent->append<Node::Debugger::Memory>("Cartridge RAM");
-  memory.ram->setSize(cartridge.ram.size());
-  memory.ram->setRead([&](u32 address) -> u8 {
-    return cartridge.ram.read(address);
-  });
-  memory.ram->setWrite([&](u32 address, u8 data) -> void {
-    return cartridge.ram.write(address, data);
-  });
+  if(cartridge.ram) {
+    memory.ram = parent->append<Node::Debugger::Memory>("Cartridge RAM");
+    memory.ram->setSize(cartridge.ram.size());
+    memory.ram->setRead([&](u32 address) -> u8 {
+      return cartridge.ram.read(address);
+    });
+    memory.ram->setWrite([&](u32 address, u8 data) -> void {
+      return cartridge.ram.write(address, data);
+    });
+  }
 }

--- a/ares/sfc/cartridge/load.cpp
+++ b/ares/sfc/cartridge/load.cpp
@@ -52,8 +52,7 @@ auto Cartridge::loadCartridge() -> void {
 
   if(auto fp = pak->read("msu1.data.rom")) loadMSU1();
 
-  debugger.memory.rom->setSize(rom.size());
-  debugger.memory.ram->setSize(ram.size());
+  debugger.load(node);
 }
 
 //

--- a/ares/sfc/coprocessor/hitachidsp/debugger.cpp
+++ b/ares/sfc/coprocessor/hitachidsp/debugger.cpp
@@ -1,4 +1,24 @@
 auto HitachiDSP::Debugger::load(Node::Object parent) -> void {
+  memory.rom = parent->append<Node::Debugger::Memory>("Cartridge ROM");
+  memory.rom->setSize(hitachidsp.rom.size());
+  memory.rom->setRead([&](u32 address) -> u8 {
+    return hitachidsp.rom.read(address);
+  });
+  memory.rom->setWrite([&](u32 address, u8 data) -> void {
+    return hitachidsp.rom.program(address, data);
+  });
+
+  if(hitachidsp.ram) {
+    memory.ram = parent->append<Node::Debugger::Memory>("Cartridge RAM");
+    memory.ram->setSize(hitachidsp.ram.size());
+    memory.ram->setRead([&](u32 address) -> u8 {
+      return hitachidsp.ram.read(address);
+    });
+    memory.ram->setWrite([&](u32 address, u8 data) -> void {
+      return hitachidsp.ram.write(address, data);
+    });
+  }
+
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "HIT");
   tracer.instruction->setAddressBits(23);
   tracer.instruction->setDepth(16);

--- a/ares/sfc/coprocessor/hitachidsp/hitachidsp.hpp
+++ b/ares/sfc/coprocessor/hitachidsp/hitachidsp.hpp
@@ -8,6 +8,11 @@ struct HitachiDSP : HG51B, Thread {
     auto load(Node::Object) -> void;
     auto instruction() -> void;
 
+    struct Memory {
+      Node::Debugger::Memory rom;
+      Node::Debugger::Memory ram;
+    } memory;
+
     struct Tracer {
       Node::Debugger::Tracer::Instruction instruction;  //todo: HG51B needs to notify HitachiDSP when instructiosn are executed
     } tracer;

--- a/ares/sfc/coprocessor/sa1/debugger.cpp
+++ b/ares/sfc/coprocessor/sa1/debugger.cpp
@@ -1,4 +1,35 @@
 auto SA1::Debugger::load(Node::Object parent) -> void {
+  memory.rom = parent->append<Node::Debugger::Memory>("Cartridge ROM");
+  memory.rom->setSize(sa1.rom.size());
+  memory.rom->setRead([&](u32 address) -> u8 {
+    return sa1.rom.read(address);
+  });
+  memory.rom->setWrite([&](u32 address, u8 data) -> void {
+    return sa1.rom.program(address, data);
+  });
+
+  if(sa1.bwram) {
+    memory.bwram = parent->append<Node::Debugger::Memory>("SA1 BWRAM");
+    memory.bwram->setSize(sa1.bwram.size());
+    memory.bwram->setRead([&](u32 address) -> u8 {
+      return sa1.bwram.read(address);
+    });
+    memory.bwram->setWrite([&](u32 address, u8 data) -> void {
+      return sa1.bwram.write(address, data);
+    });
+  }
+
+  if(sa1.iram) {
+    memory.iram = parent->append<Node::Debugger::Memory>("SA1 IRAM");
+    memory.iram->setSize(sa1.iram.size());
+    memory.iram->setRead([&](u32 address) -> u8 {
+      return sa1.iram.read(address);
+    });
+    memory.iram->setWrite([&](u32 address, u8 data) -> void {
+      return sa1.iram.write(address, data);
+    });
+  }
+
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "SA1");
   tracer.instruction->setAddressBits(24);
   tracer.instruction->setDepth(8);

--- a/ares/sfc/coprocessor/sa1/sa1.hpp
+++ b/ares/sfc/coprocessor/sa1/sa1.hpp
@@ -9,6 +9,12 @@ struct SA1 : WDC65816, Thread {
     auto instruction() -> void;
     auto interrupt(string_view) -> void;
 
+    struct Memory {
+      Node::Debugger::Memory rom;
+      Node::Debugger::Memory bwram;
+      Node::Debugger::Memory iram;
+    } memory;
+
     struct Tracer {
       Node::Debugger::Tracer::Instruction instruction;
       Node::Debugger::Tracer::Notification interrupt;

--- a/ares/sfc/coprocessor/superfx/debugger.cpp
+++ b/ares/sfc/coprocessor/superfx/debugger.cpp
@@ -1,4 +1,35 @@
 auto SuperFX::Debugger::load(Node::Object parent) -> void {
+  memory.rom = parent->append<Node::Debugger::Memory>("Cartridge ROM");
+  memory.rom->setSize(superfx.rom.size());
+  memory.rom->setRead([&](u32 address) -> u8 {
+    return superfx.rom.read(address);
+  });
+  memory.rom->setWrite([&](u32 address, u8 data) -> void {
+    return superfx.rom.program(address, data);
+  });
+
+  if(superfx.ram) {
+    memory.ram = parent->append<Node::Debugger::Memory>("SuperFX RAM");
+    memory.ram->setSize(superfx.ram.size());
+    memory.ram->setRead([&](u32 address) -> u8 {
+      return superfx.ram.read(address);
+    });
+    memory.ram->setWrite([&](u32 address, u8 data) -> void {
+      return superfx.ram.write(address, data);
+    });
+  }
+
+  if(superfx.bram) {
+    memory.bram = parent->append<Node::Debugger::Memory>("SuperFX BRAM");
+    memory.bram->setSize(superfx.bram.size());
+    memory.bram->setRead([&](u32 address) -> u8 {
+      return superfx.bram.read(address);
+    });
+    memory.bram->setWrite([&](u32 address, u8 data) -> void {
+      return superfx.bram.write(address, data);
+    });
+  }
+
   tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "GSU");
   tracer.instruction->setAddressBits(24);
   tracer.instruction->setDepth(superfx.Frequency < 12_MHz ? 8 : 16);

--- a/ares/sfc/coprocessor/superfx/superfx.hpp
+++ b/ares/sfc/coprocessor/superfx/superfx.hpp
@@ -9,6 +9,12 @@ struct SuperFX : GSU, Thread {
     auto load(Node::Object) -> void;
     auto instruction() -> void;
 
+    struct Memory {
+      Node::Debugger::Memory rom;
+      Node::Debugger::Memory ram;
+      Node::Debugger::Memory bram;
+    } memory;
+
     struct Tracer {
       Node::Debugger::Tracer::Instruction instruction;
     } tracer;


### PR DESCRIPTION
There are yet more boards that could be supported; I just fixed the ones that already had some debugger integration. For the rest, the debugger should no longer crash if cartridge.rom or cartridge.ram are not populated; they just won't show up in the memory view.

Fixes #940