### PR TITLE
ws: implement PTS-0101 flash chip emulation

### DIFF
--- a/ares/ws/cartridge/cartridge.cpp
+++ b/ares/ws/cartridge/cartridge.cpp
@@ -6,13 +6,14 @@ Cartridge& cartridge = cartridgeSlot.cartridge;
 #include "slot.cpp"
 #include "memory.cpp"
 #include "rtc.cpp"
+#include "flash.cpp"
 #include "io.cpp"
 #include "debugger.cpp"
 #include "serialization.cpp"
 
 auto Cartridge::allocate(Node::Port parent) -> Node::Peripheral {
   string name = system.name();
-  if(Model::SwanCrystal()) name = "WonderSwan Color";
+  if(Model::WonderSwanColor() || Model::SwanCrystal()) name = "WonderSwan Color";
   return node = parent->append<Node::Peripheral>(string{name, " Cartridge"});
 }
 
@@ -20,28 +21,36 @@ auto Cartridge::connect() -> void {
   if(!node->setPak(pak = platform->pak(node))) return;
 
   information = {};
+  has = {};
   information.title = pak->attribute("title");
   if(pak->attribute("orientation") == "horizontal") information.orientation = "Horizontal";
   if(pak->attribute("orientation") == "vertical"  ) information.orientation = "Vertical";
 
-  if(auto fp = pak->read("program.rom")) {
+  if(auto fp = pak->read("program.flash")) {
+    rom.allocate(fp->size());
+    rom.load(fp);
+    has.flash = true;
+  } else if(auto fp = pak->read("program.rom")) {
     rom.allocate(fp->size());
     rom.load(fp);
   }
-
+  
   if(auto fp = pak->read("save.ram")) {
     ram.allocate(fp->size());
     ram.load(fp);
+    has.sram = true;
   }
 
   if(auto fp = pak->read("save.eeprom")) {
     eeprom.allocate(fp->size(), 16, 1, 0xff);
     fp->read({eeprom.data, eeprom.size});
+    has.eeprom = true;
   }
 
   if(auto fp = pak->read("time.rtc")) {
     rtc.ram.allocate(fp->size());
     rtc.ram.load(fp);
+    has.rtc = true;
   }
 
   debugger.load(node);
@@ -52,14 +61,17 @@ auto Cartridge::disconnect() -> void {
   if(!node) return;
   save();
   debugger.unload(node);
-  Thread::destroy();
   rom.reset();
   ram.reset();
-  rtc.ram.reset();
+  rtc.reset();
 }
 
 auto Cartridge::save() -> void {
   if(!node) return;
+  
+  if(auto fp = pak->write("program.flash")) {
+    rom.save(fp);
+  }
 
   if(auto fp = pak->write("save.ram")) {
     ram.save(fp);
@@ -74,23 +86,10 @@ auto Cartridge::save() -> void {
   }
 }
 
-auto Cartridge::main() -> void {
-  if(rtc.ram) {
-    rtc.tickSecond();
-    rtc.checkAlarm();
-  }
-  step(3'072'000);
-}
-
-auto Cartridge::step(u32 clocks) -> void {
-  Thread::step(clocks);
-  synchronize(cpu);
-}
-
 auto Cartridge::power() -> void {
-  Thread::create(3'072'000, {&Cartridge::main, this});
-  eeprom.power();
-  rtc.power();
+  if(has.eeprom) eeprom.power();
+  if(has.rtc) rtc.power();
+  if(has.flash) flash.power();
 
   bus.map(this, 0x00c0, 0x00ff);
 

--- a/ares/ws/cartridge/debugger.cpp
+++ b/ares/ws/cartridge/debugger.cpp
@@ -10,7 +10,7 @@ auto Cartridge::Debugger::load(Node::Object parent) -> void {
     });
   }
 
-  if(self.ram) {
+  if(self.has.sram) {
     memory.ram = parent->append<Node::Debugger::Memory>("Cartridge RAM");
     memory.ram->setSize(self.ram.size());
     memory.ram->setRead([&](u32 address) -> u8 {
@@ -21,7 +21,7 @@ auto Cartridge::Debugger::load(Node::Object parent) -> void {
     });
   }
 
-  if(self.eeprom) {
+  if(self.has.eeprom) {
     memory.eeprom = parent->append<Node::Debugger::Memory>("Cartridge EEPROM");
     memory.eeprom->setSize(self.eeprom.size);
     memory.eeprom->setRead([&](u32 address) -> u8 {
@@ -39,12 +39,12 @@ auto Cartridge::Debugger::load(Node::Object parent) -> void {
 auto Cartridge::Debugger::unload(Node::Object parent) -> void {
   parent->remove(properties.ports);
   parent->remove(memory.rom);
-  parent->remove(memory.ram);
-  parent->remove(memory.eeprom);
+  if(self.has.sram) parent->remove(memory.ram);
+  if(self.has.eeprom) parent->remove(memory.eeprom);
   properties.ports.reset();
   memory.rom.reset();
-  memory.ram.reset();
-  memory.eeprom.reset();
+  if(self.has.sram) memory.ram.reset();
+  if(self.has.eeprom) memory.eeprom.reset();
 }
 
 auto Cartridge::Debugger::ports() -> string {
@@ -56,6 +56,17 @@ auto Cartridge::Debugger::ports() -> string {
   output.append("SRAM Bank: ", hex(self.io.sramBank, 4L), "\n");
 
   // TODO: RTC, GPO
+
+  output.append("SRAM Bank Mode: ", self.io.flashEnable ? "Flash" : "SRAM", "\n");
+  if(self.has.flash) {
+    output.append("Flash Mode: ");
+    u32 iAdded = 0;
+    if(self.flash.idmode) output.append((iAdded++ > 0) ? ", " : "", "ID");
+    if(self.flash.programmode) output.append((iAdded++ > 0) ? ", " : "", "Program");
+    if(self.flash.fastmode) output.append((iAdded++ > 0) ? ", " : "", "Fast");
+    if(self.flash.erasemode) output.append((iAdded++ > 0) ? ", " : "", "Erase");
+    output.append("\n");
+  }
 
   return output;
 }

--- a/ares/ws/cartridge/flash.cpp
+++ b/ares/ws/cartridge/flash.cpp
@@ -1,0 +1,85 @@
+// This implements the 4Mbit MBM29DL400TC NOR flash chip.
+// Not implemented:
+// - sector protection
+// - program/erase operation timings (they're instant)
+// - sector banks (it's respected for sector erase, but nowhere else)
+
+auto Cartridge::FLASH::read(n19 address, bool words) -> n16 {
+  // TODO: Is this correct?
+  if(fastmode) {
+    // Embedded Program status - completed
+    n8 data = 0;
+    data.bit(7) = self.rom.read(address).bit(7);
+    data.bit(2) = 1;
+    return data;
+  }
+
+  if(idmode) {
+    if(!words) {
+      if(address & 1) return 0;
+      address >>= 1;
+    }
+    if((address & 0xFFF) == 0x000) return 0x04;
+    if((address & 0xFFF) == 0x001) return 0x220C;
+    return 0;
+  }
+
+  if (!words) return self.rom.read(address);
+  return self.rom.read(address << 1) | (self.rom.read((address << 1) | 1) << 8);
+}
+
+auto Cartridge::FLASH::write(n19 address, n8 byte) -> void {
+  if(programmode) {
+    self.rom.write(address, self.rom.read(address) & byte);
+    programmode = false;
+    return;
+  }
+
+  if(fastmode) {
+    if(byte == 0xa0) programmode = true;
+    if(byte == 0x90) fastmode = false;
+    return;  
+  }
+
+  if(unlock == 0) {
+    if(byte == 0xf0) idmode = false;
+    if(byte == 0xaa && (address & 0xfff) == 0xaaa) unlock = 1;
+  } else if(unlock == 1) {
+    if(byte == 0x55 && (address & 0xfff) == 0x555) unlock = 2;
+    else unlock = 0;
+  } else if(unlock == 2) {
+    if(erasemode) {
+      if(byte == 0x10) {
+        for(u32 n : range(self.rom.size())) self.rom.write(n, 0xff);
+      }
+      if(byte == 0x30) {
+        u32 offset, size;
+        if(address < 0x60000)      { offset = address & 0x70000; size = 0x10000; }
+        else if(address < 0x64000) { offset = 0x60000;           size = 0x4000;  }
+        else if(address < 0x6c000) { offset = 0x64000;           size = 0x8000;  }
+        else if(address < 0x74000) { offset = address & 0x7e000; size = 0x2000;  }
+        else if(address < 0x7c000) { offset = 0x74000;           size = 0x8000;  }
+        else                       { offset = 0x7c000;           size = 0x4000;  }
+        for(u32 n : range(size)) self.rom.write(offset++, 0xff);
+      }
+      erasemode = false;
+    }
+
+    if(byte == 0xf0) idmode = false;
+    if(byte == 0x90) idmode = true;
+    if(byte == 0xa0) programmode = true;
+    if(byte == 0x80) erasemode = true;
+    if(byte == 0x20) fastmode = true;
+
+    unlock = 0;
+  }
+}
+
+auto Cartridge::FLASH::power() -> void {
+  unlock = 0;
+  idmode = false;
+  programmode = false;
+  fastmode = false;
+  erasemode = false;
+}
+

--- a/ares/ws/cartridge/io.cpp
+++ b/ares/ws/cartridge/io.cpp
@@ -71,6 +71,10 @@ auto Cartridge::readIO(n16 address) -> n8 {
     data = io.gpoData;
     break;
 
+  case 0x00ce:  //MEMORY_CTRL
+    data.bit(0) = io.flashEnable;
+    break;
+    
   }
 
   return data;
@@ -89,7 +93,7 @@ auto Cartridge::writeIO(n16 address, n8 data) -> void {
     io.sramBank.bit(0,7) = data.bit(0,7);
     break;
 
-  case 0x00d1:  //BANK_RO01_HI
+  case 0x00d1:  //BANK_SRAM_HI
     io.sramBank.bit(8,15) = data.bit(0,7);
     break;
 
@@ -98,7 +102,7 @@ auto Cartridge::writeIO(n16 address, n8 data) -> void {
     io.romBank0.bit(0,7) = data.bit(0,7);
     break;
 
-  case 0x00d3:  //BANK_RO01_HI
+  case 0x00d3:  //BANK_ROM0_HI
     io.romBank0.bit(8,15) = data.bit(0,7);
     break;
 
@@ -145,6 +149,10 @@ auto Cartridge::writeIO(n16 address, n8 data) -> void {
 
   case 0x00cd:  //GPO_DATA
     io.gpoData = data;
+    break;
+
+  case 0x00ce:  //MEMORY_CTRL
+    io.flashEnable = data.bit(0);
     break;
 
   }

--- a/ares/ws/cartridge/memory.cpp
+++ b/ares/ws/cartridge/memory.cpp
@@ -7,6 +7,11 @@ auto Cartridge::readROM(n20 address) -> n8 {
   case 3:  offset = io.romBank1 << 16 | (n16)address; break;  //30000-3ffff
   default: offset = io.romBank2 << 20 | (n20)address; break;  //40000-fffff
   }
+  if(has.flash && (flash.idmode || flash.fastmode)) {
+    n16 data = flash.read(offset >> 1, true);
+    if(address & 0x1) return data >> 8;
+    return data;
+  }
   return rom.read(offset);
 }
 
@@ -15,13 +20,23 @@ auto Cartridge::writeROM(n20 address, n8 data) -> void {
 
 //10000-1ffff
 auto Cartridge::readRAM(n20 address) -> n8 {
-  if(!ram) return 0x00;
   n32 offset = io.sramBank << 16 | (n16)address;
-  return ram.read(offset);
+  if(io.flashEnable) {
+    if(!has.flash) return 0x00;
+    return flash.read(offset, false);
+  } else {
+    if(!has.sram) return 0x00;
+    return ram.read(offset);
+  }
 }
 
 auto Cartridge::writeRAM(n20 address, n8 data) -> void {
-  if(!ram) return;
   n32 offset = io.sramBank << 16 | (n16)address;
-  ram.write(offset, data);
+  if(io.flashEnable) {
+    if(!has.flash) return;
+    flash.write(offset, data);
+  } else {
+    if(!has.sram) return;
+    ram.write(offset, data);
+  }
 }

--- a/ares/ws/cartridge/rtc.cpp
+++ b/ares/ws/cartridge/rtc.cpp
@@ -149,9 +149,29 @@ auto Cartridge::RTC::write(n8 data) -> void {
 }
 
 auto Cartridge::RTC::power() -> void {
+  Thread::create(3'072'000, {&Cartridge::RTC::main, this});
+  
   command = 0;
   index = 0;
   alarm = 0;
   alarmHour = 0;
   alarmMinute = 0;
 }
+
+auto Cartridge::RTC::reset() -> void {
+  Thread::destroy();
+
+  ram.reset();
+}
+
+auto Cartridge::RTC::main() -> void {
+  tickSecond();
+  checkAlarm();
+  step(3'072'000);
+}
+
+auto Cartridge::RTC::step(u32 clocks) -> void {
+  Thread::step(clocks);
+  synchronize(cpu);
+}
+

--- a/ares/ws/cartridge/serialization.cpp
+++ b/ares/ws/cartridge/serialization.cpp
@@ -1,15 +1,15 @@
 auto Cartridge::serialize(serializer& s) -> void {
-  Thread::serialize(s);
+  if(has.sram) {
+    s(ram);
+  }
 
-  s(ram);
-  s(eeprom);
-  s(rtc.ram);
+  if(has.eeprom) {
+    s(eeprom);
+  }
 
-  s(rtc.command);
-  s(rtc.index);
-  s(rtc.alarm);
-  s(rtc.alarmHour);
-  s(rtc.alarmMinute);
+  if(has.rtc) {
+    rtc.serialize(s);
+  }
 
   s(io.romBank0);
   s(io.romBank1);
@@ -17,4 +17,25 @@ auto Cartridge::serialize(serializer& s) -> void {
   s(io.sramBank);
   s(io.gpoEnable);
   s(io.gpoData);
+  s(io.flashEnable);
+
+  if(has.flash) {
+    s(rom);
+    s(flash.unlock);
+    s(flash.idmode);
+    s(flash.programmode);
+    s(flash.fastmode);
+    s(flash.erasemode);
+  }
+}
+
+auto Cartridge::RTC::serialize(serializer& s) -> void {
+  Thread::serialize(s);
+  s(ram);
+
+  s(command);
+  s(index);
+  s(alarm);
+  s(alarmHour);
+  s(alarmMinute);
 }

--- a/mia/medium/wonderswan.cpp
+++ b/mia/medium/wonderswan.cpp
@@ -24,7 +24,12 @@ auto WonderSwan::load(string location) -> bool {
   pak->setAttribute("title", document["game/title"].string());
   pak->setAttribute("orientation", document["game/orientation"].string());
   pak->append("manifest.bml", manifest);
-  pak->append("program.rom",  rom);
+  if(auto node = document["game/board/memory(type=Flash,content=Program)"]) {
+    pak->append("program.flash", rom);
+    Pak::load("program.flash", ".flash");
+  } else {
+    pak->append("program.rom",  rom);
+  }
 
   if(auto node = document["game/board/memory(type=RAM,content=Save)"]) {
     Medium::load(node, ".ram");
@@ -50,6 +55,9 @@ auto WonderSwan::save(string location) -> bool {
   }
   if(auto node = document["game/board/memory(type=RTC,content=Time)"]) {
     Medium::save(node, ".rtc");
+  }
+  if(auto node = document["game/board/memory(type=Flash,content=Program)"]) {
+    Pak::save("program.flash", ".flash");
   }
 
   return true;
@@ -79,6 +87,16 @@ auto WonderSwan::analyze(vector<u8>& rom) -> string {
 
   bool orientation = metadata[12] & 1;  //0 = horizontal; 1 = vertical
   bool hasRTC = metadata[13] & 1;
+  bool isWonderWitch = rom.size() == 0x80000
+    && rom[0x70000] == 'E'   // FreyaBIOS header
+    && rom[0x70001] == 'L'
+    && rom[0x70002] == 'I'
+    && rom[0x70003] == 'S'
+    && rom[0x70004] == 'A'
+    && rom[0x7fff6] == 0x00  // Publisher ID
+    && rom[0x7fff8] == 0x00  // Game ID
+    && rom[0x7fffb] == 0x04  // Save format
+    && rom[0x7fffd] == 0x01; // Mapper
 
   string s;
   s += "game\n";
@@ -89,7 +107,8 @@ auto WonderSwan::analyze(vector<u8>& rom) -> string {
   s += "  board\n";
 
   s += "    memory\n";
-  s += "      type: ROM\n";
+  if(!isWonderWitch) s += "      type: ROM\n";
+  if(isWonderWitch)  s += "      type: Flash\n";
   s +={"      size: 0x", hex(rom.size()), "\n"};
   s += "      content: Program\n";
 


### PR DESCRIPTION
This is the PCB which powers the WonderWitch.

The emulation is not perfect - in particular, it does not emulate internal flash chip timings or sector protection - but it should go well beyond what WonderWitch uses.

Special thanks to [up-n-atom](https://github.com/up-n-atom/WonderWitch) for providing the necessary schematics and datasheets.