### PR TITLE
ares: support disconnecting controller from emulated device

### DIFF
--- a/ares/a26/controller/port.cpp
+++ b/ares/a26/controller/port.cpp
@@ -10,6 +10,7 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setType("Controller");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
+  port->setDisconnect([&] { device.reset(); });
   port->setSupported({"Gamepad"});
 }
 

--- a/ares/cv/controller/port.cpp
+++ b/ares/cv/controller/port.cpp
@@ -10,6 +10,7 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setType("Controller");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
+  port->setDisconnect([&] { device.reset(); });
   port->setSupported({"Gamepad"});
 }
 

--- a/ares/fc/controller/port.cpp
+++ b/ares/fc/controller/port.cpp
@@ -10,6 +10,7 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setType("Controller");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
+  port->setDisconnect([&] { device.reset(); });
   port->setSupported({"Gamepad"});
 }
 

--- a/ares/fc/expansion/port.cpp
+++ b/ares/fc/expansion/port.cpp
@@ -9,6 +9,7 @@ auto ExpansionPort::load(Node::Object parent) -> void {
   port->setType("Expansion");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
+  port->setDisconnect([&] { device.reset(); });
   port->setSupported({"Family Keyboard"});
 }
 

--- a/ares/ms/controller/port.cpp
+++ b/ares/ms/controller/port.cpp
@@ -10,6 +10,7 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setType("Controller");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
+  port->setDisconnect([&] { device.reset(); });
   port->setSupported({"Gamepad", "Light Phaser", "Paddle", "Sports Pad", "MD Control Pad", "MD Fighting Pad", "Mega Mouse"});
 }
 

--- a/ares/msx/controller/port.cpp
+++ b/ares/msx/controller/port.cpp
@@ -10,6 +10,7 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setType("Controller");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
+  port->setDisconnect([&] { device.reset(); });
   port->setSupported({"Gamepad","Arkanoid Vaus Paddle"});
 }
 

--- a/ares/n64/controller/port.cpp
+++ b/ares/n64/controller/port.cpp
@@ -12,6 +12,7 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setType("Controller");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
+  port->setDisconnect([&] { device.reset(); });
   port->setSupported({"Gamepad", "Mouse"});
 }
 
@@ -25,7 +26,6 @@ auto ControllerPort::save() -> void {
 }
 
 auto ControllerPort::allocate(string name) -> Node::Peripheral {
-  device = {};
   if(name == "Gamepad") device = new Gamepad(port);
   if(name == "Mouse"  ) device = new Mouse(port);
   if(device) return device->node;

--- a/ares/ng/card/slot.cpp
+++ b/ares/ng/card/slot.cpp
@@ -9,6 +9,7 @@ auto CardSlot::load(Node::Object parent) -> void {
   port->setType("Memory Card");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
+  port->setDisconnect([&] { device.reset(); });
   port->setSupported({"Memory Card"});
 }
 

--- a/ares/ng/controller/port.cpp
+++ b/ares/ng/controller/port.cpp
@@ -10,6 +10,7 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setType("Controller");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
+  port->setDisconnect([&] { device.reset(); });
   port->setSupported({"Arcade Stick"});
 }
 

--- a/ares/pce/controller/port.cpp
+++ b/ares/pce/controller/port.cpp
@@ -9,6 +9,7 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setType("Controller");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
+  port->setDisconnect([&] { device.reset(); });
   port->setSupported({"Gamepad", "Avenue Pad 6", "Multitap"});
 }
 

--- a/ares/ps1/peripheral/port.cpp
+++ b/ares/ps1/peripheral/port.cpp
@@ -12,6 +12,7 @@ auto PeripheralPort::load(Node::Object parent) -> void {
   port->setType(type);
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
+  port->setDisconnect([&] { device.reset(); });
   if(type == "Controller") {
     port->setSupported({"Digital Gamepad"});
   }

--- a/ares/sfc/controller/port.cpp
+++ b/ares/sfc/controller/port.cpp
@@ -10,6 +10,7 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setType("Controller");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
+  port->setDisconnect([&] { device.reset(); });
   port->setSupported({
     "Gamepad",
     "Justifier",

--- a/ares/sg/controller/port.cpp
+++ b/ares/sg/controller/port.cpp
@@ -10,6 +10,7 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setType("Controller");
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
+  port->setDisconnect([&] { device.reset(); });
   port->setSupported({"Gamepad"});
 }
 

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -401,8 +401,6 @@ auto Presentation::loadEmulator() -> void {
       peripheralItem.onActivate([=] {
         auto port = peripheralItem.attribute<ares::Node::Port>("port");
         port->disconnect();
-        port->allocate(peripheralItem.text());
-        port->connect();
       });
       peripheralGroup.append(peripheralItem);
     }


### PR DESCRIPTION
Selecting "nothing" for a controller port from the UI only consistently blocked input from the host, and it did not reliably do the extra work required to actually disconnect the controller from the perspective of the emulated device.

This was handled only by the MD and N64 cores, but now all cores are standardized on the disconnection method originally implemented for MD.

Fixes #969. See #514 and #722 for the prior MD and N64 implementations.