### PR TITLE
n64: improve boot timeout handling

### DIFF
--- a/ares/n64/pif/hle.cpp
+++ b/ares/n64/pif/hle.cpp
@@ -349,7 +349,7 @@ auto PIF::mainHLE() -> void {
     }
     for (auto i: range(6)) intram.cpuChecksum[i] = 0;
     state = WaitTerminateBoot;
-    intram.bootTimeout = 0xfb00 * 6500;
+    intram.bootTimeout = 6 * 187500000;  //6 seconds
     return;
   }
 
@@ -367,7 +367,7 @@ auto PIF::mainHLE() -> void {
   }
 
   if(state == Error) {
-    cpu.scc.nmiPending = !cpu.scc.nmiPending;
+    cpu.scc.nmiPending = 1;
     return;
   }
 }


### PR DESCRIPTION
Raise the timeout to make Start Wars: Shadows of the Empire boot again. Also improve simulation of CPU halt; the real PIF does toggle the NMI line but it does so extremely quickly. We don't emulate PIF that often, so it's more accurate to simply keep the NMI line asserted forever, as the final effect on the CPU is the same.