### PR TITLE
ws: emulation improvements

### DIFF
--- a/ares/ws/apu/apu.cpp
+++ b/ares/ws/apu/apu.cpp
@@ -49,11 +49,11 @@ auto APU::main() -> void {
 
     // TODO: are voice/noise modes handled on different cycles than tone modes?
     switch(state.apuClock++) {
-    case 0: if(channel1.io.enable) channel1.runOutput(); break;
-    case 1: if(channel2.io.enable) channel2.runOutput(); break;
-    case 2: if(channel3.io.enable) channel3.runOutput(); break;
-    case 3: if(channel4.io.enable) channel4.runOutput(); break;
-    case 4: if(channel5.io.enable) channel5.runOutput(); break; // TODO: which cycle is this?
+    case 0: if(channel1.io.enable)                      channel1.runOutput(); break;
+    case 1: if(channel2.io.enable || channel2.io.voice) channel2.runOutput(); break;
+    case 2: if(channel3.io.enable)                      channel3.runOutput(); break;
+    case 3: if(channel4.io.enable)                      channel4.runOutput(); break;
+    case 4: if(channel5.io.enable)                      channel5.runOutput(); break; // TODO: which cycle is this?
     case 5: dma.run(); break; // TODO: which cycle is this?
     case 6: dacRun(); break; // TODO: which cycle is this?
     }
@@ -77,18 +77,18 @@ auto APU::dacRun() -> void {
   }
 
   s32 left = 0;
-  if(channel1.io.enable) left += channel1.output.left;
-  if(channel2.io.enable) left += channel2.output.left;
-  if(channel3.io.enable) left += channel3.output.left;
-  if(channel4.io.enable) left += channel4.output.left;
-  if(channel5.io.enable) left += channel5.output.left * io.headphonesConnected;
+  if(channel1.io.enable)                      left += channel1.output.left;
+  if(channel2.io.enable || channel2.io.voice) left += channel2.output.left;
+  if(channel3.io.enable)                      left += channel3.output.left;
+  if(channel4.io.enable)                      left += channel4.output.left;
+  if(channel5.io.enable)                      left += channel5.output.left * io.headphonesConnected;
 
   s32 right = 0;
-  if(channel1.io.enable) right += channel1.output.right;
-  if(channel2.io.enable) right += channel2.output.right;
-  if(channel3.io.enable) right += channel3.output.right;
-  if(channel4.io.enable) right += channel4.output.right;
-  if(channel5.io.enable) right += channel5.output.right * io.headphonesConnected;
+  if(channel1.io.enable)                      right += channel1.output.right;
+  if(channel2.io.enable || channel2.io.voice) right += channel2.output.right;
+  if(channel3.io.enable)                      right += channel3.output.right;
+  if(channel4.io.enable)                      right += channel4.output.right;
+  if(channel5.io.enable)                      right += channel5.output.right * io.headphonesConnected;
 
   if(!io.headphonesConnected) {
     left = right = sclamp<16>((((left + right) >> io.speakerShift) & 0xFF) << 7);

--- a/ares/ws/cartridge/cartridge.cpp
+++ b/ares/ws/cartridge/cartridge.cpp
@@ -8,6 +8,7 @@ Cartridge& cartridge = cartridgeSlot.cartridge;
 #include "memory.cpp"
 #include "rtc.cpp"
 #include "flash.cpp"
+#include "karnak.cpp"
 #include "io.cpp"
 #include "debugger.cpp"
 #include "serialization.cpp"
@@ -55,6 +56,8 @@ auto Cartridge::connect() -> void {
     has.rtc = true;
   }
 
+  has.karnak = pak->attribute("board") == "KARNAK";
+
   debugger.load(node);
   power();
 }
@@ -66,6 +69,7 @@ auto Cartridge::disconnect() -> void {
   rom.reset();
   ram.reset();
   rtc.reset();
+  karnak.reset();
 }
 
 auto Cartridge::save() -> void {
@@ -93,6 +97,7 @@ auto Cartridge::power() -> void {
   if(has.eeprom) eeprom.power();
   if(has.rtc) rtc.power();
   if(has.flash) flash.power();
+  if(has.karnak) karnak.power();
 
   bus.map(this, 0x00c0, 0x00ff);
 

--- a/ares/ws/cartridge/cartridge.hpp
+++ b/ares/ws/cartridge/cartridge.hpp
@@ -1,4 +1,4 @@
-struct Cartridge : IO {
+struct Cartridge : IO, Thread {
   Node::Peripheral node;
   VFS::Pak pak;
   Memory::Writable<n8> rom;
@@ -31,6 +31,7 @@ struct Cartridge : IO {
     n1 eeprom;
     n1 rtc;
     n1 flash;
+    n1 karnak;
   } has;
 
   auto title() const { return information.title; }
@@ -43,6 +44,9 @@ struct Cartridge : IO {
 
   auto save() -> void;
   auto power() -> void;
+
+  auto main() -> void;
+  auto step(u32 clocks) -> void;
 
   //memory.cpp
   auto readROM(n20 address) -> n8;
@@ -106,6 +110,21 @@ struct Cartridge : IO {
     auto alarmHour()   -> n8& { return ram[16]; }
     auto alarmMinute() -> n8& { return ram[17]; }
   } rtc;
+
+  struct KARNAK : Thread {
+    //karnak.cpp
+    auto power() -> void;
+    auto reset() -> void;
+    auto main() -> void;
+    auto step(u32 clocks) -> void;
+
+    //serialization.cpp
+    auto serialize(serializer& s) -> void;
+
+    n1 timerEnable;
+    n7 timerPeriod;
+    n9 timerCounter;
+  } karnak;
 
   struct FLASH {
     Cartridge& self;

--- a/ares/ws/cartridge/io.cpp
+++ b/ares/ws/cartridge/io.cpp
@@ -76,6 +76,20 @@ auto Cartridge::readIO(n16 address) -> n8 {
     data.bit(0) = io.flashEnable;
     break;
     
+  case 0x00d6:  //KARNAK_TIMER
+    data.bit(7) = karnak.timerEnable;
+    data.bit(6, 0) = karnak.timerPeriod;
+    break;
+
+  case 0x00d7:  //KARNAK
+    data = 0xFF;
+    break;
+
+  case 0x00d8:
+  case 0x00d9:
+    debug(unimplemented, "[KARNAK] ADPCM read ", hex(address, 2L));
+    break;
+
   }
 
   return data;
@@ -154,6 +168,16 @@ auto Cartridge::writeIO(n16 address, n8 data) -> void {
 
   case 0x00ce:  //MEMORY_CTRL
     io.flashEnable = data.bit(0);
+    break;
+
+  case 0x00d6:  //KARNAK_TIMER
+    karnak.timerEnable = data.bit(7);
+    karnak.timerPeriod = data.bit(6, 0);
+    break;
+
+  case 0x00d8:
+  case 0x00d9:
+    debug(unimplemented, "[KARNAK] ADPCM write ", hex(address, 2L), "=", hex(data, 2L));
     break;
 
   }

--- a/ares/ws/cartridge/karnak.cpp
+++ b/ares/ws/cartridge/karnak.cpp
@@ -1,0 +1,29 @@
+
+auto Cartridge::KARNAK::power() -> void {
+  Thread::create(384'000, {&Cartridge::KARNAK::main, this});
+  
+  timerEnable = 0;
+  timerPeriod = 0;
+  timerCounter = 0;
+}
+
+auto Cartridge::KARNAK::reset() -> void {
+  Thread::destroy();
+}
+
+auto Cartridge::KARNAK::main() -> void {
+  if(timerEnable) {
+    if(!timerCounter) {
+      timerCounter = (timerPeriod + 1) * 2;
+    }
+    timerCounter--;
+  }
+  cpu.irqLevel(CPU::Interrupt::Cartridge, timerEnable && !timerCounter);
+  step(1);
+}
+
+auto Cartridge::KARNAK::step(u32 clocks) -> void {
+  Thread::step(clocks);
+  synchronize(cpu);
+}
+

--- a/ares/ws/cartridge/serialization.cpp
+++ b/ares/ws/cartridge/serialization.cpp
@@ -27,6 +27,10 @@ auto Cartridge::serialize(serializer& s) -> void {
     s(flash.fastmode);
     s(flash.erasemode);
   }
+
+  if(has.karnak) {
+    karnak.serialize(s);
+  }
 }
 
 auto Cartridge::RTC::serialize(serializer& s) -> void {
@@ -38,4 +42,12 @@ auto Cartridge::RTC::serialize(serializer& s) -> void {
   s(index);
   s(fetchedData);
   s(counter);
+}
+
+auto Cartridge::KARNAK::serialize(serializer& s) -> void {
+  Thread::serialize(s);
+
+  s(timerEnable);
+  s(timerPeriod);
+  s(timerCounter);
 }

--- a/mia/medium/pocket-challenge-v2.cpp
+++ b/mia/medium/pocket-challenge-v2.cpp
@@ -1,4 +1,9 @@
 struct PocketChallengeV2 : WonderSwan {
   auto name() -> string override { return "Pocket Challenge V2"; }
   auto extensions() -> vector<string> override { return {"pcv2", "pc2"}; }
+  auto mapper(vector<u8>& rom) -> string override;
 };
+
+auto PocketChallengeV2::mapper(vector<u8>& rom) -> string {
+  return "KARNAK";
+}

--- a/mia/medium/wonderswan.cpp
+++ b/mia/medium/wonderswan.cpp
@@ -4,6 +4,7 @@ struct WonderSwan : Cartridge {
   auto load(string location) -> bool override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& rom) -> string;
+  virtual auto mapper(vector<u8>& rom) -> string;
 };
 
 auto WonderSwan::load(string location) -> bool {
@@ -23,6 +24,7 @@ auto WonderSwan::load(string location) -> bool {
   pak = new vfs::directory;
   pak->setAttribute("title", document["game/title"].string());
   pak->setAttribute("orientation", document["game/orientation"].string());
+  pak->setAttribute("board", document["game/board"].string());
   pak->append("manifest.bml", manifest);
   if(auto node = document["game/board/memory(type=Flash,content=Program)"]) {
     pak->append("program.flash", rom);
@@ -61,6 +63,10 @@ auto WonderSwan::save(string location) -> bool {
   }
 
   return true;
+}
+
+auto WonderSwan::mapper(vector<u8>& rom) -> string {
+  return rom[rom.size() - 3] >= 0x01 ? "2003" : "2001";
 }
 
 auto WonderSwan::analyze(vector<u8>& rom) -> string {
@@ -104,7 +110,7 @@ auto WonderSwan::analyze(vector<u8>& rom) -> string {
   s +={"  name:        ", Medium::name(location), "\n"};
   s +={"  title:       ", Medium::name(location), "\n"};
   s +={"  orientation: ", !orientation ? "horizontal" : "vertical", "\n"};
-  s += "  board\n";
+  s +={"  board:       ", mapper(rom), "\n"};
 
   s += "    memory\n";
   if(!isWonderWitch) s += "      type: ROM\n";


### PR DESCRIPTION
* [ws: add stub KARNAK emulation](https://github.com/ares-emulator/ares/commit/572f92fbf5cf9681128921db5c4d087530143722) - "KARNAK" is a mapper exclusive to some Pocket Challenge V2 cartridges which adds a cartridge-side interrupt timer (implemented) and some type of audio decoder, most likely ADPCM (not implemented - requires further research); in addition, this time, I did *not* forget to add it to the savestate!
* [ws: fix APU not emitting channel 2 output when only voice enabled](https://github.com/ares-emulator/ares/commit/774c69a8438e70019195ee853345ff76fb328ac2) - niche edge case discovered (and independently verified) while reading STSWS' notes on the console.