### PR TITLE
mcd/32x: default to single gamepad for Corpse Killer (E)

### DIFF
--- a/desktop-ui/emulator/mega-cd-32x.cpp
+++ b/desktop-ui/emulator/mega-cd-32x.cpp
@@ -66,8 +66,9 @@ auto MegaCD32X::load() -> bool {
   }
 
   if(auto port = root->find<ares::Node::Port>("Controller Port 2")) {
-    if(game->pak->attribute("serial") == "GM T-16201F-00") {
+    if(game->pak->attribute("serial").beginsWith("GM T-16201F")) {
       // CORPSE KILLER 32X (U) -- GM T-16201F-00
+      // CORPSE KILLER 32X (E) -- GM T-16201F-50
       // Gamepad in controller port 2 breaks input polling, so leave it disconnected.
       // No supported lightgun devices are currently emulated (Sega Menacer, ALG GameGun).
     } else {

--- a/desktop-ui/emulator/mega-cd.cpp
+++ b/desktop-ui/emulator/mega-cd.cpp
@@ -74,8 +74,9 @@ auto MegaCD::load() -> bool {
   }
 
   if(auto port = root->find<ares::Node::Port>("Controller Port 2")) {
-    if(game->pak->attribute("serial") == "GM T-162055-00") {
+    if(game->pak->attribute("serial").beginsWith("GM T-162055")) {
       // CORPSE KILLER (U) -- GM T-162055-00
+      // CORPSE KILLER (E) -- GM T-162055-50
       // Gamepad in controller port 2 breaks input polling, so leave it disconnected.
       // No supported lightgun devices are currently emulated (Sega Menacer, ALG GameGun).
     } else {


### PR DESCRIPTION
Building on #514 and #800, generalize serial comparison to match European releases.