### PR TITLE
sh2: fix illegal slot exceptions

### DIFF
--- a/ares/component/processor/sh2/instruction.cpp
+++ b/ares/component/processor/sh2/instruction.cpp
@@ -4,13 +4,11 @@ auto SH2::jump(u32 pc) -> void {
 }
 
 auto SH2::branch(u32 pc) -> void {
-  if(inDelaySlot()) return illegalSlotInstruction();
   PPC = pc;
   PPM = Branch::Take;
 }
 
 auto SH2::delaySlot(u32 pc) -> void {
-  if(inDelaySlot()) return illegalSlotInstruction();
   PPC = pc;
   PPM = Branch::Slot;
 }

--- a/ares/component/processor/sh2/instructions.cpp
+++ b/ares/component/processor/sh2/instructions.cpp
@@ -43,6 +43,7 @@ auto SH2::ANDM(u32 i) -> void {
 
 //BF disp
 auto SH2::BF(u32 d) -> void {
+  if(inDelaySlot()) return illegalSlotInstruction();
   if(SR.T == 0) {
     branch(PC + 4 + (s8)d * 2);
   }
@@ -50,6 +51,7 @@ auto SH2::BF(u32 d) -> void {
 
 //BF/S disp
 auto SH2::BFS(u32 d) -> void {
+  if(inDelaySlot()) return illegalSlotInstruction();
   if(SR.T == 0) {
     delaySlot(PC + 4 + (s8)d * 2);
   }
@@ -57,28 +59,33 @@ auto SH2::BFS(u32 d) -> void {
 
 //BRA disp
 auto SH2::BRA(u32 d) -> void {
+  if(inDelaySlot()) return illegalSlotInstruction();
   delaySlot(PC + 4 + (i12)d * 2);
 }
 
 //BRAF disp
 auto SH2::BRAF(u32 m) -> void {
+  if(inDelaySlot()) return illegalSlotInstruction();
   delaySlot(PC + 4 + R[m]);
 }
 
 //BSR disp
 auto SH2::BSR(u32 d) -> void {
+  if(inDelaySlot()) return illegalSlotInstruction();
   PR = PC;
   delaySlot(PC + 4 + (i12)d * 2);
 }
 
 //BSRF Rm
 auto SH2::BSRF(u32 m) -> void {
+  if(inDelaySlot()) return illegalSlotInstruction();
   PR = PC;
   delaySlot(PC + 4 + R[m]);
 }
 
 //BT disp
 auto SH2::BT(u32 d) -> void {
+  if(inDelaySlot()) return illegalSlotInstruction();
   if(SR.T == 1) {
     branch(PC + 4 + (s8)d * 2);
   }
@@ -86,6 +93,7 @@ auto SH2::BT(u32 d) -> void {
 
 //BT/S disp
 auto SH2::BTS(u32 d) -> void {
+  if(inDelaySlot()) return illegalSlotInstruction();
   if(SR.T == 1) {
     delaySlot(PC + 4 + (s8)d * 2);
   }
@@ -221,11 +229,13 @@ auto SH2::ILLEGAL() -> void {
 
 //JMP @Rm
 auto SH2::JMP(u32 m) -> void {
+  if(inDelaySlot()) return illegalSlotInstruction();
   delaySlot(R[m] + 4);
 }
 
 //JSR @Rm
 auto SH2::JSR(u32 m) -> void {
+  if(inDelaySlot()) return illegalSlotInstruction();
   PR = PC;
   delaySlot(R[m] + 4);
 }
@@ -605,6 +615,7 @@ auto SH2::ROTR(u32 n) -> void {
 
 //RTE
 auto SH2::RTE() -> void {
+  if(inDelaySlot()) return illegalSlotInstruction();
   delaySlot(readLong(SP + 0) + 4);
   SR  = readLong(SP + 4);
   SP += 8;
@@ -612,6 +623,7 @@ auto SH2::RTE() -> void {
 
 //RTS
 auto SH2::RTS() -> void {
+  if(inDelaySlot()) return illegalSlotInstruction();
   delaySlot(PR + 4);
 }
 
@@ -810,6 +822,7 @@ auto SH2::TAS(u32 n) -> void {
 
 //TRAPA #imm
 auto SH2::TRAPA(u32 i) -> void {
+  if(inDelaySlot()) return illegalSlotInstruction();
   push(SR);
   push(PC - 2);
   branch(readLong(VBR + i * 4) + 4);

--- a/ares/component/processor/sh2/recompiler.cpp
+++ b/ares/component/processor/sh2/recompiler.cpp
@@ -625,18 +625,22 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //BRA disp
   case 0xa0 ... 0xaf: {
-    add32(PPC, PC, imm(4 + (i12)d12 * 2));
-    mov32(PPM, imm(Branch::Slot));
+    checkDelaySlot([=] {
+      add32(PPC, PC, imm(4 + (i12)d12 * 2));
+      mov32(PPM, imm(Branch::Slot));
+    });
     return 1;
   }
 
   //BSR disp
   case 0xb0 ... 0xbf: {
-    mov32(reg(0), PC);
-    mov32(PR, reg(0));
-    add32(reg(0), reg(0), imm(4 + (i12)d12 * 2));
-    mov32(PPC, reg(0));
-    mov32(PPM, imm(Branch::Slot));
+    checkDelaySlot([=] {
+      mov32(reg(0), PC);
+      mov32(PR, reg(0));
+      add32(reg(0), reg(0), imm(4 + (i12)d12 * 2));
+      mov32(PPC, reg(0));
+      mov32(PPM, imm(Branch::Slot));
+    });
     return 1;
   }
 
@@ -723,37 +727,45 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //BT disp
   case 0x89: {
-    auto skip = cmp32_jump(T, imm(0), flag_eq);
-    add32(PPC, PC, imm(4 + (s8)d8 * 2));
-    mov32(PPM, imm(Branch::Take));
-    setLabel(skip);
+    checkDelaySlot([=] {
+      auto skip = cmp32_jump(T, imm(0), flag_eq);
+      add32(PPC, PC, imm(4 + (s8)d8 * 2));
+      mov32(PPM, imm(Branch::Take));
+      setLabel(skip);
+    });
     return 1;
   }
 
   //BF disp
   case 0x8b: {
-    auto skip = cmp32_jump(T, imm(0), flag_ne);
-    add32(PPC, PC, imm(4 + (s8)d8 * 2));
-    mov32(PPM, imm(Branch::Take));
-    setLabel(skip);
+    checkDelaySlot([=] {
+      auto skip = cmp32_jump(T, imm(0), flag_ne);
+      add32(PPC, PC, imm(4 + (s8)d8 * 2));
+      mov32(PPM, imm(Branch::Take));
+      setLabel(skip);
+    });
     return 1;
   }
 
   //BT/S disp
   case 0x8d: {
-    auto skip = cmp32_jump(T, imm(0), flag_eq);
-    add32(PPC, PC, imm(4 + (s8)d8 * 2));
-    mov32(PPM, imm(Branch::Slot));
-    setLabel(skip);
+    checkDelaySlot([=] {
+      auto skip = cmp32_jump(T, imm(0), flag_eq);
+      add32(PPC, PC, imm(4 + (s8)d8 * 2));
+      mov32(PPM, imm(Branch::Slot));
+      setLabel(skip);
+    });
     return 1;
   }
 
   //BF/S disp
   case 0x8f: {
-    auto skip = cmp32_jump(T, imm(0), flag_ne);
-    add32(PPC, PC, imm(4 + (s8)d8 * 2));
-    mov32(PPM, imm(Branch::Slot));
-    setLabel(skip);
+    checkDelaySlot([=] {
+      auto skip = cmp32_jump(T, imm(0), flag_ne);
+      add32(PPC, PC, imm(4 + (s8)d8 * 2));
+      mov32(PPM, imm(Branch::Slot));
+      setLabel(skip);
+    });
     return 1;
   }
 
@@ -783,19 +795,21 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //TRAPA #imm
   case 0xc3: {
-    getSR(reg(2));
-    sub32(reg(1), R15, imm(4));
-    mov32(R15, reg(1));
-    call(writeL);
-    sub32(reg(2), PC, imm(2));
-    sub32(reg(1), R15, imm(4));
-    mov32(R15, reg(1));
-    call(writeL);
-    add32(reg(1), VBR, imm(i * 4));
-    call(readL);
-    add32(reg(0), reg(0), imm(4));
-    mov32(PPC, reg(0));
-    mov32(PPM, imm(Branch::Take));
+    checkDelaySlot([=] {
+      getSR(reg(2));
+      sub32(reg(1), R15, imm(4));
+      mov32(R15, reg(1));
+      call(writeL);
+      sub32(reg(2), PC, imm(2));
+      sub32(reg(1), R15, imm(4));
+      mov32(R15, reg(1));
+      call(writeL);
+      add32(reg(1), VBR, imm(i * 4));
+      call(readL);
+      add32(reg(0), reg(0), imm(4));
+      mov32(PPC, reg(0));
+      mov32(PPM, imm(Branch::Take));
+    });
     return 1;
   }
 
@@ -928,12 +942,14 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //BSRF Rm
   case 0x003: {
-    mov32(reg(0), PC);
-    mov32(PR, reg(0));
-    add32(reg(0), reg(0), Rm);
-    add32(reg(0), reg(0), imm(4));
-    mov32(PPC, reg(0));
-    mov32(PPM, imm(Branch::Slot));
+    checkDelaySlot([=] {
+      mov32(reg(0), PC);
+      mov32(PR, reg(0));
+      add32(reg(0), reg(0), Rm);
+      add32(reg(0), reg(0), imm(4));
+      mov32(PPC, reg(0));
+      mov32(PPM, imm(Branch::Slot));
+    });
     return 1;
   }
 
@@ -963,10 +979,12 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //BRAF Rm
   case 0x023: {
-    add32(reg(0), PC, Rm);
-    add32(reg(0), reg(0), imm(4));
-    mov32(PPC, reg(0));
-    mov32(PPM, imm(Branch::Slot));
+    checkDelaySlot([=] {
+      add32(reg(0), PC, Rm);
+      add32(reg(0), reg(0), imm(4));
+      mov32(PPC, reg(0));
+      mov32(PPM, imm(Branch::Slot));
+    });
     return 1;
   }
 
@@ -1070,9 +1088,11 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //JSR @Rm
   case 0x40b: {
-    mov32(PR, PC);
-    add32(PPC, Rm, imm(4));
-    mov32(PPM, imm(Branch::Slot));
+    checkDelaySlot([=] {
+      mov32(PR, PC);
+      add32(PPC, Rm, imm(4));
+      mov32(PPM, imm(Branch::Slot));
+    });
     return 1;
   }
 
@@ -1270,8 +1290,10 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //JMP @Rm
   case 0x42b: {
-    add32(PPC, Rm, imm(4));
-    mov32(PPM, imm(Branch::Slot));
+    checkDelaySlot([=] {
+      add32(PPC, Rm, imm(4));
+      mov32(PPM, imm(Branch::Slot));
+    });
     return 1;
   }
 
@@ -1303,8 +1325,10 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //RTS
   case 0x000b: {
-    add32(PPC, PR, imm(4));
-    mov32(PPM, imm(Branch::Slot));
+    checkDelaySlot([=] {
+      add32(PPC, PR, imm(4));
+      mov32(PPM, imm(Branch::Slot));
+    });
     return 1;
   }
 
@@ -1343,16 +1367,18 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> bool {
 
   //RTE
   case 0x002b: {
-    mov32(reg(1), R15);
-    add32(R15, reg(1), imm(4));
-    call(readL);
-    add32(reg(0), reg(0), imm(4));
-    mov32(PPC, reg(0));
-    mov32(PPM, imm(Branch::Slot));
-    mov32(reg(1), R15);
-    add32(R15, reg(1), imm(4));
-    call(readL);
-    setSR(reg(0));
+    checkDelaySlot([=] {
+      mov32(reg(1), R15);
+      add32(R15, reg(1), imm(4));
+      call(readL);
+      add32(reg(0), reg(0), imm(4));
+      mov32(PPC, reg(0));
+      mov32(PPM, imm(Branch::Slot));
+      mov32(reg(1), R15);
+      add32(R15, reg(1), imm(4));
+      call(readL);
+      setSR(reg(0));
+    });
     return 1;
   }
 
@@ -1407,6 +1433,16 @@ auto SH2::Recompiler::setSR(reg src) -> void {
   and32(Q, src, imm(1));
   lshr32(src, src, imm(1));
   and32(M, src, imm(1));
+}
+
+template<typename F>
+auto SH2::Recompiler::checkDelaySlot(F body) -> void {
+  auto skip = cmp32_jump(PPM, imm(Branch::Step), flag_ne);
+  body();
+  auto skip2 = jump();
+  setLabel(skip);
+  call(&SH2::illegalSlotInstruction);
+  setLabel(skip2);
 }
 
 #undef Reg

--- a/ares/component/processor/sh2/sh2.hpp
+++ b/ares/component/processor/sh2/sh2.hpp
@@ -275,6 +275,7 @@ struct SH2 {
     auto emitInstruction(u16 opcode) -> bool;
     auto getSR(reg dst) -> void;
     auto setSR(reg src) -> void;
+    template<typename F> auto checkDelaySlot(F body) -> void;
 
     bump_allocator allocator;
     Pool* pools[1 << 24];

--- a/ares/component/processor/sh2/sh2.hpp
+++ b/ares/component/processor/sh2/sh2.hpp
@@ -272,11 +272,12 @@ struct SH2 {
     auto pool(u32 address) -> Pool*;
     auto block(u32 address) -> Block*;
     auto emit(u32 address) -> Block*;
-    auto emitInstruction(u16 opcode) -> bool;
+    auto emitInstruction(u16 opcode) -> u32;
     auto getSR(reg dst) -> void;
     auto setSR(reg src) -> void;
     template<typename F> auto checkDelaySlot(F body) -> void;
 
+    bool inDelaySlot;
     bump_allocator allocator;
     Pool* pools[1 << 24];
   } recompiler{*this};


### PR DESCRIPTION
This fixes the Mega-CD 32X release of Surgical Strike which actually exercises this functionality.