### PR TITLE
MCD fixes to improve compatibility

### DIFF
--- a/ares/md/controller/port.cpp
+++ b/ares/md/controller/port.cpp
@@ -31,10 +31,18 @@ auto ControllerPort::allocate(string name) -> Node::Peripheral {
 
 auto ControllerPort::power(bool reset) -> void {
   if(!reset) {
-    control = 0x00;
+    control        = 0x00;
+    dataLatch      = 0x7f;
+    serialControl  = 0x00;
+    serialTxBuffer = 0xff;
+    serialRxBuffer = 0x00;
   }
 }
 
 auto ControllerPort::serialize(serializer& s) -> void {
   s(control);
+  s(dataLatch);
+  s(serialControl);
+  s(serialTxBuffer);
+  s(serialRxBuffer);
 }

--- a/ares/md/cpu/io.cpp
+++ b/ares/md/cpu/io.cpp
@@ -36,6 +36,42 @@ auto CPU::readIO(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
     case 0xa1000c:
       data.byte(0) = extensionPort.readControl();
       break;
+
+    case 0xa1000e:
+      data.byte(0) = controllerPort1.readSerialTxData();
+      break;
+
+    case 0xa10010:
+      data.byte(0) = controllerPort1.readSerialRxData();
+      break;
+
+    case 0xa10012:
+      data.byte(0) = controllerPort1.readSerialControl();
+      break;
+
+    case 0xa10014:
+      data.byte(0) = controllerPort2.readSerialTxData();
+      break;
+
+    case 0xa10016:
+      data.byte(0) = controllerPort2.readSerialRxData();
+      break;
+
+    case 0xa10018:
+      data.byte(0) = controllerPort2.readSerialControl();
+      break;
+
+    case 0xa1001a:
+      data.byte(0) = extensionPort.readSerialTxData();
+      break;
+
+    case 0xa1001c:
+      data.byte(0) = extensionPort.readSerialRxData();
+      break;
+
+    case 0xa1001e:
+      data.byte(0) = extensionPort.readSerialControl();
+      break;
     }
 
     return data.byte(1)=data.byte(0), data;
@@ -77,6 +113,42 @@ auto CPU::writeIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
 
     case 0xa1000c:
       extensionPort.writeControl(data);
+      break;
+
+    case 0xa1000e:
+      controllerPort1.writeSerialTxData(data);
+      break;
+
+    case 0xa10010:
+      controllerPort1.writeSerialRxData(data);
+      break;
+
+    case 0xa10012:
+      controllerPort1.writeSerialControl(data);
+      break;
+
+    case 0xa10014:
+      controllerPort2.writeSerialTxData(data);
+      break;
+
+    case 0xa10016:
+      controllerPort2.writeSerialRxData(data);
+      break;
+
+    case 0xa10018:
+      controllerPort2.writeSerialControl(data);
+      break;
+
+    case 0xa1001a:
+      extensionPort.writeSerialTxData(data);
+      break;
+
+    case 0xa1001c:
+      extensionPort.writeSerialRxData(data);
+      break;
+
+    case 0xa1001e:
+      extensionPort.writeSerialControl(data);
       break;
     }
 

--- a/ares/md/mcd/bus-external.cpp
+++ b/ares/md/mcd/bus-external.cpp
@@ -9,13 +9,14 @@ auto MCD::readExternal(n1 upper, n1 lower, n22 address, n16 data) -> n16 {
   }
 
   if(address >= 0x020000 && address <= 0x03ffff) {
+    if(!io.request) return data;
     address = io.pramBank << 17 | (n17)address;
     return pram[address >> 1];
   }
 
   if(address >= 0x200000 && address <= 0x23ffff) {
     if(io.wramMode == 0) {
-    //if(io.wramSwitch == 1) return data;
+      if(io.wramSwitch == 1) return data;
       address = (n18)address >> 1;
     } else {
       if(address >= 0x220000) {
@@ -52,6 +53,7 @@ auto MCD::writeExternal(n1 upper, n1 lower, n22 address, n16 data) -> void {
   address.bit(18,20) = 0;  //mirrors
 
   if(address >= 0x020000 && address <= 0x03ffff) {
+    if(!io.request) return;
     address = io.pramBank << 17 | (n17)address;
     if(upper) pram[address >> 1].byte(1) = data.byte(1);
     if(lower) pram[address >> 1].byte(0) = data.byte(0);
@@ -60,7 +62,7 @@ auto MCD::writeExternal(n1 upper, n1 lower, n22 address, n16 data) -> void {
 
   if(address >= 0x200000 && address <= 0x23ffff) {
     if(io.wramMode == 0) {
-    //if(io.wramSwitch == 1) return;
+      if(io.wramSwitch == 1) return;
       address = (n18)address >> 1;
     } else {
       if(address >= 0x220000) {

--- a/ares/md/mcd/bus-internal.cpp
+++ b/ares/md/mcd/bus-internal.cpp
@@ -47,7 +47,8 @@ auto MCD::read(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
 auto MCD::write(n1 upper, n1 lower, n24 address, n16 data) -> void {
   address.bit(20,23) = 0;  //mirroring
 
-  if(address >= 0x000000 && address <= 0x07ffff) {
+  if(address >= 0x000000 && address <= 0x07ffff
+  && address >= (n24)io.pramProtect << 9) {
     if(upper) pram[address >> 1].byte(1) = data.byte(1);
     if(lower) pram[address >> 1].byte(0) = data.byte(0);
     return;

--- a/ares/md/mcd/io-external.cpp
+++ b/ares/md/mcd/io-external.cpp
@@ -22,7 +22,11 @@ auto MCD::readExternalIO(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
   }
 
   if(address == 0xa12004) {
-    debug(unusual, "[MCD::readExternalIO] address=0xa12004");
+    data.bit( 0, 7) = Unmapped;
+    data.bit( 8,10) = cdc.transfer.destination;
+    data.bit(11,13) = Unmapped;
+    data.bit(14)    = cdc.transfer.ready;
+    data.bit(15)    = cdc.transfer.completed;
   }
 
   if(address == 0xa12006) {
@@ -111,9 +115,9 @@ auto MCD::writeExternalIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
   }
 
   if(address == 0xa1200e) {
-    if(upper) {  //unconfirmed
-      communication.cfm = data.byte(1);
-    }
+    // 8-bit register mapped into 16-bit gate array
+    // All writes go to the high byte (special case)
+    communication.cfm = data.byte(1);
   }
 
   if(address >= 0xa12010 && address <= 0xa1201f) {

--- a/ares/md/mcd/io-internal.cpp
+++ b/ares/md/mcd/io-internal.cpp
@@ -197,13 +197,13 @@ auto MCD::writeIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
   }
 
   if(address == 0xff8002) {
-    if(lower) {
-      if(io.wramSelect != data.bit(0)) io.wramSwitchRequest = 0;
-      io.wramSelect   = data.bit(0);
-      io.wramMode     = data.bit(2);
-      io.wramPriority = data.bit(3,4);
-      if(io.wramSelect) io.wramSwitch = 0;
-    }
+    // 8-bit register mapped into 16-bit gate array
+    // All writes go to the low byte
+    if(io.wramSelect != data.bit(0)) io.wramSwitchRequest = 0;
+    io.wramSelect   = data.bit(0);
+    io.wramMode     = data.bit(2);
+    io.wramPriority = data.bit(3,4);
+    if(io.wramSelect) io.wramSwitch = 0;
   }
 
   if(address == 0xff8004) {
@@ -235,9 +235,9 @@ auto MCD::writeIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
   }
 
   if(address == 0xff800e) {
-    if(lower) {  //unconfirmed
-      communication.cfs = data.byte(0);
-    }
+    // 8-bit register mapped into 16-bit gate array
+    // All writes go to the low byte
+    communication.cfs = data.byte(0);
   }
 
   if(address >= 0xff8010 && address <= 0xff801f) {
@@ -251,9 +251,9 @@ auto MCD::writeIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
   }
 
   if(address == 0xff8030) {
-    if(lower) {
-      timer.counter = timer.frequency = data.byte(0);
-    }
+    // 8-bit register mapped into 16-bit gate array
+    // All writes go to the low byte
+    timer.counter = timer.frequency = data.byte(0);
   }
 
   if(address == 0xff8032) {
@@ -298,10 +298,10 @@ auto MCD::writeIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
   }
 
   if(address == 0xff804c) {
-    if(lower) {
-      gpu.font.color.background = data.bit(0,3);
-      gpu.font.color.foreground = data.bit(4,7);
-    }
+    // 8-bit register mapped into 16-bit gate array
+    // All writes go to the low byte
+    gpu.font.color.background = data.bit(0,3);
+    gpu.font.color.foreground = data.bit(4,7);
   }
 
   if(address == 0xff804e) {

--- a/ares/md/mcd/mcd.cpp
+++ b/ares/md/mcd/mcd.cpp
@@ -179,8 +179,10 @@ auto MCD::wait(u32 clocks) -> void {
 auto MCD::power(bool reset) -> void {
   M68000::power();
   Thread::create(12'500'000, {&MCD::main, this});
-  counter = {};
+  n32 vec4 = io.vectorLevel4;
   io = {};
+  io.vectorLevel4 = reset ? vec4 : n32(~0);
+  counter = {};
   led = {};
   irq = {};
   external = {};
@@ -193,11 +195,6 @@ auto MCD::power(bool reset) -> void {
 
   irq.reset.enable = 1;
   irq.reset.raise();
-
-  io.vectorLevel4.byte(3) = bios[0x70 >> 1].byte(1);
-  io.vectorLevel4.byte(2) = bios[0x70 >> 1].byte(0);
-  io.vectorLevel4.byte(1) = ~0;
-  io.vectorLevel4.byte(0) = ~0;
 }
 
 }

--- a/ares/md/system/serialization.cpp
+++ b/ares/md/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v132";
+static const string SerializerVersion = "v132.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
1. Fixes write access to 8-bit registers mapped into the mcd gate array, including comm flags and wordram ctrl (on subcpu side). Also, fixes initialization of h-int vector & allows cdc status reads from maincpu.
2. Ignore maincpu access to wordram & prg-ram when it's disallowed, which avoids memory corruption in games with poorly coded sync. Similarly, the write protection feature was implemented on prg-ram access by the subcpu. All of this should allow MCD Dungeon Explorer to work correctly.
3. Implements io serial registers but not the transfer logic. Currently, data can be sent out but the tx buffer remains empty, allowing MCD The Animals! to boot. Also, io data registers were revised to handle signal latching correctly.