### PR TITLE
MCD additional fixes for test validation

### DIFF
--- a/ares/md/mcd/bus-internal.cpp
+++ b/ares/md/mcd/bus-internal.cpp
@@ -7,7 +7,7 @@ auto MCD::read(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
 
   if(address >= 0x080000 && address <= 0x0bffff) {
     if(io.wramMode == 0) {
-    //if(io.wramSwitch == 0) return data;
+      if(io.wramSwitch == 0) return data;
       address = (n18)address >> 1;
       return wram[address];
     } else {
@@ -56,7 +56,11 @@ auto MCD::write(n1 upper, n1 lower, n24 address, n16 data) -> void {
 
   if(address >= 0x080000 && address <= 0x0bffff) {
     if(io.wramMode == 0) {
-    //if(io.wramSwitch == 0) return;
+      while(io.wramSwitch == 0) { // wordram is unavailable, hold for !DTACK
+        wait(7); // arbitrary wait (~4 maincpu ticks)
+        Thread::synchronize(cpu);
+        if(io.halt) return;
+      }
       address = (n18)address >> 1;
       if(upper) wram[address].byte(1) = data.byte(1);
       if(lower) wram[address].byte(0) = data.byte(0);

--- a/ares/md/mcd/mcd.cpp
+++ b/ares/md/mcd/mcd.cpp
@@ -177,14 +177,14 @@ auto MCD::wait(u32 clocks) -> void {
 }
 
 auto MCD::power(bool reset) -> void {
-  M68000::power();
   Thread::create(12'500'000, {&MCD::main, this});
+  if(!reset) irq = {};
+  resetCpu();
   n32 vec4 = io.vectorLevel4;
   io = {};
   io.vectorLevel4 = reset ? vec4 : n32(~0);
   counter = {};
   led = {};
-  irq = {};
   external = {};
   communication = {};
   cdc.power(reset);
@@ -192,7 +192,10 @@ auto MCD::power(bool reset) -> void {
   timer.power(reset);
   gpu.power(reset);
   pcm.power(reset);
+}
 
+auto MCD::resetCpu() -> void {
+  M68000::power();
   irq.reset.enable = 1;
   irq.reset.raise();
 }

--- a/ares/md/mcd/mcd.hpp
+++ b/ares/md/mcd/mcd.hpp
@@ -46,6 +46,8 @@ struct MCD : M68000, Thread {
   auto wait(u32 clocks) -> void override;
   auto power(bool reset) -> void;
 
+  auto resetCpu() -> void;
+
   //bus-internal.cpp
   auto read(n1 upper, n1 lower, n24 address, n16 data = 0) -> n16 override;
   auto write(n1 upper, n1 lower, n24 address, n16 data) -> void override;


### PR DESCRIPTION
This PR is mostly intended to fix compatibility with mcd-verificator test rom by krikzz. Note, the final test group of that program ("CDC INIT") will hang in ares due to an outstanding CDD behavior issue.

1. Fixes an external subcpu reset bug and half implements forced reset sequence on the gate array. Will need to confirm which gate array registers are supposed to be reset, but this type of reset is not commonly used.
2. When the subcpu writes wordram that's unavailable in 2M mode, DTACK will be held until the maincpu gives it up. This behavior is confirmed by mcd-verificator. However, similar behavior of wordram reads is unconfirmed. Currently the subcpu will just read back open bus, which I believe is how BlastEm handles it.