### PR TITLE
desktop-ui: check for SSE4.2 support in non-local builds 

### DIFF
--- a/desktop-ui/GNUmakefile
+++ b/desktop-ui/GNUmakefile
@@ -15,8 +15,8 @@ ifeq ($(arch),amd64)
   ifeq ($(local),true)
     flags += -march=native
   else
-    # For official builds, default to nehalem which supports up to SSE 4.2.
-    flags += -march=nehalem
+    # For official builds, default to x86-64-v2 (Intel Nehalem, AMD Bulldozer) which supports up to SSE 4.2.
+    flags += -march=x86-64-v2
   endif
 endif
 

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -140,6 +140,10 @@ else
   $(error unrecognized build type.)
 endif
 
+ifeq ($(local),true)
+  flags += -DBUILD_LOCAL
+endif
+
 # debugging information
 ifeq ($(symbols),true)
   flags += -g


### PR DESCRIPTION
By default, builds are "local", meaning they are optimized specifically for the host machine. For non-local builds such as our CI builds, we enforce a minimum CPU spec to allow the compiler to use instructions beyond the base AMD64 ISA. ares may also make use of SSE4 instructions via intrinsics in the N64 core. On AMD64, the capabilities of the host CPU are now checked at runtime and an error message will be displayed to inform users if their machine does not meet the CPU requirements of that build.

The second commit optimizes non-local builds for "x86-64-v2" instead of "nehalem". This is a more generic way of declaring an Intel Nehalem -like set of ISA extensions in newer versions of GCC (11) and Clang (12).