### PR TITLE
n64: complete generation of address errors 

### DIFF
--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -92,14 +92,17 @@ auto CPU::instruction() -> void {
   }
 
   if constexpr(Accuracy::CPU::Recompiler) {
-    auto address = devirtualize(ipu.pc)(0);
-    auto block = recompiler.block(address);
-    block->execute(*this);
+    if (auto address = devirtualize(ipu.pc)) {
+      auto block = recompiler.block(*address);
+      block->execute(*this);
+    }
   }
 
   if constexpr(Accuracy::CPU::Interpreter) {
     pipeline.address = ipu.pc;
-    pipeline.instruction = fetch(ipu.pc);
+    auto data = fetch(ipu.pc);
+    if (!data) return;
+    pipeline.instruction = *data;
     debugger.instruction();
     decoderEXECUTE();
     instructionEpilogue();

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -260,11 +260,12 @@ struct CPU : Thread {
 
   auto segment(u64 vaddr) -> Context::Segment;
   auto devirtualize(u64 vaddr) -> maybe<u64>;
-  auto fetch(u64 vaddr) -> u32;
+  auto fetch(u64 vaddr) -> maybe<u32>;
   template<u32 Size> auto busWrite(u32 address, u64 data) -> void;
   template<u32 Size> auto busRead(u32 address) -> u64;
   template<u32 Size> auto read(u64 vaddr) -> maybe<u64>;
   template<u32 Size> auto write(u64 vaddr, u64 data) -> bool;
+  template<u32 Size> auto vaddrAlignedError(u64 vaddr, bool write) -> bool;
   auto addressException(u64 vaddr) -> void;
 
   //serialization.cpp

--- a/ares/n64/cpu/exceptions.cpp
+++ b/ares/n64/cpu/exceptions.cpp
@@ -1,8 +1,7 @@
 auto CPU::Exception::trigger(u32 code, u32 coprocessor, bool tlbMiss) -> void {
   self.debugger.exception(code);
 
-  u64 vectorBase = !self.scc.status.vectorLocation ? 0x8000'0000 : 0xbfc0'0200;
-  if(self.context.bits == 64) vectorBase = (s32)vectorBase;
+  u64 vectorBase = !self.scc.status.vectorLocation ? (s32)0x8000'0000 : (s32)0xbfc0'0200;
 
   u16 vectorOffset = 0x0180;
   if(tlbMiss) {


### PR DESCRIPTION
This also handles the fetch and devirtualize case, that cover also
the situation where the CPU jumps to a misaligned PC.

Tested via
https://github.com/lemmy-64/n64-systemtest/pull/49
on both interpreter and recompiler