### PR TITLE
desktop-ui: improve terminal support on windows

### DIFF
--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -39,6 +39,11 @@ auto locate(const string& name) -> string {
 
 #include <nall/main.hpp>
 auto nall::main(Arguments arguments) -> void {
+#if defined(PLATFORM_WINDOWS)
+  bool createTerminal = arguments.take("--terminal");
+  terminal::redirectStdioToTerminal(createTerminal);
+#endif
+
   Application::setName("ares");
   Application::setScreenSaver(false);
 
@@ -74,6 +79,9 @@ auto nall::main(Arguments arguments) -> void {
     print("Usage: ares [OPTIONS]... game\n\n");
     print("Options:\n");
     print("  --help               Displays available options and exit\n");
+#if defined(PLATFORM_WINDOWS)
+    print("  --terminal           Create new terminal window\n");
+#endif
     print("  --fullscreen         Start in full screen mode\n");
     print("  --system name        Specifiy the system name\n");
     print("\n");

--- a/nall/nall.cpp
+++ b/nall/nall.cpp
@@ -16,6 +16,7 @@
 #include <nall/platform.cpp>
 #include <nall/random.cpp>
 #include <nall/run.cpp>
+#include <nall/terminal.cpp>
 #include <nall/thread.cpp>
 //currently unused by ares
 //#include <nall/smtp.cpp>

--- a/nall/terminal.cpp
+++ b/nall/terminal.cpp
@@ -1,0 +1,21 @@
+#include <nall/terminal.hpp>
+
+namespace nall::terminal {
+
+NALL_HEADER_INLINE auto redirectStdioToTerminal(bool create) -> void {
+#if defined(PLATFORM_WINDOWS)
+  if(create) {
+    FreeConsole();
+    if(!AllocConsole()) return;
+  } else if(!AttachConsole(ATTACH_PARENT_PROCESS)) {
+    return;
+  }
+
+  //unless a new terminal was requested, do not reopen already valid handles (allow redirection to/from file)
+  if(create || _get_osfhandle(_fileno(stdin )) < 0) freopen("CONIN$" , "r", stdin );
+  if(create || _get_osfhandle(_fileno(stdout)) < 0) freopen("CONOUT$", "w", stdout);
+  if(create || _get_osfhandle(_fileno(stderr)) < 0) freopen("CONOUT$", "w", stderr);
+#endif
+}
+
+}

--- a/nall/terminal.hpp
+++ b/nall/terminal.hpp
@@ -4,6 +4,8 @@
 
 namespace nall::terminal {
 
+auto redirectStdioToTerminal(bool create) -> void;
+
 inline auto escapable() -> bool {
   #if defined(PLATFORM_WINDOWS)
   //todo: colors are supported by Windows 10+ and with alternate terminals (eg msys)
@@ -63,3 +65,7 @@ template<typename... P> inline auto gray(P&&... p) -> string {
 }
 
 }
+
+#if defined(NALL_HEADER_ONLY)
+  #include <nall/terminal.cpp>
+#endif


### PR DESCRIPTION
Previously, terminal (console) support on Windows required opting in at compile time. Now, the runtime behavior is largely the same regardless of how ares is compiled.

- ares will attach to the terminal of the parent process (if present) by default and redirect any unset stdio streams.
- If the --terminal argument is provided, ares will always create a new terminal window and stdio will be redirected to it.
- Otherwise, if stdio handles were already valid on launch they will be left alone (to support redirection to/from files).