### PR TITLE
MCD compatibility/stability fixes 

### DIFF
--- a/ares/md/apu/apu.cpp
+++ b/ares/md/apu/apu.cpp
@@ -43,8 +43,8 @@ auto APU::main() -> void {
 
 auto APU::step(u32 clocks) -> void {
   Thread::step(clocks);
-  state.busreqLatch = busownerCPU() ? 1 : 0;
   Thread::synchronize(cpu);
+  state.busreqLatch = busownerCPU() ? 1 : 0;
 }
 
 auto APU::setNMI(n1 line) -> void {

--- a/ares/md/cpu/cpu.cpp
+++ b/ares/md/cpu/cpu.cpp
@@ -73,9 +73,9 @@ inline auto CPU::idle(u32 clocks) -> void {
 auto CPU::wait(u32 clocks) -> void {
   step(clocks);
   if (cyclesUntilSync <= 0) {
+    cyclesUntilSync = minCyclesBetweenSyncs;
     Thread::synchronize();
-    cyclesUntilSync += minCyclesBetweenSyncs;
-  }
+  }  
 }
 
 auto CPU::raise(Interrupt interrupt) -> void {

--- a/ares/md/m32x/sh7604.cpp
+++ b/ares/md/m32x/sh7604.cpp
@@ -55,11 +55,9 @@ auto M32X::SH7604::step(u32 clocks) -> void {
   cyclesUntilSync -= clocks;
 
   if(cyclesUntilSync <= 0) {
+    cyclesUntilSync = minCyclesBetweenSyncs;
     if(m32x.shm.active()) Thread::synchronize(m32x.shs, cpu);
     if(m32x.shs.active()) Thread::synchronize(m32x.shm, cpu);
-    while(cyclesUntilSync <= 0) {
-      cyclesUntilSync += minCyclesBetweenSyncs;
-    }
   }
 }
 

--- a/ares/md/mcd/bus-internal.cpp
+++ b/ares/md/mcd/bus-internal.cpp
@@ -58,7 +58,6 @@ auto MCD::write(n1 upper, n1 lower, n24 address, n16 data) -> void {
     if(io.wramMode == 0) {
       while(io.wramSwitch == 0) { // wordram is unavailable, hold for !DTACK
         wait(7); // arbitrary wait (~4 maincpu ticks)
-        Thread::synchronize(cpu);
         if(io.halt) return;
       }
       address = (n18)address >> 1;

--- a/ares/md/mcd/cdc.cpp
+++ b/ares/md/mcd/cdc.cpp
@@ -80,10 +80,7 @@ auto MCD::CDC::read() -> n8 {
   //DBCH: data byte counter high
   case 0x3: {
     data.bit(0,3) = transfer.length.bit(8,11);
-    data.bit(4)   =!irq.transfer.pending;
-    data.bit(5)   =!irq.transfer.pending;
-    data.bit(6)   =!irq.transfer.pending;
-    data.bit(7)   =!irq.transfer.pending;
+    data.bit(4,7) = 0;
   } break;
 
   //HEAD0: header or subheader data

--- a/ares/md/mcd/io-internal.cpp
+++ b/ares/md/mcd/io-internal.cpp
@@ -188,7 +188,7 @@ auto MCD::writeIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
 
   if(address == 0xff8000) {
     if(lower) {
-      if(data.bit(0) == 0);  //peripheral reset
+      if(data.bit(0) == 0) resetPeripheral(true); // todo: bit stays low for ~100ms
     }
     if(upper) {
       led.red   = data.bit(8);

--- a/ares/md/mcd/mcd.cpp
+++ b/ares/md/mcd/mcd.cpp
@@ -188,16 +188,23 @@ auto MCD::power(bool reset) -> void {
   external = {};
   communication = {};
   cdc.power(reset);
-  cdd.power(reset);
   timer.power(reset);
   gpu.power(reset);
   pcm.power(reset);
+  resetPeripheral(reset);
 }
 
 auto MCD::resetCpu() -> void {
   M68000::power();
   irq.reset.enable = 1;
   irq.reset.raise();
+}
+
+// A peripheral reset is expected to take ~100ms according to the dev manual.
+// The subcpu continues executing normally during this process.
+// The exact operations that occur for this reset are not known.
+auto MCD::resetPeripheral(bool reset) -> void {
+  cdd.power(reset); // reset cd drive (bios requirement)
 }
 
 }

--- a/ares/md/mcd/mcd.hpp
+++ b/ares/md/mcd/mcd.hpp
@@ -47,6 +47,7 @@ struct MCD : M68000, Thread {
   auto power(bool reset) -> void;
 
   auto resetCpu() -> void;
+  auto resetPeripheral(bool reset) -> void;
 
   //bus-internal.cpp
   auto read(n1 upper, n1 lower, n24 address, n16 data = 0) -> n16 override;

--- a/ares/md/mcd/pcm.cpp
+++ b/ares/md/mcd/pcm.cpp
@@ -27,8 +27,9 @@ auto MCD::PCM::clock() -> void {
       channel.address = channel.loop << 11;
       data = ram[channel.loop];
       if(data == 0xff) continue;  //infinite loop; does not output any sound
+    } else {
+      channel.address += channel.step;
     }
-    channel.address += channel.step;
     if(data & 0x80) {
       data = +(data & 0x7f);
     } else {

--- a/ares/md/mcd/timer.cpp
+++ b/ares/md/mcd/timer.cpp
@@ -1,5 +1,5 @@
 auto MCD::Timer::clock() -> void {
-  if(frequency && !--counter) {
+  if(frequency && !counter--) {
     counter = frequency;
     irq.raise();
   }


### PR DESCRIPTION
1. Found a consistent ares hang occurring in Snatcher due to runaway thread (hint: cpu.cyclesUntilSync was underflowing), so sync updates were revised in a few places throughout the core. Note for testing: changes were made to m32x sync.
2. PCM channel address can be read back in software. Snatcher attempts to detect sample looping by comparing against the loop start address, so the address update was revised to satisfy this check. Fixes the abnormally long wait times and softlocks.
3. Basic implementation of peripheral reset, which is used by the bios to initiate a cdd reset. The details of this reset are not entirely clear, so no other assumptions were made regarding the process. Fixes Pier Solar CD (standalone boot).
4. Corrects the update interval of the timer (validated by mcd-verificator).
5. Fixes the value read back from cdc data counter high (validated by mcd-verificator).