### PR TITLE
MD Realtec support fixes

### DIFF
--- a/ares/md/bus/inline.hpp
+++ b/ares/md/bus/inline.hpp
@@ -49,7 +49,7 @@ alwaysinline auto Bus::read(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
   if(address >= 0xc00000 && address <= 0xdfffff) {
     if(address.bit(5,7)) return cpu.ird();  //should deadlock the machine
     if(address.bit(16,18)) return cpu.ird();  //should deadlock the machine
-    address.bit(8,15) = 0;  //mirrors
+    address.bit(8,20) = 0;  //mirrors
     if(address.bit(2,3) == 3) return cpu.ird();  //should return VDP open bus
     return vdp.read(upper, lower, address, data);
   }
@@ -110,7 +110,7 @@ alwaysinline auto Bus::write(n1 upper, n1 lower, n24 address, n16 data) -> void 
   if(address >= 0xc00000 && address <= 0xdfffff) {
     if(address.bit(5,7)) return;  //should deadlock the machine
     if(address.bit(16,18)) return;  //should deadlock the machine
-    address.bit(8,15) = 0;  //mirrors
+    address.bit(8,20) = 0;  //mirrors
     return vdp.write(upper, lower, address, data);
   }
 

--- a/ares/md/cartridge/board/realtec.cpp
+++ b/ares/md/cartridge/board/realtec.cpp
@@ -7,32 +7,37 @@ struct Realtec : Interface {
   }
 
   auto read(n1 upper, n1 lower, n24 address, n16 data) -> n16 override {
-    if(address < size * 0x20000)
-      address = address + bank * 0x20000;
+    if(enable)
+      address = (address & (0x20000<<size)-1) + bank * (0x20000<<size);
     else
       address = (address & 0x1fff) + 0x7e000;
-    return rom[address >> 1];
+    return address >> 1 < rom.size() ? rom[address >> 1] : data;
   }
 
   auto write(n1 upper, n1 lower, n24 address, n16 data) -> void override {
-    if(address == 0x400000 && upper)
-      bank.bit(3, 4) = data.bit(9, 10);
+    if(address == 0x400000 && upper) {
+      bank.bit(2, 3) = data.bit(9, 10);
+      enable = data.bit(8); // unconfirmed function
+    }
     if(address == 0x402000 && upper)
-      size = data.bit(8, 13);
+      size = data.bit(9, 10); // exact function is speculative; known carts write either 02 (if 2 256KB rom banks) or 04 (if 1 512KB rom bank)
     if(address == 0x404000 && upper)
-      bank.bit(0, 2) = data.bit(8, 10);
+      bank.bit(0, 1) = data.bit(9, 10);
   }
 
   auto power(bool reset) -> void override {
-    bank = 0;
-    size = 0;
+    bank   = 0;
+    size   = 0;
+    enable = 0;
   }
 
   auto serialize(serializer& s) -> void override {
     s(bank);
     s(size);
+    s(enable);
   }
 
-  n5 bank;
-  n5 size;
+  n4 bank;
+  n2 size;
+  n1 enable;
 };


### PR DESCRIPTION
1. Revising the Realtec mapper to fix a mirroring issue and better fit use cases of known roms. Restores missing audio in Funny World/Balloon Boy.
2. Corrects VDP port mirroring (ports can be accessed at $C0xxxx, $C8xxxx, $D0xxxx, or $D8xxxx). Fixes background layer issue in The Earth Defend.