### PR TITLE
Snes rtc crash fix

### DIFF
--- a/ares/sfc/coprocessor/epsonrtc/memory.cpp
+++ b/ares/sfc/coprocessor/epsonrtc/memory.cpp
@@ -152,7 +152,7 @@ auto EpsonRTC::load(const n8* data) -> void {
 
   n64 timestamp = 0;
   for(auto byte : range(8)) {
-    timestamp |= data[8 + byte] << (byte * 8);
+    (n64)timestamp |= data[8 + byte] << (byte * 8);
   }
 
   n64 diff = (n64)time(0) - timestamp;

--- a/ares/sfc/coprocessor/sharprtc/memory.cpp
+++ b/ares/sfc/coprocessor/sharprtc/memory.cpp
@@ -43,7 +43,7 @@ auto SharpRTC::load(const n8* data) -> void {
 
   n64 timestamp = 0;
   for(auto byte : range(8)) {
-    timestamp |= data[8 + byte] << (byte * 8);
+    (n64)timestamp |= data[8 + byte] << (byte * 8);
   }
 
   n64 diff = (n64)time(0) - timestamp;

--- a/mia/medium/mega-drive.cpp
+++ b/mia/medium/mega-drive.cpp
@@ -361,6 +361,16 @@ auto MegaDrive::analyzeStorage(vector<u8>& rom, string hash) -> void {
     ram.size = 32768;
   }
 
+  //Sonic & Knuckles + Sonic the Hedgehog 3 (USA, Japan, Europe)
+  if(hash == "fba0677fde9f76df93f3e98d6310d8af68b9847bde16e253d73cd4dd8134ed23" ||
+     hash == "fa52ac946dfd576538d00aa858b790b9d81a1217e25aa5193693a4e57f4f89d9" ||
+     hash == "9cc2316eddbc874840b4913f53618a826f12c0d5ed48149855b19422231e4496") {
+    ram.mode = "lower";
+    ram.size = 0x200;
+    ram.address = 0x200000;
+    ram.enable = false;
+  }
+
   //Super Hydlide (Japan)
   if(hash == "30749097096807abf67cd1f7b2392f5789f5149ee33661e6d13113396f06a121") {
     ram.mode = "lower";


### PR DESCRIPTION
Fixes issue: https://github.com/ares-emulator/ares/issues/1026

Credit goes to @invertego who isolated the issue first while investigating this issue. 

Note: This bug has existed in the code base since 2012 (11 years ago) and was only exposed when compiling with recent versions of clang with optimizations enabled (crash doesn't happen when building with gcc). 