### PR TITLE
Add missing cast resulting in truncated timestamp

### DIFF
--- a/ares/sfc/coprocessor/epsonrtc/memory.cpp
+++ b/ares/sfc/coprocessor/epsonrtc/memory.cpp
@@ -152,7 +152,7 @@ auto EpsonRTC::load(const n8* data) -> void {
 
   n64 timestamp = 0;
   for(auto byte : range(8)) {
-    timestamp |= data[8 + byte] << (byte * 8);
+    (n64)timestamp |= data[8 + byte] << (byte * 8);
   }
 
   n64 diff = (n64)time(0) - timestamp;

--- a/ares/sfc/coprocessor/sharprtc/memory.cpp
+++ b/ares/sfc/coprocessor/sharprtc/memory.cpp
@@ -43,7 +43,7 @@ auto SharpRTC::load(const n8* data) -> void {
 
   n64 timestamp = 0;
   for(auto byte : range(8)) {
-    timestamp |= data[8 + byte] << (byte * 8);
+    (n64)timestamp |= data[8 + byte] << (byte * 8);
   }
 
   n64 diff = (n64)time(0) - timestamp;


### PR DESCRIPTION
Fixes issue: https://github.com/ares-emulator/ares/issues/1026

Credit goes to @invertego who isolated the issue first while investigating this issue.

Note: This bug has existed in the code base since 2012 (11 years ago) and was only exposed when compiling with recent versions of clang with optimizations enabled (crash doesn't happen when building with gcc).