### PR TITLE
mcd: always allocate cartridge slot

### DIFF
--- a/ares/md/m32x/io-internal.cpp
+++ b/ares/md/m32x/io-internal.cpp
@@ -14,7 +14,7 @@ auto M32X::readInternalIO(n1 upper, n1 lower, n29 address, n16 data) -> n16 {
       data.bit(3) = shs.irq.vint.enable;
     }
     data.bit( 7) = io.hintVblank;
-    data.bit( 8) = !(bool)cartridge.node;  //0 = cartridge connected
+    data.bit( 8) = !(bool)cartridge.child->pak;  //0 = cartridge connected
     data.bit( 9) = io.adapterEnable;
     data.bit(15) = vdp.framebufferAccess;
   }

--- a/desktop-ui/emulator/mega-cd-32x.cpp
+++ b/desktop-ui/emulator/mega-cd-32x.cpp
@@ -55,6 +55,11 @@ auto MegaCD32X::load() -> bool {
 
   if(!ares::MegaDrive::load(root, {"[Sega] Mega CD 32X (", region, ")"})) return false;
 
+  if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
+    port->allocate();
+    port->connect();
+  }
+
   if(auto port = root->find<ares::Node::Port>("Mega CD/Disc Tray")) {
     port->allocate();
     port->connect();

--- a/desktop-ui/emulator/mega-cd.cpp
+++ b/desktop-ui/emulator/mega-cd.cpp
@@ -63,6 +63,11 @@ auto MegaCD::load() -> bool {
 
   if(!ares::MegaDrive::load(root, {"[Sega] Mega CD (", region, ")"})) return false;
 
+  if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
+    port->allocate();
+    port->connect();
+  }
+
   if(auto port = root->find<ares::Node::Port>("Mega CD/Disc Tray")) {
     port->allocate();
     port->connect();


### PR DESCRIPTION
When booting the MD core from a CD a board is allocated on demand in Cartridge::power(), and this is critical for Mega CD 32X games to function. However, it also puts the cartridge into an inconsistent state in which allocate() was never called and therefore catridge.node is null, causing disconnect() and save() to be short-circuited. This means the board never gets cleaned up, which also means it never gets recreated in power() on subsequent loads. One consequence is that loading a MCD game followed by a MCD 32X game will cause the 32X to not actually be connected.

Given that all of these system configurations contain a cartridge slot, it follows that one should always be allocated. This implies cartridge.node will always be non-null so it cannot be used to determine if a cartridge is actually connected. This change corrects one such usage.