### PR TITLE
build: enable clang ThinLTO

### DIFF
--- a/libco/aarch64.c
+++ b/libco/aarch64.c
@@ -19,7 +19,7 @@ static void (*co_swap)(cothread_t, cothread_t) = 0;
 #else
   section(text)
 #endif
-static const uint32_t co_swap_function[1024] = {
+const uint32_t co_swap_function[1024] = {
   0x910003f0,  /* mov x16,sp           */
   0xa9007830,  /* stp x16,x30,[x1]     */
   0xa9407810,  /* ldp x16,x30,[x0]     */

--- a/libco/amd64.c
+++ b/libco/amd64.c
@@ -20,7 +20,7 @@ static void (*co_swap)(cothread_t, cothread_t) = 0;
 #endif
 #ifdef _WIN32
   /* ABI: Win64 */
-  static const unsigned char co_swap_function[4096] = {
+  const unsigned char co_swap_function[4096] = {
     0x48, 0x89, 0x22,              /* mov [rdx],rsp           */
     0x48, 0x8b, 0x21,              /* mov rsp,[rcx]           */
     0x58,                          /* pop rax                 */
@@ -87,7 +87,7 @@ static void (*co_swap)(cothread_t, cothread_t) = 0;
   }
 #else
   /* ABI: SystemV */
-  static const unsigned char co_swap_function[4096] = {
+  const unsigned char co_swap_function[4096] = {
     0x48, 0x89, 0x26,        /* mov [rsi],rsp    */
     0x48, 0x8b, 0x27,        /* mov rsp,[rdi]    */
     0x58,                    /* pop rax          */

--- a/libco/x86.c
+++ b/libco/x86.c
@@ -27,7 +27,7 @@ static void (fastcall *co_swap)(cothread_t, cothread_t) = 0;
   section(text)
 #endif
 /* ABI: fastcall */
-static const unsigned char co_swap_function[4096] = {
+const unsigned char co_swap_function[4096] = {
   0x89, 0x22,        /* mov [edx],esp    */
   0x8b, 0x21,        /* mov esp,[ecx]    */
   0x58,              /* pop eax          */

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -200,14 +200,24 @@ endif
 # link-time optimization
 ifeq ($(lto),true)
   ifeq ($(cl),true)
-    flags   += $(if $(findstring clang,$(compiler)),-flto,-GL)
-    options += -ltcg:incremental -ltcgout:$(object.path)/$(name).iobj
+    ifneq ($(findstring clang,$(compiler)),clang)
+      flags   += -GL
+      options += -ltcg:incremental -ltcgout:$(object.path)/$(name).iobj
+    else
+      flags   += -flto=thin
+      options += -lldltocache:$(object.path)/lto
+    endif
   else
     ifneq ($(findstring clang++,$(compiler)),clang++)
       flags   += -flto=auto -fno-fat-lto-objects
     else
-      flags   += -flto
+      flags   += -flto=thin
       options += -flto=thin
+      ifneq ($(platform),macos)
+        options += -Wl,--thinlto-cache-dir=$(object.path)/lto
+      else
+        options += -Wl,-cache_path_lto,$(object.path)/lto
+      endif
     endif
   endif
 endif


### PR DESCRIPTION
With ThinLTO and an incremental LTO cache, incremental link time (with LTO, of course) goes down from tens of seconds to less than a second.

For whatever reason, ThinLTO needs libco's co_swap_function to have external linkage. Who am I to argue?