### PR TITLE
build: a couple minor makefile fixes

### DIFF
--- a/desktop-ui/GNUmakefile
+++ b/desktop-ui/GNUmakefile
@@ -11,7 +11,7 @@ flags += -I. -I.. -I../ares -I../thirdparty -DMIA_LIBRARY
 nall.path := ../nall
 include $(nall.path)/GNUmakefile
 
-ifeq ($(arch),amd64)
+ifneq ($(filter $(arch),x86 amd64),)
   ifeq ($(filter cl,$(compiler)),)
     ifeq ($(local),true)
       flags += -march=native

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -213,10 +213,12 @@ ifeq ($(lto),true)
     else
       flags   += -flto=thin
       options += -flto=thin
-      ifneq ($(platform),macos)
-        options += -Wl,--thinlto-cache-dir=$(object.path)/lto
-      else
+      ifeq ($(platform),macos)
         options += -Wl,-cache_path_lto,$(object.path)/lto
+      else ifeq ($(msvc),true)
+        options += -Wl,-lldltocache:$(object.path)/lto
+      else
+        options += -Wl,--thinlto-cache-dir=$(object.path)/lto
       endif
     endif
   endif


### PR DESCRIPTION
Apply -march tuning for x86 (not just x86-64) and correctly pass the ThinLTO cache path through the non-CL Clang frontend on Windows.

The move to CMake can't come soon enough.