### PR TITLE
Proper rtc fix & clang gdb symbol generation on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ pacman -S mingw-w64-clang-x86_64-toolchain
 Once complete, open a CLANG64 terminal window and proceed with building ares. 
 
 ###### Debug Symbols
-When building with clang, by default symbols will be generated using an MSVC compatible format (CodeView) for use with Windows debugging tools. In order to generate GDB compatible symbols (Dwarf), specify the following option:  
-`symformat=dwarf`  
+When building with clang, by default symbols will be generated for debug builds using an MSVC compatible format (CodeView) for use with Windows debugging tools. In order to generate GDB compatible symbols, specify the following option:  
+`symformat=gdb`  
 
 Compilation
 -----------

--- a/ares/sfc/coprocessor/epsonrtc/memory.cpp
+++ b/ares/sfc/coprocessor/epsonrtc/memory.cpp
@@ -152,7 +152,7 @@ auto EpsonRTC::load(const n8* data) -> void {
 
   n64 timestamp = 0;
   for(auto byte : range(8)) {
-    (n64)timestamp |= data[8 + byte] << (byte * 8);
+    timestamp |= (n64)(data[8 + byte]) << (byte * 8);
   }
 
   n64 diff = (n64)time(0) - timestamp;

--- a/ares/sfc/coprocessor/sharprtc/memory.cpp
+++ b/ares/sfc/coprocessor/sharprtc/memory.cpp
@@ -43,7 +43,7 @@ auto SharpRTC::load(const n8* data) -> void {
 
   n64 timestamp = 0;
   for(auto byte : range(8)) {
-    (n64)timestamp |= data[8 + byte] << (byte * 8);
+    timestamp |= (n64)(data[8 + byte]) << (byte * 8);
   }
 
   n64 diff = (n64)time(0) - timestamp;

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -182,8 +182,8 @@ ifeq ($(symbols),true)
     flags += -g
     ifeq ($(platform),windows)
       ifeq ($(findstring clang++,$(compiler)),clang++)
-        ifeq ($(symformat),dwarf)
-          flags += -gdwarf
+        ifeq ($(symformat),gdb)
+          flags += -ggdb
         else  
           flags += -gcodeview
         endif


### PR DESCRIPTION
- Fix previous commit for SFC RTC properly that happened to work for the wrong reason (addresses: https://github.com/ares-emulator/ares/issues/1026)
- This also includes a correction for generating GDB compatible symbols on Windows when building with clang (it still creates CodeView/MSVC compatible symbols by default unless specified).