### PR TITLE
SNES - Don't rely on expanded header for region if present

### DIFF
--- a/mia/medium/super-famicom.cpp
+++ b/mia/medium/super-famicom.cpp
@@ -7,6 +7,7 @@ struct SuperFamicom : Cartridge {
 
 protected:
   auto region() const -> string;
+  auto videoRegion() const -> string;
   auto revision() const -> string;
   auto board() const -> string;
   auto label() const -> string;
@@ -394,6 +395,11 @@ auto SuperFamicom::analyze(vector<u8>& rom) -> string {
 }
 
 auto SuperFamicom::region() const -> string {
+  //Unlicensed software (homebrew, ROM hacks, etc) often change the standard region code,
+  //and then neglect to change the extended header region code. Thanks to that, we can't
+  //decode and display the full game serial + region code.
+  return videoRegion();
+
   string region;
 
   char A = data[headerAddress + 0x02];  //game type
@@ -439,6 +445,17 @@ auto SuperFamicom::region() const -> string {
   }
 
   return region ? region : "NTSC";
+}
+
+auto SuperFamicom::videoRegion() const -> string {
+  auto region = data[headerAddress + 0x29];
+  if(region == 0x00) return "NTSC";  //JPN
+  if(region == 0x01) return "NTSC";  //USA
+  if(region == 0x0b) return "NTSC";  //ROC
+  if(region == 0x0d) return "NTSC";  //KOR
+  if(region == 0x0f) return "NTSC";  //CAN
+  if(region == 0x10) return "NTSC";  //BRA
+  return "PAL";
 }
 
 auto SuperFamicom::revision() const -> string {


### PR DESCRIPTION
Since some patch authors don't always update the expanded header, we can't rely on this for region information if present.

This uses the same approach as to handle this as bsnes did. 

At a minimum, this fixes the Terranigma 60Hz NTSC patch so that the game runs at the correct framerate.