### PR TITLE
build fixes for gcc (<= 11) and clang (linux)

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -236,6 +236,9 @@ endif
 # clang settings
 ifeq ($(findstring clang++,$(compiler)),clang++)
   flags += -fno-strict-aliasing -fwrapv
+  ifneq ($(platform),macos)
+    options += -fuse-ld=lld
+  endif
   ifeq ($(arch),arm64)
     # work around bad interaction with alignas(n) when n >= 4096
     flags += -mno-global-merge
@@ -254,7 +257,6 @@ ifeq ($(platform),windows)
     flags += -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS
   endif
   options += $(call lib,ws2_32 ole32 shell32)
-  options += $(if $(findstring clang++,$(compiler)),-fuse-ld=lld)
   options += $(if $(findstring g++,$(compiler)),-mthreads -static)
   ifeq ($(console),true)
     flags += -DSUBSYTEM_CONSOLE

--- a/nall/intrinsics.hpp
+++ b/nall/intrinsics.hpp
@@ -47,7 +47,6 @@ namespace nall {
     static constexpr bool GCC       = 1;
     static constexpr bool Microsoft = 0;
   };
-  #pragma GCC diagnostic error   "-Wc++20-extensions"
   #pragma GCC diagnostic error   "-Wvla"
   #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
   #pragma GCC diagnostic warning "-Wreturn-type"


### PR DESCRIPTION
Note that `lld` is now a required package for building on Linux unless you are compiling with `g++`.