### PR TITLE
Feature: undo last save or load state

### DIFF
--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -134,16 +134,30 @@ Presentation::Presentation() {
   for(u32 slot : range(9)) {
     MenuItem item{&saveStateMenu};
     item.setText({"Slot ", 1 + slot}).onActivate([=] {
-      program.stateSave(1 + slot);
+      if(program.stateSave(1 + slot)) {
+        undoSaveStateMenu.setEnabled(true);
+      }
     });
   }
   loadStateMenu.setText("Load State").setIcon(Icon::Media::Rewind);
   for(u32 slot : range(9)) {
     MenuItem item{&loadStateMenu};
     item.setText({"Slot ", 1 + slot}).onActivate([=] {
-      program.stateLoad(1 + slot);
+      if(program.stateLoad(1 + slot)) {
+        undoLoadStateMenu.setEnabled(true);
+      }
     });
   }
+  undoSaveStateMenu.setText("Undo Last Save State").setIcon(Icon::Edit::Undo).setEnabled(false);
+  undoSaveStateMenu.onActivate([&] {
+    program.undoStateSave();
+    undoSaveStateMenu.setEnabled(false);
+  });
+  undoLoadStateMenu.setText("Undo Last Load State").setIcon(Icon::Edit::Undo).setEnabled(false);
+  undoLoadStateMenu.onActivate([&] {
+    program.undoStateLoad();
+    undoLoadStateMenu.setEnabled(false);
+  });
   captureScreenshot.setText("Capture Screenshot").setIcon(Icon::Emblem::Image).onActivate([&] {
     program.requestScreenshot = true;
   });

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -51,6 +51,8 @@ struct Presentation : Window {
     Menu toolsMenu{&menuBar};
       Menu saveStateMenu{&toolsMenu};
       Menu loadStateMenu{&toolsMenu};
+      MenuItem undoSaveStateMenu{&toolsMenu};
+      MenuItem undoLoadStateMenu{&toolsMenu};
       MenuItem captureScreenshot{&toolsMenu};
       MenuSeparator toolsMenuSeparatorA{&toolsMenu};
       MenuCheckItem pauseEmulation{&toolsMenu};

--- a/desktop-ui/program/load.cpp
+++ b/desktop-ui/program/load.cpp
@@ -74,6 +74,7 @@ auto Program::unload() -> void {
   if(!emulator) return;
 
   settings.save();
+  clearUndoStates();
   showMessage({"Unloaded ", Location::prefix(emulator->game->location)});
   emulator->unload();
   screens.reset();

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -22,6 +22,9 @@ struct Program : ares::Platform {
   //states.cpp
   auto stateSave(u32 slot) -> bool;
   auto stateLoad(u32 slot) -> bool;
+  auto undoStateSave() -> bool;
+  auto undoStateLoad() -> bool;
+  auto clearUndoStates() -> void;
 
   //status.cpp
   auto updateMessage() -> void;
@@ -66,6 +69,7 @@ struct Program : ares::Platform {
 
   struct State {
     u32 slot = 1;
+    u32 undoSlot = 1;
   } state;
 
   //rewind.cpp

--- a/desktop-ui/program/states.cpp
+++ b/desktop-ui/program/states.cpp
@@ -2,6 +2,11 @@ auto Program::stateSave(u32 slot) -> bool {
   if(!emulator) return false;
 
   auto location = emulator->locate(emulator->game->location, {".bs", slot}, settings.paths.saves);
+  string undoLocation = {location.slice(0, (location.size() - 1)), "u"};
+  if(file::move(location, undoLocation)) {
+    state.undoSlot = slot;
+  }
+
   if(auto state = emulator->root->serialize()) {
     if(file::write(location, {state.data(), state.size()})) {
       showMessage({"Saved state to slot ", slot});
@@ -16,6 +21,12 @@ auto Program::stateSave(u32 slot) -> bool {
 auto Program::stateLoad(u32 slot) -> bool {
   if(!emulator) return false;
 
+  //Store current state for undo
+  auto undoLocation = emulator->locate(emulator->game->location, {".blu"}, settings.paths.saves);
+  if(auto state = emulator->root->serialize()) {
+    file::write(undoLocation, {state.data(), state.size()});
+  }
+
   auto location = emulator->locate(emulator->game->location, {".bs", slot}, settings.paths.saves);
   if(auto memory = file::read(location)) {
     serializer state{memory.data(), (u32)memory.size()};
@@ -27,4 +38,48 @@ auto Program::stateLoad(u32 slot) -> bool {
 
   showMessage({"Failed to load state from slot ", slot});
   return false;
+}
+
+auto Program::undoStateSave() -> bool {
+  if(!emulator) return false;
+
+  auto undoLocation = emulator->locate(emulator->game->location, ".bsu", settings.paths.saves);
+  string location = {undoLocation.slice(0, (undoLocation.size() - 1)), state.undoSlot};
+  if(file::move(undoLocation, location)) {
+    showMessage({"Reverted to previous version in slot ", state.undoSlot, " of save file ", location});
+      return true;
+  } else {
+    showMessage({"Unable to revert to previous version of save file ", location});
+    return false;
+  }
+}
+
+auto Program::undoStateLoad() -> bool {
+  if(!emulator) return false;
+
+  auto undoLocation = emulator->locate(emulator->game->location, ".blu", settings.paths.saves);
+  if(auto memory = file::read(undoLocation)) {
+    serializer state{memory.data(), (u32)memory.size()};
+    if(emulator->root->unserialize(state)) {
+      showMessage({"Loaded state from undo load file ", undoLocation});
+      file::remove(undoLocation);
+      return true;
+    } else {
+      showMessage({"Failed to unserialize state from undo load file ", undoLocation});
+      return false;
+    }
+  } else {
+    showMessage({"Unable to revert to previous state from undo load file ", undoLocation});
+    return false;
+  }
+}
+
+auto Program::clearUndoStates() -> void {
+  if(!emulator) return;
+
+  auto location = emulator->locate(emulator->game->location, ".blu", settings.paths.saves);
+  file::remove(location);
+
+  location = emulator->locate(emulator->game->location, ".bsu", settings.paths.saves);
+  file::remove(location);
 }


### PR DESCRIPTION
Give the user the ability to revert from an erroneous load or overwriting a save state by mistake. 

- When undoing last load, game state will revert back to the moment before requesting loading from a save state.
- When undoing last save, it will revert to the previous state of the overwritten save state slot. Note that state is not loaded at this time, it only reverts the last save state. You can chose to load from that save state, but this functionality will not change current game state without additional user action. 