### PR TITLE
MD/MCD/M32X bugfixes

### DIFF
--- a/ares/md/mcd/mcd.cpp
+++ b/ares/md/mcd/mcd.cpp
@@ -69,6 +69,10 @@ auto MCD::allocate(Node::Port parent) -> Node::Peripheral {
 }
 
 auto MCD::connect() -> void {
+  if(auto fp = system.pak->read("backup.ram")) {
+    bram.load(fp);
+  }
+
   if(!disc->setPak(pak = platform->pak(disc))) return;
 
   information = {};
@@ -78,10 +82,6 @@ auto MCD::connect() -> void {
   if(!fd) return disconnect();
 
   cdd.insert();
-
-  if(auto fp = system.pak->read("backup.ram")) {
-    bram.load(fp);
-  }
 }
 
 auto MCD::disconnect() -> void {

--- a/ares/md/mcd/mcd.hpp
+++ b/ares/md/mcd/mcd.hpp
@@ -343,6 +343,7 @@ struct MCD : M68000, Thread {
       i32 sector;   //current frame#
       n16 sample;   //current audio sample# within current frame
       n7  track;    //current track#
+      n1  tocRead;
     } io;
 
     n1 hostClockEnable;

--- a/ares/md/mcd/serialization.cpp
+++ b/ares/md/mcd/serialization.cpp
@@ -147,6 +147,7 @@ auto MCD::CDD::serialize(serializer& s) -> void {
   s(io.sector);
   s(io.sample);
   s(io.track);
+  s(io.tocRead);
 
   s(hostClockEnable);
   s(statusPending);

--- a/ares/md/system/serialization.cpp
+++ b/ares/md/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v132.1";
+static const string SerializerVersion = "v132.2";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);

--- a/ares/md/vdp/io.cpp
+++ b/ares/md/vdp/io.cpp
@@ -332,15 +332,15 @@ auto VDP::writeControlPort(n16 data) -> void {
 
   //window plane horizontal position
   case 0x11: {
-    window.hoffset    = data.bit(0,4) << 4;
-    window.hdirection = data.bit(7);
+    window.io.hoffset    = data.bit(0,4) << 4;
+    window.io.hdirection = data.bit(7);
     return;
   }
 
   //window plane vertical position
   case 0x12: {
-    window.voffset    = data.bit(0,4) << 3;
-    window.vdirection = data.bit(7);
+    window.io.voffset    = data.bit(0,4) << 3;
+    window.io.vdirection = data.bit(7);
     return;
   }
 

--- a/ares/md/vdp/main.cpp
+++ b/ares/md/vdp/main.cpp
@@ -142,6 +142,7 @@ auto VDP::mainH32() -> void {
 
   layerA.begin();
   layerB.begin();
+  window.begin();
 
   tick<false>(); layers.hscrollFetch();
   tick<false>(); sprite.patternFetch(26);
@@ -193,6 +194,7 @@ auto VDP::mainH40() -> void {
 
   layerA.begin();
   layerB.begin();
+  window.begin();
 
   tick<true>(); layers.hscrollFetch();
   tick<true>(); sprite.patternFetch(34);

--- a/ares/md/vdp/main.cpp
+++ b/ares/md/vdp/main.cpp
@@ -114,14 +114,16 @@ auto VDP::main() -> void {
 
 auto VDP::mainH32() -> void {
   auto pixels = dac.pixels = vdp.pixels();
-  auto scanline = vcounter();
   cycles = &cyclesH32[edclk()][0];
 
   sprite.begin();
   if(dac.pixels) blocks<false, true>();
   else blocks<false, false>();
 
-  m32x.vdp.scanline(pixels, scanline);
+  if(Mega32X()) {
+    Thread::synchronize(cpu);
+    m32x.vdp.scanline(pixels, vcounter());
+  }
 
   tick<false>(); slot();
   tick<false>(); slot();
@@ -170,7 +172,10 @@ auto VDP::mainH40() -> void {
   if(dac.pixels) blocks<true, true>();
   else blocks<true, false>();
 
-  m32x.vdp.scanline(pixels, vcounter());
+  if(Mega32X()) {
+    Thread::synchronize(cpu);
+    m32x.vdp.scanline(pixels, vcounter());
+  }
 
   tick<true>(); slot();
   tick<true>(); slot();

--- a/ares/md/vdp/serialization.cpp
+++ b/ares/md/vdp/serialization.cpp
@@ -128,10 +128,14 @@ auto VDP::Attributes::serialize(serializer& s) -> void {
 }
 
 auto VDP::Window::serialize(serializer& s) -> void {
-  s(hoffset);
-  s(hdirection);
-  s(voffset);
-  s(vdirection);
+  s(latch.hoffset);
+  s(latch.hdirection);
+  s(latch.voffset);
+  s(latch.vdirection);
+  s(io.hoffset);
+  s(io.hdirection);
+  s(io.voffset);
+  s(io.vdirection);
   s(nametableAddress);
 }
 

--- a/ares/md/vdp/sprite.cpp
+++ b/ares/md/vdp/sprite.cpp
@@ -142,7 +142,7 @@ auto VDP::Sprite::patternFetch(u32) -> void {
     auto id = visibleLink;
     auto& object = cache[id];
     visibleLink = object.link;
-    if(!visibleLink) visibleStop = 1;
+    if(!visibleLink || visibleLink >= frameObjectLimit()) visibleStop = 1;
 
     auto objectY = object.y & (interlace ? 1023 : 511);
     auto height = 1 + object.height << 3 + interlace;

--- a/ares/md/vdp/vdp.hpp
+++ b/ares/md/vdp/vdp.hpp
@@ -255,6 +255,7 @@ struct VDP : Thread {
 
   struct Window {
     //window.cpp
+    auto begin() -> void;
     auto attributesFetch(s32) -> void;
     auto test() const -> bool;
     auto power(bool reset) -> void;
@@ -262,10 +263,20 @@ struct VDP : Thread {
     //serialization.cpp
     auto serialize(serializer&) -> void;
 
-    n10 hoffset;
-    n1  hdirection;
-    n10 voffset;
-    n1  vdirection;
+    struct Latch {
+      n10 hoffset;
+      n1  hdirection;
+      n10 voffset;
+      n1  vdirection;
+    } latch;
+
+    struct IO {
+      n10 hoffset;
+      n1  hdirection;
+      n10 voffset;
+      n1  vdirection;
+    } io;
+
     n16 nametableAddress;
   } window;
 

--- a/ares/md/vdp/window.cpp
+++ b/ares/md/vdp/window.cpp
@@ -1,3 +1,10 @@
+auto VDP::Window::begin() -> void {
+  latch.hoffset = io.hoffset;
+  latch.hdirection = io.hdirection;
+  latch.voffset = io.voffset;
+  latch.vdirection = io.vdirection;
+}
+
 //called 17 (H32) or 21 (H40) times
 auto VDP::Window::attributesFetch(s32 attributesIndex) -> void {
   //todo: what should happen for the window on column -1?
@@ -10,7 +17,7 @@ auto VDP::Window::attributesFetch(s32 attributesIndex) -> void {
   s32 x = attributesIndex << 4;
   s32 y = vdp.vcounter();
   vdp.layerA.windowed[0] = vdp.layerA.windowed[1];
-  vdp.layerA.windowed[1] = x < hoffset ^ hdirection || y < voffset ^ vdirection;
+  vdp.layerA.windowed[1] = x < latch.hoffset ^ latch.hdirection || y < latch.voffset ^ latch.vdirection;
   if(!vdp.layerA.windowed[1]) return;
 
   vdp.layerA.attributes.address = vdp.h40() ? nametableAddress & ~0x400 : nametableAddress & ~0;
@@ -21,9 +28,7 @@ auto VDP::Window::attributesFetch(s32 attributesIndex) -> void {
 }
 
 auto VDP::Window::power(bool reset) -> void {
-  hoffset = 0;
-  hdirection = 0;
-  voffset = 0;
-  vdirection = 0;
+  latch = {};
+  io = {};
   nametableAddress = 0;
 }


### PR DESCRIPTION
1. b6350b3c0fd7ad527ccf3db8d0b22d5ddf42c974 introduced a render issue observed when loading a CD 32X game into the US v2.00 bios (logo lacking color). Adding a sync immediately before the 32x line render fixes this. Be advised, there could be similar (potentially more subtle) sync issues affecting the vdp.
2. The sprite list may be terminated by link values that exceed the max list length (which corresponds to the h-resolution). Fixes graphical glitches in Power Drive vehicle select menu.
3. It is generally known (though details are sparse) that some vdp regs may be latched during line render and thus cannot effectively be changed mid-line. Latching the window regs ahead of the scanline fixes #117. Due to lack of solid info, other regs will not be latched without testing/confirmation first.
4. Added handling of empty drive state. This fixes #1019 where playing without a disc is an option. This also fixes an issue where an existing backup ram file would be overwritten if mcd was loaded without a disc.