### PR TITLE
nall: split main.cpp into separate translation unit

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -422,6 +422,8 @@ else
 endif
 
 # objects
-nall.objects := $(object.path)/nall.o
+nall.objects := nall nall-main
+nall.objects := $(nall.objects:%=$(object.path)/%.o)
 
 $(object.path)/nall.o: $(nall.path)/nall.cpp
+$(object.path)/nall-main.o: $(nall.path)/main.cpp

--- a/nall/main.cpp
+++ b/nall/main.cpp
@@ -1,6 +1,7 @@
 #include <nall/main.hpp>
 
 #if defined(PLATFORM_WINDOWS)
+  #include <nall/windows/windows.hpp>
   #include <objbase.h>
   #include <shellapi.h>
   #include <winsock2.h>

--- a/nall/nall.cpp
+++ b/nall/nall.cpp
@@ -10,7 +10,6 @@
 #include <nall/dl.cpp>
 #include <nall/file-map.cpp>
 #include <nall/inode.cpp>
-#include <nall/main.cpp>
 #include <nall/memory.cpp>
 #include <nall/path.cpp>
 #include <nall/platform.cpp>


### PR DESCRIPTION
When using nall as a header-only library it was possible to opt out of nall taking over main() by simply not including main.hpp. There was no mechanism to opt out when building nall as a separate translation unit because nall.cpp unconditionally pulled in main.cpp. Now, users of nall must specifically opt in by including main.cpp in their build (though header-only users still only need to include main.hpp).