### PR TITLE
n64: fix cache line selection

### DIFF
--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -111,7 +111,8 @@ auto CPU::instruction() -> void {
 
 auto CPU::instructionEpilogue() -> s32 {
   if constexpr(Accuracy::CPU::Recompiler) {
-    icache.step(ipu.pc);  //simulates timings without performing actual icache loads
+    // FIXME: ipu.pc should be devirtualized here
+    icache.step(ipu.pc, ipu.pc);  //simulates timings without performing actual icache loads
   }
 
   ipu.r[0].u64 = 0;

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -106,11 +106,11 @@ struct CPU : Thread {
   struct InstructionCache {
     CPU& self;
     struct Line;
-    auto line(u32 address) -> Line& { return lines[address >> 5 & 0x1ff]; }
+    auto line(u32 vaddr) -> Line& { return lines[vaddr >> 5 & 0x1ff]; }
 
     //used by the recompiler to simulate instruction cache fetch timing
-    auto step(u32 address) -> void {
-      auto& line = this->line(address);
+    auto step(u32 vaddr, u32 address) -> void {
+      auto& line = this->line(vaddr);
       if(!line.hit(address)) {
         self.step(48);
         line.valid = 1;
@@ -121,8 +121,8 @@ struct CPU : Thread {
     }
 
     //used by the interpreter to fully emulate the instruction cache
-    auto fetch(u32 address, CPU& cpu) -> u32 {
-      auto& line = this->line(address);
+    auto fetch(u32 vaddr, u32 address, CPU& cpu) -> u32 {
+      auto& line = this->line(vaddr);
       if(!line.hit(address)) {
         line.fill(address, cpu);
       } else {
@@ -182,9 +182,9 @@ struct CPU : Thread {
   //dcache.cpp
   struct DataCache {
     struct Line;
-    auto line(u32 address) -> Line&;
-    template<u32 Size> auto read(u32 address) -> u64;
-    template<u32 Size> auto write(u32 address, u64 data) -> void;
+    auto line(u32 vaddr) -> Line&;
+    template<u32 Size> auto read(u32 vaddr, u32 address) -> u64;
+    template<u32 Size> auto write(u32 vaddr, u32 address, u64 data) -> void;
     auto power(bool reset) -> void;
 
     //8KB

--- a/ares/n64/cpu/dcache.cpp
+++ b/ares/n64/cpu/dcache.cpp
@@ -61,8 +61,8 @@ auto CPU::DataCache::Line::writeBack() -> void {
   cpu.busWrite<Word>(tag | index | 0xc, words[3]);
 }
 
-auto CPU::DataCache::line(u32 address) -> Line& {
-  return lines[address >> 4 & 0x1ff];
+auto CPU::DataCache::line(u32 vaddr) -> Line& {
+  return lines[vaddr >> 4 & 0x1ff];
 }
 
 template<u32 Size>
@@ -90,8 +90,8 @@ auto CPU::DataCache::Line::write(u32 address, u64 data) -> void {
 }
 
 template<u32 Size>
-auto CPU::DataCache::read(u32 address) -> u64 {
-  auto& line = this->line(address);
+auto CPU::DataCache::read(u32 vaddr, u32 address) -> u64 {
+  auto& line = this->line(vaddr);
   if(!line.hit(address)) {
     if(line.valid && line.dirty) line.writeBack();
     line.fill(address);
@@ -102,8 +102,8 @@ auto CPU::DataCache::read(u32 address) -> u64 {
 }
 
 template<u32 Size>
-auto CPU::DataCache::write(u32 address, u64 data) -> void {
-  auto& line = this->line(address);
+auto CPU::DataCache::write(u32 vaddr, u32 address, u64 data) -> void {
+  auto& line = this->line(vaddr);
   if(!line.hit(address)) {
     if(line.valid && line.dirty) line.writeBack();
     return line.fill<Size>(address, data);


### PR DESCRIPTION
VR4300 icache/dcache use both the virtual address and the physical address: the former one is used to select the cacheline (just like the key to a hashtable), while the latter is used to check that the cacheline contains the correct line of memory and not another one that happens to have the same hash key.

So any access to the cache requires both addresses. This commit makes this explicit, and make sure to call the functions correctly.

The only exception where we leave a FIXME is the icache.step call in the recompiler, as we can't possibly devirtualize the PC for each opcode. This will have to be fixed in another way.