### PR TITLE
YM2612 accuracy fixes

### DIFF
--- a/ares/component/audio/ym2612/channel.cpp
+++ b/ares/component/audio/ym2612/channel.cpp
@@ -156,6 +156,7 @@ auto YM2612::Channel::power() -> void {
     op.outputLevel = 0x1fff;
     op.output = 0;
     op.prior = 0;
+    op.priorBuffer = 0;
 
     op.pitch.value = 0;
     op.pitch.reload = 0;

--- a/ares/component/audio/ym2612/serialization.cpp
+++ b/ares/component/audio/ym2612/serialization.cpp
@@ -50,6 +50,7 @@ auto YM2612::Channel::Operator::serialize(serializer& s) -> void {
   s(outputLevel);
   s(output);
   s(prior);
+  s(priorBuffer);
 
   s(pitch.value);
   s(pitch.reload);

--- a/ares/component/audio/ym2612/ym2612.hpp
+++ b/ares/component/audio/ym2612/ym2612.hpp
@@ -114,6 +114,7 @@ protected:
       n16 outputLevel = 0x1fff;
       i16 output = 0;
       i16 prior = 0;
+      i16 priorBuffer = 0;
 
       struct Pitch {
         n11 value = 0;

--- a/ares/md/system/serialization.cpp
+++ b/ares/md/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v132.2";
+static const string SerializerVersion = "v132.3";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);

--- a/ares/ng/system/serialization.cpp
+++ b/ares/ng/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v133";
+static const string SerializerVersion = "v133.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
1. Operator modulation is affected by pipeline delays, which is known thanks to RE work by Sauraen et al. Fixes #858.
2. Adding crossover distortion for authenticity. This is often referred to as "ladder effect", which is a different thing but... these elements interact to produce a distinct quality of noise at very low output volumes (and even when output is suppressed!). Note, this distortion was "fixed" in the YM3438 (used in many MD model 2 revisions) which is basically the only functional change within the chip (external amp circuit was also changed).