### PR TITLE
Add "Reset System" hotkey

### DIFF
--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -111,6 +111,11 @@ auto InputManager::createHotkeys() -> void {
     program.pause(!program.paused);
   }));
 
+  hotkeys.append(InputHotkey("Reset System").onPress([&] {
+    if(!emulator) return;
+    emulator->root->power(true);
+  }));
+
   hotkeys.append(InputHotkey("Reload Current Game").onPress([&] {
     if(!emulator) return;
     program.load(emulator, emulator->game->location);


### PR DESCRIPTION
This adds a hotkey that can be used to reset the active system.

Although this is similar to the existing "Reload Current Game" hotkey, it does have a functional difference, since a soft reset can result in the state of a system being slightly different than a cold boot.  It also does not result in resizing the emulator window and is slightly faster due to not needing to reload various resources.