### PR TITLE
pce: multiple backup ram fixes

### DIFF
--- a/ares/pce/pcd/io.cpp
+++ b/ares/pce/pcd/io.cpp
@@ -11,7 +11,7 @@ auto PCD::read(n8 bank, n13 address, n8 data) -> n8 {
     return wram.read(bank - 0x80 << 13 | address);
   }
 
-  if(bank == 0xf7 && bramEnable()) {
+  if(bank == 0xf7 && bramEnable() && address < bram.size()) {
     return bram.read(address);
   }
 
@@ -27,7 +27,7 @@ auto PCD::write(n8 bank, n13 address, n8 data) -> void {
     return wram.write(bank - 0x80 << 13 | address, data);
   }
 
-  if(bank == 0xf7 && bramEnable()) {
+  if(bank == 0xf7 && bramEnable() && address < bram.size()) {
     return bram.write(address, data);
   }
 }

--- a/ares/pce/pcd/pcd.cpp
+++ b/ares/pce/pcd/pcd.cpp
@@ -97,6 +97,7 @@ auto PCD::connect() -> void {
   // Only do this if the HUBM string is not present, to prevent overwriting
   // existing bram
   if (bram[0] != 'H' && bram[1] != 'U' && bram[2] != 'B' && bram[3] != 'M') {
+    bram.fill(0);
     bram[0] = 'H';
     bram[1] = 'U';
     bram[2] = 'B';

--- a/ares/pce/pcd/pcd.cpp
+++ b/ares/pce/pcd/pcd.cpp
@@ -45,6 +45,25 @@ auto PCD::load(Node::Object parent) -> void {
   cdda.load(node);
   adpcm.load(node);
   debugger.load(node);
+
+  if(auto fp = system.pak->read("backup.ram")) {
+    bram.load(fp);
+  }
+
+  // Initialise bram to prevent 'rma error' screens in many games
+  // Only do this if the HUBM string is not present, to prevent overwriting
+  // existing bram
+  if (bram[0] != 'H' && bram[1] != 'U' && bram[2] != 'B' && bram[3] != 'M') {
+    bram.fill(0);
+    bram[0] = 'H';
+    bram[1] = 'U';
+    bram[2] = 'B';
+    bram[3] = 'M';
+    bram[4] = 0x00;
+    bram[5] = 0x88;
+    bram[6] = 0x10;
+    bram[7] = 0x80;
+  }
 }
 
 auto PCD::unload() -> void {
@@ -88,25 +107,6 @@ auto PCD::connect() -> void {
     fd->read({subchannel.data() + sector * 96, 96});
   }
   session.decode(subchannel, 96);
-
-  if(auto fp = system.pak->read("backup.ram")) {
-    bram.load(fp);
-  }
-
-  // Initialise bram to prevent 'rma error' screens in many games
-  // Only do this if the HUBM string is not present, to prevent overwriting
-  // existing bram
-  if (bram[0] != 'H' && bram[1] != 'U' && bram[2] != 'B' && bram[3] != 'M') {
-    bram.fill(0);
-    bram[0] = 'H';
-    bram[1] = 'U';
-    bram[2] = 'B';
-    bram[3] = 'M';
-    bram[4] = 0x00;
-    bram[5] = 0x88;
-    bram[6] = 0x10;
-    bram[7] = 0x80;
-  }
 }
 
 auto PCD::disconnect() -> void {


### PR DESCRIPTION
A few issues conspired to create #1071:
1. ares was accidentally filling BRAM with FFs (and flushing it to disk) when loading a non-CD PCE game.
2. ares attempted to format BRAM automatically as needed but only wrote a header without zeroing the contents.
3. If Rondo of Blood sees a header in BRAM, it expects the free bytes to be zero initialized (or at least not FFs).

Separately, ares was causing the BIOS to incorrectly detect the size of BRAM and write an inaccurate header when formatting. I don't know if this was causing issues with any games; it's just something I noticed while investigating.