### PR TITLE
sh2: boost sync on pending interrupt

### DIFF
--- a/ares/component/processor/sh2/exceptions.cpp
+++ b/ares/component/processor/sh2/exceptions.cpp
@@ -1,6 +1,6 @@
 auto SH2::exceptionHandler() -> void {
   if(!exceptions) return;
-  if(inDelaySlot()) return;
+  if(inDelaySlot()) { cyclesUntilSync = 0; return; }
 
   if(exceptions & ResetCold) {
     exceptions &= ~ResetCold;

--- a/ares/component/processor/sh2/sh7604/interrupts.cpp
+++ b/ares/component/processor/sh2/sh7604/interrupts.cpp
@@ -1,5 +1,5 @@
 auto SH2::INTC::run() -> void {
-  if(self->inDelaySlot()) return;
+  if(self->inDelaySlot()) { self->cyclesUntilSync = 0; return; }
 
   if(self->frt.pendingOutputIRQ) {
     if(self->SR.I < iprb.frtip) {


### PR DESCRIPTION
Interrupts are deferred when the CPU is in a branch delay slot. If the recompiler repeatedly exits the code cache in a delay slot (much more likely with "min cycles between syncs" optimization active) then interrupts will be deferred indefinitely.

This is now avoided by resetting the "cycles until sync" count when interrupts are deferred due to a branch delay slot.

An alternate and possibly more robust solution would be to single step the next instruction with the interpreter. One side effect would be the generation of more compiled blocks.