### PR TITLE
n64: fix BADVADDR in TLB miss exception raised by SWR

### DIFF
--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -264,7 +264,7 @@ struct CPU : Thread {
   template<u32 Size> auto busWrite(u32 address, u64 data) -> void;
   template<u32 Size> auto busRead(u32 address) -> u64;
   template<u32 Size> auto read(u64 vaddr) -> maybe<u64>;
-  template<u32 Size> auto write(u64 vaddr, u64 data) -> bool;
+  template<u32 Size> auto write(u64 vaddr, u64 data, bool alignedError=true) -> bool;
   template<u32 Size> auto vaddrAlignedError(u64 vaddr, bool write) -> bool;
   auto addressException(u64 vaddr) -> void;
 

--- a/ares/n64/cpu/interpreter-ipu.cpp
+++ b/ares/n64/cpu/interpreter-ipu.cpp
@@ -1061,17 +1061,17 @@ auto CPU::SWL(cr64& rt, cr64& rs, s16 imm) -> void {
   if(context.bigEndian())
   switch(vaddr & 3) {
   case 0:
-    if(!write<Word>(vaddr & ~3 | 0, data >>  0)) return;
+    if(!write<Word>(vaddr + 0, data >>  0)) return;
     break;
   case 1:
-    if(!write<Byte>(vaddr & ~3 | 1, data >> 24)) return;
-    if(!write<Half>(vaddr & ~3 | 2, data >>  8)) return;
+    if(!write<Byte>(vaddr + 0, data >> 24)) return;
+    if(!write<Half>(vaddr + 1, data >>  8)) return;
     break;
   case 2:
-    if(!write<Half>(vaddr & ~3 | 2, data >> 16)) return;
+    if(!write<Half>(vaddr + 0, data >> 16)) return;
     break;
   case 3:
-    if(!write<Byte>(vaddr & ~3 | 3, data >> 24)) return;
+    if(!write<Byte>(vaddr + 0, data >> 24)) return;
     break;
   }
 }
@@ -1100,17 +1100,17 @@ auto CPU::SWR(cr64& rt, cr64& rs, s16 imm) -> void {
   if(context.bigEndian())
   switch(vaddr & 3) {
   case 0:
-    if(!write<Byte>(vaddr & ~3 | 0, data >>  0)) return;
+    if(!write<Byte>(vaddr + 0, data >>  0, false)) return;
     break;
   case 1:
-    if(!write<Half>(vaddr & ~3 | 0, data >>  0)) return;
+    if(!write<Half>(vaddr + 0, data >>  0, false)) return;
     break;
   case 2:
-    if(!write<Half>(vaddr & ~3 | 0, data >>  8)) return;
-    if(!write<Byte>(vaddr & ~3 | 2, data >>  0)) return;
+    if(!write<Byte>(vaddr + 0, data >>  0, false)) return;
+    if(!write<Half>(vaddr - 2, data >>  8, false)) return;
     break;
   case 3:
-    if(!write<Word>(vaddr & ~3 | 0, data >>  0)) return;
+    if(!write<Word>(vaddr + 0, data >>  0, false)) return;
     break;
   }
 }


### PR DESCRIPTION
SWL/SWR do not raise address errors (it's their whole reason of being), but they can still raise TLB misses if they access an unmapped memory area. In that case, the COP0 BADVADDR register is expected to contain *exactly* the address passed to them.

This happened to be true (by luck) for SWL but not for SWR: SWR in fact needs to write *before* the address passed to it, so the opcode itself was adjusting the address before calling the memory function.

Fixed by passing the misaligned address to CPU::write and telling it to skip address errors. It's not pretty: the code in CPU::write/read is a bit of a mess and it would require some refactoring but that's for another day.

Verified on real hardware by adding a new test to n64-systemtest, which is has been submitted upstream (https://github.com/lemmy-64/n64-systemtest/pull/50).