### PR TITLE
pce: fix off-by-one error for scanline interrupts

### DIFF
--- a/ares/pce/vdp-performance/vdc.cpp
+++ b/ares/pce/vdp-performance/vdc.cpp
@@ -62,10 +62,12 @@ auto VDC::vclock() -> void {
       timing.voffset = 0;
     } break;
   case VDS:
+    if(timing.voffset == latch.verticalDisplayStart - 1) {
+      timing.coincidence = 64;
+    } 
     if(timing.voffset >= latch.verticalDisplayStart) {
       timing.vstate = VDW;
       timing.voffset = 0;
-      timing.coincidence = 64;
     } break;
   case VDW:
     if(timing.voffset >= latch.verticalDisplayWidth) {

--- a/ares/pce/vdp/vdc.cpp
+++ b/ares/pce/vdp/vdc.cpp
@@ -55,9 +55,7 @@ auto VDC::hclock() -> void {
       sprite.scanline(timing.voffset);
     } break;
   case HDW:
-    //this is said to happen 4 cycles before HDW ends;
-    //however, anything less than 40 cycles causes severe graphics issues in games
-    if(timing.hoffset == latch.horizontalDisplayWidth - 40) {
+    if(timing.hoffset == latch.horizontalDisplayWidth - 4) {
       if(timing.coincidence++ == io.coincidence) irq.raise(IRQ::Line::Coincidence);
     }
     if(timing.hoffset >= latch.horizontalDisplayWidth) {
@@ -86,10 +84,12 @@ auto VDC::vclock() -> void {
       timing.voffset = 0;
     } break;
   case VDS:
+    if(timing.voffset == latch.verticalDisplayStart - 1) {
+      timing.coincidence = 64;
+    } 
     if(timing.voffset >= latch.verticalDisplayStart) {
       timing.vstate = VDW;
       timing.voffset = 0;
-      timing.coincidence = 64;
     } break;
   case VDW:
     if(timing.voffset >= latch.verticalDisplayWidth) {


### PR DESCRIPTION
This change also removes a timing hack from the pixel accurate renderer. I believe this hack may have been an attempt to work around the bug addressed by this PR, though I can't say for sure. The commit that introduced it (a57cc9f) only mentions Air Zonk, but that title currently seems fine with or without the hack. I tried some other titles and discovered that it actually causes garbage on the title screen of Victory Run, so I'm opting to remove it.

Fixes the "blue characters" part of #1086