### PR TITLE
Fallback for when a single monitor is detected but it is not primary

### DIFF
--- a/ruby/video/video.cpp
+++ b/ruby/video/video.cpp
@@ -426,6 +426,8 @@ auto Video::monitor(string name) -> Monitor {
   for(auto& monitor : monitors) {
     if(monitor.primary) return monitor;
   }
+  //if only one monitor is found, but it is not primary, use that
+  if(monitors.size() == 1) return monitors.left();
   //Video::monitors() should never let this occur
   Monitor monitor;
   monitor.name = "Primary";


### PR DESCRIPTION
On some Linux display managers, a single monitor will not be flagged as primary if it is the only one detected. This pr adds a check that will make ares use a monitor if it is the only one detected.

Possibly fixes #453 .