### PR TITLE
nall: add needed #include <stdexcept>

### DIFF
--- a/nall/arithmetic.hpp
+++ b/nall/arithmetic.hpp
@@ -3,6 +3,8 @@
 //multi-precision arithmetic
 //warning: each size is quadratically more expensive than the size before it!
 
+#include <stdexcept>
+
 #include <nall/stdint.hpp>
 #include <nall/string.hpp>
 #include <nall/range.hpp>


### PR DESCRIPTION
Missing include uncovered by libstdc++ changes in GCC 13.