### PR TITLE
libchdr: instruct glibc to declare fseeko/ftello

### DIFF
--- a/thirdparty/GNUmakefile
+++ b/thirdparty/GNUmakefile
@@ -46,3 +46,6 @@ $(object.path)/zlib_zutil.o: $(libchdr.path)/deps/zlib-1.2.11/zutil.c
 flags += -I$(libchdr.path)/include
 flags += -I$(libchdr.path)/deps/lzma-19.00/include -D_7ZIP_ST
 flags += -I$(libchdr.path)/deps/zlib-1.2.11
+
+# instruct glibc to declare fseeko/ftello
+flags += -D_LARGEFILE_SOURCE


### PR DESCRIPTION
Fixes building with Clang 16 on Linux. (#1100)

The author of that issue report has since filed an issue against libchdr (rtissera/libchdr#92), but I'd like to mitigate this sooner rather than later. The longer the build stays broken the more annoying it will be to build old revisions in the future.