### PR TITLE
n64: adjust linear response and account for precision error of axis values

### DIFF
--- a/ares/n64/controller/gamepad/gamepad.cpp
+++ b/ares/n64/controller/gamepad/gamepad.cpp
@@ -243,6 +243,10 @@ auto Gamepad::read() -> n32 {
   if(abs(ax) > cardinalMax) ax = copysign(cardinalMax, ax);
   if(abs(ay) > cardinalMax) ay = copysign(cardinalMax, ay);
   
+  //add epsilon to counteract floating point precision error
+  ax = copysign(abs(ax) + 1e-09, ax);
+  ay = copysign(abs(ay) + 1e-09, ay);
+  
   n32 data;
   data.byte(0) = s8(-ay);
   data.byte(1) = s8(+ax);


### PR DESCRIPTION
Currently, the linear response curves (lengthAbsoluteX and lengthAbsoluteY equations) use the max radius value needed to produce max diagonal (called startCardinalMax) as a variable. This is an overreach as the maximum value that the analog stick can reach in any direction is defined to be a count of 85. Therefore, startCardinalMax has been replaced by cardinalMax to reflect this. As a consequence, the equation for startCardinalMax needed to be updated as its value is determined from this equation. Moreover, the variables surrounding this equation were renamed to better reflect their purpose or remove now-unnecessary nuance.

The second commit focuses upon the precision error that became apparent with this change (and why this change took so long to happen). The values of the axes are of type double up until placed into data. diagonalMax returns a calculation just slightly below 69 at this point, causing it to be truncated to 68 after the cast. Therefore, a small epsilon is now added just before casting. This was chosen over rounding to avoid 68.49999 becoming greater than 68.5 and being rounded up to 69, thus reaching the diagonalMax value earlier than it should.