### PR TITLE
sfc: noise linear feedback shift register state constructed with or not xor

### DIFF
--- a/ares/sfc/dsp/misc.cpp
+++ b/ares/sfc/dsp/misc.cpp
@@ -24,6 +24,6 @@ auto DSP::misc30() -> void {
   //noise
   if(counterPoll(noise.frequency)) {
     s32 feedback = noise.lfsr << 13 ^ noise.lfsr << 14;
-    noise.lfsr = feedback & 0x4000 ^ noise.lfsr >> 1;
+    noise.lfsr = feedback & 0x4000 | noise.lfsr >> 1;
   }
 }


### PR DESCRIPTION
There will never be both XOR inputs set causing the XOR output to be 0 here, on any of the bits, so an OR is equivalent.  People tend to learn what | does before ^ so this makes the code easier to read; they won't be wondering why | wasn't powerful enough to be used here either like I just did.

I tested the noise31 ROM too.