### PR TITLE
n64: implement correct audio frequency for PAL consoles

### DIFF
--- a/ares/n64/ai/io.cpp
+++ b/ares/n64/ai/io.cpp
@@ -56,7 +56,7 @@ auto AI::writeWord(u32 address, u32 data_, u32& cycles) -> void {
     //AI_DACRATE
     auto frequency = dac.frequency;
     io.dacRate = data.bit(0,13);
-    dac.frequency = max(1, system.frequency() / 4 / (io.dacRate + 1)) * 1.037;
+    dac.frequency = max(1, system.videoFrequency() / (io.dacRate + 1));
     dac.period = system.frequency() / dac.frequency;
     if(frequency != dac.frequency) stream->setFrequency(dac.frequency);
   }

--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -66,9 +66,11 @@ auto System::load(Node::System& root, string name) -> bool {
 
   if(name.find("NTSC")) {
     information.region = Region::NTSC;
+    information.videoFrequency = 48'681'812;
   }
   if(name.find("PAL")) {
     information.region = Region::PAL;
+    information.videoFrequency = 49'656'530;
   }
 
   node = Node::System::create(information.name);

--- a/ares/n64/system/system.hpp
+++ b/ares/n64/system/system.hpp
@@ -8,6 +8,7 @@ struct System {
   auto region() const -> Region { return information.region; }
   auto _DD() const -> bool { return information.dd; }
   auto frequency() const -> u32 { return information.frequency; }
+  auto videoFrequency() const -> u32 { return information.videoFrequency; }
 
   //system.cpp
   auto game() -> string;
@@ -26,6 +27,7 @@ private:
     string name = "Nintendo 64";
     Region region = Region::NTSC;
     u32 frequency = 93'750'000 * 2;
+    u32 videoFrequency = 48'681'812;
     bool dd = false;
   } information;
 


### PR DESCRIPTION
Fixes #1120