### PR TITLE
correct for case sensitive file system

### DIFF
--- a/desktop-ui/GNUmakefile
+++ b/desktop-ui/GNUmakefile
@@ -27,7 +27,7 @@ include $(libco.path)/GNUmakefile
 thirdparty.path := ../thirdparty
 sljit.path := $(thirdparty.path)/sljit/sljit_src
 libchdr.path := $(thirdparty.path)/libchdr
-tzxfile.path := $(thirdparty.path)/tzxfile
+tzxfile.path := $(thirdparty.path)/TZXFile
 include $(thirdparty.path)/GNUmakefile
 
 ruby.path := ../ruby


### PR DESCRIPTION
Build will fail on case sensitive filesystem as the path reference is `tzxfile.path := $(thirdparty.path)/tzxfile` when the actual folder name is `tzxfile.path := $(thirdparty.path)/TZXFile`