### PR TITLE
libchdr: redo fseeko/ftello fix

### DIFF
--- a/thirdparty/GNUmakefile
+++ b/thirdparty/GNUmakefile
@@ -47,6 +47,9 @@ flags += -I$(libchdr.path)/include
 flags += -I$(libchdr.path)/deps/lzma-19.00/include -D_7ZIP_ST
 flags += -I$(libchdr.path)/deps/zlib-1.2.13
 
+# instruct glibc to declare fseeko/ftello
+flags += -D_LARGEFILE_SOURCE
+
 tzxfile.objects := TZXAudioGenerator TZXBlock TZXBlockArchiveInfo TZXBlockCustomInfo
 tzxfile.objects += TZXBlockGroupEnd TZXBlockGroupStart TZXBlockHardwareType TZXBlockLoopEnd
 tzxfile.objects += TZXBlockLoopStart TZXBlockMessage TZXBlockPause TZXBlockPulseSequence


### PR DESCRIPTION
Commit 66e01e0 inadvertently (I assume) removed this fix introduced in #1106.