### PR TITLE
Fix: replace deprecated CGDisplayIOServicePort on macOS

### DIFF
--- a/ruby/video/video.cpp
+++ b/ruby/video/video.cpp
@@ -331,7 +331,8 @@ auto Video::hasMonitors() -> vector<Monitor> {
       auto screenDictionary = [screen deviceDescription];
       auto screenID = [screenDictionary objectForKey:@"NSScreenNumber"];
       auto displayID = [screenID unsignedIntValue];
-      auto displayPort = CGDisplayIOServicePort(displayID);
+      CFUUIDRef displayUUID = CGDisplayCreateUUIDFromDisplayID(displayID);
+      io_service_t displayPort = CGDisplayGetDisplayIDFromUUID(displayUUID);
       auto dictionary = IODisplayCreateInfoDictionary(displayPort, 0);
       CFRetain(dictionary);
       if(auto names = (CFDictionaryRef)CFDictionaryGetValue(dictionary, CFSTR(kDisplayProductName))) {


### PR DESCRIPTION
This patch resolves a deprecation warning raised at compile time on macOS.
Note the replacement functions have been available since macOS 10.4.

References:
- https://stackoverflow.com/a/48450870
- [CGDisplayIOServicePort](https://developer.apple.com/documentation/coregraphics/1543516-cgdisplayioserviceport?language=objc)
- [CGDisplayCreateUUIDFromDisplayID](https://developer.apple.com/documentation/colorsync/1458801-cgdisplaycreateuuidfromdisplayid?language=objc)
- [CGDisplayGetDisplayIDFromUUID](https://developer.apple.com/documentation/colorsync/1462999-cgdisplaygetdisplayidfromuuid?language=objc)