### PR TITLE
Add "Weave" deinterlacing support to N64 emulator

### DIFF
--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -25,6 +25,7 @@ auto option(string name, string value) -> bool {
   if(name == "Quality" && value == "UHD") vulkan.internalUpscale = 4;
   if(name == "Supersampling") vulkan.supersampleScanout = value.boolean();
   if(name == "Disable Video Interface Processing") vulkan.disableVideoInterfaceProcessing = value.boolean();
+  if(name == "Weave Deinterlacing") vulkan.weaveDeinterlacing = value.boolean();
   if(vulkan.internalUpscale == 1) vulkan.supersampleScanout = false;
   vulkan.outputUpscale = vulkan.supersampleScanout ? 1 : vulkan.internalUpscale;
   #endif

--- a/ares/n64/vi/vi.cpp
+++ b/ares/n64/vi/vi.cpp
@@ -98,7 +98,12 @@ auto VI::refresh() -> void {
     if(rgba) {
       screen->setViewport(0, 0, width, height);
       for(u32 y : range(height)) {
-        auto source = rgba + width * y * sizeof(u32);
+        u32 y_fix = y; 
+        // When weave interlacing is active, we need to fix the order of interleaved lines for the image output
+        // but only when the VI is set to interlance and we don't use supersampling (causes severe bugs)
+        // Otherwise proceed as normal
+        if(io.serrate == 1 && vulkan.weaveDeinterlacing && !vulkan.supersampleScanout) y_fix = (y % 2 == 0)? y+1 : y-1; // Swap each even/odd line
+        auto source = rgba + width * y_fix * sizeof(u32);
         auto target = screen->pixels(1).data() + y * vulkan.outputUpscale * 640;
         for(u32 x : range(width)) {
           target[x] = source[x * 4 + 0] << 16 | source[x * 4 + 1] << 8 | source[x * 4 + 2] << 0;

--- a/ares/n64/vulkan/vulkan.cpp
+++ b/ares/n64/vulkan/vulkan.cpp
@@ -159,6 +159,15 @@ auto Vulkan::scanoutAsync(bool field) -> bool {
   if(disableVideoInterfaceProcessing) {
     options.vi = {false, false, false, false, false, false};
   }
+  if(!supersampleScanout){
+    options.blend_previous_frame = weaveDeinterlacing;
+    options.upscale_deinterlacing = !weaveDeinterlacing;
+  }
+  else {
+    options.blend_previous_frame = false;
+    options.upscale_deinterlacing = true;
+  }
+
 
   if(implementation->scanout.fence) {
     implementation->scanout.fence->wait();

--- a/ares/n64/vulkan/vulkan.hpp
+++ b/ares/n64/vulkan/vulkan.hpp
@@ -20,6 +20,7 @@ struct Vulkan {
 
   bool enable = true;
   bool disableVideoInterfaceProcessing = false;
+  bool weaveDeinterlacing = false;
   u32  internalUpscale = 1;  //1, 2, 4, 8
   bool supersampleScanout = false;
   u32  outputUpscale = supersampleScanout ? 1 : internalUpscale;

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -97,6 +97,7 @@ auto Nintendo64::load() -> bool {
   ares::Nintendo64::option("Enable GPU acceleration", false);
 #endif
   ares::Nintendo64::option("Disable Video Interface Processing", settings.video.disableVideoInterfaceProcessing);
+  ares::Nintendo64::option("Weave Deinterlacing", settings.video.weaveDeinterlacing);
 
   if(!ares::Nintendo64::load(root, {"[Nintendo] ", name, " (", region, ")"})) return false;
 

--- a/desktop-ui/emulator/nintendo-64dd.cpp
+++ b/desktop-ui/emulator/nintendo-64dd.cpp
@@ -75,6 +75,7 @@ auto Nintendo64DD::load() -> bool {
   ares::Nintendo64::option("Enable GPU acceleration", false);
 #endif
   ares::Nintendo64::option("Disable Video Interface Processing", settings.video.disableVideoInterfaceProcessing);
+  ares::Nintendo64::option("Weave Deinterlacing", settings.video.weaveDeinterlacing);
 
   if(!ares::Nintendo64::load(root, {"[Nintendo] Nintendo 64DD (", region, ")"})) return false;
 

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -70,6 +70,7 @@ auto Settings::process(bool load) -> void {
   bind(string,  "Video/Quality", video.quality);
   bind(boolean, "Video/Supersampling", video.supersampling);
   bind(boolean, "Video/DisableVideoInterfaceProcessing", video.disableVideoInterfaceProcessing);
+  bind(boolean, "Video/WeaveDeinterlacing", video.weaveDeinterlacing);
 
   bind(string,  "Audio/Driver", audio.driver);
   bind(string,  "Audio/Device", audio.device);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -31,6 +31,7 @@ struct Settings : Markup::Node {
     string quality = "SD";
     bool supersampling = false;
     bool disableVideoInterfaceProcessing = false;
+    bool weaveDeinterlacing = false;
   } video;
 
   struct Audio {
@@ -125,6 +126,9 @@ struct VideoSettings : VerticalLayout {
   HorizontalLayout disableVideoInterfaceProcessingLayout{this, Size{~0, 0}, 5};
     CheckLabel disableVideoInterfaceProcessingOption{&disableVideoInterfaceProcessingLayout, Size{0, 0}, 5};
     Label disableVideoInterfaceProcessingHint{&disableVideoInterfaceProcessingLayout, Size{0, 0}};
+  HorizontalLayout weaveDeinterlacingLayout{this, Size{~0, 0}, 5};
+    CheckLabel weaveDeinterlacingOption{&weaveDeinterlacingLayout, Size{0, 0}, 5};
+    Label weaveDeinterlacingHint{&weaveDeinterlacingLayout, Size{0, 0}};
   HorizontalLayout renderQualityLayout{this, Size{~0, 0}, 5};
     RadioLabel renderQualitySD{&renderQualityLayout, Size{0, 0}};
     RadioLabel renderQualityHD{&renderQualityLayout, Size{0, 0}};

--- a/desktop-ui/settings/video.cpp
+++ b/desktop-ui/settings/video.cpp
@@ -72,6 +72,14 @@ auto VideoSettings::construct() -> void {
   });
   disableVideoInterfaceProcessingLayout.setAlignment(1).setPadding(12_sx, 0);
   disableVideoInterfaceProcessingHint.setText("Disables Video Interface post processing to render image from VRAM directly").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
+  weaveDeinterlacingOption.setText("Weave Deinterlacing").setChecked(settings.video.weaveDeinterlacing).onToggle([&] {
+    settings.video.weaveDeinterlacing = weaveDeinterlacingOption.checked();
+    if(emulator) emulator->setBoolean("(Experimental) Double the perceived horizontal resolution, disabled when supersampling is used", settings.video.weaveDeinterlacing);
+  });
+  weaveDeinterlacingLayout.setAlignment(1).setPadding(12_sx, 0);
+  weaveDeinterlacingHint.setText("(Experimental) Double the perceived horizontal resolution, disabled when supersampling is used").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
   renderQualitySD.setText("SD Quality").onActivate([&] {
     settings.video.quality = "SD";
     renderSupersamplingOption.setChecked(false).setEnabled(false);
@@ -102,5 +110,6 @@ auto VideoSettings::construct() -> void {
   renderSupersamplingLayout.setCollapsible(true).setVisible(false);
   renderSettingsHint.setCollapsible(true).setVisible(false);
   disableVideoInterfaceProcessingLayout.setCollapsible(true).setVisible(false);
+  weaveDeinterlacingLayout.setCollapsible(true).setVisible(false);
   #endif
 }


### PR DESCRIPTION
When an interlaced output is made by the game, an N64 emulator right now only allows "Bob" deinterlacing, this PR also adds a "Weave" deinterlace option:
- when a Weave Deinterlacing option is selected in the configuration panel, parallel-rdp and vulkan are configured to produce such output
- weave deinterlacing internally is only enabled and used when VI's interlacing is enabled and parallel-rdp's supersampling is disabled, otherwise "Bob" deinterlacing mode is used
- internally the output image is also modified with even/odd lines swapped to fix graphical bug
- weave deinterlacing mode is experimental since it hasn't been tested with all games/homebrew, but it shouldn't cause any issues, especially with it being disabled