### PR TITLE
[N64] Set weave default to true, disable supersampling when weave option enabled

### DIFF
--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -31,7 +31,7 @@ struct Settings : Markup::Node {
     string quality = "SD";
     bool supersampling = false;
     bool disableVideoInterfaceProcessing = false;
-    bool weaveDeinterlacing = false;
+    bool weaveDeinterlacing = true;
   } video;
 
   struct Audio {

--- a/desktop-ui/settings/video.cpp
+++ b/desktop-ui/settings/video.cpp
@@ -78,6 +78,7 @@ auto VideoSettings::construct() -> void {
     if(emulator) emulator->setBoolean("(Experimental) Double the perceived horizontal resolution, disabled when supersampling is used", settings.video.weaveDeinterlacing);
     if(weaveDeinterlacingOption.checked() == true) {
       renderSupersamplingOption.setChecked(false).setEnabled(false);
+      settings.video.supersampling = false;
     } else {
       if(settings.video.quality != "SD") renderSupersamplingOption.setEnabled(true);
     }

--- a/desktop-ui/settings/video.cpp
+++ b/desktop-ui/settings/video.cpp
@@ -84,25 +84,33 @@ auto VideoSettings::construct() -> void {
     }
   });
   weaveDeinterlacingLayout.setAlignment(1).setPadding(12_sx, 0);
-  weaveDeinterlacingHint.setText("(Experimental) Double the perceived horizontal resolution, disabled when supersampling is used").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+  weaveDeinterlacingHint.setText("Doubles the perceived horizontal resolution, incompatible with supersampling").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
   renderQualitySD.setText("SD Quality").onActivate([&] {
     settings.video.quality = "SD";
     renderSupersamplingOption.setChecked(false).setEnabled(false);
+    settings.video.supersampling = false;
+    weaveDeinterlacingOption.setEnabled(true);
   });
   renderQualityHD.setText("HD Quality").onActivate([&] {
     settings.video.quality = "HD";
-    renderSupersamplingOption.setChecked(settings.video.supersampling).setEnabled(true);
+    if(weaveDeinterlacingOption.checked() == false) renderSupersamplingOption.setChecked(settings.video.supersampling).setEnabled(true);
   });
   renderQualityUHD.setText("UHD Quality").onActivate([&] {
     settings.video.quality = "UHD";
-    renderSupersamplingOption.setChecked(settings.video.supersampling).setEnabled(true);
+    if(weaveDeinterlacingOption.checked() == false) renderSupersamplingOption.setChecked(settings.video.supersampling).setEnabled(true);
   });
   if(settings.video.quality == "SD") renderQualitySD.setChecked();
   if(settings.video.quality == "HD") renderQualityHD.setChecked();
   if(settings.video.quality == "UHD") renderQualityUHD.setChecked();
   renderSupersamplingOption.setText("Supersampling").setChecked(settings.video.supersampling && settings.video.quality != "SD").setEnabled(settings.video.quality != "SD").onToggle([&] {
     settings.video.supersampling = renderSupersamplingOption.checked();
+    if(renderSupersamplingOption.checked() == true) {
+      weaveDeinterlacingOption.setEnabled(false).setChecked(false);
+      settings.video.weaveDeinterlacing = false;
+    } else {
+      weaveDeinterlacingOption.setEnabled(true);
+    }
   });
   renderSupersamplingLayout.setAlignment(1).setPadding(12_sx, 0);
   renderSupersamplingHint.setText("Scales HD and UHD resolutions back down to SD").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);

--- a/desktop-ui/settings/video.cpp
+++ b/desktop-ui/settings/video.cpp
@@ -76,6 +76,11 @@ auto VideoSettings::construct() -> void {
   weaveDeinterlacingOption.setText("Weave Deinterlacing").setChecked(settings.video.weaveDeinterlacing).onToggle([&] {
     settings.video.weaveDeinterlacing = weaveDeinterlacingOption.checked();
     if(emulator) emulator->setBoolean("(Experimental) Double the perceived horizontal resolution, disabled when supersampling is used", settings.video.weaveDeinterlacing);
+    if(weaveDeinterlacingOption.checked() == true) {
+      renderSupersamplingOption.setChecked(false).setEnabled(false);
+    } else {
+      if(settings.video.quality != "SD") renderSupersamplingOption.setEnabled(true);
+    }
   });
   weaveDeinterlacingLayout.setAlignment(1).setPadding(12_sx, 0);
   weaveDeinterlacingHint.setText("(Experimental) Double the perceived horizontal resolution, disabled when supersampling is used").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);


### PR DESCRIPTION
- Weave deinterlacing is now defaulted to true
- If weave deinterlacing is enabled, uncheck & disable the supersampling option