### PR TITLE
n64: implement accurate PI DMA timings

### DIFF
--- a/ares/n64/pi/io.cpp
+++ b/ares/n64/pi/io.cpp
@@ -42,12 +42,12 @@ auto PI::ioRead(u32 address) -> u32 {
 
   if(address == 7) {
     //PI_BSD_DOM1_PGS
-    data.bit(0,7) = bsd1.pageSize;
+    data.bit(0,3) = bsd1.pageSize;
   }
 
   if(address == 8) {
     //PI_BSD_DOM1_RLS
-    data.bit(0,7) = bsd1.releaseDuration;
+    data.bit(0,1) = bsd1.releaseDuration;
   }
 
   if(address == 9) {
@@ -98,7 +98,7 @@ auto PI::ioWrite(u32 address, u32 data_) -> void {
     //PI_READ_LENGTH
     io.readLength = n24(data);
     io.dmaBusy = 1;
-    queue.insert(Queue::PI_DMA_Read, io.readLength * 36);
+    queue.insert(Queue::PI_DMA_Read, dmaDuration(true));
     dmaRead();
   }
 
@@ -106,7 +106,7 @@ auto PI::ioWrite(u32 address, u32 data_) -> void {
     //PI_WRITE_LENGTH
     io.writeLength = n24(data);
     io.dmaBusy = 1;
-    queue.insert(Queue::PI_DMA_Write, io.writeLength * 36);
+    queue.insert(Queue::PI_DMA_Write, dmaDuration(false));
     dmaWrite();
   }
 
@@ -136,12 +136,12 @@ auto PI::ioWrite(u32 address, u32 data_) -> void {
 
   if(address == 7) {
     //PI_BSD_DOM1_PGS
-    bsd1.pageSize = data.bit(0,7);
+    bsd1.pageSize = data.bit(0,3);
   }
 
   if(address == 8) {
     //PI_BSD_DOM1_RLS
-    bsd1.releaseDuration = data.bit(0,7);
+    bsd1.releaseDuration = data.bit(0,1);
   }
 
   if(address == 9) {

--- a/ares/n64/pi/pi.hpp
+++ b/ares/n64/pi/pi.hpp
@@ -22,6 +22,7 @@ struct PI : Memory::RCP<PI> {
   auto dmaRead() -> void;
   auto dmaWrite() -> void;
   auto dmaFinished() -> void;
+  auto dmaDuration(bool read) -> u32;
 
   //io.cpp
   auto ioRead(u32 address) -> u32;
@@ -55,8 +56,8 @@ struct PI : Memory::RCP<PI> {
   struct BSD {
     n8 latency;
     n8 pulseWidth;
-    n8 pageSize;
-    n8 releaseDuration;
+    n4 pageSize;
+    n2 releaseDuration;
   } bsd1, bsd2;
 };
 


### PR DESCRIPTION
The previous formula was a decent approximation, but it looks like 6105
antipiracy protection requires a better one (in addition to better RSP
timings that already went in).

Fixes https://github.com/ares-emulator/ares/issues/129 (Jet Force Gemini and Mickey Speedway USA)