### PR TITLE
n64: correct implementation of out of bounds RDRAM reads and writes

### DIFF
--- a/ares/n64/rdram/rdram.hpp
+++ b/ares/n64/rdram/rdram.hpp
@@ -2,7 +2,20 @@
 
 struct RDRAM : Memory::RCP<RDRAM> {
   Node::Object node;
-  Memory::Writable ram;
+
+  struct Writable : public Memory::Writable {
+    template<u32 Size>
+    auto read(u32 address) -> u64 {
+      if (address >= size) return 0;
+      return Memory::Writable::read<Size>(address);
+    }
+
+    template<u32 Size>
+    auto write(u32 address, u64 value) -> void {
+      if (address >= size) return;
+      Memory::Writable::write<Size>(address, value);
+    }
+  } ram;
 
   struct Debugger {
     //debugger.cpp


### PR DESCRIPTION
There is no RDRAM mirroring. All addresses from 0x0000_0000 to 0x03EF_FFFF go to the RI which puts the correct packet on the RDRAM bus. Then, given the standard mapping of RDRAM chips configured by IPL3 at boot, no chips will reply to packets on addresses > 8 MiB (or 4 MiB without the expansion pak) and thus writes will be ignored, and the RI will make reads return 0.