### PR TITLE
n64: implement rsp vu pipeline timings

### DIFF
--- a/ares/n64/rsp/decoder.cpp
+++ b/ares/n64/rsp/decoder.cpp
@@ -1,0 +1,368 @@
+#define jp(id, name, ...) case id: return decoder##name(instruction)
+#define op(id, name, ...) case id: { OpInfo info = {}; __VA_ARGS__; return info; }
+
+#define RD    (instruction >> 11 & 31)
+#define RT    (instruction >> 16 & 31)
+#define RS    (instruction >> 21 & 31)
+#define VD    (instruction >>  6 & 31)
+#define VS    (instruction >> 11 & 31)
+#define VT    (instruction >> 16 & 31)
+
+#define RUse(n)  info.r.use |= 1 << n
+#define RDef(n)  info.r.def |= 1 << n
+#define RDefB(n) (void)0  //bypassable
+#define VUse(n)  info.v.use |= 1 << n
+#define VDef(n)  info.v.def |= 1 << n
+#define VGUse(n) info.v.use |= 0xff << (n & ~7)
+#define VGDef(n) info.v.def |= 0xff << (n & ~7)
+#define Load     info.flags |= OpInfo::Load
+#define Store    info.flags |= OpInfo::Store
+#define Branch   info.flags |= OpInfo::Branch
+#define Vector   info.flags |= OpInfo::Vector
+
+auto RSP::decoderEXECUTE(u32 instruction) const -> OpInfo {
+  switch(instruction >> 26) {
+  jp(0x00, SPECIAL);
+  jp(0x01, REGIMM);
+  op(0x02, J, Branch);
+  op(0x03, JAL, Branch);
+  op(0x04, BEQ, RUse(RS), RUse(RT), Branch);
+  op(0x05, BNE, RUse(RS), RUse(RT), Branch);
+  op(0x06, BLEZ, RUse(RS), Branch);
+  op(0x07, BGTZ, RUse(RS), Branch);
+  op(0x08, ADDI, RDefB(RT), RUse(RS));
+  op(0x09, ADDIU, RDefB(RT), RUse(RS));
+  op(0x0a, SLTI, RDefB(RT), RUse(RS));
+  op(0x0b, SLTIU, RDefB(RT), RUse(RS));
+  op(0x0c, ANDI, RDefB(RT), RUse(RS));
+  op(0x0d, ORI, RDefB(RT), RUse(RS));
+  op(0x0e, XORI, RDefB(RT), RUse(RS));
+  op(0x0f, LUI, RDefB(RT));
+  jp(0x10, SCC);
+  op(0x11, INVALID);  //COP1
+  jp(0x12, VU);
+  op(0x13, INVALID);  //COP3
+  op(0x14, INVALID);  //BEQL
+  op(0x15, INVALID);  //BNEL
+  op(0x16, INVALID);  //BLEZL
+  op(0x17, INVALID);  //BGTZL
+  op(0x18, INVALID);  //DADDI
+  op(0x19, INVALID);  //DADDIU
+  op(0x1a, INVALID);  //LDL
+  op(0x1b, INVALID);  //LDR
+  op(0x1c, INVALID);
+  op(0x1d, INVALID);
+  op(0x1e, INVALID);
+  op(0x1f, INVALID);
+  op(0x20, LB, RDef(RT), RUse(RS), Load);
+  op(0x21, LH, RDef(RT), RUse(RS), Load);
+  op(0x22, INVALID);  //LWL
+  op(0x23, LW, RDef(RT), RUse(RS), Load);
+  op(0x24, LBU, RDef(RT), RUse(RS), Load);
+  op(0x25, LHU, RDef(RT), RUse(RS), Load);
+  op(0x26, INVALID);  //LWR
+  op(0x27, LWU, RDef(RT), RUse(RS), Load);
+  op(0x28, SB, RUse(RT), RUse(RS), Store);
+  op(0x29, SH, RUse(RT), RUse(RS), Store);
+  op(0x2a, INVALID);  //SWL
+  op(0x2b, SW, RUse(RT), RUse(RS), Store);
+  op(0x2c, INVALID);  //SDL
+  op(0x2d, INVALID);  //SDR
+  op(0x2e, INVALID);  //SWR
+  op(0x2f, INVALID);  //CACHE
+  op(0x30, INVALID);  //LL
+  op(0x31, INVALID);  //LWC1
+  jp(0x32, LWC2);
+  op(0x33, INVALID);  //LWC3
+  op(0x34, INVALID);  //LLD
+  op(0x35, INVALID);  //LDC1
+  op(0x36, INVALID);  //LDC2
+  op(0x37, INVALID);  //LD
+  op(0x38, INVALID);  //SC
+  op(0x39, INVALID);  //SWC1
+  jp(0x3a, SWC2);
+  op(0x3b, INVALID);  //SWC3
+  op(0x3c, INVALID);  //SCD
+  op(0x3d, INVALID);  //SDC1
+  op(0x3e, INVALID);  //SDC2
+  op(0x3f, INVALID);  //SD
+  }
+  return {};
+}
+
+auto RSP::decoderSPECIAL(u32 instruction) const -> OpInfo {
+  switch(instruction & 0x3f) {
+  op(0x00, SLL, RDefB(RD), RUse(RT));
+  op(0x01, INVALID);
+  op(0x02, SRL, RDefB(RD), RUse(RT));
+  op(0x03, SRA, RDefB(RD), RUse(RT));
+  op(0x04, SLLV, RDefB(RD), RUse(RT), RUse(RS));
+  op(0x05, INVALID);
+  op(0x06, SRLV, RDefB(RD), RUse(RT), RUse(RS));
+  op(0x07, SRAV, RDefB(RD), RUse(RT), RUse(RS));
+  op(0x08, JR, RUse(RS), Branch);
+  op(0x09, JALR, RDefB(RD), RUse(RS), Branch);
+  op(0x0a, INVALID);
+  op(0x0b, INVALID);
+  op(0x0c, INVALID);  //SYSCALL
+  op(0x0d, BREAK, Branch);
+  op(0x0e, INVALID);
+  op(0x0f, INVALID);  //SYNC
+  op(0x10, INVALID);  //MFHI
+  op(0x11, INVALID);  //MTHI
+  op(0x12, INVALID);  //MFLO
+  op(0x13, INVALID);  //MTLO
+  op(0x14, INVALID);  //DSLLV
+  op(0x15, INVALID);
+  op(0x16, INVALID);  //DSRLV
+  op(0x17, INVALID);  //DSRAV
+  op(0x18, INVALID);  //MULT
+  op(0x19, INVALID);  //MULTU
+  op(0x1a, INVALID);  //DIV
+  op(0x1b, INVALID);  //DIVU
+  op(0x1c, INVALID);  //DMULT
+  op(0x1d, INVALID);  //DMULTU
+  op(0x1e, INVALID);  //DDIV
+  op(0x1f, INVALID);  //DDIVU
+  op(0x20, ADDU, RDefB(RD), RUse(RS), RUse(RT));  //ADD
+  op(0x21, ADDU, RDefB(RD), RUse(RS), RUse(RT));
+  op(0x22, SUBU, RDefB(RD), RUse(RS), RUse(RT));  //SUB
+  op(0x23, SUBU, RDefB(RD), RUse(RS), RUse(RT));
+  op(0x24, AND, RDefB(RD), RUse(RS), RUse(RT));
+  op(0x25, OR, RDefB(RD), RUse(RS), RUse(RT));
+  op(0x26, XOR, RDefB(RD), RUse(RS), RUse(RT));
+  op(0x27, NOR, RDefB(RD), RUse(RS), RUse(RT));
+  op(0x28, INVALID);
+  op(0x29, INVALID);
+  op(0x2a, SLT, RDefB(RD), RUse(RS), RUse(RT));
+  op(0x2b, SLTU, RDefB(RD), RUse(RS), RUse(RT));
+  op(0x2c, INVALID);  //DADD
+  op(0x2d, INVALID);  //DADDU
+  op(0x2e, INVALID);  //DSUB
+  op(0x2f, INVALID);  //DSUBU
+  op(0x30, INVALID);  //TGE
+  op(0x31, INVALID);  //TGEU
+  op(0x32, INVALID);  //TLT
+  op(0x33, INVALID);  //TLTU
+  op(0x34, INVALID);  //TEQ
+  op(0x35, INVALID);
+  op(0x36, INVALID);  //TNE
+  op(0x37, INVALID);
+  op(0x38, INVALID);  //DSLL
+  op(0x39, INVALID);
+  op(0x3a, INVALID);  //DSRL
+  op(0x3b, INVALID);  //DSRA
+  op(0x3c, INVALID);  //DSLL32
+  op(0x3d, INVALID);
+  op(0x3e, INVALID);  //DSRL32
+  op(0x3f, INVALID);  //DSRA32
+  }
+  return {};
+}
+
+auto RSP::decoderREGIMM(u32 instruction) const -> OpInfo {
+  switch(instruction >> 16 & 0x1f) {
+  op(0x00, BLTZ, RUse(RS), Branch);
+  op(0x01, BGEZ, RUse(RS), Branch);
+  op(0x02, INVALID);  //BLTZL
+  op(0x03, INVALID);  //BGEZL
+  op(0x04, INVALID);
+  op(0x05, INVALID);
+  op(0x06, INVALID);
+  op(0x07, INVALID);
+  op(0x08, INVALID);  //TGEI
+  op(0x09, INVALID);  //TGEIU
+  op(0x0a, INVALID);  //TLTI
+  op(0x0b, INVALID);  //TLTIU
+  op(0x0c, INVALID);  //TEQI
+  op(0x0d, INVALID);
+  op(0x0e, INVALID);  //TNEI
+  op(0x0f, INVALID);
+  op(0x10, BLTZAL, RUse(RS), Branch);
+  op(0x11, BGEZAL, RUse(RS), Branch);
+  op(0x12, INVALID);  //BLTZALL
+  op(0x13, INVALID);  //BGEZALL
+  op(0x14, INVALID);
+  op(0x15, INVALID);
+  op(0x16, INVALID);
+  op(0x17, INVALID);
+  op(0x18, INVALID);
+  op(0x19, INVALID);
+  op(0x1a, INVALID);
+  op(0x1b, INVALID);
+  op(0x1c, INVALID);
+  op(0x1d, INVALID);
+  op(0x1e, INVALID);
+  op(0x1f, INVALID);
+  }
+  return {};
+}
+
+auto RSP::decoderSCC(u32 instruction) const -> OpInfo {
+  switch(instruction >> 21 & 0x1f) {
+  op(0x00, MFC0, RDef(RT), Load, Store);
+  op(0x01, INVALID);  //DMFC0
+  op(0x02, INVALID);  //CFC0
+  op(0x03, INVALID);
+  op(0x04, MTC0, RUse(RT), Load, Store);
+  op(0x05, INVALID);  //DMTC0
+  op(0x06, INVALID);  //CTC0
+  op(0x07, INVALID);
+  op(0x08, INVALID);  //BC0
+  op(0x09, INVALID);
+  op(0x0a, INVALID);
+  op(0x0b, INVALID);
+  op(0x0c, INVALID);
+  op(0x0d, INVALID);
+  op(0x0e, INVALID);
+  op(0x0f, INVALID);
+  }
+  return {};
+}
+
+auto RSP::decoderVU(u32 instruction) const -> OpInfo {
+  switch(instruction >> 21 & 0x1f) {
+  op(0x00, MFC2, RDef(RT), VUse(VS), Load, Store);
+  op(0x01, INVALID);  //DMFC2
+  op(0x02, CFC2, RDef(RT), Load, Store);
+  op(0x03, INVALID);
+  op(0x04, MTC2, RUse(RT), VDef(VS), Load, Store);
+  op(0x05, INVALID);  //DMTC2
+  op(0x06, CTC2, RUse(RT), Load, Store);
+  op(0x07, INVALID);
+  op(0x08, INVALID);  //BC2
+  op(0x09, INVALID);
+  op(0x0a, INVALID);
+  op(0x0b, INVALID);
+  op(0x0c, INVALID);
+  op(0x0d, INVALID);
+  op(0x0e, INVALID);
+  op(0x0f, INVALID);
+  }
+
+  switch(instruction & 0x3f) {
+  op(0x00, VMULF, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x01, VMULU, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x02, VRNDP, VDef(VD), VUse(VT), Vector);
+  op(0x03, VMULQ, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x04, VMUDL, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x05, VMUDM, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x06, VMUDN, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x07, VMUDH, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x08, VMACF, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x09, VMACU, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x0a, VRNDN, VDef(VD), VUse(VT), Vector);
+  op(0x0b, VMACQ, VDef(VD), Vector);
+  op(0x0c, VMADL, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x0d, VMADM, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x0e, VMADN, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x0f, VMADH, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x10, VADD, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x11, VSUB, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x12, VZERO, Vector);  //VSUT
+  op(0x13, VABS, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x14, VADDC, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x15, VSUBC, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x16, VZERO, Vector);  //VADDB
+  op(0x17, VZERO, Vector);  //VSUBB
+  op(0x18, VZERO, Vector);  //VACCB
+  op(0x19, VZERO, Vector);  //VSUCB
+  op(0x1a, VZERO, Vector);  //VSAD
+  op(0x1b, VZERO, Vector);  //VSAC
+  op(0x1c, VZERO, Vector);  //VSUM
+  op(0x1d, VSAR, VDef(VD), Vector);
+  op(0x1e, VZERO, Vector);
+  op(0x1f, VZERO, Vector);
+  op(0x20, VLT, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x21, VEQ, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x22, VNE, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x23, VGE, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x24, VCL, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x25, VCH, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x26, VCR, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x27, VMRG, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x28, VAND, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x29, VNAND, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x2a, VOR, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x2b, VNOR, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x2c, VXOR, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x2d, VNXOR, VDef(VD), VUse(VS), VUse(VT), Vector);
+  op(0x2e, VZERO, Vector);
+  op(0x2f, VZERO, Vector);
+  op(0x30, VRCP, VDef(VD), VUse(VT), Vector);
+  op(0x31, VRCPL, VDef(VD), VUse(VT), Vector);
+  op(0x32, VRCPH, VDef(VD), VUse(VT), Vector);
+  op(0x33, VMOV, VDef(VD), VUse(VT), Vector);
+  op(0x34, VRSQ, VDef(VD), VUse(VT), Vector);
+  op(0x35, VRSQL, VDef(VD), VUse(VT), Vector);
+  op(0x36, VRSQH, VDef(VD), VUse(VT), Vector);
+  op(0x37, VNOP, Vector);
+  op(0x38, VZERO, Vector);  //VEXTT
+  op(0x39, VZERO, Vector);  //VEXTQ
+  op(0x3a, VZERO, Vector);  //VEXTN
+  op(0x3b, VZERO, Vector);
+  op(0x3c, VZERO, Vector);  //VINST
+  op(0x3d, VZERO, Vector);  //VINSQ
+  op(0x3e, VZERO, Vector);  //VINSN
+  op(0x3f, VNOP, Vector);  //VNULL
+  }
+  return {};
+}
+
+auto RSP::decoderLWC2(u32 instruction) const -> OpInfo {
+  switch(instruction >> 11 & 0x1f) {
+  op(0x00, LBV, VDef(VT), RUse(RS), Load);
+  op(0x01, LSV, VDef(VT), RUse(RS), Load);
+  op(0x02, LLV, VDef(VT), RUse(RS), Load);
+  op(0x03, LDV, VDef(VT), RUse(RS), Load);
+  op(0x04, LQV, VDef(VT), RUse(RS), Load);
+  op(0x05, LRV, VDef(VT), RUse(RS), Load);
+  op(0x06, LPV, VDef(VT), RUse(RS), Load);
+  op(0x07, LUV, VDef(VT), RUse(RS), Load);
+  op(0x08, LHV, VDef(VT), RUse(RS), Load);
+  op(0x09, LFV, VDef(VT), RUse(RS), Load);
+//op(0x0a, LWV, VDef(VT), RUse(RS), Load);  //not present on N64 RSP
+  op(0x0b, LTV, VGDef(VT), RUse(RS), Load);
+  }
+  return {};
+}
+
+auto RSP::decoderSWC2(u32 instruction) const -> OpInfo {
+  switch(instruction >> 11 & 0x1f) {
+  op(0x00, SBV, VUse(VT), RUse(RS), Store);
+  op(0x01, SSV, VUse(VT), RUse(RS), Store);
+  op(0x02, SLV, VUse(VT), RUse(RS), Store);
+  op(0x03, SDV, VUse(VT), RUse(RS), Store);
+  op(0x04, SQV, VUse(VT), RUse(RS), Store);
+  op(0x05, SRV, VUse(VT), RUse(RS), Store);
+  op(0x06, SPV, VUse(VT), RUse(RS), Store);
+  op(0x07, SUV, VUse(VT), RUse(RS), Store);
+  op(0x08, SHV, VUse(VT), RUse(RS), Store);
+  op(0x09, SFV, VUse(VT), RUse(RS), Store);
+  op(0x0a, SWV, VUse(VT), RUse(RS), Store);
+  op(0x0b, STV, VGUse(VT), RUse(RS), Store);
+  }
+  return {};
+}
+
+#undef RUse
+#undef RDef
+#undef RDefB
+#undef VUse
+#undef VDef
+#undef VGUse
+#undef VGDef
+#undef Load
+#undef Store
+#undef Branch
+#undef Vector
+
+#undef RD
+#undef RT
+#undef RS
+#undef VD
+#undef VS
+#undef VT
+
+#undef jp
+#undef op

--- a/ares/n64/rsp/interpreter.cpp
+++ b/ares/n64/rsp/interpreter.cpp
@@ -6,10 +6,10 @@
 #define VS vpu.r[VSn]
 #define VT vpu.r[VTn]
 
-#define jp(id, name, ...) case id: return decoder##name(__VA_ARGS__)
-#define op(id, flags, name, ...) case id: pipeline flags; return name(__VA_ARGS__)
-#define br(id, flags, name, ...) case id: pipeline flags; return name(__VA_ARGS__)
-#define vu(id, flags, name, ...) case id: pipeline flags; \
+#define jp(id, name, ...) case id: return interpreter##name(__VA_ARGS__)
+#define op(id, name, ...) case id: return name(__VA_ARGS__)
+#define br(id, name, ...) case id: return name(__VA_ARGS__)
+#define vu(id, name, ...) case id: \
   switch(E) { \
   case 0x0: return name<0x0>(__VA_ARGS__); \
   case 0x1: return name<0x1>(__VA_ARGS__); \
@@ -41,338 +41,333 @@
 #define IMMu16 u16(OP)
 #define IMMu26 (OP & 0x03ff'ffff)
 
-#define R .regRead
-#define W .regWrite
-#define L .load()
-#define S .store()
-
-auto RSP::decoderEXECUTE() -> void {
+auto RSP::interpreterEXECUTE() -> void {
   switch(OP >> 26) {
   jp(0x00, SPECIAL);
   jp(0x01, REGIMM);
-  br(0x02,                , J, IMMu26);
-  br(0x03,                , JAL, IMMu26);
-  br(0x04, R(RSn) R(RTn)  , BEQ, RS, RT, IMMi16);
-  br(0x05, R(RSn) R(RTn)  , BNE, RS, RT, IMMi16);
-  br(0x06, R(RSn)         , BLEZ, RS, IMMi16);
-  br(0x07, R(RSn)         , BGTZ, RS, IMMi16);
-  op(0x08, R(RSn)         , ADDIU, RT, RS, IMMi16);  //ADDI
-  op(0x09, R(RSn)         , ADDIU, RT, RS, IMMi16);
-  op(0x0a, R(RSn)         , SLTI, RT, RS, IMMi16);
-  op(0x0b, R(RSn)         , SLTIU, RT, RS, IMMi16);
-  op(0x0c, R(RSn)         , ANDI, RT, RS, IMMu16);
-  op(0x0d, R(RSn)         , ORI, RT, RS, IMMu16);
-  op(0x0e, R(RSn)         , XORI, RT, RS, IMMu16);
-  op(0x0f,                , LUI, RT, IMMu16);
+  br(0x02, J, IMMu26);
+  br(0x03, JAL, IMMu26);
+  br(0x04, BEQ, RS, RT, IMMi16);
+  br(0x05, BNE, RS, RT, IMMi16);
+  br(0x06, BLEZ, RS, IMMi16);
+  br(0x07, BGTZ, RS, IMMi16);
+  op(0x08, ADDIU, RT, RS, IMMi16);  //ADDI
+  op(0x09, ADDIU, RT, RS, IMMi16);
+  op(0x0a, SLTI, RT, RS, IMMi16);
+  op(0x0b, SLTIU, RT, RS, IMMi16);
+  op(0x0c, ANDI, RT, RS, IMMu16);
+  op(0x0d, ORI, RT, RS, IMMu16);
+  op(0x0e, XORI, RT, RS, IMMu16);
+  op(0x0f, LUI, RT, IMMu16);
   jp(0x10, SCC);
-  op(0x11,                , INVALID);  //COP1
+  op(0x11, INVALID);  //COP1
   jp(0x12, VU);
-  op(0x13,                , INVALID);  //COP3
-  op(0x14,                , INVALID);  //BEQL
-  op(0x15,                , INVALID);  //BNEL
-  op(0x16,                , INVALID);  //BLEZL
-  op(0x17,                , INVALID);  //BGTZL
-  op(0x18,                , INVALID);  //DADDI
-  op(0x19,                , INVALID);  //DADDIU
-  op(0x1a,                , INVALID);  //LDL
-  op(0x1b,                , INVALID);  //LDR
-  op(0x1c,                , INVALID);
-  op(0x1d,                , INVALID);
-  op(0x1e,                , INVALID);
-  op(0x1f,                , INVALID);
-  op(0x20, R(RSn) W(RTn) L, LB, RT, RS, IMMi16);
-  op(0x21, R(RSn) W(RTn) L, LH, RT, RS, IMMi16);
-  op(0x22,                , INVALID);  //LWL
-  op(0x23, R(RSn) W(RTn) L, LW, RT, RS, IMMi16);
-  op(0x24, R(RSn) W(RTn) L, LBU, RT, RS, IMMi16);
-  op(0x25, R(RSn) W(RTn) L, LHU, RT, RS, IMMi16);
-  op(0x26,                , INVALID);  //LWR
-  op(0x27, R(RSn) W(RTn) L, LWU, RT, RS, IMMi16);
-  op(0x28, R(RTn) R(RSn) S, SB, RT, RS, IMMi16);
-  op(0x29, R(RTn) R(RSn) S, SH, RT, RS, IMMi16);
-  op(0x2a,                , INVALID);  //SWL
-  op(0x2b, R(RTn) R(RSn) S, SW, RT, RS, IMMi16);
-  op(0x2c,                , INVALID);  //SDL
-  op(0x2d,                , INVALID);  //SDR
-  op(0x2e,                , INVALID);  //SWR
-  op(0x2f,                , INVALID);  //CACHE
-  op(0x30,                , INVALID);  //LL
-  op(0x31,                , INVALID);  //LWC1
+  op(0x13, INVALID);  //COP3
+  op(0x14, INVALID);  //BEQL
+  op(0x15, INVALID);  //BNEL
+  op(0x16, INVALID);  //BLEZL
+  op(0x17, INVALID);  //BGTZL
+  op(0x18, INVALID);  //DADDI
+  op(0x19, INVALID);  //DADDIU
+  op(0x1a, INVALID);  //LDL
+  op(0x1b, INVALID);  //LDR
+  op(0x1c, INVALID);
+  op(0x1d, INVALID);
+  op(0x1e, INVALID);
+  op(0x1f, INVALID);
+  op(0x20, LB, RT, RS, IMMi16);
+  op(0x21, LH, RT, RS, IMMi16);
+  op(0x22, INVALID);  //LWL
+  op(0x23, LW, RT, RS, IMMi16);
+  op(0x24, LBU, RT, RS, IMMi16);
+  op(0x25, LHU, RT, RS, IMMi16);
+  op(0x26, INVALID);  //LWR
+  op(0x27, LWU, RT, RS, IMMi16);
+  op(0x28, SB, RT, RS, IMMi16);
+  op(0x29, SH, RT, RS, IMMi16);
+  op(0x2a, INVALID);  //SWL
+  op(0x2b, SW, RT, RS, IMMi16);
+  op(0x2c, INVALID);  //SDL
+  op(0x2d, INVALID);  //SDR
+  op(0x2e, INVALID);  //SWR
+  op(0x2f, INVALID);  //CACHE
+  op(0x30, INVALID);  //LL
+  op(0x31, INVALID);  //LWC1
   jp(0x32, LWC2);
-  op(0x33,                , INVALID);  //LWC3
-  op(0x34,                , INVALID);  //LLD
-  op(0x35,                , INVALID);  //LDC1
-  op(0x36,                , INVALID);  //LDC2
-  op(0x37,                , INVALID);  //LD
-  op(0x38,                , INVALID);  //SC
-  op(0x39,                , INVALID);  //SWC1
+  op(0x33, INVALID);  //LWC3
+  op(0x34, INVALID);  //LLD
+  op(0x35, INVALID);  //LDC1
+  op(0x36, INVALID);  //LDC2
+  op(0x37, INVALID);  //LD
+  op(0x38, INVALID);  //SC
+  op(0x39, INVALID);  //SWC1
   jp(0x3a, SWC2);
-  op(0x3b,                , INVALID);  //SWC3
-  op(0x3c,                , INVALID);  //SCD
-  op(0x3d,                , INVALID);  //SDC1
-  op(0x3e,                , INVALID);  //SDC2
-  op(0x3f,                , INVALID);  //SD
+  op(0x3b, INVALID);  //SWC3
+  op(0x3c, INVALID);  //SCD
+  op(0x3d, INVALID);  //SDC1
+  op(0x3e, INVALID);  //SDC2
+  op(0x3f, INVALID);  //SD
   }
 }
 
-auto RSP::decoderSPECIAL() -> void {
+auto RSP::interpreterSPECIAL() -> void {
   switch(OP & 0x3f) {
-  op(0x00, R(RTn)       , SLL, RD, RT, SA);
-  op(0x01,              , INVALID);
-  op(0x02, R(RTn)       , SRL, RD, RT, SA);
-  op(0x03, R(RTn)       , SRA, RD, RT, SA);
-  op(0x04, R(RTn) R(RSn), SLLV, RD, RT, RS);
-  op(0x05,              , INVALID);
-  op(0x06, R(RTn) R(RSn), SRLV, RD, RT, RS);
-  op(0x07, R(RTn) R(RSn), SRAV, RD, RT, RS);
-  br(0x08, R(RSn)       , JR, RS);
-  br(0x09, R(RSn)       , JALR, RD, RS);
-  op(0x0a,              , INVALID);
-  op(0x0b,              , INVALID);
-  op(0x0c,              , INVALID);  //SYSCALL
-  br(0x0d,              , BREAK);
-  op(0x0e,              , INVALID);
-  op(0x0f,              , INVALID);  //SYNC
-  op(0x10,              , INVALID);  //MFHI
-  op(0x11,              , INVALID);  //MTHI
-  op(0x12,              , INVALID);  //MFLO
-  op(0x13,              , INVALID);  //MTLO
-  op(0x14,              , INVALID);  //DSLLV
-  op(0x15,              , INVALID);
-  op(0x16,              , INVALID);  //DSRLV
-  op(0x17,              , INVALID);  //DSRAV
-  op(0x18,              , INVALID);  //MULT
-  op(0x19,              , INVALID);  //MULTU
-  op(0x1a,              , INVALID);  //DIV
-  op(0x1b,              , INVALID);  //DIVU
-  op(0x1c,              , INVALID);  //DMULT
-  op(0x1d,              , INVALID);  //DMULTU
-  op(0x1e,              , INVALID);  //DDIV
-  op(0x1f,              , INVALID);  //DDIVU
-  op(0x20, R(RSn) R(RTn), ADDU, RD, RS, RT);  //ADD
-  op(0x21, R(RSn) R(RTn), ADDU, RD, RS, RT);
-  op(0x22, R(RSn) R(RTn), SUBU, RD, RS, RT);  //SUB
-  op(0x23, R(RSn) R(RTn), SUBU, RD, RS, RT);
-  op(0x24, R(RSn) R(RTn), AND, RD, RS, RT);
-  op(0x25, R(RSn) R(RTn), OR, RD, RS, RT);
-  op(0x26, R(RSn) R(RTn), XOR, RD, RS, RT);
-  op(0x27, R(RSn) R(RTn), NOR, RD, RS, RT);
-  op(0x28,              , INVALID);
-  op(0x29,              , INVALID);
-  op(0x2a, R(RSn) R(RTn), SLT, RD, RS, RT);
-  op(0x2b, R(RSn) R(RTn), SLTU, RD, RS, RT);
-  op(0x2c,              , INVALID);  //DADD
-  op(0x2d,              , INVALID);  //DADDU
-  op(0x2e,              , INVALID);  //DSUB
-  op(0x2f,              , INVALID);  //DSUBU
-  op(0x30,              , INVALID);  //TGE
-  op(0x31,              , INVALID);  //TGEU
-  op(0x32,              , INVALID);  //TLT
-  op(0x33,              , INVALID);  //TLTU
-  op(0x34,              , INVALID);  //TEQ
-  op(0x35,              , INVALID);
-  op(0x36,              , INVALID);  //TNE
-  op(0x37,              , INVALID);
-  op(0x38,              , INVALID);  //DSLL
-  op(0x39,              , INVALID);
-  op(0x3a,              , INVALID);  //DSRL
-  op(0x3b,              , INVALID);  //DSRA
-  op(0x3c,              , INVALID);  //DSLL32
-  op(0x3d,              , INVALID);
-  op(0x3e,              , INVALID);  //DSRL32
-  op(0x3f,              , INVALID);  //DSRA32
+  op(0x00, SLL, RD, RT, SA);
+  op(0x01, INVALID);
+  op(0x02, SRL, RD, RT, SA);
+  op(0x03, SRA, RD, RT, SA);
+  op(0x04, SLLV, RD, RT, RS);
+  op(0x05, INVALID);
+  op(0x06, SRLV, RD, RT, RS);
+  op(0x07, SRAV, RD, RT, RS);
+  br(0x08, JR, RS);
+  br(0x09, JALR, RD, RS);
+  op(0x0a, INVALID);
+  op(0x0b, INVALID);
+  op(0x0c, INVALID);  //SYSCALL
+  br(0x0d, BREAK);
+  op(0x0e, INVALID);
+  op(0x0f, INVALID);  //SYNC
+  op(0x10, INVALID);  //MFHI
+  op(0x11, INVALID);  //MTHI
+  op(0x12, INVALID);  //MFLO
+  op(0x13, INVALID);  //MTLO
+  op(0x14, INVALID);  //DSLLV
+  op(0x15, INVALID);
+  op(0x16, INVALID);  //DSRLV
+  op(0x17, INVALID);  //DSRAV
+  op(0x18, INVALID);  //MULT
+  op(0x19, INVALID);  //MULTU
+  op(0x1a, INVALID);  //DIV
+  op(0x1b, INVALID);  //DIVU
+  op(0x1c, INVALID);  //DMULT
+  op(0x1d, INVALID);  //DMULTU
+  op(0x1e, INVALID);  //DDIV
+  op(0x1f, INVALID);  //DDIVU
+  op(0x20, ADDU, RD, RS, RT);  //ADD
+  op(0x21, ADDU, RD, RS, RT);
+  op(0x22, SUBU, RD, RS, RT);  //SUB
+  op(0x23, SUBU, RD, RS, RT);
+  op(0x24, AND, RD, RS, RT);
+  op(0x25, OR, RD, RS, RT);
+  op(0x26, XOR, RD, RS, RT);
+  op(0x27, NOR, RD, RS, RT);
+  op(0x28, INVALID);
+  op(0x29, INVALID);
+  op(0x2a, SLT, RD, RS, RT);
+  op(0x2b, SLTU, RD, RS, RT);
+  op(0x2c, INVALID);  //DADD
+  op(0x2d, INVALID);  //DADDU
+  op(0x2e, INVALID);  //DSUB
+  op(0x2f, INVALID);  //DSUBU
+  op(0x30, INVALID);  //TGE
+  op(0x31, INVALID);  //TGEU
+  op(0x32, INVALID);  //TLT
+  op(0x33, INVALID);  //TLTU
+  op(0x34, INVALID);  //TEQ
+  op(0x35, INVALID);
+  op(0x36, INVALID);  //TNE
+  op(0x37, INVALID);
+  op(0x38, INVALID);  //DSLL
+  op(0x39, INVALID);
+  op(0x3a, INVALID);  //DSRL
+  op(0x3b, INVALID);  //DSRA
+  op(0x3c, INVALID);  //DSLL32
+  op(0x3d, INVALID);
+  op(0x3e, INVALID);  //DSRL32
+  op(0x3f, INVALID);  //DSRA32
   }
 }
 
-auto RSP::decoderREGIMM() -> void {
+auto RSP::interpreterREGIMM() -> void {
   switch(OP >> 16 & 0x1f) {
-  br(0x00, R(RSn), BLTZ, RS, IMMi16);
-  br(0x01, R(RSn), BGEZ, RS, IMMi16);
-  op(0x02,       , INVALID);  //BLTZL
-  op(0x03,       , INVALID);  //BGEZL
-  op(0x04,       , INVALID);
-  op(0x05,       , INVALID);
-  op(0x06,       , INVALID);
-  op(0x07,       , INVALID);
-  op(0x08,       , INVALID);  //TGEI
-  op(0x09,       , INVALID);  //TGEIU
-  op(0x0a,       , INVALID);  //TLTI
-  op(0x0b,       , INVALID);  //TLTIU
-  op(0x0c,       , INVALID);  //TEQI
-  op(0x0d,       , INVALID);
-  op(0x0e,       , INVALID);  //TNEI
-  op(0x0f,       , INVALID);
-  br(0x10, R(RSn), BLTZAL, RS, IMMi16);
-  br(0x11, R(RSn), BGEZAL, RS, IMMi16);
-  op(0x12,       , INVALID);  //BLTZALL
-  op(0x13,       , INVALID);  //BGEZALL
-  op(0x14,       , INVALID);
-  op(0x15,       , INVALID);
-  op(0x16,       , INVALID);
-  op(0x17,       , INVALID);
-  op(0x18,       , INVALID);
-  op(0x19,       , INVALID);
-  op(0x1a,       , INVALID);
-  op(0x1b,       , INVALID);
-  op(0x1c,       , INVALID);
-  op(0x1d,       , INVALID);
-  op(0x1e,       , INVALID);
-  op(0x1f,       , INVALID);
+  br(0x00, BLTZ, RS, IMMi16);
+  br(0x01, BGEZ, RS, IMMi16);
+  op(0x02, INVALID);  //BLTZL
+  op(0x03, INVALID);  //BGEZL
+  op(0x04, INVALID);
+  op(0x05, INVALID);
+  op(0x06, INVALID);
+  op(0x07, INVALID);
+  op(0x08, INVALID);  //TGEI
+  op(0x09, INVALID);  //TGEIU
+  op(0x0a, INVALID);  //TLTI
+  op(0x0b, INVALID);  //TLTIU
+  op(0x0c, INVALID);  //TEQI
+  op(0x0d, INVALID);
+  op(0x0e, INVALID);  //TNEI
+  op(0x0f, INVALID);
+  br(0x10, BLTZAL, RS, IMMi16);
+  br(0x11, BGEZAL, RS, IMMi16);
+  op(0x12, INVALID);  //BLTZALL
+  op(0x13, INVALID);  //BGEZALL
+  op(0x14, INVALID);
+  op(0x15, INVALID);
+  op(0x16, INVALID);
+  op(0x17, INVALID);
+  op(0x18, INVALID);
+  op(0x19, INVALID);
+  op(0x1a, INVALID);
+  op(0x1b, INVALID);
+  op(0x1c, INVALID);
+  op(0x1d, INVALID);
+  op(0x1e, INVALID);
+  op(0x1f, INVALID);
   }
 }
 
-auto RSP::decoderSCC() -> void {
+auto RSP::interpreterSCC() -> void {
   switch(OP >> 21 & 0x1f) {
-  op(0x00, W(RTn) L S, MFC0, RT, RDn);
-  op(0x01,           , INVALID);  //DMFC0
-  op(0x02,           , INVALID);  //CFC0
-  op(0x03,           , INVALID);
-  op(0x04, R(RTn) L S, MTC0, RT, RDn);
-  op(0x05,           , INVALID);  //DMTC0
-  op(0x06,           , INVALID);  //CTC0
-  op(0x07,           , INVALID);
-  op(0x08,           , INVALID);  //BC0
-  op(0x09,           , INVALID);
-  op(0x0a,           , INVALID);
-  op(0x0b,           , INVALID);
-  op(0x0c,           , INVALID);
-  op(0x0d,           , INVALID);
-  op(0x0e,           , INVALID);
-  op(0x0f,           , INVALID);
+  op(0x00, MFC0, RT, RDn);
+  op(0x01, INVALID);  //DMFC0
+  op(0x02, INVALID);  //CFC0
+  op(0x03, INVALID);
+  op(0x04, MTC0, RT, RDn);
+  op(0x05, INVALID);  //DMTC0
+  op(0x06, INVALID);  //CTC0
+  op(0x07, INVALID);
+  op(0x08, INVALID);  //BC0
+  op(0x09, INVALID);
+  op(0x0a, INVALID);
+  op(0x0b, INVALID);
+  op(0x0c, INVALID);
+  op(0x0d, INVALID);
+  op(0x0e, INVALID);
+  op(0x0f, INVALID);
   }
 }
 
-auto RSP::decoderVU() -> void {
+auto RSP::interpreterVU() -> void {
   #define E (OP >> 7 & 15)
   switch(OP >> 21 & 0x1f) {
-  vu(0x00, W(RTn) L S, MFC2, RT, VS);
-  op(0x01,           , INVALID);  //DMFC2
-  op(0x02, W(RTn) L S, CFC2, RT, RDn);
-  op(0x03,           , INVALID);
-  vu(0x04, R(RTn) L S, MTC2, RT, VS);
-  op(0x05,           , INVALID);  //DMTC2
-  op(0x06, R(RTn) L S, CTC2, RT, RDn);
-  op(0x07,           , INVALID);
-  op(0x08,           , INVALID);  //BC2
-  op(0x09,           , INVALID);
-  op(0x0a,           , INVALID);
-  op(0x0b,           , INVALID);
-  op(0x0c,           , INVALID);
-  op(0x0d,           , INVALID);
-  op(0x0e,           , INVALID);
-  op(0x0f,           , INVALID);
+  vu(0x00, MFC2, RT, VS);
+  op(0x01, INVALID);  //DMFC2
+  op(0x02, CFC2, RT, RDn);
+  op(0x03, INVALID);
+  vu(0x04, MTC2, RT, VS);
+  op(0x05, INVALID);  //DMTC2
+  op(0x06, CTC2, RT, RDn);
+  op(0x07, INVALID);
+  op(0x08, INVALID);  //BC2
+  op(0x09, INVALID);
+  op(0x0a, INVALID);
+  op(0x0b, INVALID);
+  op(0x0c, INVALID);
+  op(0x0d, INVALID);
+  op(0x0e, INVALID);
+  op(0x0f, INVALID);
   }
   #undef E
 
   #define E  (OP >> 21 & 15)
   #define DE (OP >> 11 &  7)
   switch(OP & 0x3f) {
-  vu(0x00, , VMULF, VD, VS, VT);
-  vu(0x01, , VMULU, VD, VS, VT);
-  vu(0x02, , VRNDP, VD, VSn, VT);
-  vu(0x03, , VMULQ, VD, VS, VT);
-  vu(0x04, , VMUDL, VD, VS, VT);
-  vu(0x05, , VMUDM, VD, VS, VT);
-  vu(0x06, , VMUDN, VD, VS, VT);
-  vu(0x07, , VMUDH, VD, VS, VT);
-  vu(0x08, , VMACF, VD, VS, VT);
-  vu(0x09, , VMACU, VD, VS, VT);
-  vu(0x0a, , VRNDN, VD, VSn, VT);
-  op(0x0b, , VMACQ, VD);
-  vu(0x0c, , VMADL, VD, VS, VT);
-  vu(0x0d, , VMADM, VD, VS, VT);
-  vu(0x0e, , VMADN, VD, VS, VT);
-  vu(0x0f, , VMADH, VD, VS, VT);
-  vu(0x10, , VADD, VD, VS, VT);
-  vu(0x11, , VSUB, VD, VS, VT);
-  vu(0x12, , VZERO, VD, VS, VT); //VSUT
-  vu(0x13, , VABS, VD, VS, VT);
-  vu(0x14, , VADDC, VD, VS, VT);
-  vu(0x15, , VSUBC, VD, VS, VT);
-  vu(0x16, , VZERO, VD, VS, VT); //VADDB
-  vu(0x17, , VZERO, VD, VS, VT); //VSUBB
-  vu(0x18, , VZERO, VD, VS, VT); //VACCB
-  vu(0x19, , VZERO, VD, VS, VT); //VSUCB
-  vu(0x1a, , VZERO, VD, VS, VT); //VSAD
-  vu(0x1b, , VZERO, VD, VS, VT); //VSAC
-  vu(0x1c, , VZERO, VD, VS, VT); //VSUM
-  vu(0x1d, , VSAR, VD, VS);
-  vu(0x1e, , VZERO, VD, VS, VT);
-  vu(0x1f, , VZERO, VD, VS, VT);
-  vu(0x20, , VLT, VD, VS, VT);
-  vu(0x21, , VEQ, VD, VS, VT);
-  vu(0x22, , VNE, VD, VS, VT);
-  vu(0x23, , VGE, VD, VS, VT);
-  vu(0x24, , VCL, VD, VS, VT);
-  vu(0x25, , VCH, VD, VS, VT);
-  vu(0x26, , VCR, VD, VS, VT);
-  vu(0x27, , VMRG, VD, VS, VT);
-  vu(0x28, , VAND, VD, VS, VT);
-  vu(0x29, , VNAND, VD, VS, VT);
-  vu(0x2a, , VOR, VD, VS, VT);
-  vu(0x2b, , VNOR, VD, VS, VT);
-  vu(0x2c, , VXOR, VD, VS, VT);
-  vu(0x2d, , VNXOR, VD, VS, VT);
-  vu(0x2e, , VZERO, VD, VS, VT);
-  vu(0x2f, , VZERO, VD, VS, VT);
-  vu(0x30, , VRCP, VD, DE, VT);
-  vu(0x31, , VRCPL, VD, DE, VT);
-  vu(0x32, , VRCPH, VD, DE, VT);
-  vu(0x33, , VMOV, VD, DE, VT);
-  vu(0x34, , VRSQ, VD, DE, VT);
-  vu(0x35, , VRSQL, VD, DE, VT);
-  vu(0x36, , VRSQH, VD, DE, VT);
-  op(0x37, , VNOP);
-  vu(0x38, , VZERO, VD, VS, VT); //VEXTT
-  vu(0x39, , VZERO, VD, VS, VT); //VEXTQ
-  vu(0x3a, , VZERO, VD, VS, VT); //VEXTN
-  vu(0x3b, , VZERO, VD, VS, VT);
-  vu(0x3c, , VZERO, VD, VS, VT); //VINST
-  vu(0x3d, , VZERO, VD, VS, VT); //VINSQ
-  vu(0x3e, , VZERO, VD, VS, VT); //VINSN
-  op(0x3f, , VNOP); //VNULL
+  vu(0x00, VMULF, VD, VS, VT);
+  vu(0x01, VMULU, VD, VS, VT);
+  vu(0x02, VRNDP, VD, VSn, VT);
+  vu(0x03, VMULQ, VD, VS, VT);
+  vu(0x04, VMUDL, VD, VS, VT);
+  vu(0x05, VMUDM, VD, VS, VT);
+  vu(0x06, VMUDN, VD, VS, VT);
+  vu(0x07, VMUDH, VD, VS, VT);
+  vu(0x08, VMACF, VD, VS, VT);
+  vu(0x09, VMACU, VD, VS, VT);
+  vu(0x0a, VRNDN, VD, VSn, VT);
+  op(0x0b, VMACQ, VD);
+  vu(0x0c, VMADL, VD, VS, VT);
+  vu(0x0d, VMADM, VD, VS, VT);
+  vu(0x0e, VMADN, VD, VS, VT);
+  vu(0x0f, VMADH, VD, VS, VT);
+  vu(0x10, VADD, VD, VS, VT);
+  vu(0x11, VSUB, VD, VS, VT);
+  vu(0x12, VZERO, VD, VS, VT); //VSUT
+  vu(0x13, VABS, VD, VS, VT);
+  vu(0x14, VADDC, VD, VS, VT);
+  vu(0x15, VSUBC, VD, VS, VT);
+  vu(0x16, VZERO, VD, VS, VT); //VADDB
+  vu(0x17, VZERO, VD, VS, VT); //VSUBB
+  vu(0x18, VZERO, VD, VS, VT); //VACCB
+  vu(0x19, VZERO, VD, VS, VT); //VSUCB
+  vu(0x1a, VZERO, VD, VS, VT); //VSAD
+  vu(0x1b, VZERO, VD, VS, VT); //VSAC
+  vu(0x1c, VZERO, VD, VS, VT); //VSUM
+  vu(0x1d, VSAR, VD, VS);
+  vu(0x1e, VZERO, VD, VS, VT);
+  vu(0x1f, VZERO, VD, VS, VT);
+  vu(0x20, VLT, VD, VS, VT);
+  vu(0x21, VEQ, VD, VS, VT);
+  vu(0x22, VNE, VD, VS, VT);
+  vu(0x23, VGE, VD, VS, VT);
+  vu(0x24, VCL, VD, VS, VT);
+  vu(0x25, VCH, VD, VS, VT);
+  vu(0x26, VCR, VD, VS, VT);
+  vu(0x27, VMRG, VD, VS, VT);
+  vu(0x28, VAND, VD, VS, VT);
+  vu(0x29, VNAND, VD, VS, VT);
+  vu(0x2a, VOR, VD, VS, VT);
+  vu(0x2b, VNOR, VD, VS, VT);
+  vu(0x2c, VXOR, VD, VS, VT);
+  vu(0x2d, VNXOR, VD, VS, VT);
+  vu(0x2e, VZERO, VD, VS, VT);
+  vu(0x2f, VZERO, VD, VS, VT);
+  vu(0x30, VRCP, VD, DE, VT);
+  vu(0x31, VRCPL, VD, DE, VT);
+  vu(0x32, VRCPH, VD, DE, VT);
+  vu(0x33, VMOV, VD, DE, VT);
+  vu(0x34, VRSQ, VD, DE, VT);
+  vu(0x35, VRSQL, VD, DE, VT);
+  vu(0x36, VRSQH, VD, DE, VT);
+  op(0x37, VNOP);
+  vu(0x38, VZERO, VD, VS, VT); //VEXTT
+  vu(0x39, VZERO, VD, VS, VT); //VEXTQ
+  vu(0x3a, VZERO, VD, VS, VT); //VEXTN
+  vu(0x3b, VZERO, VD, VS, VT);
+  vu(0x3c, VZERO, VD, VS, VT); //VINST
+  vu(0x3d, VZERO, VD, VS, VT); //VINSQ
+  vu(0x3e, VZERO, VD, VS, VT); //VINSN
+  op(0x3f, VNOP); //VNULL
   }
   #undef E
   #undef DE
 }
 
-auto RSP::decoderLWC2() -> void {
+auto RSP::interpreterLWC2() -> void {
   #define E     (OP >> 7 & 15)
   #define IMMi7 i7(OP)
   switch(OP >> 11 & 0x1f) {
-  vu(0x00, R(RSn) L, LBV, VT, RS, IMMi7);
-  vu(0x01, R(RSn) L, LSV, VT, RS, IMMi7);
-  vu(0x02, R(RSn) L, LLV, VT, RS, IMMi7);
-  vu(0x03, R(RSn) L, LDV, VT, RS, IMMi7);
-  vu(0x04, R(RSn) L, LQV, VT, RS, IMMi7);
-  vu(0x05, R(RSn) L, LRV, VT, RS, IMMi7);
-  vu(0x06, R(RSn) L, LPV, VT, RS, IMMi7);
-  vu(0x07, R(RSn) L, LUV, VT, RS, IMMi7);
-  vu(0x08, R(RSn) L, LHV, VT, RS, IMMi7);
-  vu(0x09, R(RSn) L, LFV, VT, RS, IMMi7);
-//vu(0x0a, R(RSn) L, LWV, VT, RS, IMMi7);  //not present on N64 RSP
-  vu(0x0b, R(RSn) L, LTV, VTn, RS, IMMi7);
+  vu(0x00, LBV, VT, RS, IMMi7);
+  vu(0x01, LSV, VT, RS, IMMi7);
+  vu(0x02, LLV, VT, RS, IMMi7);
+  vu(0x03, LDV, VT, RS, IMMi7);
+  vu(0x04, LQV, VT, RS, IMMi7);
+  vu(0x05, LRV, VT, RS, IMMi7);
+  vu(0x06, LPV, VT, RS, IMMi7);
+  vu(0x07, LUV, VT, RS, IMMi7);
+  vu(0x08, LHV, VT, RS, IMMi7);
+  vu(0x09, LFV, VT, RS, IMMi7);
+//vu(0x0a, LWV, VT, RS, IMMi7);  //not present on N64 RSP
+  vu(0x0b, LTV, VTn, RS, IMMi7);
   }
   #undef E
   #undef IMMi7
 }
 
-auto RSP::decoderSWC2() -> void {
+auto RSP::interpreterSWC2() -> void {
   #define E     (OP >> 7 & 15)
   #define IMMi7 i7(OP)
   switch(OP >> 11 & 0x1f) {
-  vu(0x00, R(RSn) S, SBV, VT, RS, IMMi7);
-  vu(0x01, R(RSn) S, SSV, VT, RS, IMMi7);
-  vu(0x02, R(RSn) S, SLV, VT, RS, IMMi7);
-  vu(0x03, R(RSn) S, SDV, VT, RS, IMMi7);
-  vu(0x04, R(RSn) S, SQV, VT, RS, IMMi7);
-  vu(0x05, R(RSn) S, SRV, VT, RS, IMMi7);
-  vu(0x06, R(RSn) S, SPV, VT, RS, IMMi7);
-  vu(0x07, R(RSn) S, SUV, VT, RS, IMMi7);
-  vu(0x08, R(RSn) S, SHV, VT, RS, IMMi7);
-  vu(0x09, R(RSn) S, SFV, VT, RS, IMMi7);
-  vu(0x0a, R(RSn) S, SWV, VT, RS, IMMi7);
-  vu(0x0b, R(RSn) S, STV, VTn, RS, IMMi7);
+  vu(0x00, SBV, VT, RS, IMMi7);
+  vu(0x01, SSV, VT, RS, IMMi7);
+  vu(0x02, SLV, VT, RS, IMMi7);
+  vu(0x03, SDV, VT, RS, IMMi7);
+  vu(0x04, SQV, VT, RS, IMMi7);
+  vu(0x05, SRV, VT, RS, IMMi7);
+  vu(0x06, SPV, VT, RS, IMMi7);
+  vu(0x07, SUV, VT, RS, IMMi7);
+  vu(0x08, SHV, VT, RS, IMMi7);
+  vu(0x09, SFV, VT, RS, IMMi7);
+  vu(0x0a, SWV, VT, RS, IMMi7);
+  vu(0x0b, STV, VTn, RS, IMMi7);
   }
   #undef E
   #undef IMMi7
@@ -380,11 +375,6 @@ auto RSP::decoderSWC2() -> void {
 
 auto RSP::INVALID() -> void {
 }
-
-#undef L
-#undef S
-#undef R
-#undef W
 
 #undef SA
 #undef RDn
@@ -400,6 +390,7 @@ auto RSP::INVALID() -> void {
 #undef jp
 #undef op
 #undef br
+#undef vu
 
 #undef OP
 #undef RD

--- a/ares/n64/rsp/serialization.cpp
+++ b/ares/n64/rsp/serialization.cpp
@@ -5,10 +5,12 @@ auto RSP::serialize(serializer& s) -> void {
 
   s(pipeline.address);
   s(pipeline.instruction);
-  s(pipeline.previous.load);
-  s(pipeline.previous.lockReg);
-  s(pipeline.previous2.load);
-  s(pipeline.previous2.lockReg);
+  s(pipeline.singleIssue);
+  for(auto& p : pipeline.previous) {
+    s(p.load);
+    s(p.rWrite);
+    s(p.vWrite);
+  }
 
   s(dma.pending);
   s(dma.current);

--- a/ares/n64/system/serialization.cpp
+++ b/ares/n64/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v133";
+static const string SerializerVersion = "v133.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   serializer s;


### PR DESCRIPTION
Implement vector unit (VU) timing including dual issue with the SU. Tested against real hardware with a random instruction stream generator.

Known limitations:
- Invalid/missing instruction timings not implemented.
- CFC2/CTC2 dual issue restrictions not implemented.
- Some corner-case dual issue restrictions (e.g. LTV + VNOP) not implemented. On real hardware, VU instructions with a DE operand are sometimes prevented from dual issuing with vector loads under seemingly erroneous conditions.