### PR TITLE
Revert "ws: fix off-by-one in line IRQ handling"

### DIFF
--- a/ares/ws/ppu/ppu.cpp
+++ b/ares/ws/ppu/ppu.cpp
@@ -187,10 +187,7 @@ auto PPU::unload() -> void {
 //vtotal<143 inhibits vblank and repeats the screen image until vcounter=144
 //todo: unknown how votal<143 interferes with vcompare interrupts
 auto PPU::main() -> void {
-  n8 nextVcounter = io.vcounter + 1;
-  if(nextVcounter >= max(144, io.vtotal + 1)) nextVcounter = 0;
-
-  if(nextVcounter == io.vcompare) cpu.raise(CPU::Interrupt::LineCompare);
+  if(io.vcounter == io.vcompare) cpu.raise(CPU::Interrupt::LineCompare);
   if(htimer.step()) cpu.raise(CPU::Interrupt::HblankTimer);
 
   if(io.vcounter < 144) {
@@ -216,11 +213,12 @@ auto PPU::main() -> void {
     step(256);
   }
 
-  io.vcounter = nextVcounter;
-  if(io.vcounter == 0) return frame();
+  io.vcounter++;
+  if(io.vcounter >= max(144, io.vtotal + 1)) return frame();
 }
 
 auto PPU::frame() -> void {
+  io.vcounter = 0;
   io.field = !io.field;
   screen->setViewport(0, 0, screen->width(), screen->height());
   screen->frame();


### PR DESCRIPTION
Reverts ares-emulator/ares#1158

The fix provides the correct visual results, but for the wrong reasons. After FluBBa's review, it seems a much deeper analysis of the PPU behaviour is required.