### PR TITLE
ws: (more) cycle-accurate apu implementation

### DIFF
--- a/ares/ws/apu/apu.cpp
+++ b/ares/ws/apu/apu.cpp
@@ -37,28 +37,49 @@ auto APU::unload() -> void {
 }
 
 auto APU::main() -> void {
-  // further verification could always be useful
-  u32 steps = accurate ? 1 : 128;
-  for(u32 s = 0; s < steps; s++) {
-    // TODO: is the period value (run()) updated before or after the outputs (runOutput())?
-    channel1.run();
-    channel2.run();
-    channel3.run();
-    if(++state.sweepClock == 0) channel3.sweep(); // TODO: which cycle is this, or is it separate?
-    channel4.run();
+  if(accurate) {
+    // TODO: Are the channels ticked before or after the memory fetch?
+    channel1.tick();
+    channel2.tick();
+    channel3.tick();
+    if(++state.sweepClock == 0) channel3.sweep(); // TODO: Is there any relationship between this clock and I/O ports?
+    channel4.tick();
 
-    // TODO: are voice/noise modes handled on different cycles than tone modes?
     switch(state.apuClock++) {
-    case 0: if(channel1.io.enable)                      channel1.runOutput(); break;
-    case 1: if(channel2.io.enable || channel2.io.voice) channel2.runOutput(); break;
-    case 2: if(channel3.io.enable)                      channel3.runOutput(); break;
-    case 3: if(channel4.io.enable)                      channel4.runOutput(); break;
-    case 4: if(channel5.io.enable)                      channel5.runOutput(); break; // TODO: which cycle is this?
-    case 5: dma.run(); break; // TODO: which cycle is this?
-    case 6: dacRun(); break; // TODO: which cycle is this?
+    case 0:   apu.output(); break;
+    case 64:  dma.run(); break; // TODO: Which cycle is this performed on?
+    case 122: io.output = {}; break;
+    case 123: if(channel5.io.enable)                      channel5.runOutput(); break; // TODO: Which cycle is this performed on?
+    case 124: if(channel1.io.enable)                      channel1.output(); break;
+    case 125: if(channel2.io.enable || channel2.io.voice) channel2.output(); break;
+    case 126: if(channel3.io.enable)                      channel3.output(); break;
+    case 127: if(channel4.io.enable)                      channel4.output(); break;
     }
+
+    step(1);
+  } else {
+    io.output = {};
+
+    for(u32 s = 0; s < 128; s++) {
+      channel1.tick();
+      channel2.tick();
+      channel3.tick();
+      if(++state.sweepClock == 0) channel3.sweep();
+      channel4.tick();
+    }
+
+    dma.run();
+    
+    channel5.runOutput();
+    if(channel1.io.enable)                      channel1.output();
+    if(channel2.io.enable || channel2.io.voice) channel2.output();
+    if(channel3.io.enable)                      channel3.output();
+    if(channel4.io.enable)                      channel4.output();
+
+    apu.output();
+
+    step(128);
   }
-  step(steps);
 }
 
 auto APU::sample(u32 channel, n5 index) -> n4 {
@@ -68,7 +89,7 @@ auto APU::sample(u32 channel, n5 index) -> n4 {
   unreachable;
 }
 
-auto APU::dacRun() -> void {
+auto APU::output() -> void {
   bool outputEnable = io.headphonesConnected ? io.headphonesEnable : io.speakerEnable;
 
   if(!outputEnable) {
@@ -76,25 +97,18 @@ auto APU::dacRun() -> void {
     return;
   }
 
-  s32 left = 0;
-  if(channel1.io.enable)                      left += channel1.output.left;
-  if(channel2.io.enable || channel2.io.voice) left += channel2.output.left;
-  if(channel3.io.enable)                      left += channel3.output.left;
-  if(channel4.io.enable)                      left += channel4.output.left;
-  if(channel5.io.enable)                      left += channel5.output.left * io.headphonesConnected;
+  s32 left  = io.output.left;
+  s32 right = io.output.right;
 
-  s32 right = 0;
-  if(channel1.io.enable)                      right += channel1.output.right;
-  if(channel2.io.enable || channel2.io.voice) right += channel2.output.right;
-  if(channel3.io.enable)                      right += channel3.output.right;
-  if(channel4.io.enable)                      right += channel4.output.right;
-  if(channel5.io.enable)                      right += channel5.output.right * io.headphonesConnected;
-
-  if(!io.headphonesConnected) {
-    left = right = sclamp<16>((((left + right) >> io.speakerShift) & 0xFF) << 7);
-  } else {
+  if(io.headphonesConnected) {
+    if(channel5.io.enable) {
+      left  += channel5.output.left;
+      right += channel5.output.right;
+    }
     left = sclip<16>(left << 5);
     right = sclip<16>(right << 5);
+  } else {
+    left = right = sclamp<16>((((left + right) >> io.speakerShift) & 0xFF) << 7);
   }
 
   //ASWAN has three volume steps (0%, 50%, 100%); SPHINX and SPHINX2 have four (0%, 33%, 66%, 100%)
@@ -114,7 +128,7 @@ auto APU::power() -> void {
   bus.map(this, 0x004e, 0x0050);
   bus.map(this, 0x0052);
   bus.map(this, 0x006a, 0x006b);
-  bus.map(this, 0x0080, 0x0095);
+  bus.map(this, 0x0080, 0x009b);
   bus.map(this, 0x009e);
 
   dma.power();
@@ -128,7 +142,7 @@ auto APU::power() -> void {
   io.headphonesConnected = system.headphones->value();
   io.masterVolume = SoC::ASWAN() ? 2 : 3;
   state = {};
-
+  
   state.apuClock = 0;
   state.sweepClock = 0;
 }

--- a/ares/ws/apu/apu.hpp
+++ b/ares/ws/apu/apu.hpp
@@ -12,7 +12,7 @@ struct APU : Thread, IO {
 
   auto main() -> void;
   auto sample(u32 channel, n5 index) -> n4;
-  auto dacRun() -> void;
+  auto output() -> void;
   auto step(u32 clocks) -> void;
   auto power() -> void;
 
@@ -64,8 +64,8 @@ struct APU : Thread, IO {
 
   struct Channel1 {
     //channel1.cpp
-    auto run() -> void;
-    auto runOutput() -> void;
+    auto tick() -> void;
+    auto output() -> void;
     auto power() -> void;
 
     //serialization.cpp
@@ -82,17 +82,12 @@ struct APU : Thread, IO {
       n11 period;
       n5  sampleOffset;
     } state;
-
-    struct Output {
-      n8 left;
-      n8 right;
-    } output;
   } channel1;
 
   struct Channel2 {
     //channel2.cpp
-    auto run() -> void;
-    auto runOutput() -> void;
+    auto tick() -> void;
+    auto output() -> void;
     auto power() -> void;
 
     //serialization.cpp
@@ -114,18 +109,13 @@ struct APU : Thread, IO {
       n11 period;
       n5  sampleOffset;
     } state;
-
-    struct Output {
-      n8 left;
-      n8 right;
-    } output;
   } channel2;
 
   struct Channel3 {
     //channel3.cpp
     auto sweep() -> void;
-    auto run() -> void;
-    auto runOutput() -> void;
+    auto tick() -> void;
+    auto output() -> void;
     auto power() -> void;
 
     //serialization.cpp
@@ -146,18 +136,13 @@ struct APU : Thread, IO {
       n5  sampleOffset;
       i32 sweepCounter;
     } state;
-
-    struct Output {
-      n8 left;
-      n8 right;
-    } output;
   } channel3;
 
   struct Channel4 {
     //channel4.cpp
     auto noiseSample() -> n4;
-    auto run() -> void;
-    auto runOutput() -> void;
+    auto tick() -> void;
+    auto output() -> void;
     auto power() -> void;
 
     //serialization.cpp
@@ -180,11 +165,6 @@ struct APU : Thread, IO {
       n1  noiseOutput;
       n15 noiseLFSR;
     } state;
-
-    struct Output {
-      n8 left;
-      n8 right;
-    } output;
   } channel4;
 
   struct Channel5 {
@@ -223,6 +203,12 @@ struct APU : Thread, IO {
     n1 headphonesEnable;
     n1 headphonesConnected;
     n2 masterVolume;
+    
+    // This output covers Channels 1-4 (excluding Hyper Voice)
+    struct Output {
+      n10 left;
+      n10 right;
+    } output;
   } io;
 
   struct State {

--- a/ares/ws/apu/channel1.cpp
+++ b/ares/ws/apu/channel1.cpp
@@ -1,18 +1,17 @@
-auto APU::Channel1::run() -> void {
+auto APU::Channel1::tick() -> void {
   if(--state.period == io.pitch) {
     state.period = 0;
     state.sampleOffset++;
   }
 }
 
-auto APU::Channel1::runOutput() -> void {
+auto APU::Channel1::output() -> void {
   auto sample = apu.sample(1, state.sampleOffset);
-  output.left  = sample * io.volumeLeft;
-  output.right = sample * io.volumeRight;
+  apu.io.output.left  += sample * io.volumeLeft;
+  apu.io.output.right += sample * io.volumeRight;
 }
 
 auto APU::Channel1::power() -> void {
   io = {};
   state = {};
-  output = {};
 }

--- a/ares/ws/apu/channel2.cpp
+++ b/ares/ws/apu/channel2.cpp
@@ -1,4 +1,4 @@
-auto APU::Channel2::run() -> void {
+auto APU::Channel2::tick() -> void {
   if (!io.voice) {
     if(--state.period == io.pitch) {
       state.period = 0;
@@ -7,20 +7,19 @@ auto APU::Channel2::run() -> void {
   }
 }
 
-auto APU::Channel2::runOutput() -> void {
+auto APU::Channel2::output() -> void {
   if(io.voice) {
     n8 volume = io.volumeLeft << 4 | io.volumeRight << 0;
-    output.left  = io.voiceEnableLeftFull  ? volume : (n8)(io.voiceEnableLeftHalf  ? (volume >> 1) : 0);
-    output.right = io.voiceEnableRightFull ? volume : (n8)(io.voiceEnableRightHalf ? (volume >> 1) : 0);
+    apu.io.output.left  += io.voiceEnableLeftFull  ? volume : (n8)(io.voiceEnableLeftHalf  ? (volume >> 1) : 0);
+    apu.io.output.right += io.voiceEnableRightFull ? volume : (n8)(io.voiceEnableRightHalf ? (volume >> 1) : 0);
   } else {
     auto sample = apu.sample(2, state.sampleOffset);
-    output.left  = sample * io.volumeLeft;
-    output.right = sample * io.volumeRight;
+    apu.io.output.left  += sample * io.volumeLeft;
+    apu.io.output.right += sample * io.volumeRight;
   }
 }
 
 auto APU::Channel2::power() -> void {
   io = {};
   state = {};
-  output = {};
 }

--- a/ares/ws/apu/channel3.cpp
+++ b/ares/ws/apu/channel3.cpp
@@ -5,21 +5,20 @@ auto APU::Channel3::sweep() -> void {
   }
 }
 
-auto APU::Channel3::run() -> void {
+auto APU::Channel3::tick() -> void {
   if(--state.period == io.pitch) {
     state.period = 0;
     state.sampleOffset++;
   }
 }
 
-auto APU::Channel3::runOutput() -> void {
+auto APU::Channel3::output() -> void {
   auto sample = apu.sample(3, state.sampleOffset);
-  output.left  = sample * io.volumeLeft;
-  output.right = sample * io.volumeRight;
+  apu.io.output.left  += sample * io.volumeLeft;
+  apu.io.output.right += sample * io.volumeRight;
 }
 
 auto APU::Channel3::power() -> void {
   io = {};
   state = {};
-  output = {};
 }

--- a/ares/ws/apu/channel4.cpp
+++ b/ares/ws/apu/channel4.cpp
@@ -2,7 +2,7 @@ auto APU::Channel4::noiseSample() -> n4 {
   return state.noiseOutput ? 0xf : 0x0;
 }
 
-auto APU::Channel4::run() -> void {
+auto APU::Channel4::tick() -> void {
   if(--state.period == io.pitch) {
     state.period = 0;
     state.sampleOffset++;
@@ -23,14 +23,13 @@ auto APU::Channel4::run() -> void {
   }
 }
 
-auto APU::Channel4::runOutput() -> void {
+auto APU::Channel4::output() -> void {
   auto sample = io.noise ? noiseSample() : apu.sample(4, state.sampleOffset);
-  output.left  = sample * io.volumeLeft;
-  output.right = sample * io.volumeRight;
+  apu.io.output.left  += sample * io.volumeLeft;
+  apu.io.output.right += sample * io.volumeRight;
 }
 
 auto APU::Channel4::power() -> void {
   io = {};
   state = {};
-  output = {};
 }

--- a/ares/ws/apu/io.cpp
+++ b/ares/ws/apu/io.cpp
@@ -125,6 +125,19 @@ auto APU::readIO(n16 address) -> n8 {
     data = channel5.state.data;
     break;
 
+  case range2(0x0096, 0x0097):  //SND_OUT_R
+    data = io.output.right.byte(address - 0x0086);
+    break;
+
+  case range2(0x0098, 0x0099):  //SND_OUT_L
+    data = io.output.right.byte(address - 0x0086);
+    break;
+
+  case range2(0x009a, 0x009b): { //SND_OUT_M
+    n11 outputM = io.output.left + io.output.right;
+    data = outputM.byte(address - 0x0086);
+  } break;
+
   case 0x009e:  //SND_VOLUME
     if(!SoC::ASWAN()) {
       data.bit(0,1) = io.masterVolume;

--- a/ares/ws/apu/serialization.cpp
+++ b/ares/ws/apu/serialization.cpp
@@ -14,6 +14,8 @@ auto APU::serialize(serializer& s) -> void {
   s(io.headphonesEnable);
   s(io.headphonesConnected);
   s(io.masterVolume);
+  s(io.output.left);
+  s(io.output.right);
   s(state.sweepClock);
   s(state.apuClock);
 }
@@ -39,8 +41,6 @@ auto APU::Channel1::serialize(serializer& s) -> void {
   s(io.enable);
   s(state.period);
   s(state.sampleOffset);
-  s(output.left);
-  s(output.right);
 }
 
 auto APU::Channel2::serialize(serializer& s) -> void {
@@ -55,8 +55,6 @@ auto APU::Channel2::serialize(serializer& s) -> void {
   s(io.voiceEnableRightFull);
   s(state.period);
   s(state.sampleOffset);
-  s(output.left);
-  s(output.right);
 }
 
 auto APU::Channel3::serialize(serializer& s) -> void {
@@ -70,8 +68,6 @@ auto APU::Channel3::serialize(serializer& s) -> void {
   s(state.period);
   s(state.sampleOffset);
   s(state.sweepCounter);
-  s(output.left);
-  s(output.right);
 }
 
 auto APU::Channel4::serialize(serializer& s) -> void {
@@ -87,8 +83,6 @@ auto APU::Channel4::serialize(serializer& s) -> void {
   s(state.sampleOffset);
   s(state.noiseOutput);
   s(state.noiseLFSR);
-  s(output.left);
-  s(output.right);
 }
 
 auto APU::Channel5::serialize(serializer& s) -> void {


### PR DESCRIPTION
Work in progress.

Also done:

* Implement undocumented APU debug ports (0x94, 0x96, 0x98)
* Implement separate code path for "accuracy disabled" mode (~2-3% faster on my un-scientific CPU tests).