### PR TITLE
n64: cpu timing improvements

### DIFF
--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -115,7 +115,7 @@ struct CPU : Thread {
         line.valid = 1;
         line.tag   = address & ~0x0000'0fff;
       } else {
-        self.step(2 * 2);
+        self.step(1 * 2);
       }
     }
 
@@ -125,7 +125,7 @@ struct CPU : Thread {
       if(!line.hit(address)) {
         line.fill(address, cpu);
       } else {
-        cpu.step(2 * 2);
+        cpu.step(1 * 2);
       }
       return line.read(address);
     }

--- a/ares/n64/cpu/interpreter-fpu.cpp
+++ b/ares/n64/cpu/interpreter-fpu.cpp
@@ -421,6 +421,7 @@ auto CPU::FADD_S(u8 fd, u8 fs, u8 ft) -> void {
   CHECK_FPE(f32, ffd, FS(f32) + FT(f32));
   if(!fpuCheckOutput(ffd)) return;
   FD(f32) = ffd;
+  step((3 - 1) * 2);
 }
 
 auto CPU::FADD_D(u8 fd, u8 fs, u8 ft) -> void {
@@ -431,6 +432,7 @@ auto CPU::FADD_D(u8 fd, u8 fs, u8 ft) -> void {
   CHECK_FPE(f64, ffd, ffs + fft);
   if(!fpuCheckOutput(ffd)) return;
   FD(f64) = ffd;
+  step((3 - 1) * 2);
 }
 
 auto CPU::FCEIL_L_S(u8 fd, u8 fs) -> void {
@@ -439,6 +441,7 @@ auto CPU::FCEIL_L_S(u8 fd, u8 fs) -> void {
   if(!fpuCheckInputConv<s64>(ffs)) return;
   CHECK_FPE(s64, ffd, roundCeil<s64>(ffs));
   FD(s64) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FCEIL_L_D(u8 fd, u8 fs) -> void {
@@ -447,6 +450,7 @@ auto CPU::FCEIL_L_D(u8 fd, u8 fs) -> void {
   if(!fpuCheckInputConv<s64>(ffs)) return;
   CHECK_FPE(s64, ffd, roundCeil<s64>(ffs));
   FD(s64) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FCEIL_W_S(u8 fd, u8 fs) -> void {
@@ -455,6 +459,7 @@ auto CPU::FCEIL_W_S(u8 fd, u8 fs) -> void {
   if(!fpuCheckInputConv<s32>(ffs)) return;
   CHECK_FPE_CONV(s32, ffd, roundCeil<s32>(ffs));
   FD(s32) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FCEIL_W_D(u8 fd, u8 fs) -> void {
@@ -463,6 +468,7 @@ auto CPU::FCEIL_W_D(u8 fd, u8 fs) -> void {
   if(!fpuCheckInputConv<s32>(ffs)) return;
   CHECK_FPE_CONV(s32, ffd, roundCeil<s32>(ffs));
   FD(s32) = ffd;
+  step((5 - 1) * 2);
 }
 
 #define  XORDERED(type, value, quiet) \
@@ -652,6 +658,7 @@ auto CPU::FCVT_S_D(u8 fd, u8 fs) -> void {
   CHECK_FPE(f32, ffd, (f32)ffs);
   if(!fpuCheckOutput(ffd)) return;
   FD(f32) = ffd;
+  step((2 - 1) * 2);
 }
 
 auto CPU::FCVT_S_W(u8 fd, u8 fs) -> void {
@@ -660,6 +667,7 @@ auto CPU::FCVT_S_W(u8 fd, u8 fs) -> void {
   CHECK_FPE(f32, ffd, ffs);
   if(!fpuCheckOutput(ffd)) return;
   FD(f32) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FCVT_S_L(u8 fd, u8 fs) -> void {
@@ -672,6 +680,7 @@ auto CPU::FCVT_S_L(u8 fd, u8 fs) -> void {
   CHECK_FPE(f32, ffd, (f32)ffs);
   if(!fpuCheckOutput(ffd)) return;
   FD(f32) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FCVT_D_S(u8 fd, u8 fs) -> void {
@@ -694,6 +703,7 @@ auto CPU::FCVT_D_W(u8 fd, u8 fs) -> void {
   CHECK_FPE(f64, ffd, (f64)ffs);
   if(!fpuCheckOutput(ffd)) return;
   FD(f64) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FCVT_D_L(u8 fd, u8 fs) -> void {
@@ -706,6 +716,7 @@ auto CPU::FCVT_D_L(u8 fd, u8 fs) -> void {
   CHECK_FPE(f64, ffd, (f64)ffs);
   if(!fpuCheckOutput(ffd)) return;
   FD(f64) = ffs;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FCVT_L_S(u8 fd, u8 fs) -> void {
@@ -714,6 +725,7 @@ auto CPU::FCVT_L_S(u8 fd, u8 fs) -> void {
   if(!fpuCheckInputConv<s64>(ffs)) return;
   CHECK_FPE(s64, ffd, roundCurrent<s64>(ffs));
   FD(s64) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FCVT_L_D(u8 fd, u8 fs) -> void {
@@ -722,6 +734,7 @@ auto CPU::FCVT_L_D(u8 fd, u8 fs) -> void {
   if(!fpuCheckInputConv<s64>(ffs)) return;
   CHECK_FPE(s64, ffd, roundCurrent<s64>(ffs));
   FD(s64) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FCVT_W_S(u8 fd, u8 fs) -> void {
@@ -730,6 +743,7 @@ auto CPU::FCVT_W_S(u8 fd, u8 fs) -> void {
   if(!fpuCheckInputConv<s32>(ffs)) return;
   CHECK_FPE_CONV(s32, ffd, roundCurrent<s32>(ffs));
   FD(s32) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FCVT_W_D(u8 fd, u8 fs) -> void {
@@ -738,6 +752,7 @@ auto CPU::FCVT_W_D(u8 fd, u8 fs) -> void {
   if(!fpuCheckInputConv<s32>(ffs)) return;
   CHECK_FPE_CONV(s32, ffd, roundCurrent<s32>(ffs));
   FD(s32) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FDIV_S(u8 fd, u8 fs, u8 ft) -> void {
@@ -748,6 +763,7 @@ auto CPU::FDIV_S(u8 fd, u8 fs, u8 ft) -> void {
   CHECK_FPE(f32, ffd, ffs / fft);
   if(!fpuCheckOutput(ffd)) return;
   FD(f32) = ffd;
+  step((29 - 1) * 2);
 }
 
 auto CPU::FDIV_D(u8 fd, u8 fs, u8 ft) -> void {
@@ -758,6 +774,7 @@ auto CPU::FDIV_D(u8 fd, u8 fs, u8 ft) -> void {
   CHECK_FPE(f64, ffd, ffs / fft);
   if(!fpuCheckOutput(ffd)) return;
   FD(f64) = ffd;
+  step((58 - 1) * 2);
 }
 
 auto CPU::FFLOOR_L_S(u8 fd, u8 fs) -> void {
@@ -766,6 +783,7 @@ auto CPU::FFLOOR_L_S(u8 fd, u8 fs) -> void {
   if(!fpuCheckInputConv<s64>(ffs)) return;
   CHECK_FPE(s64, ffd, roundFloor<s64>(ffs));
   FD(s64) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FFLOOR_L_D(u8 fd, u8 fs) -> void {
@@ -774,6 +792,7 @@ auto CPU::FFLOOR_L_D(u8 fd, u8 fs) -> void {
   if(!fpuCheckInputConv<s64>(ffs)) return;
   CHECK_FPE(s64, ffd, roundFloor<s64>(ffs));
   FD(s64) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FFLOOR_W_S(u8 fd, u8 fs) -> void {
@@ -782,6 +801,7 @@ auto CPU::FFLOOR_W_S(u8 fd, u8 fs) -> void {
   if(!fpuCheckInputConv<s32>(ffs)) return;
   CHECK_FPE_CONV(s32, ffd, roundFloor<s32>(ffs));
   FD(s32) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FFLOOR_W_D(u8 fd, u8 fs) -> void {
@@ -790,6 +810,7 @@ auto CPU::FFLOOR_W_D(u8 fd, u8 fs) -> void {
   if(!fpuCheckInputConv<s32>(ffs)) return;
   CHECK_FPE_CONV(s32, ffd, roundFloor<s32>(ffs));
   FD(s32) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FMOV_S(u8 fd, u8 fs) -> void {
@@ -810,6 +831,7 @@ auto CPU::FMUL_S(u8 fd, u8 fs, u8 ft) -> void {
   CHECK_FPE(f32, ffd, ffs * fft);
   if(!fpuCheckOutput(ffd)) return;
   FD(f32) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FMUL_D(u8 fd, u8 fs, u8 ft) -> void {
@@ -820,6 +842,7 @@ auto CPU::FMUL_D(u8 fd, u8 fs, u8 ft) -> void {
   CHECK_FPE(f64, ffd, ffs * fft);
   if(!fpuCheckOutput(ffd)) return;
   FD(f64) = ffd;
+  step((8 - 1) * 2);
 }
 
 auto CPU::FNEG_S(u8 fd, u8 fs) -> void {
@@ -847,6 +870,7 @@ auto CPU::FROUND_L_S(u8 fd, u8 fs) -> void {
   CHECK_FPE(s64, ffd, roundNearest<s64>(ffs));
   if(ffd != ffs && fpeInexact()) return exception.floatingPoint();
   FD(s64) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FROUND_L_D(u8 fd, u8 fs) -> void {
@@ -856,6 +880,7 @@ auto CPU::FROUND_L_D(u8 fd, u8 fs) -> void {
   CHECK_FPE(s64, ffd, roundNearest<s64>(ffs));
   if(ffd != ffs && fpeInexact()) return exception.floatingPoint();
   FD(s64) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FROUND_W_S(u8 fd, u8 fs) -> void {
@@ -865,6 +890,7 @@ auto CPU::FROUND_W_S(u8 fd, u8 fs) -> void {
   CHECK_FPE_CONV(s32, ffd, roundNearest<s32>(ffs));
   if(ffd != ffs && fpeInexact()) return exception.floatingPoint();
   FD(s32) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FROUND_W_D(u8 fd, u8 fs) -> void {
@@ -874,6 +900,7 @@ auto CPU::FROUND_W_D(u8 fd, u8 fs) -> void {
   CHECK_FPE_CONV(s32, ffd, roundNearest<s32>(ffs));
   if(ffd != ffs && fpeInexact()) return exception.floatingPoint();
   FD(s32) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FSQRT_S(u8 fd, u8 fs) -> void {
@@ -883,6 +910,7 @@ auto CPU::FSQRT_S(u8 fd, u8 fs) -> void {
   CHECK_FPE(f32, ffd, squareRoot(ffs));
   if(!fpuCheckOutput(ffd)) return;
   FD(f32) = ffd;
+  step((29 - 1) * 2);
 }
 
 auto CPU::FSQRT_D(u8 fd, u8 fs) -> void {
@@ -892,6 +920,7 @@ auto CPU::FSQRT_D(u8 fd, u8 fs) -> void {
   CHECK_FPE(f64, ffd, squareRoot(ffs));
   if(!fpuCheckOutput(ffd)) return;
   FD(f64) = ffd;
+  step((58 - 1) * 2);
 }
 
 auto CPU::FSUB_S(u8 fd, u8 fs, u8 ft) -> void {
@@ -902,6 +931,7 @@ auto CPU::FSUB_S(u8 fd, u8 fs, u8 ft) -> void {
   CHECK_FPE(f32, ffd, ffs - fft);
   if(!fpuCheckOutput(ffd)) return;
   FD(f32) = ffd;
+  step((3 - 1) * 2);
 }
 
 auto CPU::FSUB_D(u8 fd, u8 fs, u8 ft) -> void {
@@ -912,6 +942,7 @@ auto CPU::FSUB_D(u8 fd, u8 fs, u8 ft) -> void {
   CHECK_FPE(f64, ffd, ffs - fft);
   if(!fpuCheckOutput(ffd)) return;
   FD(f64) = ffd;
+  step((3 - 1) * 2);
 }
 
 auto CPU::FTRUNC_L_S(u8 fd, u8 fs) -> void {
@@ -921,6 +952,7 @@ auto CPU::FTRUNC_L_S(u8 fd, u8 fs) -> void {
   CHECK_FPE(s64, ffd, roundTrunc<s64>(ffs));
   if((f32)ffd != ffs && fpeInexact()) return exception.floatingPoint();
   FD(s64) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FTRUNC_L_D(u8 fd, u8 fs) -> void {
@@ -930,6 +962,7 @@ auto CPU::FTRUNC_L_D(u8 fd, u8 fs) -> void {
   CHECK_FPE(s64, ffd, roundTrunc<s64>(ffs));
   if((f64)ffd != ffs && fpeInexact()) return exception.floatingPoint();
   FD(s64) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FTRUNC_W_S(u8 fd, u8 fs) -> void {
@@ -939,6 +972,7 @@ auto CPU::FTRUNC_W_S(u8 fd, u8 fs) -> void {
   CHECK_FPE_CONV(s32, ffd, roundTrunc<s32>(ffs));
   if((f32)ffd != ffs && fpeInexact()) return exception.floatingPoint();
   FD(s32) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::FTRUNC_W_D(u8 fd, u8 fs) -> void {
@@ -948,6 +982,7 @@ auto CPU::FTRUNC_W_D(u8 fd, u8 fs) -> void {
   CHECK_FPE_CONV(s32, ffd, roundTrunc<s32>(ffs));
   if((f64)ffd != ffs && fpeInexact()) return exception.floatingPoint();
   FD(s32) = ffd;
+  step((5 - 1) * 2);
 }
 
 auto CPU::LDC1(u8 ft, cr64& rs, s16 imm) -> void {

--- a/ares/n64/cpu/interpreter-ipu.cpp
+++ b/ares/n64/cpu/interpreter-ipu.cpp
@@ -269,7 +269,7 @@ auto CPU::DDIV(cr64& rs, cr64& rt) -> void {
     LO.u64 = rs.s64 < 0 ? +1 : -1;
     HI.u64 = rs.s64;
   }
-  step(69 * 2);
+  step((69 - 1) * 2);
 }
 
 auto CPU::DDIVU(cr64& rs, cr64& rt) -> void {
@@ -281,7 +281,7 @@ auto CPU::DDIVU(cr64& rs, cr64& rt) -> void {
     LO.u64 = -1;
     HI.u64 = rs.u64;
   }
-  step(69 * 2);
+  step((69 - 1) * 2);
 }
 
 auto CPU::DIV(cr64& rs, cr64& rt) -> void {
@@ -294,7 +294,7 @@ auto CPU::DIV(cr64& rs, cr64& rt) -> void {
     LO.u64 = rs.s32 < 0 ? +1 : -1;
     HI.u64 = rs.s32;
   }
-  step(37 * 2);
+  step((37 - 1) * 2);
 }
 
 auto CPU::DIVU(cr64& rs, cr64& rt) -> void {
@@ -306,7 +306,7 @@ auto CPU::DIVU(cr64& rs, cr64& rt) -> void {
     LO.u64 = -1;
     HI.u64 = rs.s32;
   }
-  step(37 * 2);
+  step((37 - 1) * 2);
 }
 
 auto CPU::DMULT(cr64& rs, cr64& rt) -> void {
@@ -329,7 +329,7 @@ auto CPU::DMULT(cr64& rs, cr64& rt) -> void {
   LO.u64 = result >>  0;
   HI.u64 = result >> 64;
 #endif
-  step(8 * 2);
+  step((8 - 1) * 2);
 }
 
 auto CPU::DMULTU(cr64& rs, cr64& rt) -> void {
@@ -346,7 +346,7 @@ auto CPU::DMULTU(cr64& rs, cr64& rt) -> void {
   LO.u64 = result >>  0;
   HI.u64 = result >> 64;
 #endif
-  step(8 * 2);
+  step((8 - 1) * 2);
 }
 
 auto CPU::DSLL(r64& rd, cr64& rt, u8 sa) -> void {
@@ -786,14 +786,14 @@ auto CPU::MULT(cr64& rs, cr64& rt) -> void {
   u64 result = s64(rs.s32) * s64(rt.s32);
   LO.u64 = s32(result >>  0);
   HI.u64 = s32(result >> 32);
-  step(5 * 2);
+  step((5 - 1) * 2);
 }
 
 auto CPU::MULTU(cr64& rs, cr64& rt) -> void {
   u64 result = u64(rs.u32) * u64(rt.u32);
   LO.u64 = s32(result >>  0);
   HI.u64 = s32(result >> 32);
-  step(5 * 2);
+  step((5 - 1) * 2);
 }
 
 auto CPU::NOR(r64& rd, cr64& rs, cr64& rt) -> void {

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -35,9 +35,10 @@ auto CPU::Recompiler::emit(u32 address) -> Block* {
   while(true) {
     u32 instruction = bus.read<Word>(address, thread);
     bool branched = emitEXECUTE(instruction);
-    if(unlikely(instruction == 0x1000'ffff)) {
+    if(unlikely(instruction == 0x1000'ffff  //beq 0,0,<pc>
+             || instruction == (2 << 26 | address >> 2 & 0x3ff'ffff))) {  //j <pc>
       //accelerate idle loops
-      mov32(reg(1), imm(64));
+      mov32(reg(1), imm(64 * 2));
       call(&CPU::step);
     }
     call(&CPU::instructionEpilogue);


### PR DESCRIPTION
This PR was motivated by the observation that ares was running the main CPU much, much slower than real hardware. Unfortunately, this was covering for timing inaccuracies in other places. With this corrected, many hardware inaccurate slowdowns have disappeared, but in some cases ares is now visibly faster than real hardware. These will be addressed, in time, with further improvements to ares' timing accuracy.

I've been building a framework for collecting instruction traces and playing them back on real hardware for timing measurement. Using a trace from SM64 with all loads/stores removed and with all instructions fully loaded into the icache, ares went from 58% of real hardware speed to 97% after these changes. Note that these figures are not indicative the overall speed of the emulated system, but they highlight the severity of the CPU slowdown ares was experiencing in the most extreme cases.

Given that the emulated CPU is now running faster than before, there may be increased demand on the host CPU. However, there should be no impact for games that A) are not fully utilizing the CPU and B) have a trivial idle loop that can be detected by ares. To further minimize the impact, I have expanded the detection of idle loops to include jumps in addition to branch instructions.