### PR TITLE
n64: clamp to octagon edge instead of scale

### DIFF
--- a/ares/n64/controller/gamepad/gamepad.cpp
+++ b/ares/n64/controller/gamepad/gamepad.cpp
@@ -234,9 +234,12 @@ auto Gamepad::read() -> n32 {
     auto edgey = copysign(min(abs(edgex * slope), cardinalMax / (1.0 / abs(slope) + (cardinalMax - diagonalMax) / diagonalMax)), ay);
     edgex = edgey / slope;
 
-    auto scale = sqrt(edgex * edgex + edgey * edgey) / outerDeadzoneRadiusMax;
-    ax *= scale;
-    ay *= scale;
+    length = sqrt(ax * ax + ay * ay);
+    auto distanceToEdge = sqrt(edgex * edgex + edgey * edgey);
+    if(length > distanceToEdge) {
+      ax = edgex;
+      ay = edgey;
+    }
   }
 
   //keep cardinal input within positive and negative bounds of cardinalMax


### PR DESCRIPTION
This PR addresses an issue where the input was always being scaled by the edge of the octagon even when within the bounds of the octagon. This caused input to not be scaled as linearly as it should have been. Therefore, an if statement has been added to check if the input's current length is beyond the edge of the octagon. If so, a clamp is now applied with the values of edgex and edgey. The scale never considered the magnitude of the input, only direction. Thus, a snap back effect could occur with that method.