### PR TITLE
desktop-ui: save settings when closing the settings dialogue

### DIFF
--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -155,6 +155,7 @@ auto Settings::process(bool load) -> void {
 
 SettingsWindow::SettingsWindow() {
   onClose([&] {
+    save();
     setVisible(false);
     //cancel any pending input assignment requests, if any
     inputSettings.setVisible(false);


### PR DESCRIPTION
Before settings were only saved when closing ares.