### PR TITLE
Add support for system-wide installation of Ares on Linux

### DIFF
--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -26,10 +26,15 @@ auto locate(const string& name) -> string {
   location = {Path::userData(), "ares/", name};
   if(inode::exists(location)) return location;
 
-  // On non-windows platforms, after exhausting other options,
-  // default to userData, on Windows, default to program dir
+  // On non-windows platforms, this time check the shared
+  // data directory, on Windows, default to program dir,
   // this ensures Portable mode is the default on Windows platforms.
   #if !defined(PLATFORM_WINDOWS)
+    string shared_location = {Path::sharedData(), "ares/", name};
+    if(inode::exists(shared_location)) return shared_location;
+
+    // On non-windows platforms, after exhausting other options,
+    // default to userData.
     directory::create({Path::userData(), "ares/"});
     return {Path::userData(), "ares/", name};
   #else 

--- a/mia/mia.cpp
+++ b/mia/mia.cpp
@@ -28,10 +28,15 @@ auto locate(const string& name) -> string {
   location = {Path::userData(), "ares/", name};
   if(inode::exists(location)) return location;
 
-  // On non-windows platforms, after exhausting other options,
-  // default to userData, on Windows, default to program dir
+  // On non-windows platforms, this time check the shared
+  // data directory, on Windows, default to program dir
   // this ensures Portable mode is the default on Windows platforms.
 #if !defined(PLATFORM_WINDOWS)
+  string shared_location = {Path::sharedData(), "ares/", name};
+  if(inode::exists(shared_location)) return shared_location;
+
+  // On non-windows platforms, after exhausting other options,
+  // default to userData
   directory::create({Path::userData(), "ares/"});
   return {Path::userData(), "ares/", name};
 #else


### PR DESCRIPTION
This PR, as the title says, adds support for system-wide installation of Ares on Linux. Basically it will attempt to locate the shaders and the databases also in the system folders (e.g. in /usr/share/ares), not just in the home and, if portable, in its application directory. 

This allows Ares, as-it-is, to load properly shaders and databases, thus avoiding additional maintenance burdens for packagers (Flatpak, AUR, and also distro packages).

I haven't yet seen issues with these changes, but I have received positive feedback so that's good enough for me.

The only caveat is that this PR is still untested on BSD, although I don't think it will cause issues on that platform too. But if someone is kind enough to test this on BSD for us...;)

It fixes #1173 .