### PR TITLE
n64: raise vi line interrupt post-increment

### DIFF
--- a/ares/n64/vi/vi.cpp
+++ b/ares/n64/vi/vi.cpp
@@ -62,11 +62,6 @@ auto VI::unload() -> void {
 
 auto VI::main() -> void {
   while(Thread::clock < 0) {
-    //field is not compared
-    if(io.vcounter << 1 == io.coincidence) {
-      mi.raise(MI::IRQ::VI);
-    }
-
     if(++io.vcounter >= (Region::NTSC() ? 262 : 312) + io.field) {
       io.vcounter = 0;
       io.field = io.field + 1 & io.serrate;
@@ -78,6 +73,11 @@ auto VI::main() -> void {
       #endif
       refreshed = true;
       screen->frame();
+    }
+
+    //field is not compared
+    if(io.vcounter << 1 == io.coincidence) {
+      mi.raise(MI::IRQ::VI);
     }
 
     if(Region::NTSC()) step(system.frequency() / 60 / 262);


### PR DESCRIPTION
The interrupt should be raised while the current line still equals the comparison value.

This fixes FIFA 64.