### PR TITLE
n64: improve idle loop detection

### DIFF
--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -104,7 +104,7 @@ auto CPU::instruction() -> void {
     }
 
     if (auto address = devirtualize(ipu.pc)) {
-      auto block = recompiler.block(*address);
+      auto block = recompiler.block(ipu.pc, *address);
       block->execute(*this);
     }
   }

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -894,10 +894,10 @@ struct CPU : Thread {
     }
 
     auto pool(u32 address) -> Pool*;
-    auto block(u32 address) -> Block*;
+    auto block(u32 vaddr, u32 address) -> Block*;
     auto fastFetchBlock(u32 address) -> Block*;
 
-    auto emit(u32 address) -> Block*;
+    auto emit(u32 vaddr, u32 address) -> Block*;
     auto emitEXECUTE(u32 instruction) -> bool;
     auto emitSPECIAL(u32 instruction) -> bool;
     auto emitREGIMM(u32 instruction) -> bool;

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -4,9 +4,9 @@ auto CPU::Recompiler::pool(u32 address) -> Pool* {
   return pool;
 }
 
-auto CPU::Recompiler::block(u32 address) -> Block* {
+auto CPU::Recompiler::block(u32 vaddr, u32 address) -> Block* {
   if(auto block = pool(address)->blocks[address >> 2 & 0x3f]) return block;
-  auto block = emit(address);
+  auto block = emit(vaddr, address);
   pool(address)->blocks[address >> 2 & 0x3f] = block;
   memory::jitprotect(true);
   return block;
@@ -18,7 +18,7 @@ auto CPU::Recompiler::fastFetchBlock(u32 address) -> Block* {
   return nullptr;
 }
 
-auto CPU::Recompiler::emit(u32 address) -> Block* {
+auto CPU::Recompiler::emit(u32 vaddr, u32 address) -> Block* {
   if(unlikely(allocator.available() < 1_MiB)) {
     print("CPU allocator flush\n");
     memory::jitprotect(false);
@@ -36,7 +36,7 @@ auto CPU::Recompiler::emit(u32 address) -> Block* {
     u32 instruction = bus.read<Word>(address, thread);
     bool branched = emitEXECUTE(instruction);
     if(unlikely(instruction == 0x1000'ffff  //beq 0,0,<pc>
-             || instruction == (2 << 26 | address >> 2 & 0x3ff'ffff))) {  //j <pc>
+             || instruction == (2 << 26 | vaddr >> 2 & 0x3ff'ffff))) {  //j <pc>
       //accelerate idle loops
       mov32(reg(1), imm(64 * 2));
       call(&CPU::step);


### PR DESCRIPTION
We should compare the virtual address, not physical, to the jump target. This fixes idle loop detection in games like Turok 2 & 3.