### PR TITLE
Add audio hotkeys

### DIFF
--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -124,6 +124,21 @@ auto InputManager::createHotkeys() -> void {
   hotkeys.append(InputHotkey("Quit Emulator").onPress([&] {
     program.quit();
   }));
+
+  hotkeys.append(InputHotkey("Mute Audio").onPress([&] {
+    if(!emulator) return;
+    program.mute();
+  }));
+
+  hotkeys.append(InputHotkey("Increase Audio").onPress([&] {
+    if(!emulator) return;
+    if(settings.audio.volume <= (f64)(1.9)) settings.audio.volume += (f64)(0.1);
+  }));
+
+  hotkeys.append(InputHotkey("Decrease Audio").onPress([&] {
+    if(!emulator) return;
+    if(settings.audio.volume >= (f64)(0.1)) settings.audio.volume -= (f64)(0.1);
+  }));
 }
 
 auto InputManager::pollHotkeys() -> void {

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -33,6 +33,7 @@ struct Program : ares::Platform {
 
   //utility.cpp
   auto pause(bool) -> void;
+  auto mute() -> void;
   auto paletteUpdate() -> void;
   auto runAheadUpdate() -> void;
   auto captureScreenshot(const u32* data, u32 pitch, u32 width, u32 height) -> void;

--- a/desktop-ui/program/utility.cpp
+++ b/desktop-ui/program/utility.cpp
@@ -9,6 +9,11 @@ auto Program::pause(bool state) -> void {
   }
 }
 
+auto Program::mute() -> void {
+  settings.audio.mute = !settings.audio.mute;
+  presentation.muteAudioSetting.setChecked(settings.audio.mute);
+}
+
 auto Program::paletteUpdate() -> void {
   if(!emulator) return;
   for(auto& screen : emulator->root->find<ares::Node::Video::Screen>()) {


### PR DESCRIPTION
Addresses feature request defined here: https://github.com/ares-emulator/ares/issues/1181 

3 new hotkeys can be set now in Settings > Hotkeys

- Mute audio is an on/off toggle
- Increase/Decrease audio will adjust by 10% (0.1) with each key press