### PR TITLE
recompiler: allocate code cache early in main

### DIFF
--- a/ares/ares/memory/fixed-allocator.cpp
+++ b/ares/ares/memory/fixed-allocator.cpp
@@ -2,12 +2,15 @@
 
 namespace ares::Memory {
 
+constexpr u32 fixedBufferSize = 128_MiB;
+
 #if defined(PLATFORM_MACOS)
-//stub for unsupported platforms
+//dynamic allocation for unsupported platforms
 FixedAllocator::FixedAllocator() {
+  _allocator.resize(fixedBufferSize, bump_allocator::executable);
 }
 #else
-alignas(4096) u8 fixedBuffer[128_MiB];
+alignas(4096) u8 fixedBuffer[fixedBufferSize];
 
 FixedAllocator::FixedAllocator() {
   _allocator.resize(sizeof(fixedBuffer), 0, fixedBuffer);

--- a/ares/component/processor/sh2/sh2.cpp
+++ b/ares/component/processor/sh2/sh2.cpp
@@ -65,7 +65,9 @@ auto SH2::power(bool reset) -> void {
 
   if constexpr(Accuracy::Recompiler) {
     auto buffer = ares::Memory::FixedAllocator::get().tryAcquire(64_MiB);
+    memory::jitprotect(false);
     recompiler.allocator.resize(64_MiB, bump_allocator::executable | bump_allocator::zero_fill, buffer);
+    memory::jitprotect(true);
     recompiler.reset();
   }
 }

--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -168,7 +168,9 @@ auto CPU::power(bool reset) -> void {
 
   if constexpr(Accuracy::CPU::Recompiler) {
     auto buffer = ares::Memory::FixedAllocator::get().tryAcquire(64_MiB);
+    memory::jitprotect(false);
     recompiler.allocator.resize(64_MiB, bump_allocator::executable | bump_allocator::zero_fill, buffer);
+    memory::jitprotect(true);
     recompiler.reset();
   }
 }

--- a/ares/n64/rsp/rsp.cpp
+++ b/ares/n64/rsp/rsp.cpp
@@ -142,7 +142,9 @@ auto RSP::power(bool reset) -> void {
 
   if constexpr(Accuracy::RSP::Recompiler) {
     auto buffer = ares::Memory::FixedAllocator::get().tryAcquire(64_MiB);
+    memory::jitprotect(false);
     recompiler.allocator.resize(64_MiB, bump_allocator::executable | bump_allocator::zero_fill, buffer);
+    memory::jitprotect(true);
     recompiler.reset();
   }
 

--- a/ares/ps1/cpu/cpu.cpp
+++ b/ares/ps1/cpu/cpu.cpp
@@ -258,7 +258,9 @@ auto CPU::power(bool reset) -> void {
 
   if constexpr(Accuracy::CPU::Recompiler) {
     auto buffer = ares::Memory::FixedAllocator::get().tryAcquire(64_MiB);
+    memory::jitprotect(false);
     recompiler.allocator.resize(64_MiB, bump_allocator::executable | bump_allocator::zero_fill, buffer);
+    memory::jitprotect(true);
     recompiler.reset();
   }
 }

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -44,6 +44,11 @@ auto locate(const string& name) -> string {
 
 #include <nall/main.hpp>
 auto nall::main(Arguments arguments) -> void {
+#if defined(PLATFORM_MACOS)
+  //force early allocation for better proximity to executable code
+  ares::Memory::FixedAllocator::get();
+#endif
+
 #if defined(PLATFORM_WINDOWS)
   bool createTerminal = arguments.take("--terminal");
   terminal::redirectStdioToTerminal(createTerminal);


### PR DESCRIPTION
On Windows and Linux, ares uses a buffer in the bss section for the recompiler code cache. On macOS this buffer must be dynamically allocated for security reasons. The distance between the code cache and the rest of the ares executable has a large influence on performance on all platforms because there are microarchitecural thresholds beyond which branches will never be correctly predicted by the CPU.

To make performance more consistent on macOS, we can make this dynamic allocation sooner, at the top of main(), before the address space has become too cluttered with allocations made by other code.