### PR TITLE
desktop-ui: add fast load option to load menu

### DIFF
--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -374,7 +374,24 @@ auto Presentation::loadEmulators() -> void {
     }
   }
   loadMenu.append(MenuSeparator());
+  
+  { MenuItem loadFastAction{&loadMenu};
+    loadFastAction.setText("Load fast" ELLIPSIS).setIcon(Icon::Emblem::Folder).onActivate([&] {  
+      string location;
+      BrowserDialog dialog;
+      dialog.setTitle({"Load Game"});
+      dialog.setPath(Path::desktop());
+      dialog.setAlignment(presentation);
+      dialog.setFilters({"All|*"});
 
+      if(auto location = program.openFile(dialog)) {
+        if(auto emulator = program.identify(location))
+          program.load(emulator, location);
+      }
+    });  
+  }
+  loadMenu.append(MenuSeparator());  
+  
   //build emulator load list
   for(auto& emulator : emulators) {
     MenuItem item;


### PR DESCRIPTION
I discovered you can drag & drop any game ROM to ares and it will load without choosing a emulator (mia can identity the correct emulator).
I like this and I want to use this via the menu too :)

If a file cannot be recognized or its 64DD stuff or something, there will be a error displayed, just like with the existing drag & drop functionality.

Looks like this:
![grafik](https://github.com/ares-emulator/ares/assets/54060/9ad83af7-548e-4583-a297-da365d071b0f)
