### PR TITLE
build: prefer clang only on win/macos/bsd

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you would like to use SDL for input, you will need to install the following t
 
 ##### Building with clang
 
-clang++ is now the preferred compiler for ares. If it is detected, the build will default to building with clang. It is necessary to install both the `clang` and `lld` packages. If you would like to manually specify a compiler, you can use the following option: `compiler=[g++|clang++]`  
+clang++ is now the preferred compiler for ares. If clang is detected on Windows/macOS/BSD, it will be selected by default. On Linux and other platforms, g++ remains the default if present. To build with clang, it is necessary to install both the `clang` and `lld` packages. If you would like to manually specify a compiler, you can use the following option: `compiler=[g++|clang++]`  
   
 --------------
 

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -70,11 +70,18 @@ endif
 
 # compiler detection
 ifeq ($(compiler),)
-  # prefer clang
-  ifneq ($(call which,clang++),)
-    compiler := clang++
+  ifneq ($(filter windows macos bsd,$(platform)),)
+    compilers := clang++ g++
   else
-    compiler := g++
+    compilers := g++ clang++
+  endif
+
+  ifneq ($(call which,$(word 1, $(compilers))),)
+    compiler := $(word 1, $(compilers))
+  else ifneq ($(call which,$(word 2, $(compilers))),)
+    compiler := $(word 2, $(compilers))
+  else
+    $(error unknown compiler, please specify manually.)
   endif
 endif
 
@@ -316,6 +323,8 @@ endif
 default: all;
 
 nall.verbose:
+	$(info Compiler:)
+	$(info $([space]) $(compiler))
 	$(info Compiler Flags:)
 	$(foreach n,$(sort $(call unique,$(flags))),$(if $(filter-out -I%,$n),$(info $([space]) $n)))
 	$(info Linker Options:)


### PR DESCRIPTION
Up until 67d1647d6e5f99bb1edb9cd82914ce1b0115c912, clang was the assumed compiler on macOS and BSD, and g++ was the default everywhere else.

After that commit, we defaulted to clang on all platforms if it was found in the user's path. It has since become clear that while a number of Linux users have clang in their path, many have not installed critical packages necessary to build C++ software and are completely unaware of this state of affairs or which packages need installing.

To simplify matters, we will revert to the default of g++ on systems other than Windows, macOS, and BSD. Additionally, the `verbose` target will now print the compiler in use, as this is pretty relevant information for diagnosing build issues.