### PR TITLE
Move region radio to load menu

### DIFF
--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -73,25 +73,13 @@ Presentation::Presentation() {
   });
   videoShaderMenu.setText("Shader").setIcon(Icon::Emblem::Image);
   loadShaders();
-  bootOptionsMenu.setText("Boot Options").setIcon(Icon::Place::Settings);
+
   fastBoot.setText("Fast Boot").setChecked(settings.boot.fast).onToggle([&] {
     settings.boot.fast = fastBoot.checked();
   });
   launchDebugger.setText("Launch Debugger").setChecked(settings.boot.debugger).onToggle([&] {
     settings.boot.debugger = launchDebugger.checked();
   });
-  preferNTSCU.setText("Prefer US").onActivate([&] {
-    settings.boot.prefer = "NTSC-U";
-  });
-  preferNTSCJ.setText("Prefer Japan").onActivate([&] {
-    settings.boot.prefer = "NTSC-J";
-  });
-  preferPAL.setText("Prefer Europe").onActivate([&] {
-    settings.boot.prefer = "PAL";
-  });
-  if(settings.boot.prefer == "NTSC-U") preferNTSCU.setChecked();
-  if(settings.boot.prefer == "NTSC-J") preferNTSCJ.setChecked();
-  if(settings.boot.prefer == "PAL") preferPAL.setChecked();
   muteAudioSetting.setText("Mute Audio").setChecked(settings.audio.mute).onToggle([&] {
     settings.audio.mute = muteAudioSetting.checked();
   });
@@ -418,9 +406,25 @@ auto Presentation::loadEmulators() -> void {
     });
   }
 
-  #if !defined(PLATFORM_MACOS)
   loadMenu.append(MenuSeparator());
-    
+
+  preferNTSCU.setText("NTSC-U").onActivate([&] {
+  settings.boot.prefer = "NTSC-U";
+  });
+  preferNTSCJ.setText("NTSC-J").onActivate([&] {
+    settings.boot.prefer = "NTSC-J";
+  });
+  preferPAL.setText("PAL").onActivate([&] {
+    settings.boot.prefer = "PAL";
+  });
+  if(settings.boot.prefer == "NTSC-U") preferNTSCU.setChecked();
+  if(settings.boot.prefer == "NTSC-J") preferNTSCJ.setChecked();
+  if(settings.boot.prefer == "PAL") preferPAL.setChecked();
+
+  loadMenu.append(MenuSeparator());
+
+  #if !defined(PLATFORM_MACOS)
+
   { MenuItem quit{&loadMenu};
     quit.setIcon(Icon::Action::Quit);
     quit.setText("Quit");

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -396,6 +396,7 @@ auto Presentation::loadEmulators() -> void {
     }
     menu.append(item);
   }
+
   if(enabled == 0) {
     //if the user disables every system, give an indication for how to re-add systems to the load menu
     MenuItem item{&loadMenu};
@@ -408,18 +409,20 @@ auto Presentation::loadEmulators() -> void {
 
   loadMenu.append(MenuSeparator());
 
+  Group preferRegionGroup;
+  MenuRadioItem preferNTSCU{&loadMenu};
   preferNTSCU.setText("NTSC-U").onActivate([&] {
-  settings.boot.prefer = "NTSC-U";
+    settings.boot.prefer = "NTSC-U";
   });
+
+  MenuRadioItem preferNTSCJ{&loadMenu};
   preferNTSCJ.setText("NTSC-J").onActivate([&] {
     settings.boot.prefer = "NTSC-J";
   });
+  MenuRadioItem preferPAL{&loadMenu};
   preferPAL.setText("PAL").onActivate([&] {
     settings.boot.prefer = "PAL";
   });
-  if(settings.boot.prefer == "NTSC-U") preferNTSCU.setChecked();
-  if(settings.boot.prefer == "NTSC-J") preferNTSCJ.setChecked();
-  if(settings.boot.prefer == "PAL") preferPAL.setChecked();
 
   loadMenu.append(MenuSeparator());
 

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -12,6 +12,10 @@ struct Presentation : Window {
 
   MenuBar menuBar{this};
     Menu loadMenu{&menuBar};
+        MenuRadioItem preferNTSCU{&loadMenu};
+        MenuRadioItem preferNTSCJ{&loadMenu};
+        MenuRadioItem preferPAL{&loadMenu};
+        Group preferRegionGroup{&preferNTSCU, &preferNTSCJ, &preferPAL};
     Menu systemMenu{&menuBar};
     Menu settingsMenu{&menuBar};
       Menu videoSizeMenu{&settingsMenu};
@@ -29,15 +33,8 @@ struct Presentation : Window {
         MenuCheckItem videoAdaptiveSizing{&videoOutputMenu};
         MenuCheckItem videoAutoCentering{&videoOutputMenu};
       Menu videoShaderMenu{&settingsMenu};
-      Menu bootOptionsMenu{&settingsMenu};
-        MenuCheckItem fastBoot{&bootOptionsMenu};
-        MenuCheckItem launchDebugger{&bootOptionsMenu};
-        MenuSeparator bootOptionsSeparator{&bootOptionsMenu};
-        MenuRadioItem preferNTSCU{&bootOptionsMenu};
-        MenuRadioItem preferNTSCJ{&bootOptionsMenu};
-        MenuRadioItem preferPAL{&bootOptionsMenu};
-        Group preferRegionGroup{&preferNTSCU, &preferNTSCJ, &preferPAL};
-      MenuSeparator groupSettingsSeparatpr{&settingsMenu};
+      MenuCheckItem fastBoot{&settingsMenu};
+      MenuCheckItem launchDebugger{&settingsMenu};
       MenuCheckItem muteAudioSetting{&settingsMenu};
       MenuCheckItem showStatusBarSetting{&settingsMenu};
       MenuSeparator audioSettingsSeparator{&settingsMenu};

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -12,10 +12,6 @@ struct Presentation : Window {
 
   MenuBar menuBar{this};
     Menu loadMenu{&menuBar};
-        MenuRadioItem preferNTSCU{&loadMenu};
-        MenuRadioItem preferNTSCJ{&loadMenu};
-        MenuRadioItem preferPAL{&loadMenu};
-        Group preferRegionGroup{&preferNTSCU, &preferNTSCJ, &preferPAL};
     Menu systemMenu{&menuBar};
     Menu settingsMenu{&menuBar};
       Menu videoSizeMenu{&settingsMenu};


### PR DESCRIPTION
The idea here is that this is a machine setting and should be plainly visible every time a game is loaded. When region is buried in a settings submenu, people forget that they've left it in PAL mode. This has led to several false bug reports.

<s>I wasn't able to get it to show up, but this is a start and a real coder can finish.</s> It shows up, but something is still wrong.

Maybe we can also discuss the merits of having this setting force the region once it's moved to this more visible place. Old systems don't have internal data from which to glean the region, and many mega drive games have incorrect header information that throws off detection attempts. It is also currently impossible to see region error screens and easter eggs.