### PR TITLE
fc: Lowered saturation

### DIFF
--- a/ares/fc/ppu/color.cpp
+++ b/ares/fc/ppu/color.cpp
@@ -1,5 +1,5 @@
 auto PPU::color(n32 n) -> n64 {
-  f64 saturation = 2.0;
+  f64 saturation = 1.5;
   f64 hue = 0.0;
   f64 contrast = 1.0;
   f64 brightness = 1.0;


### PR DESCRIPTION
Lowered saturation value from 2.0 to 1.5 to match other implementations of NTSC (Nintendulator, puNES, Nestopia, Mesen, etc.)