### PR TITLE
Added Pak4, Hicom, Hap2000 and K188in1 Mappers to the SMS core. And fixing missleading mapper name.

### DIFF
--- a/ares/ms/cartridge/board/board.cpp
+++ b/ares/ms/cartridge/board/board.cpp
@@ -7,6 +7,7 @@ namespace Board {
 #include "janggun.cpp"
 #include "pak4.cpp"
 #include "hicom.cpp"
+#include "hap2000.cpp"
 
 auto Interface::load(Memory::Readable<n8>& memory, string name) -> bool {
   if(auto fp = pak->read(name)) {

--- a/ares/ms/cartridge/board/board.cpp
+++ b/ares/ms/cartridge/board/board.cpp
@@ -3,11 +3,12 @@ namespace Board {
 #include "sega.cpp"
 #include "codemasters.cpp"
 #include "korea.cpp"
-#include "msx.cpp"
+#include "zemina.cpp"
 #include "janggun.cpp"
 #include "pak4.cpp"
 #include "hicom.cpp"
 #include "hap2000.cpp"
+#include "k188in1.cpp"
 
 auto Interface::load(Memory::Readable<n8>& memory, string name) -> bool {
   if(auto fp = pak->read(name)) {

--- a/ares/ms/cartridge/board/board.cpp
+++ b/ares/ms/cartridge/board/board.cpp
@@ -5,6 +5,8 @@ namespace Board {
 #include "korea.cpp"
 #include "msx.cpp"
 #include "janggun.cpp"
+#include "pak4.cpp"
+#include "hicom.cpp"
 
 auto Interface::load(Memory::Readable<n8>& memory, string name) -> bool {
   if(auto fp = pak->read(name)) {

--- a/ares/ms/cartridge/board/hap2000.cpp
+++ b/ares/ms/cartridge/board/hap2000.cpp
@@ -1,0 +1,62 @@
+
+struct Hap2000 : Interface {
+  using Interface::Interface;
+  Memory::Readable<n8> rom;
+
+  auto load() -> void override {
+    Interface::load(rom, "program.rom");
+  }
+
+  auto save() -> void override {
+  }
+
+  auto unload() -> void override {
+  }
+
+  auto read(n16 address, n8 data) -> n8 override {
+    if(address <= 0x3fff) // static
+		return rom.read((address & 0x3fff));
+		
+    if(address < 0xbfff) // banked
+		return rom.read( (romBank * 0x8000) + (address));
+	
+    return data;
+  }
+
+  auto write(n16 address, n8 data) -> void override {
+	  if ( address == 0x2000){
+		  print(data);
+		  print("\n");
+		  romBank = data;
+	  }
+	  /*
+	switch (address){
+		case 0x3ffe:
+			reg[0] = data;
+			romBank[0] = data % bank_count;
+			romBank[2] = ((reg[0] & 0x30) + reg[2]) % bank_count;
+			break;
+		case 0x7fff:
+			reg[1] = data;
+			romBank[1] = data % bank_count;
+			break;
+		case 0xbfff:
+			reg[2] = data;
+			romBank[2] = ((reg[0] & 0x30) + reg[2]) % bank_count;
+			break;
+	}*/
+  }
+
+  auto power() -> void override {
+    romBank = 0;
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(romBank);
+  }
+
+  n8 romBank;
+};
+
+
+

--- a/ares/ms/cartridge/board/hap2000.cpp
+++ b/ares/ms/cartridge/board/hap2000.cpp
@@ -1,62 +1,38 @@
-
-struct Hap2000 : Interface {
+struct Hap2000: Interface {
   using Interface::Interface;
-  Memory::Readable<n8> rom;
+  Memory::Readable < n8 > rom;
 
   auto load() -> void override {
     Interface::load(rom, "program.rom");
   }
 
-  auto save() -> void override {
-  }
+  auto save() -> void override {}
 
-  auto unload() -> void override {
-  }
+  auto unload() -> void override {}
 
   auto read(n16 address, n8 data) -> n8 override {
-    if(address <= 0x3fff) // static
-		return rom.read((address & 0x3fff));
-		
-    if(address < 0xbfff) // banked
-		return rom.read( (romBank * 0x8000) + (address));
-	
+    if (address <= 0x3fff) // static
+      return rom.read((address & 0x3fff));
+
+    if (address < 0xbfff) // banked
+      return rom.read((romBank * 0x8000) + (address));
+
     return data;
   }
 
   auto write(n16 address, n8 data) -> void override {
-	  if ( address == 0x2000){
-		  print(data);
-		  print("\n");
-		  romBank = data;
-	  }
-	  /*
-	switch (address){
-		case 0x3ffe:
-			reg[0] = data;
-			romBank[0] = data % bank_count;
-			romBank[2] = ((reg[0] & 0x30) + reg[2]) % bank_count;
-			break;
-		case 0x7fff:
-			reg[1] = data;
-			romBank[1] = data % bank_count;
-			break;
-		case 0xbfff:
-			reg[2] = data;
-			romBank[2] = ((reg[0] & 0x30) + reg[2]) % bank_count;
-			break;
-	}*/
+    if (address == 0x2000) {
+      romBank = data;
+    }
   }
 
   auto power() -> void override {
     romBank = 0;
   }
 
-  auto serialize(serializer& s) -> void override {
+  auto serialize(serializer & s) -> void override {
     s(romBank);
   }
 
   n8 romBank;
 };
-
-
-

--- a/ares/ms/cartridge/board/hicom.cpp
+++ b/ares/ms/cartridge/board/hicom.cpp
@@ -1,0 +1,44 @@
+
+struct Hicom : Interface {
+  using Interface::Interface;
+  Memory::Readable<n8> rom;
+
+  auto load() -> void override {
+    Interface::load(rom, "program.rom");
+  }
+
+  auto save() -> void override {
+  }
+
+  auto unload() -> void override {
+  }
+
+  auto read(n16 address, n8 data) -> n8 override {
+    if(address <= 0x7fff)
+      return rom.read( (m_rom_bank_base * 0x8000) | (address&0x7fff));
+      
+    return data;
+  }
+
+  auto write(n16 address, n8 data) -> void override {
+	if (address == 0xffff){
+		m_rom_bank_base = data % (m_rom_page_count << 1);
+		print(m_rom_bank_base);
+		print("\n");
+	}
+  }
+
+  auto power() -> void override {
+    m_rom_bank_base = 0;
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(m_rom_bank_base);
+  }
+
+  n8 m_rom_bank_base;
+  n8 m_rom_page_count = 5;
+};
+
+
+

--- a/ares/ms/cartridge/board/hicom.cpp
+++ b/ares/ms/cartridge/board/hicom.cpp
@@ -1,44 +1,36 @@
-
-struct Hicom : Interface {
+struct Hicom: Interface {
   using Interface::Interface;
-  Memory::Readable<n8> rom;
+  Memory::Readable < n8 > rom;
 
   auto load() -> void override {
     Interface::load(rom, "program.rom");
   }
 
-  auto save() -> void override {
-  }
+  auto save() -> void override {}
 
-  auto unload() -> void override {
-  }
+  auto unload() -> void override {}
 
   auto read(n16 address, n8 data) -> n8 override {
-    if(address <= 0x7fff)
-      return rom.read( (m_rom_bank_base * 0x8000) | (address&0x7fff));
-      
+    if (address <= 0x7fff)
+      return rom.read((m_rom_bank_base * 0x8000) | (address & 0x7fff));
+
     return data;
   }
 
   auto write(n16 address, n8 data) -> void override {
-	if (address == 0xffff){
-		m_rom_bank_base = data % (m_rom_page_count << 1);
-		print(m_rom_bank_base);
-		print("\n");
-	}
+    if (address == 0xffff) {
+      m_rom_bank_base = data % (m_rom_page_count << 1);
+    }
   }
 
   auto power() -> void override {
     m_rom_bank_base = 0;
   }
 
-  auto serialize(serializer& s) -> void override {
+  auto serialize(serializer & s) -> void override {
     s(m_rom_bank_base);
   }
 
   n8 m_rom_bank_base;
   n8 m_rom_page_count = 5;
 };
-
-
-

--- a/ares/ms/cartridge/board/hicom.cpp
+++ b/ares/ms/cartridge/board/hicom.cpp
@@ -12,25 +12,25 @@ struct Hicom: Interface {
 
   auto read(n16 address, n8 data) -> n8 override {
     if (address <= 0x7fff)
-      return rom.read((m_rom_bank_base * 0x8000) | (address & 0x7fff));
+      return rom.read((romBank * 0x8000) | (address & 0x7fff));
 
     return data;
   }
 
   auto write(n16 address, n8 data) -> void override {
     if (address == 0xffff) {
-      m_rom_bank_base = data % (m_rom_page_count << 1);
+      romBank = data % (romBankCount << 1);
     }
   }
 
   auto power() -> void override {
-    m_rom_bank_base = 0;
+    romBank = 0;
   }
 
   auto serialize(serializer & s) -> void override {
-    s(m_rom_bank_base);
+    s(romBank);
   }
 
-  n8 m_rom_bank_base;
-  n8 m_rom_page_count = 5;
+  n8 romBank;
+  n8 romBankCount = 5;
 };

--- a/ares/ms/cartridge/board/k188in1.cpp
+++ b/ares/ms/cartridge/board/k188in1.cpp
@@ -1,0 +1,42 @@
+
+// TODO: Game 6 and 13 do not work, posibly others also fail.
+
+struct K188in1: Interface {
+  using Interface::Interface;
+  Memory::Readable < n8 > rom;
+
+  auto load() -> void override {
+    Interface::load(rom, "program.rom");
+  }
+
+  auto save() -> void override {
+  }
+
+  auto unload() -> void override {
+  }
+
+  auto read(n16 address, n8 data) -> n8 override {
+    if (address <= 0x3fff) // static
+      return rom.read((address & 0x3fff));
+    if (address <= 0xbfff) // banked
+      return rom.read((address-0x4000)+(romBank*0x2000));
+
+    return data;
+  }
+  
+  auto write(n16 address, n8 data) -> void override {
+    if ((address & 0x6000) == 0x2000) {
+      romBank = data ^ 0x1F;
+    }
+  }
+
+  auto power() -> void override {
+    romBank = 0;
+  }
+
+  auto serialize(serializer & s) -> void override {
+    s(romBank);
+  }
+
+  n16 romBank;
+};

--- a/ares/ms/cartridge/board/pak4.cpp
+++ b/ares/ms/cartridge/board/pak4.cpp
@@ -1,53 +1,50 @@
-
-struct Pak4 : Interface {
+struct Pak4: Interface {
   using Interface::Interface;
-  Memory::Readable<n8> rom;
+  Memory::Readable < n8 > rom;
 
   auto load() -> void override {
     Interface::load(rom, "program.rom");
   }
 
-  auto save() -> void override {
-  }
+  auto save() -> void override {}
 
-  auto unload() -> void override {
-  }
+  auto unload() -> void override {}
 
   auto read(n16 address, n8 data) -> n8 override {
-    if(address <= 0xbfff)
-		return rom.read((romBank[address>>14]<<14) + (address & 0x3fff));
+    if (address <= 0xbfff)
+      return rom.read((romBank[address >> 14] << 14) + (address & 0x3fff));
     return data;
   }
 
   auto write(n16 address, n8 data) -> void override {
-	switch (address){
-		case 0x3ffe:
-			reg[0] = data;
-			romBank[0] = data % bank_count;
-			romBank[2] = ((reg[0] & 0x30) + reg[2]) % bank_count;
-			break;
-		case 0x7fff:
-			reg[1] = data;
-			romBank[1] = data % bank_count;
-			break;
-		case 0xbfff:
-			reg[2] = data;
-			romBank[2] = ((reg[0] & 0x30) + reg[2]) % bank_count;
-			break;
-	}
+    switch (address) {
+    case 0x3ffe:
+      reg[0] = data;
+      romBank[0] = data % bank_count;
+      romBank[2] = ((reg[0] & 0x30) + reg[2]) % bank_count;
+      break;
+    case 0x7fff:
+      reg[1] = data;
+      romBank[1] = data % bank_count;
+      break;
+    case 0xbfff:
+      reg[2] = data;
+      romBank[2] = ((reg[0] & 0x30) + reg[2]) % bank_count;
+      break;
+    }
   }
 
   auto power() -> void override {
     romBank[0] = 0;
     romBank[1] = 1;
     romBank[2] = 2;
-    
+
     reg[0] = 0;
     reg[1] = 0;
     reg[2] = 0;
   }
 
-  auto serialize(serializer& s) -> void override {
+  auto serialize(serializer & s) -> void override {
     s(romBank);
   }
 
@@ -55,6 +52,3 @@ struct Pak4 : Interface {
   n8 romBank[4];
   n8 bank_count = 0xff; // idk what values correct.
 };
-
-
-

--- a/ares/ms/cartridge/board/pak4.cpp
+++ b/ares/ms/cartridge/board/pak4.cpp
@@ -1,0 +1,60 @@
+
+struct Pak4 : Interface {
+  using Interface::Interface;
+  Memory::Readable<n8> rom;
+
+  auto load() -> void override {
+    Interface::load(rom, "program.rom");
+  }
+
+  auto save() -> void override {
+  }
+
+  auto unload() -> void override {
+  }
+
+  auto read(n16 address, n8 data) -> n8 override {
+    if(address <= 0xbfff)
+		return rom.read((romBank[address>>14]<<14) + (address & 0x3fff));
+    return data;
+  }
+
+  auto write(n16 address, n8 data) -> void override {
+	switch (address){
+		case 0x3ffe:
+			reg[0] = data;
+			romBank[0] = data % bank_count;
+			romBank[2] = ((reg[0] & 0x30) + reg[2]) % bank_count;
+			break;
+		case 0x7fff:
+			reg[1] = data;
+			romBank[1] = data % bank_count;
+			break;
+		case 0xbfff:
+			reg[2] = data;
+			romBank[2] = ((reg[0] & 0x30) + reg[2]) % bank_count;
+			break;
+	}
+  }
+
+  auto power() -> void override {
+    romBank[0] = 0;
+    romBank[1] = 1;
+    romBank[2] = 2;
+    
+    reg[0] = 0;
+    reg[1] = 0;
+    reg[2] = 0;
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(romBank);
+  }
+
+  n8 reg[4];
+  n8 romBank[4];
+  n8 bank_count = 0xff; // idk what values correct.
+};
+
+
+

--- a/ares/ms/cartridge/board/zemina.cpp
+++ b/ares/ms/cartridge/board/zemina.cpp
@@ -1,8 +1,8 @@
-struct MSX : Interface {
+struct Zemina : Interface {
   using Interface::Interface;
   Memory::Readable<n8> rom;
 
-  MSX(Cartridge& cartridge, bool nemesis) : Interface(cartridge), nemesis(nemesis) {
+  Zemina(Cartridge& cartridge, bool nemesis) : Interface(cartridge), nemesis(nemesis) {
   }
 
   auto load() -> void override {

--- a/ares/ms/cartridge/cartridge.cpp
+++ b/ares/ms/cartridge/cartridge.cpp
@@ -30,6 +30,7 @@ auto Cartridge::connect() -> void {
   
   // WIP
   if(information.board == "Korea_NB") board = new Board::Korea{*this}; // TODO: Some of these games work but should not have bank switching.
+  if(information.board == "Hap2000") board = new Board::Hap2000{*this}; // 2 Hap in 1 - David-2 ~ Moai-ui bomul (KR)
   
   
   if(!board) board = new Board::Interface{*this};

--- a/ares/ms/cartridge/cartridge.cpp
+++ b/ares/ms/cartridge/cartridge.cpp
@@ -27,10 +27,10 @@ auto Cartridge::connect() -> void {
   if(information.board == "Janggun") board = new Board::Janggun{*this};
   if(information.board == "Hicom") board = new Board::Hicom{*this};
   if(information.board == "pak4") board = new Board::Pak4{*this}; // 4 PAK All Action (Australia)
+  if(information.board == "Hap2000") board = new Board::Hap2000{*this}; // 2 Hap in 1 - David-2 ~ Moai-ui bomul (KR)
   
   // WIP
   if(information.board == "Korea_NB") board = new Board::Korea{*this}; // TODO: Some of these games work but should not have bank switching.
-  if(information.board == "Hap2000") board = new Board::Hap2000{*this}; // 2 Hap in 1 - David-2 ~ Moai-ui bomul (KR)
   
   
   if(!board) board = new Board::Interface{*this};

--- a/ares/ms/cartridge/cartridge.cpp
+++ b/ares/ms/cartridge/cartridge.cpp
@@ -23,8 +23,15 @@ auto Cartridge::connect() -> void {
   if(information.board == "Codemasters") board = new Board::Codemasters{*this};
   if(information.board == "Korea") board = new Board::Korea{*this};
   if(information.board == "MSX") board = new Board::MSX{*this, 0};
-  if(information.board == "MSX#A") board = new Board::MSX{*this, 1};
+  if(information.board == "Nemesis") board = new Board::MSX{*this, 1}; // Nemesis (Korea)
   if(information.board == "Janggun") board = new Board::Janggun{*this};
+  if(information.board == "Hicom") board = new Board::Hicom{*this};
+  if(information.board == "pak4") board = new Board::Pak4{*this}; // 4 PAK All Action (Australia)
+  
+  // WIP
+  if(information.board == "Korea_NB") board = new Board::Korea{*this}; // TODO: Some of these games work but should not have bank switching.
+  
+  
   if(!board) board = new Board::Interface{*this};
   board->pak = pak;
   board->load();

--- a/ares/ms/cartridge/cartridge.cpp
+++ b/ares/ms/cartridge/cartridge.cpp
@@ -22,14 +22,16 @@ auto Cartridge::connect() -> void {
   if(information.board == "Sega") board = new Board::Sega{*this};
   if(information.board == "Codemasters") board = new Board::Codemasters{*this};
   if(information.board == "Korea") board = new Board::Korea{*this};
-  if(information.board == "MSX") board = new Board::MSX{*this, 0};
-  if(information.board == "Nemesis") board = new Board::MSX{*this, 1}; // Nemesis (Korea)
+  if(information.board == "Zemina") board = new Board::Zemina{*this, 0}; // Zemina made games
+  if(information.board == "Zemina_Nemesis") board = new Board::Zemina{*this, 1}; // Zemina's Nemesis port only
   if(information.board == "Janggun") board = new Board::Janggun{*this};
   if(information.board == "Hicom") board = new Board::Hicom{*this};
   if(information.board == "pak4") board = new Board::Pak4{*this}; // 4 PAK All Action (Australia)
   if(information.board == "Hap2000") board = new Board::Hap2000{*this}; // 2 Hap in 1 - David-2 ~ Moai-ui bomul (KR)
+  if(information.board == "K188in1") board = new Board::K188in1{*this}; // Korean 188 in 1
   
   // WIP
+  
   if(information.board == "Korea_NB") board = new Board::Korea{*this}; // TODO: Some of these games work but should not have bank switching.
   
   

--- a/mia/medium/master-system.cpp
+++ b/mia/medium/master-system.cpp
@@ -108,6 +108,82 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
     region = "NTSC-J";
   }
 
+  //4pak
+  //===========
+
+  //4 PAK All Action (Australia)
+  if(hash == "fe2ef2e550b5ca4ecf81786cda858e0f3e537dd3cdf70316c8453320ea4e6957") {
+    board  = "pak4";
+    region = "PAL";
+    ram    = 0;
+  }
+
+  //Hicom
+  //===========
+
+  //The Best Game Collection - Hang On + Pit Pot + Spy vs Spy (Korea)##
+  if(hash == "11ef490394ad30bfa795295f0195177f7ac92153521a97dc3d9a817912cd185c") {
+    board  = "Hicom";
+    region = "PAL";
+    ram    = 0;
+  }
+
+  //The Best Game Collection - Great Baseball + Great Soccer + Super Tennis (Korea)##
+  if(hash == "dcd0195f5e9eef77c5ffd23413b54206daa8eacaf9adb41618c16b43c9bf3eb3") {
+    board  = "Hicom";
+    region = "PAL";
+    ram    = 0;
+  }
+
+  //The Best Game Collection - Teddy Boy Blues + Pit-Pot + Astro Flash (Korea)##
+  if(hash == "5e8dba358c6e5ced67d6fd6d3c8e3124ac6bcde73ae5b1b89fe31d5733451fb0") {
+    board  = "Hicom";
+    region = "PAL";
+    ram    = 0;
+  }
+
+  //The Best Game Collection - Teddy Boy Blues + Great Soccer + Comical Machine Gun Joe (Korea)##
+  if(hash == "bee055caea0282a505afd08452000aca3a46ee7a2a7ed1f7cfa09b43580a8431") {
+    board  = "Hicom";
+    region = "PAL";
+    ram    = 0;
+  }
+
+  //The Best Game Collection - Ghost House + Teddy Boy Blues + Seishun Scandal (Korea)##
+  if(hash == "395cf05e2eabc7d47f57e501239f60d35933f450b2205895d25f380ae4b23a7c") {
+    board  = "Hicom";
+    region = "PAL";
+    ram    = 0;
+  }
+
+  //The Best Game Collection - Satellite-7 + Great Baseball + Seishun Scandal (Korea)##
+  if(hash == "6f09849fa4f5904cc9554c15b4522da49160cf99f81895c1df80d3b4bfc0f033") {
+    board  = "Hicom";
+    region = "PAL";
+    ram    = 0;
+  }
+
+  //The Best Game Collection (Korea, 8 in 1 Ver. A)##
+  if(hash == "572dfcc5ade1251c38b729ee86d78e37fde29d948d19f2292aeff32685db9129") {
+    board  = "Hicom";
+    region = "PAL";
+    ram    = 0;
+  }
+
+  //The Best Game Collection (Korea, 8 in 1 Ver. B)##
+  if(hash == "6b829e41da9b7a0f2f0b0fcdbd644e311178ee7958e69ea6a1590dd4794a2834") {
+    board  = "Hicom";
+    region = "PAL";
+    ram    = 0;
+  }
+
+  //The Best Game Collection (Korea, 8 in 1 Ver. C)##
+  if(hash == "addf8f41dfb2698cb4e5d01bdff29bfda898d099e651c08d7536eb9e2bb14f5e") {
+    board  = "Hicom";
+    region = "PAL";
+    ram    = 0;
+  }
+
   //Codemasters
   //===========
 
@@ -125,13 +201,20 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
     ram    = 0;
   }
 
+  //The Excellent Dizzy Collection (Europe, USA, prototype)
+  if(hash == "f9cfcad94d7fa8a863d7b9fbeda5ed02e29787f3b56bc6114aea900c2bb44831") {
+    board  = "Codemasters";
+    region = "PAL";
+    ram    = 0;
+  }
+
   //Fantastic Dizzy (Europe)
   if(hash == "f0b9f293ec534f38e1028016e7e8bcb56a96591faa88d6e8ec5cab2bd5abfb3b") {
     board  = "Codemasters";
     region = "PAL";
     ram    = 0;
   }
-
+  
   //Micro Machines (Europe)
   if(hash == "cfbc86deccdcd31b64f886b1c344cc017e39c665928820bdfa16ae65d281057a") {
     board  = "Codemasters";
@@ -139,11 +222,56 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
     ram    = 0;
   }
 
+  //Korean No-Bank Mapper
+  //=====
+  //Bubble Bobble (Korea, YM Soft)##
+  if(hash == "1ec2649067ac12a952fc12b86d1e4474c31aefaa7c2c2252c246cc7cdb3ceb05") {
+    board  = "Korea_NB";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+  
+  //C_So! (Korea)
+  if(hash == "60716197f2643a5c87e38d26f32f370e328e740aaaea879b521986c31f8cdded") {
+    board  = "Korea_NB";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+
+  //FA Tetris (Korea)
+  if(hash == "46d86dd5782b248430cd84e9ba5b4fc68abec6472213bb898b2dbb213b4debcf") {
+    board  = "Korea_NB";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+
+  //Flashpoint (Korea)##
+  if(hash == "c6d945e79a22cc6da9ed6937d6a93a6df64835f1a577454e1c90b03e7d245186") {
+    board  = "Korea_NB";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+
+  //Xyzolog (Korea)##
+  if(hash == "dfb4cf3d3e793f09c683965b5fbc1c1f4d8b580326fc08ecab093275e0aeb537") {
+    board  = "Korea_NB";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+
+
   //Korea
   //=====
 
-  //C_So! (Korea)
-  if(hash == "60716197f2643a5c87e38d26f32f370e328e740aaaea879b521986c31f8cdded") {
+  //Jang Pung II (Korea)
+  if(hash == "49df982e7da155d54f5d99aea338d0ada262b28ed6033ff1f88146b976d8b312") {
+    board  = "Korea";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+
+  //Jang Pung 3 (Korea)
+  if(hash == "ef489ab1a6215957309dff64e672b9a5b66de3826841e523f9d2fea412c6911d") {
     board  = "Korea";
     region = "NTSC-J";
     ram    = 0;
@@ -155,15 +283,31 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
     region = "NTSC-J";
     ram    = 0;
   }
+  
+/* // MAME says it uses the Korea mapper but the whole game breaks with it? (Verify whats correct)
+  //Hong Kil Dong (Korea) 
+  if(hash == "b190090854b109ce69e1255dd189e8e985a3339bc083b102c4af73a2d20ca6d7") {
+    board  = "Korea";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+*/
 
-  //FA Tetris (Korea)
-  if(hash == "46d86dd5782b248430cd84e9ba5b4fc68abec6472213bb898b2dbb213b4debcf") {
+  //Sangokushi 3 (Korea)
+  if(hash == "db3773c81e9c3975f6ba7a6dd06df25b5d5210c69a6d1f13a0b7d5c92b4e0094") {
     board  = "Korea";
     region = "NTSC-J";
     ram    = 0;
   }
 
-  //MSX
+  //Super Boy II (Korea)
+  if(hash == "4dcec910ed8ff1f0d105457bedaf566e188d40b09efaaf35f28a56d4c5675555") {
+    board  = "Korea";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+
+  //Zemina
   //===
 
   //Cyborg Z (Korea)
@@ -183,13 +327,6 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
   //Knightmare II: The Maze of Galious (Korea)
   if(hash == "a906127be07469e6083ef6eb9657f5ece6ffe65b3cf793a0423959fc446e2799") {
     board  = "MSX";
-    region = "NTSC-J";
-    ram    = 0;
-  }
-
-  //Nemesis (Korea)
-  if(hash == "c5b5126b0fdcacc70f350c3673f8d081b8d59d2db251ef917bf3ca8dd3d63430") {
-    board  = "MSX#A";
     region = "NTSC-J";
     ram    = 0;
   }
@@ -222,11 +359,71 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
     ram    = 0;
   }
 
+
+
+  //Nemesis
+  //===
+  
+  //Nemesis (Korea)
+  if(hash == "c5b5126b0fdcacc70f350c3673f8d081b8d59d2db251ef917bf3ca8dd3d63430") {
+    board  = "Nemesis";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+  
   //Janggun
   //=======
 
   //Janggun-ui Adeul (Korea)
   if(hash == "e3c19e14a934f0995a046b8fa9d5c8db53fc02979273e747a5083b45996861c4") {
+    board  = "Janggun";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+  
+  //Korean 188 in 1
+  //=======
+
+  //Game Mo-eumjip 188 Hap (Korea) (v0)##
+  if(hash == "f6fa88b8f0396e1bda26e00fd8427effc26aaabed6f811aef68efec32b4c4df3") {
+    board  = "Janggun";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+  //Game Mo-eumjip 188 Hap (Korea) (v1)##
+  if(hash == "e77553e86a0359c45e5b8250666ea402b0ae0d989b7fce0c28b42954cb5e106a") {
+    board  = "Janggun";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+  
+  //Seo Jin Multi-cart
+  //=======
+
+  //Super Game 11-in-1 (Korea)##
+  if(hash == "08bc15836676cb0f4cc4d0deadcc23a51903bc384cc4b3050c8fae34518e1b78") {
+    board  = "Janggun";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+  
+  //Unknown Mappers
+  //=======
+
+  //Super Multi Game - Super 125 in 1 (Korea)##
+  if(hash == "1f9cd857c8e8922826b4781872b656f6ff677d04f2bb4efdb11db8860fdba255") {
+    board  = "Janggun";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+  //Super Game 52 Hap (Korea)##
+  if(hash == "af2822e40a46e32cb7ceaa5e54708b23554bd01f673c06a217c42dd5a8745535") {
+    board  = "Janggun";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+  //Super Game 45 (Korea)## [same mapper as "Super Game 52 Hap (Korea)"?]
+  if(hash == "26463c23acf6ebf6277cc1b1448bf284c8244943fb8f5f24608a64b1f20c7d55") {
     board  = "Janggun";
     region = "NTSC-J";
     ram    = 0;

--- a/mia/medium/master-system.cpp
+++ b/mia/medium/master-system.cpp
@@ -311,7 +311,7 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
   
   //Zemina / Nemesis
   //===
-  //Nemesis (Korea)##
+  //Nemesis (Korea)
   if(hash == "c5b5126b0fdcacc70f350c3673f8d081b8d59d2db251ef917bf3ca8dd3d63430") {
     board  = "Zemina_Nemesis";
     region = "NTSC-J";
@@ -322,14 +322,14 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
   //===
   //Super Boy 3
   
-  //Nemesis 2 (Korea)##
+  //Nemesis 2 (Korea)
   if(hash == "52d0772347e1bd73eea1a31f19400a4e24b43fb148b265ace9018ce2b677b3e4") {
     board  = "Zemina";
     region = "NTSC-J";
     ram    = 0;
   }
   
-  //Penguin Adventure (Korea)##
+  //Penguin Adventure (Korea)
   if(hash == "17958bcf247f6d18b616c519cc1466f7250901ada61831890ca58767fbfbb4b8") {
     board  = "Zemina";
     region = "NTSC-J";
@@ -343,7 +343,7 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
     ram    = 0;
   }
 
-  //Cyborg Z (Korea) ##
+  //Cyborg Z (Korea) 
   if(hash == "685530e434c9d78da8441475f795591210873622622b7f3168348ce08abc7f8e") {
     board  = "Zemina";
     region = "NTSC-J";
@@ -411,46 +411,6 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
     ram    = 0;
   }
   
-  //Seo Jin Multi-cart
-  //=======
-
-  //Super Game 11-in-1 (Korea)##
-  if(hash == "08bc15836676cb0f4cc4d0deadcc23a51903bc384cc4b3050c8fae34518e1b78") {
-    board  = "Janggun";
-    region = "NTSC-J";
-    ram    = 0;
-  }
-  
-  //Unknown Mappers
-  //=======
-
-  //Super Multi Game - Super 125 in 1 (Korea)##
-  if(hash == "1f9cd857c8e8922826b4781872b656f6ff677d04f2bb4efdb11db8860fdba255") {
-    board  = "Janggun";
-    region = "NTSC-J";
-    ram    = 0;
-  }
-  //Super Game 52 Hap (Korea)##
-  if(hash == "af2822e40a46e32cb7ceaa5e54708b23554bd01f673c06a217c42dd5a8745535") {
-    board  = "Janggun";
-    region = "NTSC-J";
-    ram    = 0;
-  }
-  //Super Game 45 (Korea)## [same mapper as "Super Game 52 Hap (Korea)"?]
-  if(hash == "26463c23acf6ebf6277cc1b1448bf284c8244943fb8f5f24608a64b1f20c7d55") {
-    board  = "Janggun";
-    region = "NTSC-J";
-    ram    = 0;
-  }
-  //Bubble Bobble (Korea, YM Soft)
-  // TODO: NOT WORKING!XX
-  if(hash == "1ec2649067ac12a952fc12b86d1e4474c31aefaa7c2c2252c246cc7cdb3ceb05") {
-    board  = "Korea_NB";
-    region = "NTSC-J";
-    ram    = 0;
-  }
-  
-
   string s;
   s += "game\n";
   s +={"  sha256: ", hash, "\n"};

--- a/mia/medium/master-system.cpp
+++ b/mia/medium/master-system.cpp
@@ -121,63 +121,63 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
   //Hicom
   //===========
 
-  //The Best Game Collection - Hang On + Pit Pot + Spy vs Spy (Korea)##
+  //The Best Game Collection - Hang On + Pit Pot + Spy vs Spy (Korea)
   if(hash == "11ef490394ad30bfa795295f0195177f7ac92153521a97dc3d9a817912cd185c") {
     board  = "Hicom";
     region = "PAL";
     ram    = 0;
   }
 
-  //The Best Game Collection - Great Baseball + Great Soccer + Super Tennis (Korea)##
+  //The Best Game Collection - Great Baseball + Great Soccer + Super Tennis (Korea)
   if(hash == "dcd0195f5e9eef77c5ffd23413b54206daa8eacaf9adb41618c16b43c9bf3eb3") {
     board  = "Hicom";
     region = "PAL";
     ram    = 0;
   }
 
-  //The Best Game Collection - Teddy Boy Blues + Pit-Pot + Astro Flash (Korea)##
+  //The Best Game Collection - Teddy Boy Blues + Pit-Pot + Astro Flash (Korea)
   if(hash == "5e8dba358c6e5ced67d6fd6d3c8e3124ac6bcde73ae5b1b89fe31d5733451fb0") {
     board  = "Hicom";
     region = "PAL";
     ram    = 0;
   }
 
-  //The Best Game Collection - Teddy Boy Blues + Great Soccer + Comical Machine Gun Joe (Korea)##
+  //The Best Game Collection - Teddy Boy Blues + Great Soccer + Comical Machine Gun Joe (Korea)
   if(hash == "bee055caea0282a505afd08452000aca3a46ee7a2a7ed1f7cfa09b43580a8431") {
     board  = "Hicom";
     region = "PAL";
     ram    = 0;
   }
 
-  //The Best Game Collection - Ghost House + Teddy Boy Blues + Seishun Scandal (Korea)##
+  //The Best Game Collection - Ghost House + Teddy Boy Blues + Seishun Scandal (Korea)
   if(hash == "395cf05e2eabc7d47f57e501239f60d35933f450b2205895d25f380ae4b23a7c") {
     board  = "Hicom";
     region = "PAL";
     ram    = 0;
   }
 
-  //The Best Game Collection - Satellite-7 + Great Baseball + Seishun Scandal (Korea)##
+  //The Best Game Collection - Satellite-7 + Great Baseball + Seishun Scandal (Korea)
   if(hash == "6f09849fa4f5904cc9554c15b4522da49160cf99f81895c1df80d3b4bfc0f033") {
     board  = "Hicom";
     region = "PAL";
     ram    = 0;
   }
 
-  //The Best Game Collection (Korea, 8 in 1 Ver. A)##
+  //The Best Game Collection (Korea, 8 in 1 Ver. A)
   if(hash == "572dfcc5ade1251c38b729ee86d78e37fde29d948d19f2292aeff32685db9129") {
     board  = "Hicom";
     region = "PAL";
     ram    = 0;
   }
 
-  //The Best Game Collection (Korea, 8 in 1 Ver. B)##
+  //The Best Game Collection (Korea, 8 in 1 Ver. B)
   if(hash == "6b829e41da9b7a0f2f0b0fcdbd644e311178ee7958e69ea6a1590dd4794a2834") {
     board  = "Hicom";
     region = "PAL";
     ram    = 0;
   }
 
-  //The Best Game Collection (Korea, 8 in 1 Ver. C)##
+  //The Best Game Collection (Korea, 8 in 1 Ver. C)
   if(hash == "addf8f41dfb2698cb4e5d01bdff29bfda898d099e651c08d7536eb9e2bb14f5e") {
     board  = "Hicom";
     region = "PAL";
@@ -381,54 +381,6 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
     ram    = 0;
   }
   
-  //Korean 188 in 1
-  //=======
-
-  //Game Mo-eumjip 188 Hap (Korea) (v0)##
-  if(hash == "f6fa88b8f0396e1bda26e00fd8427effc26aaabed6f811aef68efec32b4c4df3") {
-    board  = "Janggun";
-    region = "NTSC-J";
-    ram    = 0;
-  }
-  //Game Mo-eumjip 188 Hap (Korea) (v1)##
-  if(hash == "e77553e86a0359c45e5b8250666ea402b0ae0d989b7fce0c28b42954cb5e106a") {
-    board  = "Janggun";
-    region = "NTSC-J";
-    ram    = 0;
-  }
-  
-  //Seo Jin Multi-cart
-  //=======
-
-  //Super Game 11-in-1 (Korea)##
-  if(hash == "08bc15836676cb0f4cc4d0deadcc23a51903bc384cc4b3050c8fae34518e1b78") {
-    board  = "Janggun";
-    region = "NTSC-J";
-    ram    = 0;
-  }
-  
-  //Unknown Mappers
-  //=======
-
-  //Super Multi Game - Super 125 in 1 (Korea)##
-  if(hash == "1f9cd857c8e8922826b4781872b656f6ff677d04f2bb4efdb11db8860fdba255") {
-    board  = "Janggun";
-    region = "NTSC-J";
-    ram    = 0;
-  }
-  //Super Game 52 Hap (Korea)##
-  if(hash == "af2822e40a46e32cb7ceaa5e54708b23554bd01f673c06a217c42dd5a8745535") {
-    board  = "Janggun";
-    region = "NTSC-J";
-    ram    = 0;
-  }
-  //Super Game 45 (Korea)## [same mapper as "Super Game 52 Hap (Korea)"?]
-  if(hash == "26463c23acf6ebf6277cc1b1448bf284c8244943fb8f5f24608a64b1f20c7d55") {
-    board  = "Janggun";
-    region = "NTSC-J";
-    ram    = 0;
-  }
-
   string s;
   s += "game\n";
   s +={"  sha256: ", hash, "\n"};

--- a/mia/medium/master-system.cpp
+++ b/mia/medium/master-system.cpp
@@ -224,19 +224,6 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
 
   //Korean No-Bank Mapper
   //=====
-  //Bubble Bobble (Korea, YM Soft)##
-  if(hash == "1ec2649067ac12a952fc12b86d1e4474c31aefaa7c2c2252c246cc7cdb3ceb05") {
-    board  = "Korea_NB";
-    region = "NTSC-J";
-    ram    = 0;
-  }
-  
-  //C_So! (Korea)
-  if(hash == "60716197f2643a5c87e38d26f32f370e328e740aaaea879b521986c31f8cdded") {
-    board  = "Korea_NB";
-    region = "NTSC-J";
-    ram    = 0;
-  }
 
   //FA Tetris (Korea)
   if(hash == "46d86dd5782b248430cd84e9ba5b4fc68abec6472213bb898b2dbb213b4debcf") {
@@ -244,8 +231,23 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
     region = "NTSC-J";
     ram    = 0;
   }
+  
+  //Sky Jaguar
+  if(hash == "6b154d9fde7c8c6f1cf45adc50bf4727197746bb30c25f2f3f65874cc85cdf3e") {
+    board  = "Korea_NB";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+  
+  //Sky Jaguar [Clover]
+  if(hash == "05462f928c1b39716dea4b230e2ed36b923e9fff47b81fa47c7afdce7cb57e49") {
+    board  = "Korea_NB";
+    region = "NTSC-J";
+    ram    = 0;
+  }
 
-  //Flashpoint (Korea)##
+  //Flashpoint (Korea)
+  // TODO: NOT WORKING!
   if(hash == "c6d945e79a22cc6da9ed6937d6a93a6df64835f1a577454e1c90b03e7d245186") {
     board  = "Korea_NB";
     region = "NTSC-J";
@@ -306,67 +308,64 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
     region = "NTSC-J";
     ram    = 0;
   }
+  
+  //Zemina / Nemesis
+  //===
+  //Nemesis (Korea)##
+  if(hash == "c5b5126b0fdcacc70f350c3673f8d081b8d59d2db251ef917bf3ca8dd3d63430") {
+    board  = "Zemina_Nemesis";
+    region = "NTSC-J";
+    ram    = 0;
+  }
 
   //Zemina
   //===
-
-  //Cyborg Z (Korea)
-  if(hash == "685530e434c9d78da8441475f795591210873622622b7f3168348ce08abc7f8e") {
-    board  = "MSX";
-    region = "NTSC-J";
-    ram    = 0;
-  }
-
-  //F-1 Spirit: The Way to Formula-1 (Korea)
-  if(hash == "42dbc2ccf30a8d8e6d1d64fd0abb98d2f29b06da2113cedb9ed15af57fd9cfe0") {
-    board  = "MSX";
-    region = "NTSC-J";
-    ram    = 0;
-  }
-
-  //Knightmare II: The Maze of Galious (Korea)
-  if(hash == "a906127be07469e6083ef6eb9657f5ece6ffe65b3cf793a0423959fc446e2799") {
-    board  = "MSX";
-    region = "NTSC-J";
-    ram    = 0;
-  }
-
-  //Nemesis 2 (Korea)
+  //Super Boy 3
+  
+  //Nemesis 2 (Korea)##
   if(hash == "52d0772347e1bd73eea1a31f19400a4e24b43fb148b265ace9018ce2b677b3e4") {
-    board  = "MSX";
+    board  = "Zemina";
     region = "NTSC-J";
     ram    = 0;
   }
-
-  //Penguin Adventure (Korea)
+  
+  //Penguin Adventure (Korea)##
   if(hash == "17958bcf247f6d18b616c519cc1466f7250901ada61831890ca58767fbfbb4b8") {
-    board  = "MSX";
+    board  = "Zemina";
     region = "NTSC-J";
     ram    = 0;
   }
 
   //Street Master (Korea)
   if(hash == "cad9e768d6c7a1f781f2bf6c13ceab9142135d36fadab8db4b77edc9ae926be7") {
-    board  = "MSX";
+    board  = "Zemina";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+
+  //Cyborg Z (Korea) ##
+  if(hash == "685530e434c9d78da8441475f795591210873622622b7f3168348ce08abc7f8e") {
+    board  = "Zemina";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+
+  //Knightmare II: The Maze of Galious (Korea)
+  if(hash == "a906127be07469e6083ef6eb9657f5ece6ffe65b3cf793a0423959fc446e2799") {
+    board  = "Zemina";
     region = "NTSC-J";
     ram    = 0;
   }
 
   //Wonsiin (Korea)
   if(hash == "ee22d7b7fcd59e81ee6fda7b82356883d9c3d8ea3c99e6591487d1f28d569073") {
-    board  = "MSX";
+    board  = "Zemina";
     region = "NTSC-J";
     ram    = 0;
   }
-
-
-
-  //Nemesis
-  //===
-  
-  //Nemesis (Korea)
-  if(hash == "c5b5126b0fdcacc70f350c3673f8d081b8d59d2db251ef917bf3ca8dd3d63430") {
-    board  = "Nemesis";
+  //F-1 Spirit: The Way to Formula-1 (Korea)
+  if(hash == "42dbc2ccf30a8d8e6d1d64fd0abb98d2f29b06da2113cedb9ed15af57fd9cfe0") {
+    board  = "Zemina";
     region = "NTSC-J";
     ram    = 0;
   }
@@ -391,6 +390,65 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
     ram    = 0;
   }
   
+  
+  //Korean 188 in 1
+  // TODO: Game 6 and 13 do not work, posibly others also fail.
+  //=======
+  
+  //Not public dump
+  // 128 Hap (KR)
+
+  //Game Mo-eumjip 188 Hap (Korea) (v0)##
+  if(hash == "f6fa88b8f0396e1bda26e00fd8427effc26aaabed6f811aef68efec32b4c4df3") {
+    board  = "K188in1";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+  //Game Mo-eumjip 188 Hap (Korea) (v1)##
+  if(hash == "e77553e86a0359c45e5b8250666ea402b0ae0d989b7fce0c28b42954cb5e106a") {
+    board  = "K188in1";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+  
+  //Seo Jin Multi-cart
+  //=======
+
+  //Super Game 11-in-1 (Korea)##
+  if(hash == "08bc15836676cb0f4cc4d0deadcc23a51903bc384cc4b3050c8fae34518e1b78") {
+    board  = "Janggun";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+  
+  //Unknown Mappers
+  //=======
+
+  //Super Multi Game - Super 125 in 1 (Korea)##
+  if(hash == "1f9cd857c8e8922826b4781872b656f6ff677d04f2bb4efdb11db8860fdba255") {
+    board  = "Janggun";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+  //Super Game 52 Hap (Korea)##
+  if(hash == "af2822e40a46e32cb7ceaa5e54708b23554bd01f673c06a217c42dd5a8745535") {
+    board  = "Janggun";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+  //Super Game 45 (Korea)## [same mapper as "Super Game 52 Hap (Korea)"?]
+  if(hash == "26463c23acf6ebf6277cc1b1448bf284c8244943fb8f5f24608a64b1f20c7d55") {
+    board  = "Janggun";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+  //Bubble Bobble (Korea, YM Soft)
+  // TODO: NOT WORKING!XX
+  if(hash == "1ec2649067ac12a952fc12b86d1e4474c31aefaa7c2c2252c246cc7cdb3ceb05") {
+    board  = "Korea_NB";
+    region = "NTSC-J";
+    ram    = 0;
+  }
   
 
   string s;

--- a/mia/medium/master-system.cpp
+++ b/mia/medium/master-system.cpp
@@ -254,7 +254,7 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
     ram    = 0;
   }
 
-  //Xyzolog (Korea)##
+  //Xyzolog (Korea)
   if(hash == "dfb4cf3d3e793f09c683965b5fbc1c1f4d8b580326fc08ecab093275e0aeb537") {
     board  = "Korea_NB";
     region = "NTSC-J";
@@ -398,19 +398,20 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
   //Not public dump
   // 128 Hap (KR)
 
-  //Game Mo-eumjip 188 Hap (Korea) (v0)##
+  //Game Mo-eumjip 188 Hap (Korea) (v0)
   if(hash == "f6fa88b8f0396e1bda26e00fd8427effc26aaabed6f811aef68efec32b4c4df3") {
     board  = "K188in1";
     region = "NTSC-J";
     ram    = 0;
   }
-  //Game Mo-eumjip 188 Hap (Korea) (v1)##
+  //Game Mo-eumjip 188 Hap (Korea) (v1)
   if(hash == "e77553e86a0359c45e5b8250666ea402b0ae0d989b7fce0c28b42954cb5e106a") {
     board  = "K188in1";
     region = "NTSC-J";
     ram    = 0;
   }
   
+
   string s;
   s += "game\n";
   s +={"  sha256: ", hash, "\n"};

--- a/mia/medium/master-system.cpp
+++ b/mia/medium/master-system.cpp
@@ -381,6 +381,18 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
     ram    = 0;
   }
   
+  //Hap2000
+  //=======
+
+  //2 Hap in 1 - David-2 ~ Moai-ui bomul (KR)
+  if(hash == "cf6aa5727748f7042ff7942972a27bed015e1e30976606adaad6f8ef0ec214b6") {
+    board  = "Hap2000";
+    region = "NTSC-J";
+    ram    = 0;
+  }
+  
+  
+
   string s;
   s += "game\n";
   s +={"  sha256: ", hash, "\n"};


### PR DESCRIPTION
Addded these two mappers, Pak4 works with "4 PAK All Action"(as its the only game known to use it) and Hicom works with the following:

The Best Game Collection - Hang On + Pit Pot + Spy vs Spy (Korea)
The Best Game Collection - Great Baseball + Great Soccer + Super Tennis (Korea)
The Best Game Collection - Teddy Boy Blues + Pit-Pot + Astro Flash (Korea)
The Best Game Collection - Teddy Boy Blues + Great Soccer + Comical Machine Gun Joe (Korea)
The Best Game Collection - Ghost House + Teddy Boy Blues + Seishun Scandal (Korea)
The Best Game Collection - Satellite-7 + Great Baseball + Seishun Scandal (Korea)
The Best Game Collection (Korea, 8 in 1 Ver. A)
The Best Game Collection (Korea, 8 in 1 Ver. B)
The Best Game Collection (Korea, 8 in 1 Ver. C)


Working on more mappers as soon as i get back from workys.


Edits:
- Filled in a bunch of enterys of bootleg games / multis.
- Added Hap2000 Mapper. [ 2 Hap in 1 - David-2 ~ Moai-ui bomul (KR) ]
- Added K188in1 Mapper. [ Game Mo-eumjip 188 Hap (Korea) ] (not a few games do not boot at the moment.)
- Renamed the MSX mapper to Zemina. (to make it clear what it is, as lots of MSX ports dont use it and those that do are made by Zemina)
