### PR TITLE
ws: properly implement INT_BASE port

### DIFF
--- a/ares/ws/cpu/io.cpp
+++ b/ares/ws/cpu/io.cpp
@@ -38,7 +38,7 @@ auto CPU::readIO(n16 address) -> n8 {
 
   case 0x00b0:  //INT_BASE
     data  = io.interruptBase;
-    data |= SoC::ASWAN() ? 3 : 0;
+    data |= bit::first(io.interruptStatus);
     break;
 
   case 0x00b2:  //INT_ENABLE
@@ -104,7 +104,7 @@ auto CPU::writeIO(n16 address, n8 data) -> void {
     break;
 
   case 0x00b0:  //INT_BASE
-    io.interruptBase = SoC::ASWAN() ? data & ~7 : data & ~1;
+    io.interruptBase = data & ~7;
     break;
 
   case 0x00b2:  //INT_ENABLE

--- a/ares/ws/cpu/io.cpp
+++ b/ares/ws/cpu/io.cpp
@@ -38,7 +38,7 @@ auto CPU::readIO(n16 address) -> n8 {
 
   case 0x00b0:  //INT_BASE
     data  = io.interruptBase;
-    data |= bit::first(io.interruptStatus);
+    data |= bit::last(io.interruptStatus);
     break;
 
   case 0x00b2:  //INT_ENABLE

--- a/nall/bit.hpp
+++ b/nall/bit.hpp
@@ -78,6 +78,14 @@ namespace bit {
     return first;
   }
 
+  //return index of the last bit set (or zero of no bits are set)
+  //last(0b11000) == 4
+  constexpr inline auto last(u64 x) -> u32 {
+    u32 i = 0;
+    while(x) { x >>= 1; i++; }
+    return i > 0 ? --i : i;
+  }
+
   //round up to next highest single bit:
   //round(15) == 16, round(16) == 16, round(17) == 32
   constexpr inline auto round(u64 x) -> u64 {


### PR DESCRIPTION
Validated with a test ROM: https://github.com/asiekierka/ws-test-suite/blob/main/src/mono/soc/interrupt_ports/main.c (binaries available in CI)