### PR TITLE
ws: Adjust ROM/SRAM bus timings.

### DIFF
--- a/ares/component/processor/v30mz/memory.cpp
+++ b/ares/component/processor/v30mz/memory.cpp
@@ -40,7 +40,7 @@ template<> auto V30MZ::write<Word>(u16 segment, u16 address, u16 data) -> void {
 }
 
 template<> auto V30MZ::in<Byte>(u16 address) -> u16 {
-  step(1);
+  step(ioSpeed(address));
   u16 data = 0;
   data |= in(address++) << 0;
   return data;
@@ -48,22 +48,22 @@ template<> auto V30MZ::in<Byte>(u16 address) -> u16 {
 
 template<> auto V30MZ::in<Word>(u16 address) -> u16 {
   u16 data = 0;
-  step(1);
+  step(ioSpeed(address));
   data |= in(address++) << 0;
-  if(!(address & 1)) step(1);
+  if(ioWidth(address) == Byte || !(address & 1)) step(ioSpeed(address));
   data |= in(address++) << 8;
   return data;
 }
 
 template<> auto V30MZ::out<Byte>(u16 address, u16 data) -> void {
-  step(1);
+  step(ioSpeed(address));
   out(address++, data >> 0);
 }
 
 template<> auto V30MZ::out<Word>(u16 address, u16 data) -> void {
-  step(1);
+  step(ioSpeed(address));
   out(address++, data >> 0);
-  if(!(address & 1)) step(1);
+  if(ioWidth(address) == Byte || !(address & 1)) step(ioSpeed(address));
   out(address++, data >> 8);
 }
 

--- a/ares/component/processor/v30mz/memory.cpp
+++ b/ares/component/processor/v30mz/memory.cpp
@@ -9,7 +9,7 @@ template<> auto V30MZ::read<Word>(u16 segment, u16 address) -> u32 {
   u32 data = 0;
   step(speed(segment * 16 + address));
   data |= read(segment * 16 + address++) << 0;
-  if(width(address) == Byte || !(address & 1)) step(speed(segment * 16 + address));
+  if(width(segment * 16 + address) == Byte || !(address & 1)) step(speed(segment * 16 + address));
   data |= read(segment * 16 + address++) << 8;
   return data;
 }
@@ -18,11 +18,11 @@ template<> auto V30MZ::read<Long>(u16 segment, u16 address) -> u32 {
   u32 data = 0;
   step(speed(segment * 16 + address));
   data |= read(segment * 16 + address++) <<  0;
-  if(width(address) == Byte || !(address & 1)) step(speed(segment * 16 + address));
+  if(width(segment * 16 + address) == Byte || !(address & 1)) step(speed(segment * 16 + address));
   data |= read(segment * 16 + address++) <<  8;
-  if(width(address) == Byte || !(address & 1)) step(speed(segment * 16 + address));
+  if(width(segment * 16 + address) == Byte || !(address & 1)) step(speed(segment * 16 + address));
   data |= read(segment * 16 + address++) << 16;
-  if(width(address) == Byte || !(address & 1)) step(speed(segment * 16 + address));
+  if(width(segment * 16 + address) == Byte || !(address & 1)) step(speed(segment * 16 + address));
   data |= read(segment * 16 + address++) << 24;
   return data;
 }
@@ -35,7 +35,7 @@ template<> auto V30MZ::write<Byte>(u16 segment, u16 address, u16 data) -> void {
 template<> auto V30MZ::write<Word>(u16 segment, u16 address, u16 data) -> void {
   step(speed(segment * 16 + address));
   write(segment * 16 + address++, data >> 0);
-  if(width(address) == Byte || !(address & 1)) step(speed(segment * 16 + address));
+  if(width(segment * 16 + address) == Byte || !(address & 1)) step(speed(segment * 16 + address));
   write(segment * 16 + address++, data >> 8);
 }
 

--- a/ares/component/processor/v30mz/v30mz.hpp
+++ b/ares/component/processor/v30mz/v30mz.hpp
@@ -32,6 +32,8 @@ struct V30MZ {
   virtual auto write(n20 address, n8 data) -> void = 0;
   virtual auto in(n16 port) -> n8 = 0;
   virtual auto out(n16 port, n8 data) -> void = 0;
+  virtual auto ioWidth(n16 port) -> u32 = 0;
+  virtual auto ioSpeed(n16 port) -> n32 = 0;
 
   //v30mz.cpp
   auto power() -> void;

--- a/ares/ws/cpu/cpu.cpp
+++ b/ares/ws/cpu/cpu.cpp
@@ -55,6 +55,18 @@ auto CPU::write(n20 address, n8 data) -> void {
   return bus.write(address, data);
 }
 
+auto CPU::ioWidth(n16 port) -> u32 {
+  if(port >= 0xC0 && port <= 0xFF)
+    return Byte;
+  return Word;
+}
+
+auto CPU::ioSpeed(n16 port) -> n32 {
+  if(port >= 0xC0 && port <= 0xFF)
+    return (cpu.io.cartridgeIoWait || SoC::ASWAN()) ? 2 : 1;
+  return 1;
+}
+
 auto CPU::in(n16 port) -> n8 {
   return bus.readIO(port & 0x01ff);
 }

--- a/ares/ws/cpu/cpu.cpp
+++ b/ares/ws/cpu/cpu.cpp
@@ -68,11 +68,11 @@ auto CPU::ioSpeed(n16 port) -> n32 {
 }
 
 auto CPU::in(n16 port) -> n8 {
-  return bus.readIO(port & 0x01ff);
+  return bus.readIO(port);
 }
 
 auto CPU::out(n16 port, n8 data) -> void {
-  return bus.writeIO(port & 0x01ff, data);
+  return bus.writeIO(port, data);
 }
 
 auto CPU::power() -> void {

--- a/ares/ws/cpu/cpu.cpp
+++ b/ares/ws/cpu/cpu.cpp
@@ -42,8 +42,8 @@ auto CPU::width(n20 address) -> u32 {
 auto CPU::speed(n20 address) -> n32 {
   switch(address >> 16) {
     case 0: return 1; // internal RAM
-    case 1: return system.color() ? 1 : 3; // SRAM
-    default: return io.cartridgeRomWait ? 3 : 1; // cartridge ROM
+    case 1: return (cpu.io.cartridgeSramWait || SoC::ASWAN()) ? 2 : 1; // SRAM
+    default: return io.cartridgeRomWait ? 2 : 1; // cartridge ROM
   }
 }
 

--- a/ares/ws/cpu/cpu.hpp
+++ b/ares/ws/cpu/cpu.hpp
@@ -92,6 +92,7 @@ struct CPU : V30MZ, Thread, IO {
     n1 cartridgeEnable;
     n1 cartridgeRomWidth; // 0 = 8-bit; 1 = 16-bit
     n1 cartridgeRomWait; // 0 = +0 cycles; 1 = +1 cycle
+    n1 cartridgeClock;
     n1 cartridgeSramWait; // 0 = +0 cycles; 1 = +1 cycle
     n1 cartridgeIoWait; // 0 = +0 cycles; 1 = +1 cycle
     n8 interruptBase;

--- a/ares/ws/cpu/cpu.hpp
+++ b/ares/ws/cpu/cpu.hpp
@@ -66,6 +66,7 @@ struct CPU : V30MZ, Thread, IO {
     CPU& self;
 
     //dma.cpp
+    auto valid(n20 address) -> bool;
     auto transfer() -> void;
 
     n20 source;

--- a/ares/ws/cpu/cpu.hpp
+++ b/ares/ws/cpu/cpu.hpp
@@ -89,6 +89,7 @@ struct CPU : V30MZ, Thread, IO {
     n1 cartridgeEnable;
     n1 cartridgeRomWidth; // 0 = 8-bit; 1 = 16-bit
     n1 cartridgeRomWait; // 0 = 3 cycles; 1 = 1 cycle
+    n1 cartridgeSramWait;
     n8 interruptBase;
     n8 interruptEnable;
     n8 interruptStatus;

--- a/ares/ws/cpu/cpu.hpp
+++ b/ares/ws/cpu/cpu.hpp
@@ -44,6 +44,8 @@ struct CPU : V30MZ, Thread, IO {
   auto write(n20 address, n8 data) -> void override;
   auto in(n16 port) -> n8 override;
   auto out(n16 port, n8 data) -> void override;
+  auto ioWidth(n16 port) -> u32 override;
+  auto ioSpeed(n16 port) -> n32 override;
 
   auto power() -> void;
 
@@ -88,8 +90,9 @@ struct CPU : V30MZ, Thread, IO {
   struct IO {
     n1 cartridgeEnable;
     n1 cartridgeRomWidth; // 0 = 8-bit; 1 = 16-bit
-    n1 cartridgeRomWait; // 0 = 3 cycles; 1 = 1 cycle
-    n1 cartridgeSramWait;
+    n1 cartridgeRomWait; // 0 = +0 cycles; 1 = +1 cycle
+    n1 cartridgeSramWait; // 0 = +0 cycles; 1 = +1 cycle
+    n1 cartridgeIoWait; // 0 = +0 cycles; 1 = +1 cycle
     n8 interruptBase;
     n8 interruptEnable;
     n8 interruptStatus;

--- a/ares/ws/cpu/debugger.cpp
+++ b/ares/ws/cpu/debugger.cpp
@@ -60,12 +60,20 @@ auto CPU::Debugger::ports() -> string {
   output.append("\n");
 
   output.append("NMI on Low Battery: ", self.io.nmiOnLowBattery ? "enabled" : "disabled", "\n");
-
-  output.append("Cartridge Bus: ",
-    self.io.cartridgeEnable ? "enabled" : "disabled", ", ",
-    self.io.cartridgeRomWidth ? "16-bit" : "8-bit", ", ",
-    self.io.cartridgeRomWait ? "3 wait cycles" : "1 wait cycle",
+  output.append("Boot ROM lockout: ",
+    self.io.cartridgeEnable ? "enabled" : "disabled",
     "\n");
+
+  output.append("Cartridge ROM bus: ",
+    self.io.cartridgeRomWidth ? "16-bit" : "8-bit", ", ",
+    self.io.cartridgeRomWait ? "2 cycles" : "1 cycle",
+    "\n");
+
+  if (!SoC::ASWAN()) {
+    output.append("Cartridge SRAM bus: 8-bit, ",
+      self.io.cartridgeSramWait ? "2 cycles" : "1 cycle",
+      "\n");
+  }
 
   return output;
 }

--- a/ares/ws/cpu/debugger.cpp
+++ b/ares/ws/cpu/debugger.cpp
@@ -73,6 +73,10 @@ auto CPU::Debugger::ports() -> string {
     output.append("Cartridge SRAM bus: 8-bit, ",
       self.io.cartridgeSramWait ? "2 cycles" : "1 cycle",
       "\n");
+
+    output.append("Cartridge I/O bus: 8-bit, ",
+      self.io.cartridgeIoWait ? "2 cycles" : "1 cycle",
+      "\n");
   }
 
   return output;

--- a/ares/ws/cpu/dma.cpp
+++ b/ares/ws/cpu/dma.cpp
@@ -1,6 +1,10 @@
+auto CPU::DMA::valid(n20 address) -> bool {
+  return cpu.speed(address) == 1 && cpu.width(address) == Word;
+}
+
 auto CPU::DMA::transfer() -> void {
   //length of 0 or SRAM source address cause immediate termination
-  if(length == 0 || source.byte(2) == 1) {
+  if(length == 0 || !valid(source)) {
     enable = 0;
     return;
   }
@@ -10,7 +14,7 @@ auto CPU::DMA::transfer() -> void {
     self.step(2);
     u16 data = 0;
     //once DMA is started; SRAM reads still incur time penalty, but do not transfer
-    if(source.byte(2) != 1) {
+    if(valid(source)) {
       data |= self.read(source + 0) << 0;
       data |= self.read(source + 1) << 8;
       self.write(target + 0, data >> 0);

--- a/ares/ws/cpu/serialization.cpp
+++ b/ares/ws/cpu/serialization.cpp
@@ -12,6 +12,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(io.cartridgeRomWidth);
   s(io.cartridgeRomWait);
   s(io.cartridgeSramWait);
+  s(io.cartridgeIoWait);
   s(io.interruptBase);
   s(io.interruptEnable);
   s(io.interruptStatus);

--- a/ares/ws/cpu/serialization.cpp
+++ b/ares/ws/cpu/serialization.cpp
@@ -11,6 +11,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(io.cartridgeEnable);
   s(io.cartridgeRomWidth);
   s(io.cartridgeRomWait);
+  s(io.cartridgeClock);
   s(io.cartridgeSramWait);
   s(io.cartridgeIoWait);
   s(io.interruptBase);

--- a/ares/ws/cpu/serialization.cpp
+++ b/ares/ws/cpu/serialization.cpp
@@ -11,6 +11,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(io.cartridgeEnable);
   s(io.cartridgeRomWidth);
   s(io.cartridgeRomWait);
+  s(io.cartridgeSramWait);
   s(io.interruptBase);
   s(io.interruptEnable);
   s(io.interruptStatus);

--- a/ares/ws/memory/memory.cpp
+++ b/ares/ws/memory/memory.cpp
@@ -56,12 +56,14 @@ auto Bus::map(IO* io, u16 lo, maybe<u16> hi) -> void {
 }
 
 auto Bus::readIO(n16 address) -> n8 {
+  if((address & 0x1ff) < 0x0b8) address &= 0x1ff;
   if(auto io = port[address]) return io->readIO(address);
-  if(address == 0x00ca) return 0x80;  //Mama Mitte (unknown status bit)
-  return 0x00;
+  if(address == 0x00ca) return 0x80; // Mama Mitte (unknown status bit)
+  return system.color() ? 0x00 : 0x90; // open bus
 }
 
 auto Bus::writeIO(n16 address, n8 data) -> void {
+  if((address & 0x1ff) < 0x0b8) address &= 0x1ff;
   if(auto io = port[address]) return io->writeIO(address, data);
 }
 

--- a/ares/ws/system/io.cpp
+++ b/ares/ws/system/io.cpp
@@ -6,7 +6,7 @@ auto System::readIO(n16 address) -> n8 {
   case 0x0060:  //DISP_MODE
     data.bit(0)    = io.unknown0;
     data.bit(1)    = cpu.io.cartridgeSramWait;
-    data.bit(3)    = io.unknown3;
+    data.bit(3)    = cpu.io.cartridgeIoWait;
     data.bit(5, 7) = io.mode.bit(0, 2);
     break;
 
@@ -41,7 +41,7 @@ auto System::writeIO(n16 address, n8 data) -> void {
   case 0x0060:  //DISP_MODE
     io.unknown0 = data.bit(0);
     cpu.io.cartridgeSramWait = data.bit(1);
-    io.unknown3 = data.bit(3);
+    cpu.io.cartridgeIoWait = data.bit(3);
     io.mode     = data.bit(5,7);
     break;
 

--- a/ares/ws/system/io.cpp
+++ b/ares/ws/system/io.cpp
@@ -4,7 +4,7 @@ auto System::readIO(n16 address) -> n8 {
   switch(address) {
 
   case 0x0060:  //DISP_MODE
-    data.bit(0)    = io.unknown0;
+    data.bit(0)    = cpu.io.cartridgeClock;
     data.bit(1)    = cpu.io.cartridgeSramWait;
     data.bit(3)    = cpu.io.cartridgeIoWait;
     data.bit(5, 7) = io.mode.bit(0, 2);
@@ -39,7 +39,7 @@ auto System::writeIO(n16 address, n8 data) -> void {
   switch(address) {
 
   case 0x0060:  //DISP_MODE
-    io.unknown0 = data.bit(0);
+    cpu.io.cartridgeClock = data.bit(0);
     cpu.io.cartridgeSramWait = data.bit(1);
     cpu.io.cartridgeIoWait = data.bit(3);
     io.mode     = data.bit(5,7);

--- a/ares/ws/system/io.cpp
+++ b/ares/ws/system/io.cpp
@@ -5,7 +5,7 @@ auto System::readIO(n16 address) -> n8 {
 
   case 0x0060:  //DISP_MODE
     data.bit(0)    = io.unknown0;
-    data.bit(1)    = io.unknown1;
+    data.bit(1)    = cpu.io.cartridgeSramWait;
     data.bit(3)    = io.unknown3;
     data.bit(5, 7) = io.mode.bit(0, 2);
     break;
@@ -40,7 +40,7 @@ auto System::writeIO(n16 address, n8 data) -> void {
 
   case 0x0060:  //DISP_MODE
     io.unknown0 = data.bit(0);
-    io.unknown1 = data.bit(1);
+    cpu.io.cartridgeSramWait = data.bit(1);
     io.unknown3 = data.bit(3);
     io.mode     = data.bit(5,7);
     break;

--- a/ares/ws/system/serialization.cpp
+++ b/ares/ws/system/serialization.cpp
@@ -39,7 +39,6 @@ auto System::unserialize(serializer& s) -> bool {
 
 auto System::serialize(serializer& s, bool synchronize) -> void {
   scheduler.setSynchronize(synchronize);
-  s(io.unknown0);
   s(io.mode);
   s(eeprom);
   s(cpu);

--- a/ares/ws/system/serialization.cpp
+++ b/ares/ws/system/serialization.cpp
@@ -40,7 +40,6 @@ auto System::unserialize(serializer& s) -> bool {
 auto System::serialize(serializer& s, bool synchronize) -> void {
   scheduler.setSynchronize(synchronize);
   s(io.unknown0);
-  s(io.unknown1);
   s(io.unknown3);
   s(io.mode);
   s(eeprom);

--- a/ares/ws/system/serialization.cpp
+++ b/ares/ws/system/serialization.cpp
@@ -40,7 +40,6 @@ auto System::unserialize(serializer& s) -> bool {
 auto System::serialize(serializer& s, bool synchronize) -> void {
   scheduler.setSynchronize(synchronize);
   s(io.unknown0);
-  s(io.unknown3);
   s(io.mode);
   s(eeprom);
   s(cpu);

--- a/ares/ws/system/system.hpp
+++ b/ares/ws/system/system.hpp
@@ -80,12 +80,6 @@ struct System : IO {
   auto memory() const -> u32 { return io.mode.bit(2) == 0 ? 16_KiB : 64_KiB; }
   auto color() const -> bool { return io.mode.bit(2) != 0; }
 
-  //mode:
-  //0xx => 2bpp, mono, planar tiledata (WSC enhancements locked)
-  //10x => 2bpp, color, planar tiledata (WSC enhancements unlocked)
-  //110 => 4bpp, color, planar tiledata
-  //111 => 4bpp, color, packed tiledata
-
   //system.cpp
   auto game() -> string;
   auto run() -> void;
@@ -114,8 +108,10 @@ struct System : IO {
 
 private:
   struct IO {
-    //$0060  DISP_MODE
-    n1 unknown0;
+    //0xx => 2bpp, mono, planar tiledata (WSC enhancements locked)
+    //10x => 2bpp, color, planar tiledata (WSC enhancements unlocked)
+    //110 => 4bpp, color, planar tiledata
+    //111 => 4bpp, color, packed tiledata
     n3 mode;
   } io;
 

--- a/ares/ws/system/system.hpp
+++ b/ares/ws/system/system.hpp
@@ -116,8 +116,6 @@ private:
   struct IO {
     //$0060  DISP_MODE
     n1 unknown0;
-    n1 unknown1;
-    n1 unknown3;
     n3 mode;
   } io;
 


### PR DESCRIPTION
Implements port 0x60 bit 1 and 3, a newly-discovered way to change the cartridge SRAM and I/O bus speed. Also fixes a regression, and adjusts the ROM bus speed to match a test ROM.

~~Marked as draft as validation on ASWAN ("mono" system) is required.~~ Nobody stepped up for 3 months, so, ehh. It's still more accurate than it was.