### PR TITLE
ws: fix sound DMA readout values when disabled

### DIFF
--- a/ares/ws/apu/dma.cpp
+++ b/ares/ws/apu/dma.cpp
@@ -9,9 +9,9 @@ auto APU::DMA::run() -> void {
 
   n8 data = 0x00;
   if(!io.hold) {
-    data = bus.read(state.source);
-    if(io.direction == 0) state.source++;
-    if(io.direction == 1) state.source--;
+    data = bus.read(io.source);
+    if(io.direction == 0) io.source++;
+    if(io.direction == 1) io.source--;
   }
 
   if(io.target == 0) {
@@ -22,11 +22,11 @@ auto APU::DMA::run() -> void {
   }
 
   if(io.hold) return;
-  if(--state.length) return;
+  if(--io.length) return;
 
   if(io.loop) {
-    state.source = io.source;
-    state.length = io.length;
+    io.source = state.source;
+    io.length = state.length;
   } else {
     io.enable = 0;
   }

--- a/ares/ws/apu/io.cpp
+++ b/ares/ws/apu/io.cpp
@@ -5,12 +5,12 @@ auto APU::readIO(n16 address) -> n8 {
 
   case range3(0x004a, 0x004c):  //SDMA_SRC
     if(!system.color()) break;
-    data = dma.state.source.byte(address - 0x004a);
+    data = dma.io.source.byte(address - 0x004a);
     break;
 
   case range3(0x004e, 0x0050):  //SDMA_LEN
     if(!system.color()) break;
-    data = dma.state.length.byte(address - 0x004e);
+    data = dma.io.length.byte(address - 0x004e);
     break;
 
   case 0x0052:  //SDMA_CTRL


### PR DESCRIPTION
Used a test ROM to verify, but it won't be out for some time as it requires a toolchain update and the packaging system is in the middle of a rewrite.

Essentially, sound DMA source/length can be read when disabled; it's the *external* (CPU-visible) source/length values which change, but the *internal* ones which are used for auto-repeat. ares had them the right way around, but exposed the *internal* ones on readout instead of the *external* ones, preventing readout when Sound DMA was disabled; this feels like the least invasive fix.