### PR TITLE
build: miscellaneous fixes

### DIFF
--- a/mia/GNUmakefile
+++ b/mia/GNUmakefile
@@ -9,6 +9,7 @@ include $(nall.path)/GNUmakefile
 
 thirdparty.path := ../thirdparty
 libchdr.path := $(thirdparty.path)/libchdr
+tzxfile.path := $(thirdparty.path)/TZXFile
 include $(thirdparty.path)/GNUmakefile
 
 hiro.path := ../hiro
@@ -25,8 +26,8 @@ $(object.path)/ares.o: $(ares.path)/ares/ares.cpp
 $(object.path)/mia.o: $(mia.path)/mia.cpp
 $(object.path)/resource.o: $(mia.path)/resource/resource.cpp
 
-all.objects := $(libchdr.objects) $(nall.objects) $(hiro.objects) $(objects)
-all.options := $(libchdr.options) $(nall.options) $(hiro.options) $(options)
+all.objects := $(libchdr.objects) $(tzxfile.objects) $(nall.objects) $(hiro.objects) $(objects)
+all.options := $(libchdr.options) $(tzxfile.options) $(nall.options) $(hiro.options) $(options)
 
 $(all.objects): | $(object.path)
 

--- a/nall/gdb/server.cpp
+++ b/nall/gdb/server.cpp
@@ -1,5 +1,7 @@
 #include <nall/gdb/server.hpp>
 
+#include <inttypes.h>
+
 using string = ::nall::string;
 using string_view = ::nall::string_view;
 
@@ -277,7 +279,7 @@ namespace nall::GDB {
       case 's': {
         if(cmdName.size() > 1) {
           u64 address = cmdName.slice(1).integer();
-          printf("stepping at address unsupported, ignore (%016lX)\n", address);
+          printf("stepping at address unsupported, ignore (%016" PRIX64 ")\n", address);
         }
 
         shouldReply = false;

--- a/nall/gdb/server.cpp
+++ b/nall/gdb/server.cpp
@@ -112,7 +112,7 @@ namespace nall::GDB {
   {
     auto cmdParts = cmd.split(":");
     auto cmdName = cmdParts[0];
-    char cmdPrefix = cmdName.size() > 0 ? cmdName[0] : ' ';
+    char cmdPrefix = cmdName.size() > 0 ? cmdName(0) : ' ';
 
     if constexpr(GDB_LOG_MESSAGES) {
       printf("GDB <: %s\n", cmdBuffer.data());
@@ -317,7 +317,7 @@ namespace nall::GDB {
       case 'z': // remove breakpoint (e.g. "z0,801a0ef4,4")
       {
         bool isInsert = cmdPrefix == 'Z';
-        bool isHardware = cmdName[1] == '1'; // 0=software, 1=hardware
+        bool isHardware = cmdName(1) == '1'; // 0=software, 1=hardware
         auto sepIdxMaybe = cmdName.findFrom(3, ",");
         u32 sepIdx = sepIdxMaybe ? (sepIdxMaybe.get()+3) : 0;
 
@@ -331,7 +331,7 @@ namespace nall::GDB {
         }
         Watchpoint wp{addressStart, addressEnd, address};
 
-        switch(cmdName[1]) {
+        switch(cmdName(1)) {
           case '0': // (hardware/software breakpoints are the same for us)
           case '1': addOrRemoveEntry(breakpoints, address, isInsert); break;
           

--- a/nall/tcptext/tcp-socket.cpp
+++ b/nall/tcptext/tcp-socket.cpp
@@ -1,4 +1,6 @@
 #include <nall/tcptext/tcp-socket.hpp>
+
+#include <inttypes.h>
 #include <memory>
 #include <thread>
 
@@ -198,7 +200,7 @@ NALL_HEADER_INLINE auto Socket::open(u32 port, bool useIPv4) -> bool {
         }
 
         if constexpr(TCP_LOG_MESSAGES) {
-          printf("%.4f | TCP >: [%ld]: %.*s\n", (f64)chrono::millisecond() / 1000.0, localSendBuffer.size(), localSendBuffer.size() > 100 ? 100 : (int)localSendBuffer.size(), (char*)localSendBuffer.data());
+          printf("%.4f | TCP >: [%" PRIu64 "]: %.*s\n", (f64)chrono::millisecond() / 1000.0, localSendBuffer.size(), localSendBuffer.size() > 100 ? 100 : (int)localSendBuffer.size(), (char*)localSendBuffer.data());
         }
 
         localSendBuffer.resize(0);

--- a/tools/genius/GNUmakefile
+++ b/tools/genius/GNUmakefile
@@ -1,6 +1,6 @@
 name := genius
 build := stable
-flags += -I../../ -DNALL_HEADER_ONLY
+flags += -I../../
 
 nall.path := ../../nall
 include $(nall.path)/GNUmakefile


### PR DESCRIPTION
Fix various recently introduced build issues.

Some background for the string indexing thing: using operator[] to index nall::string causes some ambiguous overload errors in 32-bit builds. This isn't the first time it's come up, but since it's so easy to work around (using operator() instead) I haven't bothered to try to fix it.