### PR TITLE
recompiler: avoid overallocation in code buffer

### DIFF
--- a/nall/bump-allocator.hpp
+++ b/nall/bump-allocator.hpp
@@ -88,9 +88,9 @@ struct bump_allocator {
     _offset = nextOffset(size);  //alignment
   }
 
-  auto tryAcquire(u32 size) -> u8* {
+  auto tryAcquire(u32 size, bool reserve = true) -> u8* {
     if((nextOffset(size)) > _capacity) return nullptr;
-    return acquire(size);
+    return reserve ? acquire(size) : acquire();
   }
 
 private:

--- a/nall/recompiler/generic/generic.hpp
+++ b/nall/recompiler/generic/generic.hpp
@@ -31,6 +31,7 @@ namespace nall::recompiler {
 
     auto endFunction() -> u8* {
       u8* code = (u8*)sljit_generate_code(compiler);
+      allocator.reserve(sljit_get_generated_code_size(compiler));
       resetCompiler();
       return code;
     }

--- a/thirdparty/sljitAllocator.cpp
+++ b/thirdparty/sljitAllocator.cpp
@@ -5,5 +5,5 @@
 
 auto sljit_nall_malloc_exec(sljit_uw size, void* exec_allocator_data) -> void* {
   auto allocator = (nall::bump_allocator*)exec_allocator_data;
-  return allocator->acquire(size);
+  return allocator->tryAcquire(size, false);
 }


### PR DESCRIPTION
sljit performs a single (potentially) oversized executable memory allocation before generating code. Instead of reserving the requested amount of space, we can reserve only the used amount and eliminate some dead space between code blocks.