### PR TITLE
Add "Games" app category to bundle .plist on macOS to facilitate Sonoma's Game Mode

### DIFF
--- a/desktop-ui/resource/ares.plist
+++ b/desktop-ui/resource/ares.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <key>LSApplicationCategoryType</key>
+  <string>public.app-category.games</string>
   <key>CFBundleIdentifier</key>
   <string>dev.ares.ares</string>
   <key>CFBundleDisplayName</key>


### PR DESCRIPTION
macOS 14 (Sonoma)'s Game Mode offers some small benefits for ares, including lower latency for bluetooth peripherals and potential minor performance gains. The system has various ways of detecting that an application is a game and enabling game mode, but ares does not currently engage it. Adding the "Games" app category key value pair to the bundle .plist is one way of hinting to macOS that Game Mode should be enaged. In my testing, adding this key to ares's bundle .plist successfully activates Game Mode when ares is fullscreened.

![image](https://github.com/ares-emulator/ares/assets/6864788/5c5727f9-88da-423e-af19-9fd08ed8eb91)
