### PR TITLE
md: implement opn2 restart w/out resetting the thread clock

### DIFF
--- a/ares/md/apu/apu.cpp
+++ b/ares/md/apu/apu.cpp
@@ -89,7 +89,7 @@ auto APU::restart() -> void {
   state.nmiLine = 0;
   state.intLine = 0;
   state.busreqLatch = state.busreqLine;
-  opn2.power(true);
+  opn2.restart();
 }
 
 }

--- a/ares/md/opn2/opn2.cpp
+++ b/ares/md/opn2/opn2.cpp
@@ -37,4 +37,9 @@ auto OPN2::power(bool reset) -> void {
   Thread::create(system.frequency() / 7.0, {&OPN2::main, this});
 }
 
+auto OPN2::restart() -> void {
+  YM2612::power();
+  Thread::restart({&OPN2::main, this});
+}
+
 }

--- a/ares/md/opn2/opn2.hpp
+++ b/ares/md/opn2/opn2.hpp
@@ -12,6 +12,7 @@ struct OPN2 : YM2612, Thread {
   auto step(u32 clocks) -> void;
 
   auto power(bool reset) -> void;
+  auto restart() -> void;
 
   //serialization.cpp
   auto serialize(serializer&) -> void;


### PR DESCRIPTION
Before this change, the OPN2 thread had to play catch-up, generating a bunch of samples and potentially overflowing the resampler queue in the audio stream, as observed in Shining Force.