### PR TITLE
md: refresh & bus timing fixes

### DIFF
--- a/ares/component/processor/m68000/m68000.cpp
+++ b/ares/component/processor/m68000/m68000.cpp
@@ -66,7 +66,7 @@ auto M68000::exception(u32 exception, u32 vector, u32 priority) -> void {
   if(exception == Exception::Interrupt) {
     // IACK vector number acquisition (+4 cyc normal or +10 to +18 cyc autovectored)
     // & justify vector number (+4 cyc)
-    idle(16+4); // assuming autovector cycles (approximated for Megadrive)
+    idle(14+4); // assuming autovector cycles (approximated for Megadrive)
     r.i = priority;
   }
 

--- a/ares/md/apu/bus.cpp
+++ b/ares/md/apu/bus.cpp
@@ -33,7 +33,9 @@ auto APU::write(n16 address, n8 data) -> void {
 }
 
 auto APU::readExternal(n24 address) -> n8 {
+  step(3); // approximate Z80 delay
   while(MegaDrive::bus.acquired() && !scheduler.synchronizing()) step(1);
+  cpu.state.stolenMcycles += 68; // approximate 68K delay; 68 Mclk ~= 9.7 68k clk
   MegaDrive::bus.acquire(MegaDrive::Bus::APU);
 
   n8 data = 0xff;
@@ -54,7 +56,9 @@ auto APU::readExternal(n24 address) -> n8 {
 }
 
 auto APU::writeExternal(n24 address, n8 data) -> void {
+  step(3); // approximate Z80 delay
   while(MegaDrive::bus.acquired() && !scheduler.synchronizing()) step(1);
+  cpu.state.stolenMcycles += 68; // approximate 68K delay; 68 Mclk ~= 9.7 68k clk
   MegaDrive::bus.acquire(MegaDrive::Bus::APU);
 
   if(address >= 0x000000 && address <= 0x9fffff

--- a/ares/md/cpu/cpu.cpp
+++ b/ares/md/cpu/cpu.cpp
@@ -60,6 +60,8 @@ auto CPU::main() -> void {
 }
 
 auto CPU::step(u32 clocks) -> void {
+  clocks += state.stolenMcycles/7;
+  state.stolenMcycles -= state.stolenMcycles/7 * 7;
   refresh.ram += clocks;
   refresh.external += clocks;
   Thread::step(clocks);

--- a/ares/md/cpu/cpu.hpp
+++ b/ares/md/cpu/cpu.hpp
@@ -82,6 +82,7 @@ struct CPU : M68000, Thread {
 
   struct State {
     n32 interruptPending;
+    int stolenMcycles = 0;
   } state;
 
   int cyclesUntilSync = 0;

--- a/ares/md/cpu/cpu.hpp
+++ b/ares/md/cpu/cpu.hpp
@@ -74,8 +74,8 @@ struct CPU : M68000, Thread {
     static constexpr int ramLowBound       = 113;
     static constexpr int ramHighBound      = 132;
     static constexpr int ramLength         = 3;
-    static constexpr int externalLowBound  = 126;
-    static constexpr int externalHighBound = 132;
+    static constexpr int externalLowBound  = 121;
+    static constexpr int externalHighBound = 128;
     static constexpr int externalLength    = 2;
 
   } refresh;

--- a/ares/md/cpu/serialization.cpp
+++ b/ares/md/cpu/serialization.cpp
@@ -10,4 +10,5 @@ auto CPU::serialize(serializer& s) -> void {
   s(refresh.external);
   s(refresh.externalEnd);
   s(state.interruptPending);
+  s(state.stolenMcycles);
 }

--- a/ares/md/system/serialization.cpp
+++ b/ares/md/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v133";
+static const string SerializerVersion = "v133.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
1. Bus refreshes needed a clean up and readjustment. Timings were compared against US Model 1 VA3 via Ti_'s test_inst_speed rom. Yellow values are ok, as they normally skew lower due to refresh. Some reds still remain (of the regular instruction tests) that appear to be off by 1.
2. Basic implementation of delays incurred on both main 68k and z80. Delay values are tuned according to Ti_'s misc_test rom tests ("Z80 DELAY ON ROM READ", "M68K DELAY ON Z80 ROM READ"). Hardware tests indicate that z80 delay may skew lower towards 170, while m68k delay typically sticks to 460. This change puts ares at ~178 z80 delay & ~461 68k delay. Fixes #255.
3. Trivial readjustment of m68000 interrupt timing. Approx'd autovector delay changed to 14 cycles, which happens to be the median of the expected range (10-18).