### PR TITLE
wdc65816: fix PLB wrapping in emulation mode

### DIFF
--- a/ares/component/processor/wdc65816/instructions-other.cpp
+++ b/ares/component/processor/wdc65816/instructions-other.cpp
@@ -205,9 +205,10 @@ E S.h = 0x01;
 auto WDC65816::instructionPullB() -> void {
   idle();
   idle();
-L B = pull();
+L B = pullN();
   ZF = B == 0;
   NF = B & 0x80;
+E S.h = 0x01;
 }
 
 auto WDC65816::instructionPullP() -> void {


### PR DESCRIPTION
>Regarding PLB, it looks like it reads from $200 and snes9x, mesen, bsnes, and the official CPU manual all got it wrong.

Reproduced and verified on real hardware via https://github.com/gilyon/snes-tests