### PR TITLE
Add homebrew mode (with a few checks to N64 core)

### DIFF
--- a/ares/n64/cpu/dcache.cpp
+++ b/ares/n64/cpu/dcache.cpp
@@ -132,3 +132,6 @@ auto CPU::DataCache::power(bool reset) -> void {
     for(auto& word : line.words) word = 0;
   }
 }
+
+template
+auto CPU::DataCache::Line::write<Byte>(u32 address, u64 data) -> void;

--- a/ares/n64/pi/bus.hpp
+++ b/ares/n64/pi/bus.hpp
@@ -97,8 +97,12 @@ inline auto PI::busWrite(u32 address, u32 data) -> void {
     return;
   }
   if(address <= 0x13ff'ffff) {
-    writeForceFinish(); //Debugging channel for homebrew, be gentle
-    return cartridge.isviewer.write<Size>(address, data);
+    if(system.homebrewMode) {
+      writeForceFinish(); //Debugging channel for homebrew, be gentle
+      return cartridge.isviewer.write<Size>(address, data);      
+    } else {
+      debug(unhandled, "[PI::busWrite] attempt to write to ISViewer: enable homebrew mode in settings to enable ISViewer emulation");
+    }
   }
   if(address <= 0x7fff'ffff) return;
 }

--- a/ares/n64/rdram/rdram.hpp
+++ b/ares/n64/rdram/rdram.hpp
@@ -24,6 +24,7 @@ struct RDRAM : Memory::RCP<RDRAM> {
 
     struct Memory {
       Node::Debugger::Memory ram;
+      Node::Debugger::Memory dcache;
     } memory;
 
     struct Tracer {

--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -31,6 +31,7 @@ auto option(string name, string value) -> bool {
   if(vulkan.internalUpscale == 1) vulkan.supersampleScanout = false;
   vulkan.outputUpscale = vulkan.supersampleScanout ? 1 : vulkan.internalUpscale;
   #endif
+  if(name == "Homebrew Mode") system.homebrewMode = value.boolean();
   return true;
 }
 

--- a/ares/n64/system/system.hpp
+++ b/ares/n64/system/system.hpp
@@ -1,6 +1,7 @@
 struct System {
   Node::System node;
   VFS::Pak pak;
+  bool homebrewMode = false;
 
   enum class Region : u32 { NTSC, PAL };
 

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -81,7 +81,6 @@ auto nall::main(Arguments arguments) -> void {
   }
 
   inputManager.create();
-  Emulator::construct();
   settings.load();
 
   if(arguments.find("--setting")) {
@@ -103,6 +102,8 @@ auto nall::main(Arguments arguments) -> void {
     }
     settings.process(true);
   }
+
+  Emulator::construct();
 
   if(arguments.take("--help")) {
     print("Usage: ares [OPTIONS]... game(s)\n\n");

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -99,6 +99,7 @@ auto Nintendo64::load() -> bool {
 #endif
   ares::Nintendo64::option("Disable Video Interface Processing", settings.video.disableVideoInterfaceProcessing);
   ares::Nintendo64::option("Weave Deinterlacing", settings.video.weaveDeinterlacing);
+  ares::Nintendo64::option("Homebrew Mode", settings.general.homebrewMode);
 
   if(!ares::Nintendo64::load(root, {"[Nintendo] ", name, " (", region, ")"})) return false;
 

--- a/desktop-ui/emulator/nintendo-64dd.cpp
+++ b/desktop-ui/emulator/nintendo-64dd.cpp
@@ -76,6 +76,7 @@ auto Nintendo64DD::load() -> bool {
 #endif
   ares::Nintendo64::option("Disable Video Interface Processing", settings.video.disableVideoInterfaceProcessing);
   ares::Nintendo64::option("Weave Deinterlacing", settings.video.weaveDeinterlacing);
+  ares::Nintendo64::option("Homebrew Mode", settings.general.homebrewMode);
 
   if(!ares::Nintendo64::load(root, {"[Nintendo] Nintendo 64DD (", region, ")"})) return false;
 

--- a/desktop-ui/settings/options.cpp
+++ b/desktop-ui/settings/options.cpp
@@ -21,4 +21,10 @@ auto OptionSettings::construct() -> void {
   });
   autoSaveMemoryLayout.setAlignment(1);
       autoSaveMemoryHint.setText("Helps safeguard game saves from being lost").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
+  homebrewMode.setText("Homebrew Development Mode").setChecked(settings.general.homebrewMode).onToggle([&] {
+    settings.general.homebrewMode = homebrewMode.checked();
+  });
+  homebrewModeLayout.setAlignment(1);
+      homebrewModeHint.setText("Activate core-specific features to help homebrew developers").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 }

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -98,6 +98,7 @@ auto Settings::process(bool load) -> void {
   bind(boolean, "General/Rewind", general.rewind);
   bind(boolean, "General/RunAhead", general.runAhead);
   bind(boolean, "General/AutoSaveMemory", general.autoSaveMemory);
+  bind(boolean, "General/HomebrewMode", general.homebrewMode);
 
   bind(natural, "Rewind/Length", rewind.length);
   bind(natural, "Rewind/Frequency", rewind.frequency);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -65,6 +65,7 @@ struct Settings : Markup::Node {
     bool rewind = false;
     bool runAhead = false;
     bool autoSaveMemory = true;
+    bool homebrewMode = false;
   } general;
 
   struct Rewind {
@@ -238,6 +239,9 @@ struct OptionSettings : VerticalLayout {
   HorizontalLayout autoSaveMemoryLayout{this, Size{~0, 0}, 5};
     CheckLabel autoSaveMemory{&autoSaveMemoryLayout, Size{0, 0}, 5};
     Label autoSaveMemoryHint{&autoSaveMemoryLayout, Size{~0, 0}};
+  HorizontalLayout homebrewModeLayout{this, Size{~0, 0}, 5};
+    CheckLabel homebrewMode{&homebrewModeLayout, Size{0, 0}, 5};
+    Label homebrewModeHint{&homebrewModeLayout, Size{~0, 0}};
 };
 
 struct FirmwareSettings : VerticalLayout {


### PR DESCRIPTION
This PR adds a new general setting called "homebrew mode", that can be used as an umbrella setting for all kind of developer-related aids in the emulator. This will also allow resource intensives checks to be added (eg: N64 RDP command list validation).

For now, we hook this to the N64 core only in two ways:

 * ISVIewer emulation is now only performed in homebrew mode. This is obviously not resource intensive, but it would have naturally been an homebrew mode feature, if it existed at the time. Normally, games should behave exactly like on a real N64, where there is no ISViewer peripheral plugged in into the PI bus.
 * A new cache coherency check is added to PI DMA. If a DMA is performed to/from RDRAM locations for which the CPU holds a valid cacheline, a warning is emitted to the console as the game is probably buggy.

Slightly unrelated, a commit also adds a new "DCache" memory viewer, to see the memory from the point of view of the CPU (so with data cache taken into account). This is useful to ROM hackers which don't care about the physical RDRAM contents but rather the memory contents as written by the CPU.