### PR TITLE
n64: Add D64 file format support

### DIFF
--- a/mia/medium/nintendo-64dd.cpp
+++ b/mia/medium/nintendo-64dd.cpp
@@ -1,6 +1,6 @@
 struct Nintendo64DD : FloppyDisk {
   auto name() -> string override { return "Nintendo 64DD"; }
-  auto extensions() -> vector<string> override { return {"n64dd", "ndd"}; }
+  auto extensions() -> vector<string> override { return {"n64dd", "ndd", "d64"}; }
   auto load(string location) -> bool override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& rom, vector<u8> errorTable) -> string;
@@ -21,12 +21,10 @@ auto Nintendo64DD::load(string location) -> bool {
   array_view<u8> view{input};
   auto errorTable = createErrorTable(view);
   if(!errorTable) return false;
-
   this->location = location;
   this->manifest = analyze(input, errorTable);
   auto document = BML::unserialize(manifest);
   if(!document) return false;
-
   pak = shared_pointer{new vfs::directory};
   pak->setAttribute("title", document["game/title"].string());
   pak->setAttribute("region", document["game/region"].string());
@@ -53,7 +51,12 @@ auto Nintendo64DD::save(string location) -> bool {
 }
 
 auto Nintendo64DD::analyze(vector<u8>& rom, vector<u8> errorTable) -> string {
-  bool dev = errorTable[12] == 0;
+  //basic disk format check (further d64 check will be done later)
+  b1 ndd = (rom.size() == 0x3DEC800);
+  b1 mame = (rom.size() == 0x435B0C0);
+  b1 d64 = (rom.size() >= 0x4F08) && (rom.size() < 0x3D79140);
+
+  b1 dev = errorTable[12] == 0;
   string region = "NTSC-J";
   u32 systemBlocks[4] = {0, 1, 8, 9};
   for(u32 n : range(4)) {
@@ -74,6 +77,8 @@ auto Nintendo64DD::analyze(vector<u8>& rom, vector<u8> errorTable) -> string {
   for(u32 n : range(2)) {
     if(errorTable[diskIdBlocks[n]]) continue;
     u32 diskIdOffset = diskIdBlocks[n] * 0x4D08;
+    if(d64) diskIdOffset = 0x100;
+
     id.append((char)rom[diskIdOffset + 0x00]);
     id.append((char)rom[diskIdOffset + 0x01]);
     id.append((char)rom[diskIdOffset + 0x02]);
@@ -100,8 +105,12 @@ auto Nintendo64DD::repeatCheck(array_view<u8> input, u32 repeat, u32 size) -> bo
 }
 
 auto Nintendo64DD::createErrorTable(array_view<u8> input) -> vector<u8> {
-  //if neither mame or ndd format, don't do anything
-  if ((input.size() != 0x435B0C0) && (input.size() != 0x3DEC800)) return {};
+  //basic disk format check (further d64 check will be done later)
+  b1 ndd = (input.size() == 0x3DEC800);
+  b1 mame = (input.size() == 0x435B0C0);
+  b1 d64 = (input.size() >= 0x4F08) && (input.size() < 0x3D79140);
+  //if neither mame or ndd or d64 format, don't do anything
+  if (!ndd && !mame && !d64) return {};
 
   input.begin();
   vector<u8> output;
@@ -110,51 +119,22 @@ auto Nintendo64DD::createErrorTable(array_view<u8> input) -> vector<u8> {
   //perform basic system area check, check if the data repeats and validity
   output[12] = 0;
   u32 systemBlocks[4] = {0, 1, 8, 9};
-  for(u32 n : range(4)) {
-    u32 systemOffset = systemBlocks[n]*0x4D08;
-    output[systemBlocks[n]] = 1;
-
-    //validity check
-    if((input[systemOffset + 0x00] != 0xE8)             //region magic (jpn & usa)
-    && (input[systemOffset + 0x00] != 0x22)) continue;
-    if((input[systemOffset + 0x01] != 0x48)
-    && (input[systemOffset + 0x01] != 0x63)) continue;
-    if((input[systemOffset + 0x02] != 0xD3)
-    && (input[systemOffset + 0x02] != 0xEE)) continue;
-    if((input[systemOffset + 0x03] != 0x16)
-    && (input[systemOffset + 0x03] != 0x56)) continue;
-
-    if(input[systemOffset + 0x04] != 0x10) continue;  //format type
-    if(input[systemOffset + 0x05] <  0x10) continue;  //disk type
-    if(input[systemOffset + 0x05] >= 0x17) continue;
-    if(input[systemOffset + 0x18] != 0xFF) continue;  //always 0xFF
-    if(input[systemOffset + 0x19] != 0xFF) continue;
-    if(input[systemOffset + 0x1A] != 0xFF) continue;
-    if(input[systemOffset + 0x1B] != 0xFF) continue;
-    if(input[systemOffset + 0x1C] != 0x80) continue;  //load address
-
-    //repeat check
-    array_view<u8> block{input.data() + systemOffset, 0xE8 * 0x55};
-    if (!repeatCheck(block, 0x55, 0xE8))   continue;
-
-    output[systemBlocks[n]] = 0;
-
-    //confirmed retail, inject error in block 12
-    output[12] = 1;
-  }
-
-  //if retail info check is bad, check if it's a dev one
-  if(output[12] == 0) {
+  if(ndd || mame) {
+    //ndd and mame format only
     for(u32 n : range(4)) {
-      u32 systemBlock = (input.size() == 0x3DEC800) ? (systemBlocks[n]+2)^1 : (systemBlocks[n]+2);
-      u32 systemOffset = systemBlock * 0x4D08;
-      output[systemBlocks[n]+2] = 1;
+      u32 systemOffset = systemBlocks[n]*0x4D08;
+      output[systemBlocks[n]] = 1;
 
       //validity check
-      if(input[systemOffset + 0x00] != 0x00) continue;  //region magic (dev)
-      if(input[systemOffset + 0x01] != 0x00) continue;
-      if(input[systemOffset + 0x02] != 0x00) continue;
-      if(input[systemOffset + 0x03] != 0x00) continue;
+      if((input[systemOffset + 0x00] != 0xE8)             //region magic (jpn & usa)
+      && (input[systemOffset + 0x00] != 0x22)) continue;
+      if((input[systemOffset + 0x01] != 0x48)
+      && (input[systemOffset + 0x01] != 0x63)) continue;
+      if((input[systemOffset + 0x02] != 0xD3)
+      && (input[systemOffset + 0x02] != 0xEE)) continue;
+      if((input[systemOffset + 0x03] != 0x16)
+      && (input[systemOffset + 0x03] != 0x56)) continue;
+
       if(input[systemOffset + 0x04] != 0x10) continue;  //format type
       if(input[systemOffset + 0x05] <  0x10) continue;  //disk type
       if(input[systemOffset + 0x05] >= 0x17) continue;
@@ -165,32 +145,107 @@ auto Nintendo64DD::createErrorTable(array_view<u8> input) -> vector<u8> {
       if(input[systemOffset + 0x1C] != 0x80) continue;  //load address
 
       //repeat check
-      array_view<u8> block{input.data() + systemOffset, 0xC0 * 0x55};
-      if (!repeatCheck(block, 0x55, 0xC0))   continue;
+      array_view<u8> block{input.data() + systemOffset, 0xE8 * 0x55};
+      if(!repeatCheck(block, 0x55, 0xE8))   continue;
 
+      output[systemBlocks[n]] = 0;
+
+      //confirmed retail, inject error in block 12
+      output[12] = 1;
+    }
+
+    //if retail info check is bad, check if it's a dev one
+    if(output[12] == 0) {
+      for(u32 n : range(4)) {
+        u32 systemBlock = ndd ? (systemBlocks[n]+2)^1 : (systemBlocks[n]+2);
+        u32 systemOffset = systemBlock * 0x4D08;
+        output[systemBlocks[n]+2] = 1;
+
+        //validity check
+        if(input[systemOffset + 0x00] != 0x00) continue;  //region magic (dev)
+        if(input[systemOffset + 0x01] != 0x00) continue;
+        if(input[systemOffset + 0x02] != 0x00) continue;
+        if(input[systemOffset + 0x03] != 0x00) continue;
+        if(input[systemOffset + 0x04] != 0x10) continue;  //format type
+        if(input[systemOffset + 0x05] <  0x10) continue;  //disk type
+        if(input[systemOffset + 0x05] >= 0x17) continue;
+        if(input[systemOffset + 0x18] != 0xFF) continue;  //always 0xFF
+        if(input[systemOffset + 0x19] != 0xFF) continue;
+        if(input[systemOffset + 0x1A] != 0xFF) continue;
+        if(input[systemOffset + 0x1B] != 0xFF) continue;
+        if(input[systemOffset + 0x1C] != 0x80) continue;  //load address
+
+        //repeat check
+        array_view<u8> block{input.data() + systemOffset, 0xC0 * 0x55};
+        if(!repeatCheck(block, 0x55, 0xC0))   continue;
+
+        output[systemBlocks[n]+2] = 0;
+      }
+    }
+  } else if(d64) {
+    //d64 format only, assume development disk
+    output[12] = 0;
+    for(u32 n : range(4)) {
+      output[systemBlocks[n]] = 1;
       output[systemBlocks[n]+2] = 0;
+    }
+    for(u32 n : range(0x100)) {
+      if(n == 0x005)  if(input[n] >= 0x07) return {};  //disk type
+                      else continue;
+      if(n == 0x006)  if(input[n] >= 0x02) return {};  //load size
+                      else continue;
+      if(n == 0x007)  continue;
+      if(n == 0x01C)  if(input[n] != 0x80) return {};  //load address
+                      else continue;
+      if(n == 0x01D)  continue;
+      if(n == 0x01E)  continue;
+      if(n == 0x01F)  continue;
+      if(n == 0x0E0)  if(input[n] > 0x10) return {}; //rom lba end
+                      else continue;
+      if(n == 0x0E1)  continue;
+      if(n == 0x0E2)  if(input[n] > 0x10 && input[n] < 0xFF) return {}; //ram lba start
+                      else continue;
+      if(n == 0x0E3)  continue;
+      if(n == 0x0E4)  if(input[n] > 0x10 && input[n] < 0xFF) return {}; //ram lba end
+                      else continue;
+      if(n == 0x0E5)  continue;
+
+      if(input[n] != 0x00) return {};
     }
   }
 
   //check disk id info
   u32 diskIdBlocks[2] = {14, 15};
-  for(u32 n : range(2)) {
-    u32 diskIdOffset = diskIdBlocks[n]*0x4D08;
-    output[diskIdBlocks[n]] = 1;
+  if(ndd || mame) {
+    for(u32 n : range(2)) {
+      u32 diskIdOffset = diskIdBlocks[n]*0x4D08;
+      output[diskIdBlocks[n]] = 1;
 
-    //repeat check
-    array_view<u8> block{input.data() + diskIdOffset, 0xE8 * 0x55};
-    if (!repeatCheck(block, 0x55, 0xE8))   continue;
+      //repeat check
+      array_view<u8> block{input.data() + diskIdOffset, 0xE8 * 0x55};
+      if(!repeatCheck(block, 0x55, 0xE8))   continue;
 
-    output[diskIdBlocks[n]] = 0;
+      output[diskIdBlocks[n]] = 0;
+    }
+  } else if(d64) {
+    for(u32 n : range(2)) {
+      output[diskIdBlocks[n]] = 0;
+    }
   }
 
   return output;
 }
 
 auto Nintendo64DD::transform(array_view<u8> input, vector<u8> errorTable) -> vector<u8> {
+  //basic disk format check (further d64 check will be done later)
+  b1 ndd = (input.size() == 0x3DEC800);
+  b1 mame = (input.size() == 0x435B0C0);
+  b1 d64 = (input.size() >= 0x4F08) && (input.size() < 0x3D79140);
+  //if neither mame or ndd or d64 format, don't do anything
+  if (!ndd && !mame && !d64) return {};
+
   //only recognize base retail ndd for now
-  if(input.size() == 0x435B0C0) {
+  if(mame) {
     //mame physical format (canon ares format)
     //just copy
     input.begin();
@@ -203,34 +258,36 @@ auto Nintendo64DD::transform(array_view<u8> input, vector<u8> errorTable) -> vec
     return output;
   }
 
-  if(input.size() != 0x3DEC800) return {};
-  //ndd dump format (convert to mame format)
-
-  //perform basic system area check
-  b1 systemCheck = false;
-  b1 dev = errorTable[12] == 0;
-  u32 systemBlocks[4] = {9, 8, 1, 0};
   u32 systemOffset = 0;
-  for(u32 n : range(4)) {
-    if(dev) {
-      u32 systemBlock = systemBlocks[n]+2;
-      if(errorTable[systemBlock] == 0) {
-        systemCheck = true;
-        systemOffset = (systemBlock^1)*0x4D08;
-      }
-    } else {
-      u32 systemBlock = systemBlocks[n];
-      if(errorTable[systemBlock] == 0) {
-        systemCheck = true;
-        systemOffset = systemBlock*0x4D08;
+  b1 dev = errorTable[12] == 0;
+  if(ndd) {
+    //ndd dump format (convert to mame format)
+
+    //perform basic system area check
+    b1 systemCheck = false;
+    u32 systemBlocks[4] = {9, 8, 1, 0};
+    for(u32 n : range(4)) {
+      if(dev) {
+        u32 systemBlock = systemBlocks[n]+2;
+        if(errorTable[systemBlock] == 0) {
+          systemCheck = true;
+          systemOffset = (systemBlock^1)*0x4D08;
+        }
+      } else {
+        u32 systemBlock = systemBlocks[n];
+        if(errorTable[systemBlock] == 0) {
+          systemCheck = true;
+          systemOffset = systemBlock*0x4D08;
+        }
       }
     }
+
+    //check failed
+    if(!systemCheck) return {};
   }
 
-  //check failed
-  if(!systemCheck) return {};
-
   //make sure to use valid disk info when converting
+  input.begin();
   array_view<u8> dataFormat{input.data() + systemOffset, 0xE8};
 
   //ndd conv
@@ -261,41 +318,132 @@ auto Nintendo64DD::transform(array_view<u8> input, vector<u8> errorTable) -> vec
   };
   u16 trackPhysicalTable[] = {0x000, 0x09E, 0x13C, 0x1D1, 0x266, 0x2FB, 0x390, 0x425,
                               0x091, 0x12F, 0x1C4, 0x259, 0x2EE, 0x383, 0x418, 0x48A};
-  u32 vzone = 0;
 
-  for (; lba < 0x10DC; lba++) {
-    if (lba >= vzoneLbaTable[type][vzone]) vzone++;
-    u32 pzoneCalc = vzone2pzoneTable[type][vzone];
-    u32 headCalc = (pzoneCalc > 7) ? 1 : 0;
+  if(ndd) {
+    u32 vzone = 0;
+    for (; lba < 0x10DC; lba++) {
+      if (lba >= vzoneLbaTable[type][vzone]) vzone++;
+      u32 pzoneCalc = vzone2pzoneTable[type][vzone];
+      u32 headCalc = (pzoneCalc > 7) ? 1 : 0;
 
-    u32 lba_vzone = lba;
-    if (vzone > 0) lba_vzone -= vzoneLbaTable[type][vzone - 1];
+      u32 lba_vzone = lba;
+      if (vzone > 0) lba_vzone -= vzoneLbaTable[type][vzone - 1];
 
-    u32 trackStart = trackPhysicalTable[headCalc ? pzoneCalc - 8 : pzoneCalc];
-    u32 trackCalc = trackPhysicalTable[pzoneCalc];
-    if (headCalc) trackCalc -= (lba_vzone >> 1);
-    else trackCalc += (lba_vzone >> 1);
+      u32 trackStart = trackPhysicalTable[headCalc ? pzoneCalc - 8 : pzoneCalc];
+      u32 trackCalc = trackPhysicalTable[pzoneCalc];
+      if (headCalc) trackCalc -= (lba_vzone >> 1);
+      else trackCalc += (lba_vzone >> 1);
 
-    u32 defectOffset = 0;
-    if (pzoneCalc > 0) defectOffset = dataFormat[8 + pzoneCalc - 1];
-    u32 defectAmount = dataFormat[8 + pzoneCalc] - defectOffset;
+      u32 defectOffset = 0;
+      if (pzoneCalc > 0) defectOffset = dataFormat[8 + pzoneCalc - 1];
+      u32 defectAmount = dataFormat[8 + pzoneCalc] - defectOffset;
 
-    while ((defectAmount != 0) && ((dataFormat[0x20 + defectOffset] + trackStart) <= trackCalc)) {
-      trackCalc++;
-      defectOffset++;
-      defectAmount--;
+      while ((defectAmount != 0) && ((dataFormat[0x20 + defectOffset] + trackStart) <= trackCalc)) {
+        trackCalc++;
+        defectOffset++;
+        defectAmount--;
+      }
+
+      u32 blockCalc = ((lba & 3) == 0 || (lba & 3) == 3) ? 0 : 1;
+
+      u32 startOffsetTable[16] = {0x0,0x5F15E0,0xB79D00,0x10801A0,0x1523720,0x1963D80,0x1D414C0,0x20BBCE0,
+                                  0x23196E0,0x28A1E00,0x2DF5DC0,0x3299340,0x36D99A0,0x3AB70E0,0x3E31900,0x4149200};
+      u32 offsetCalc = startOffsetTable[pzoneCalc];
+      offsetCalc += (trackCalc - trackStart) * (blockSizeTable[headCalc ? pzoneCalc - 7 : pzoneCalc] * 2);
+      offsetCalc += blockSizeTable[headCalc ? pzoneCalc - 7 : pzoneCalc] * blockCalc;
+
+      for(u32 n : range(blockSizeTable[headCalc ? pzoneCalc - 7 : pzoneCalc]))
+        output[offsetCalc + n] = input.read();
+    }
+  }
+  if(d64) {
+    //copy tons of system area stuff (we can cheat on this one)
+    u32 systemBlocks[4] = {0, 1, 8, 9};
+    for(u32 n : range(4)) {
+      u32 offsetCalc = (systemBlocks[n] + (dev ? 2 : 0)) * blockSizeTable[0];
+      //copy first sector of system data
+      for(u32 m : range(dev ? 0xC0 : 0xE8)) {
+        output[offsetCalc + m] = dataFormat[m];
+      }
+      //inject proper disk data
+      output[offsetCalc + 0x004] = 0x10;  //format type
+      output[offsetCalc + 0x005] += 0x10; //disk type
+      //copy to all sectors
+      for(u32 m : range(85)) {
+        for(u32 l : range(dev ? 0xC0 : 0xE8)) {
+          output[offsetCalc + (m * (dev ? 0xC0 : 0xE8)) + l] = output[offsetCalc + l];
+        }
+      }
+    }
+    //same for disk id
+    u32 diskIdBlocks[2] = {14, 15};
+    for(u32 n : range(2)) {
+      u32 offsetCalc = diskIdBlocks[n] * blockSizeTable[0];
+      //copy disk id to all sectors
+      for(u32 m : range(85)) {
+        for(u32 l : range(blockSizeTable[0] / 85)) {
+          output[offsetCalc + (m * (blockSizeTable[0] / 85)) + l] = input[0x100 + l];
+        }
+      }
     }
 
-    u32 blockCalc = ((lba & 3) == 0 || (lba & 3) == 3) ? 0 : 1;
+    //get lba info
+    u32 rom_start_lba = 24;
+    u32 rom_end_lba = (input[0xE0] << 8) + input[0xE1] + 24;
+    u32 ram_start_lba = (input[0xE2] << 8) + input[0xE3];
+    u32 ram_end_lba = (input[0xE4] << 8) + input[0xE5];
+    //either both are 0xFFFF or aren't
+    if((ram_start_lba == 0xFFFF) && (ram_end_lba != 0xFFFF)) return {};
+    if((ram_start_lba != 0xFFFF) && (ram_end_lba == 0xFFFF)) return {};
+    //add base lba
+    if((ram_start_lba != 0xFFFF) && (ram_end_lba != 0xFFFF)) {
+      ram_start_lba += 24;
+      ram_end_lba += 24;
+    }
 
-    u32 startOffsetTable[16] = {0x0,0x5F15E0,0xB79D00,0x10801A0,0x1523720,0x1963D80,0x1D414C0,0x20BBCE0,
-                                0x23196E0,0x28A1E00,0x2DF5DC0,0x3299340,0x36D99A0,0x3AB70E0,0x3E31900,0x4149200};
-    u32 offsetCalc = startOffsetTable[pzoneCalc];
-    offsetCalc += (trackCalc - trackStart) * (blockSizeTable[headCalc ? pzoneCalc - 7 : pzoneCalc] * 2);
-    offsetCalc += blockSizeTable[headCalc ? pzoneCalc - 7 : pzoneCalc] * blockCalc;
+    //copy lbas
+    input += 0x200;
+    u32 vzone = 0;
+    for (; lba < 0x10DC; lba++) {
+      if (lba >= vzoneLbaTable[type][vzone]) vzone++;
 
-    for(u32 n : range(blockSizeTable[headCalc ? pzoneCalc - 7 : pzoneCalc]))
-      output[offsetCalc + n] = input.read();
+      //skip those that can't be copied
+      if (lba < rom_start_lba) continue;
+      if (lba > rom_end_lba && lba < ram_start_lba) continue;
+      if (lba > ram_end_lba) continue;
+
+      u32 pzoneCalc = vzone2pzoneTable[type][vzone];
+      u32 headCalc = (pzoneCalc > 7) ? 1 : 0;
+
+      u32 lba_vzone = lba;
+      if (vzone > 0) lba_vzone -= vzoneLbaTable[type][vzone - 1];
+
+      u32 trackStart = trackPhysicalTable[headCalc ? pzoneCalc - 8 : pzoneCalc];
+      u32 trackCalc = trackPhysicalTable[pzoneCalc];
+      if (headCalc) trackCalc -= (lba_vzone >> 1);
+      else trackCalc += (lba_vzone >> 1);
+
+      u32 defectOffset = 0;
+      if (pzoneCalc > 0) defectOffset = dataFormat[8 + pzoneCalc - 1];
+      u32 defectAmount = dataFormat[8 + pzoneCalc] - defectOffset;
+
+      while ((defectAmount != 0) && ((dataFormat[0x20 + defectOffset] + trackStart) <= trackCalc)) {
+        trackCalc++;
+        defectOffset++;
+        defectAmount--;
+      }
+
+      u32 blockCalc = ((lba & 3) == 0 || (lba & 3) == 3) ? 0 : 1;
+
+      u32 startOffsetTable[16] = {0x0,0x5F15E0,0xB79D00,0x10801A0,0x1523720,0x1963D80,0x1D414C0,0x20BBCE0,
+                                  0x23196E0,0x28A1E00,0x2DF5DC0,0x3299340,0x36D99A0,0x3AB70E0,0x3E31900,0x4149200};
+      u32 offsetCalc = startOffsetTable[pzoneCalc];
+      offsetCalc += (trackCalc - trackStart) * (blockSizeTable[headCalc ? pzoneCalc - 7 : pzoneCalc] * 2);
+      offsetCalc += blockSizeTable[headCalc ? pzoneCalc - 7 : pzoneCalc] * blockCalc;
+
+      for(u32 n : range(blockSizeTable[headCalc ? pzoneCalc - 7 : pzoneCalc]))
+        output[offsetCalc + n] = input.read();
+    }
   }
 
   return output;


### PR DESCRIPTION
Adds D64 file format support, which is the official master 64DD data file format, which is basically NDD but a lot of the useless data trimmed out and disk formatting data kept to a minimum.

Works in this way:
- Adds *.d64 file extension to the list.
- Redo code that uses clearer variables to keep track of recognized 64DD disk file format.
- Add a file size check to do a proper format recognition and avoid errors.
- Additional data validity checks.
- D64 conversion to the internal disk format (I refer to it as MAME format) by reusing the same algorithm as NDD while ignoring blocks of data that are not present.