### PR TITLE
n64: add 64dd disk swapping + safety checks + change manufacture timestamp

### DIFF
--- a/ares/n64/dd/controller.cpp
+++ b/ares/n64/dd/controller.cpp
@@ -187,7 +187,11 @@ auto DD::command(n16 command) -> void {
 auto DD::mechaResponse() -> void {
   if(state.seek) {
     state.seek = 0;
-    motorActive();
+    if (io.status.diskPresent) {
+      motorActive();
+    } else {
+      motorStop();
+    }
   }
   io.status.busyState = 0;
   raise(IRQ::MECHA);

--- a/ares/n64/dd/dd.hpp
+++ b/ares/n64/dd/dd.hpp
@@ -125,6 +125,7 @@ private:
       n1 writeProtect;
       n1 mechaError;
       n1 diskChanged;
+      n1 diskPresent;
     } status;
 
     n16 currentTrack;

--- a/ares/n64/dd/io.cpp
+++ b/ares/n64/dd/io.cpp
@@ -20,7 +20,7 @@ auto DD::readHalf(u32 address) -> u16 {
     data.bit(4) = io.status.spindleMotorStopped;
     data.bit(6) = io.status.resetState;
     data.bit(7) = io.status.busyState;
-    data.bit(8) = (bool)disk; //disk present
+    data.bit(8) = io.status.diskPresent;
     data.bit(9) = irq.mecha.line;
     data.bit(10) = irq.bm.line;
     data.bit(11) = io.bm.error;
@@ -57,7 +57,7 @@ auto DD::readHalf(u32 address) -> u16 {
     data.bit(0,7) = io.error.sector;
     data.bit(8) = io.error.selfStop;
     data.bit(9) = io.error.clockUnlock;
-    data.bit(10) = ~(bool)disk; //no disk
+    data.bit(10) = ~io.status.diskPresent; //no disk
     data.bit(11) = io.error.offTrack;
     data.bit(12) = io.error.overrun;
     data.bit(13) = io.error.spindle;


### PR DESCRIPTION
This adds:
- 64DD Disk Swapping for both 64DD standalone games and N64 Combo games (only if a disk is loaded).
- Safety checks to prevent corruptions.
- Change manufacture timestamp and line to differenciate different disk files from each other to avoid confusion