### PR TITLE
n64: enable rumble support for homebrew

### DIFF
--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -622,7 +622,7 @@ auto Nintendo64::analyze(vector<u8>& data) -> string {
     if(config.bit(4,7) == 6) {sram = 128_KiB;}
     if(config.bit(0) == 1)   {rtc = true;}
     rpak = true;
-    cpak = true;
+    cpak = false;
   }
 
   string s;


### PR DESCRIPTION
Before this PR, mia always assigned the rumble pak + controller pak to homebrew ROMs without an known ID:

https://github.com/ares-emulator/ares/blob/fa0f9a715fc9e14d48220ba2339ca1273b9d5d5b/mia/medium/nintendo-64.cpp#L624

Because the desktop-ui ALWAYS assigns controller pak to controller #1 and rumble paks ONLY to controller #2-3, 
rumble never worked at all for these unknown homebrew games.

https://github.com/ares-emulator/ares/blob/fa0f9a715fc9e14d48220ba2339ca1273b9d5d5b/desktop-ui/emulator/nintendo-64.cpp#L148

This fixes this problem by not enabling controller pak for not known homebrew games.

I guess this should be fine, because I think most homebrew devs will use flash or sram for saving, instead of controller pak, 
because the save space is very limited on controller pak for indivudal games and there is no advantage using it.