### PR TITLE
desktop-ui: disable color bleed for HD content

### DIFF
--- a/desktop-ui/emulator/emulator.cpp
+++ b/desktop-ui/emulator/emulator.cpp
@@ -165,7 +165,7 @@ auto Emulator::setOverscan(bool value) -> bool {
 
 auto Emulator::setColorBleed(bool value) -> bool {
   if(auto screen = root->scan<ares::Node::Video::Screen>("Screen")) {
-    screen->setColorBleed(value);
+    screen->setColorBleed(screen->height() < 720 ? value : false);  //only apply to sub-HD content
     return true;
   }
 


### PR DESCRIPTION
This effect runs on the CPU, which is expensive for HD content and incredibly so for UHD content. It doesn't make much sense to apply to non-SD content, in any case.

Currently this only affects the N64 core in HD and UHD modes.