### PR TITLE
n64: put dd rtc into a struct + serialize rtc + update serializer version

### DIFF
--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -64,7 +64,7 @@ auto CPU::synchronize() -> void {
     case Queue::SI_DMA_Write:  return si.dmaWrite();
     case Queue::SI_BUS_Write:  return si.writeFinished();
     case Queue::RTC_Tick:      return cartridge.rtc.tick();
-    case Queue::DD_Clock_Tick:  return dd.rtcTickClock();
+    case Queue::DD_Clock_Tick:  return dd.rtc.tickClock();
     case Queue::DD_MECHA_Response:  return dd.mechaResponse();
     case Queue::DD_BM_Request:  return dd.bmRequest();
     case Queue::DD_Motor_Mode:  return dd.motorChange();

--- a/ares/n64/dd/controller.cpp
+++ b/ares/n64/dd/controller.cpp
@@ -144,22 +144,22 @@ auto DD::command(n16 command) -> void {
       }
     } break;
     case Command::SetRTCYearMonth: {
-      rtc.write<Half>(0, io.data);
+      rtc.ram.write<Half>(0, io.data);
     } break;
     case Command::SetRTCDayHour: {
-      rtc.write<Half>(2, io.data);
+      rtc.ram.write<Half>(2, io.data);
     } break;
     case Command::SetRTCMinuteSecond: {
-      rtc.write<Half>(4, io.data);
+      rtc.ram.write<Half>(4, io.data);
     } break;
     case Command::GetRTCYearMonth: {
-      io.data = rtc.read<Half>(0);
+      io.data = rtc.ram.read<Half>(0);
       } break;
     case Command::GetRTCDayHour: {
-      io.data = rtc.read<Half>(2);
+      io.data = rtc.ram.read<Half>(2);
       } break;
     case Command::GetRTCMinuteSecond: {
-      io.data = rtc.read<Half>(4);
+      io.data = rtc.ram.read<Half>(4);
       } break;
     case Command::SetLEDBlinkRate: {
       if (io.data.bit(24,31) != 0) ctl.ledOnTime = io.data.bit(24,31);

--- a/ares/n64/dd/dd.cpp
+++ b/ares/n64/dd/dd.cpp
@@ -24,14 +24,13 @@ auto DD::load(Node::Object parent) -> void {
   c2s.allocate(0x400);
   ds.allocate(0x100);
   ms.allocate(0x40);
-  rtc.allocate(0x10);
 
   // TODO: Detect correct CIC from ipl rom
   if(auto fp = system.pak->read("64dd.ipl.rom")) {
     iplrom.load(fp);
   }
 
-  rtcLoad();
+  rtc.load();
 
   debugger.load(parent->append<Node::Object>("Nintendo 64DD"));
 }
@@ -127,7 +126,7 @@ auto DD::save() -> void {
     disk.save(fp);
   }
   
-  rtcSave();
+  rtc.save();
 }
 
 auto DD::power(bool reset) -> void {

--- a/ares/n64/dd/dd.hpp
+++ b/ares/n64/dd/dd.hpp
@@ -11,7 +11,6 @@ struct DD : Memory::PI<DD> {
   Memory::Writable c2s;
   Memory::Writable ds;
   Memory::Writable ms;
-  Memory::Writable rtc;
   Memory::Writable disk;
   Memory::Writable error;
 
@@ -26,6 +25,19 @@ struct DD : Memory::PI<DD> {
       Node::Debugger::Tracer::Notification io;
     } tracer;
   } debugger;
+
+  struct RTC {
+    Memory::Writable ram;
+
+    //rtc.cpp
+    auto load() -> void;
+    auto reset() -> void;
+    auto save() -> void;
+    auto serialize(serializer& s) -> void;
+    auto tick(u32 offset) -> void;
+    auto tickClock() -> void;
+    auto tickSecond() -> void;
+  } rtc;
 
   auto title() const -> string { return information.title; }
   auto cic() const -> string { return information.cic; }
@@ -58,13 +70,6 @@ struct DD : Memory::PI<DD> {
   auto motorStandby() -> void;
   auto motorStop() -> void;
   auto motorChange() -> void;
-
-  //rtc.cpp
-  auto rtcLoad() -> void;
-  auto rtcSave() -> void;
-  auto rtcTick(u32 offset) -> void;
-  auto rtcTickClock() -> void;
-  auto rtcTickSecond() -> void;
 
   //io.cpp
   auto readHalf(u32 address) -> u16;

--- a/ares/n64/dd/rtc.cpp
+++ b/ares/n64/dd/rtc.cpp
@@ -1,71 +1,80 @@
-auto DD::rtcLoad() -> void {
+auto DD::RTC::load() -> void {
+  ram.allocate(0x10);
   if(auto fp = system.pak->read("time.rtc")) {
-    rtc.load(fp);
+    ram.load(fp);
   }
 
   n64 check = 0;
-  for(auto n : range(8)) check.byte(n) = rtc.read<Byte>(n);
+  for(auto n : range(8)) check.byte(n) = ram.read<Byte>(n);
   if(!~check) return;  //new save file
 
   n64 timestamp = 0;
-  for(auto n : range(8)) timestamp.byte(n) = rtc.read<Byte>(8 + n);
+  for(auto n : range(8)) timestamp.byte(n) = ram.read<Byte>(8 + n);
   if(!~timestamp) return;  //new save file
 
   timestamp = time(0) - timestamp;
-  while(timestamp--) rtcTickSecond();
+  while(timestamp--) tickSecond();
 }
 
-auto DD::rtcSave() -> void {
+auto DD::RTC::reset() -> void {
+  ram.reset();
+}
+
+auto DD::RTC::save() -> void {
   n64 timestamp = time(0);
-  for(auto n : range(8)) rtc.write<Byte>(8 + n, timestamp.byte(n));
+  for(auto n : range(8)) ram.write<Byte>(8 + n, timestamp.byte(n));
 
   if(auto fp = system.pak->write("time.rtc")) {
-    rtc.save(fp);
+    ram.save(fp);
   }
 }
 
-auto DD::rtcTick(u32 offset) -> void {
-  u8 n = rtc.read<Byte>(offset);
-  if((++n & 0xf) > 9) n = (n & 0xf0) + 0x10;
-  if((n & 0xf0) > 0x90) n = 0;
-  rtc.write<Byte>(offset, n);
+auto DD::RTC::serialize(serializer& s) -> void {
+  s(ram);
 }
 
-auto DD::rtcTickClock() -> void {
-  rtcTickSecond();
+auto DD::RTC::tick(u32 offset) -> void {
+  u8 n = ram.read<Byte>(offset);
+  if((++n & 0xf) > 9) n = (n & 0xf0) + 0x10;
+  if((n & 0xf0) > 0x90) n = 0;
+  ram.write<Byte>(offset, n);
+}
+
+auto DD::RTC::tickClock() -> void {
+  tickSecond();
   queue.remove(Queue::DD_Clock_Tick);
   queue.insert(Queue::DD_Clock_Tick, 187'500'000);
 }
 
-auto DD::rtcTickSecond() -> void {
+auto DD::RTC::tickSecond() -> void {
   //second
-  rtcTick(5);
-  if(rtc.read<Byte>(5) < 0x60) return;
-  rtc.write<Byte>(5, 0);
+  tick(5);
+  if(ram.read<Byte>(5) < 0x60) return;
+  ram.write<Byte>(5, 0);
 
   //minute
-  rtcTick(4);
-  if(rtc.read<Byte>(4) < 0x60) return;
-  rtc.write<Byte>(4, 0);
+  tick(4);
+  if(ram.read<Byte>(4) < 0x60) return;
+  ram.write<Byte>(4, 0);
 
   //hour
-  rtcTick(3);
-  if(rtc.read<Byte>(3) < 0x24) return;
-  rtc.write<Byte>(3, 0);
+  tick(3);
+  if(ram.read<Byte>(3) < 0x24) return;
+  ram.write<Byte>(3, 0);
 
   //day
   u32 daysInMonth[12] = {0x31, 0x28, 0x31, 0x30, 0x31, 0x30, 0x31, 0x31, 0x30, 0x31, 0x30, 0x31};
-  if(rtc.read<Byte>(0) && !(BCD::decode(rtc.read<Byte>(0)) % 4)) daysInMonth[1]++;
+  if(ram.read<Byte>(0) && !(BCD::decode(ram.read<Byte>(0)) % 4)) daysInMonth[1]++;
 
-  rtcTick(2);
-  if(rtc.read<Byte>(2) <= daysInMonth[BCD::decode(rtc.read<Byte>(1))-1]) return;
-  rtc.write<Byte>(2, 1);
+  tick(2);
+  if(ram.read<Byte>(2) <= daysInMonth[BCD::decode(ram.read<Byte>(1))-1]) return;
+  ram.write<Byte>(2, 1);
 
   //month
-  rtcTick(1);
-  if(rtc.read<Byte>(1) < 0x12) return;
-  rtc.write<Byte>(1, 1);
+  tick(1);
+  if(ram.read<Byte>(1) < 0x12) return;
+  ram.write<Byte>(1, 1);
 
   //year
-  rtcTick(0);
+  tick(0);
 }

--- a/ares/n64/dd/serialization.cpp
+++ b/ares/n64/dd/serialization.cpp
@@ -1,4 +1,6 @@
 auto DD::serialize(serializer& s) -> void {
+  s(rtc);
+
   s(irq.bm.line);
   s(irq.bm.mask);
   s(irq.mecha.line);

--- a/ares/n64/system/serialization.cpp
+++ b/ares/n64/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v133.1";
+static const string SerializerVersion = "v134.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   serializer s;

--- a/ares/n64/system/serialization.cpp
+++ b/ares/n64/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v134.1";
+static const string SerializerVersion = "v134";
 
 auto System::serialize(bool synchronize) -> serializer {
   serializer s;


### PR DESCRIPTION
I seperated the RTC into its own struct as it can be easily seperated, and added serialization for it for save states.
Tested working.