### PR TITLE
build: fix level 1 msvc warnings

### DIFF
--- a/libco/settings.h
+++ b/libco/settings.h
@@ -32,7 +32,7 @@
 #endif
 
 #if defined(_MSC_VER)
-  #pragma section(".text", execute, read)
+  #pragma section(".text")
   #define section(name) __declspec(allocate(".text"))
 #elif defined(__APPLE__)
   #define section(name) __attribute__((section("__TEXT,__" #name)))

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -117,9 +117,10 @@ endif
 
 # global compiler flags
 ifeq ($(cl),true)
-  flags.c      = -nologo -W0 -Fd$(object.path)/ -TC -std:c11
-  flags.cpp    = -nologo -W0 -Fd$(object.path)/ -TP -std:c++17 -EHsc
-  options      = -nologo $(if $(findstring clang,$(compiler)),-fuse-ld=lld) -link
+  flags.c      = -TC -std:c11
+  flags.cpp    = -TP -std:c++17 -EHsc
+  flags       += -nologo -W1 -Fd$(object.path)/ 
+  options     += -nologo $(if $(findstring clang,$(compiler)),-fuse-ld=lld) -link
 else
   flags.c      = -x c -std=c11
   flags.cpp    = -x c++ -std=c++17

--- a/nall/file-buffer.hpp
+++ b/nall/file-buffer.hpp
@@ -229,10 +229,10 @@ private:
 
   auto bufferSynchronize() -> void {
     if(!fileHandle) return;
-    if(bufferOffset == (fileOffset & ~(buffer.size() - 1))) return;
+    if(bufferOffset == (fileOffset & ~u64(buffer.size() - 1))) return;
 
     bufferFlush();
-    bufferOffset = fileOffset & ~(buffer.size() - 1);
+    bufferOffset = fileOffset & ~u64(buffer.size() - 1);
     fseek(fileHandle, bufferOffset, SEEK_SET);
     u64 length = bufferOffset + buffer.size() <= fileSize ? buffer.size() : fileSize & buffer.size() - 1;
     if(length) (void)fread(buffer.data(), 1, length, fileHandle);

--- a/nall/file-map.cpp
+++ b/nall/file-map.cpp
@@ -41,14 +41,17 @@ NALL_HEADER_INLINE auto file_map::open(const string& filename, u32 mode_) -> boo
 
   _file = CreateFileW(utf16_t(filename), desiredAccess, FILE_SHARE_READ, nullptr,
     creationDisposition, FILE_ATTRIBUTE_NORMAL, nullptr);
-  if(_file == INVALID_HANDLE_VALUE) return false;
+  if(_file == INVALID_HANDLE_VALUE) {
+    _file = nullptr;
+    return false;
+  }
 
   _size = GetFileSize(_file, nullptr);
 
   _map = CreateFileMapping(_file, nullptr, protection, 0, _size, nullptr);
-  if(_map == INVALID_HANDLE_VALUE) {
+  if(_map == nullptr) {
     CloseHandle(_file);
-    _file = INVALID_HANDLE_VALUE;
+    _file = nullptr;
     return false;
   }
 
@@ -62,14 +65,14 @@ NALL_HEADER_INLINE auto file_map::close() -> void {
     _data = nullptr;
   }
 
-  if(_map != INVALID_HANDLE_VALUE) {
+  if(_map != nullptr) {
     CloseHandle(_map);
-    _map = INVALID_HANDLE_VALUE;
+    _map = nullptr;
   }
 
-  if(_file != INVALID_HANDLE_VALUE) {
+  if(_file != nullptr) {
     CloseHandle(_file);
-    _file = INVALID_HANDLE_VALUE;
+    _file = nullptr;
   }
 
   _open = false;

--- a/nall/file-map.hpp
+++ b/nall/file-map.hpp
@@ -50,8 +50,8 @@ private:
 
   #if defined(API_WINDOWS)
 
-  HANDLE _file = INVALID_HANDLE_VALUE;
-  HANDLE _map  = INVALID_HANDLE_VALUE;
+  HANDLE _file = nullptr;
+  HANDLE _map  = nullptr;
 
 public:
   auto operator=(file_map&& source) -> file_map& {
@@ -67,8 +67,8 @@ public:
     source._open = false;
     source._data = nullptr;
     source._size = 0;
-    source._file = INVALID_HANDLE_VALUE;
-    source._map = INVALID_HANDLE_VALUE;
+    source._file = nullptr;
+    source._map = nullptr;
 
     return *this;
   }

--- a/nall/intrinsics.hpp
+++ b/nall/intrinsics.hpp
@@ -64,6 +64,8 @@ namespace nall {
     static constexpr bool GCC       = 0;
     static constexpr bool Microsoft = 1;
   };
+  #pragma warning(disable:4804)  //unsafe use of type 'bool' in operation
+  #pragma warning(disable:4805)  //unsafe mix of type 'bool' and type 'type' in operation
   #pragma warning(disable:4996)  //libc "deprecation" warnings
 #else
   #error "unable to detect compiler"

--- a/nall/platform.hpp
+++ b/nall/platform.hpp
@@ -67,10 +67,6 @@ namespace Math {
   #define MSG_NOSIGNAL 0
   #define PATH_MAX 260
 
-  #if !defined(INVALID_HANDLE_VALUE)
-    #define INVALID_HANDLE_VALUE ((HANDLE)-1)
-  #endif
-
   typedef void* HANDLE;
 
   inline auto access(const char* path, int amode) -> int { return _waccess(nall::utf16_t(path), amode); }


### PR DESCRIPTION
Level 1 warnings are considered "severe" and, unsurprisingly, turning them on revealed some true bugs.

- file-buffer.hpp: What should have been a zero extend followed by a complement was instead a complement followed by a zero extend, inadvertently truncating the file seek offset to 32 bits.
- file-map.cpp: What should have been a nullptr check after CreateFileMapping() was instead a check for INVALID_HANDLE_VALUE. The warning pointing me toward this was not technically about the misuse but rather the redefinition of INVALID_HANDLE_VALUE in nall. I've removed this and any reference to INVALID_HANDLE_VALUE except for error checks immediately after calls to the few APIs that return it.