### PR TITLE
build: fix level 2 msvc warnings

### DIFF
--- a/ares/ares/scheduler/scheduler.hpp
+++ b/ares/ares/scheduler/scheduler.hpp
@@ -41,7 +41,7 @@ private:
   vector<Thread*> _threads;
   bool _synchronize = false;
 
-  friend class Thread;
+  friend struct Thread;
 };
 
 extern Scheduler scheduler;

--- a/ares/ares/scheduler/thread.hpp
+++ b/ares/ares/scheduler/thread.hpp
@@ -46,5 +46,5 @@ protected:
   u64 _scalar = 0;
   u64 _clock = 0;
 
-  friend class Scheduler;
+  friend struct Scheduler;
 };

--- a/ares/md/controller/port.hpp
+++ b/ares/md/controller/port.hpp
@@ -60,7 +60,7 @@ protected:
   n8 serialControl;
   n8 serialTxBuffer;
   n8 serialRxBuffer;
-  friend class Controller;
+  friend struct Controller;
 };
 
 extern ControllerPort controllerPort1;

--- a/ares/n64/rsp/interpreter-vpu.cpp
+++ b/ares/n64/rsp/interpreter-vpu.cpp
@@ -150,7 +150,7 @@ auto RSP::CTC2(cr32& rt, u8 rd) -> void {
 
   if constexpr(Accuracy::RSP::SIMD) {
     #if ARCHITECTURE_SUPPORTS_SSE4_1
-    static const v128 mask = _mm_set_epi16(0x0101, 0x0202, 0x0404, 0x0808, 0x1010, 0x2020, 0x4040, 0x8080);
+    static const v128 mask = _mm_set_epi16(0x0101, 0x0202, 0x0404, 0x0808, 0x1010, 0x2020, 0x4040, 0x8080u);
     lo->v128 = _mm_cmpeq_epi8(_mm_and_si128(_mm_set1_epi8(~rt.u32 >> 0), mask), zero);
     hi->v128 = _mm_cmpeq_epi8(_mm_and_si128(_mm_set1_epi8(~rt.u32 >> 8), mask), zero);
     #endif

--- a/ares/ng/card/slot.hpp
+++ b/ares/ng/card/slot.hpp
@@ -26,7 +26,7 @@ struct CardSlot {
 
 protected:
   const string name;
-  friend class Card;
+  friend struct Card;
 };
 
 extern CardSlot cardSlot;

--- a/ares/ng/controller/port.hpp
+++ b/ares/ng/controller/port.hpp
@@ -20,7 +20,7 @@ struct ControllerPort {
 
 protected:
   const string name;
-  friend class Controller;
+  friend struct Controller;
 };
 
 extern ControllerPort controllerPort1;

--- a/ares/sfc/cartridge/cartridge.hpp
+++ b/ares/sfc/cartridge/cartridge.hpp
@@ -107,7 +107,7 @@ private:
   auto saveSPC7110(Markup::Node) -> void;
   auto saveOBC1(Markup::Node) -> void;
 
-  friend class ICD;
+  friend struct ICD;
 };
 
 #include "slot.hpp"

--- a/ares/sfc/system/system.hpp
+++ b/ares/sfc/system/system.hpp
@@ -41,7 +41,7 @@ private:
   //serialization.cpp
   auto serialize(serializer&, bool synchronize) -> void;
 
-  friend class Cartridge;
+  friend struct Cartridge;
 };
 
 extern Random random;

--- a/desktop-ui/input/input.hpp
+++ b/desktop-ui/input/input.hpp
@@ -77,7 +77,7 @@ private:
   function<void ()> press;
   function<void ()> release;
   s16 state = 0;
-  friend class InputManager;
+  friend struct InputManager;
 };
 
 struct InputNode {

--- a/hiro/core/widget/tab-frame.hpp
+++ b/hiro/core/widget/tab-frame.hpp
@@ -2,7 +2,7 @@
 struct mTabFrame : mWidget {
   Declare(TabFrame)
   using mObject::remove;
-  friend class mTabFrameItem;
+  friend struct mTabFrameItem;
 
   auto append(sTabFrameItem item) -> type&;
   auto doChange() const -> void;

--- a/hiro/extension/browser-dialog.hpp
+++ b/hiro/extension/browser-dialog.hpp
@@ -46,7 +46,7 @@ private:
 
   auto _run() -> vector<string>;
 
-  friend class BrowserDialogWindow;
+  friend struct BrowserDialogWindow;
 };
 
 #endif

--- a/hiro/extension/fixed-layout.hpp
+++ b/hiro/extension/fixed-layout.hpp
@@ -58,7 +58,7 @@ private:
     sSizable sizable;
   } state;
 
-  friend class mFixedLayout;
+  friend struct mFixedLayout;
 };
 
 #endif

--- a/hiro/extension/horizontal-layout.hpp
+++ b/hiro/extension/horizontal-layout.hpp
@@ -75,7 +75,7 @@ private:
     f32 spacing = 5_sx;
   } state;
 
-  friend class mHorizontalLayout;
+  friend struct mHorizontalLayout;
 };
 
 #endif

--- a/hiro/extension/table-layout.hpp
+++ b/hiro/extension/table-layout.hpp
@@ -77,7 +77,7 @@ private:
     f32 spacing = 5_sx;
   } state;
 
-  friend class mTableLayout;
+  friend struct mTableLayout;
 };
 
 struct mTableLayoutRow : mObject {
@@ -95,7 +95,7 @@ private:
     f32 spacing = 5_sy;
   } state;
 
-  friend class mTableLayout;
+  friend struct mTableLayout;
 };
 
 struct mTableLayoutCell : mObject {
@@ -122,7 +122,7 @@ private:
     Size size;
   } state;
 
-  friend class mTableLayout;
+  friend struct mTableLayout;
 };
 
 #endif

--- a/hiro/extension/vertical-layout.hpp
+++ b/hiro/extension/vertical-layout.hpp
@@ -75,7 +75,7 @@ private:
     f32 spacing = 5_sy;
   } state;
 
-  friend class mVerticalLayout;
+  friend struct mVerticalLayout;
 };
 
 #endif

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -119,7 +119,7 @@ endif
 ifeq ($(cl),true)
   flags.c      = -TC -std:c11
   flags.cpp    = -TP -std:c++17 -EHsc
-  flags       += -nologo -W1 -Fd$(object.path)/ 
+  flags       += -nologo -W2 -Fd$(object.path)/ 
   options     += -nologo $(if $(findstring clang,$(compiler)),-fuse-ld=lld) -link
 else
   flags.c      = -x c -std=c11

--- a/nall/hid.hpp
+++ b/nall/hid.hpp
@@ -17,7 +17,7 @@ struct Input {
 private:
   string _name;
   s16 _value = 0;
-  friend class Group;
+  friend struct Group;
 };
 
 struct Group : vector<Input> {
@@ -36,7 +36,7 @@ struct Group : vector<Input> {
 
 private:
   string _name;
-  friend class Device;
+  friend struct Device;
 };
 
 struct Device : vector<Group> {

--- a/nall/intrinsics.hpp
+++ b/nall/intrinsics.hpp
@@ -64,6 +64,8 @@ namespace nall {
     static constexpr bool GCC       = 0;
     static constexpr bool Microsoft = 1;
   };
+  #pragma warning(disable:4146)  //unary minus operator applied to unsigned type, result still unsigned
+  #pragma warning(disable:4244)  //conversion from 'type1' to 'type2', possible loss of data
   #pragma warning(disable:4804)  //unsafe use of type 'bool' in operation
   #pragma warning(disable:4805)  //unsafe mix of type 'bool' and type 'type' in operation
   #pragma warning(disable:4996)  //libc "deprecation" warnings

--- a/nall/random.hpp
+++ b/nall/random.hpp
@@ -57,7 +57,7 @@ private:
   static const u64 crc64 = 0xc96c'5795'd787'0f42;
   u64 lfsr = crc64;
 
-  friend class RNG<LFSR>;
+  friend struct RNG<LFSR>;
 };
 
 struct PCG : RNG<PCG> {
@@ -91,7 +91,7 @@ private:
   u64 state = 0;
   u64 increment = 0;
 
-  friend class RNG<PCG>;
+  friend struct RNG<PCG>;
 };
 
 }
@@ -121,7 +121,7 @@ private:
   Cipher::XChaCha20 context{0, 0};
   u32 counter = 0;
 
-  friend class RNG<XChaCha20>;
+  friend struct RNG<XChaCha20>;
 };
 
 }

--- a/nall/string/markup/node.hpp
+++ b/nall/string/markup/node.hpp
@@ -40,7 +40,7 @@ protected:
   auto _lookup(const string& path) const -> Node;
   auto _create(const string& path) -> Node;
 
-  friend class Node;
+  friend struct Node;
 };
 
 struct Node {

--- a/ruby/audio/audio.hpp
+++ b/ruby/audio/audio.hpp
@@ -39,7 +39,7 @@ struct AudioDriver {
 
 protected:
   Audio& super;
-  friend class Audio;
+  friend struct Audio;
 
   bool exclusive = false;
   uintptr context = 0;

--- a/ruby/input/input.hpp
+++ b/ruby/input/input.hpp
@@ -20,7 +20,7 @@ struct InputDriver {
 
 protected:
   Input& super;
-  friend class Input;
+  friend struct Input;
 
   uintptr context = 0;
 };

--- a/ruby/video/video.hpp
+++ b/ruby/video/video.hpp
@@ -38,7 +38,7 @@ struct VideoDriver {
 
 protected:
   Video& super;
-  friend class Video;
+  friend struct Video;
 
   bool fullScreen = false;
   string monitor = "Primary";

--- a/thirdparty/TZXFile/TZXBlock.cpp
+++ b/thirdparty/TZXFile/TZXBlock.cpp
@@ -14,7 +14,7 @@ TZXBlock::~TZXBlock()
 
 float TZXBlock::GetAudioBufferOffsetLocationInSeconds()
 {
-    float time = m_nAudioBufferOffsetLocation;
+    float time = (float)m_nAudioBufferOffsetLocation;
     time = time / (float)TZX_AUDIO_DATARATE;
     return time;
 }


### PR DESCRIPTION
Level 2 warnings are considered "significant" and turning them on revealed one issue that could, in the future, have affected MSVC-ABI builds using either CL or Clang.

MSVC's C++ name mangling distinguishes between classes and structs, and throughout the ares codebase there were friend declarations using "class" to refer to types that were defined with "struct".

I don't see any value in retaining this inconsistency, especially considering that ares otherwise avoids the "class" keyword (though I spotted a few uses that crept in from recent commits).