### PR TITLE
ps1: initialize _active member in peripherals

### DIFF
--- a/ares/ps1/peripheral/digital-gamepad/digital-gamepad.hpp
+++ b/ares/ps1/peripheral/digital-gamepad/digital-gamepad.hpp
@@ -29,5 +29,5 @@ struct DigitalGamepad : PeripheralDevice {
     DataUpper,
   } state = State::Idle;
 
-  bool _active;
+  bool _active = false;
 };

--- a/ares/ps1/peripheral/dualshock/dualshock.hpp
+++ b/ares/ps1/peripheral/dualshock/dualshock.hpp
@@ -53,5 +53,5 @@ struct DualShock : PeripheralDevice {
   vector<u8> outputData;
   vector<n8> inputData;
 
-  bool _active;
+  bool _active = false;
 };

--- a/ares/ps1/peripheral/memory-card/memory-card.cpp
+++ b/ares/ps1/peripheral/memory-card/memory-card.cpp
@@ -28,6 +28,7 @@ auto MemoryCard::save() -> void {
 
 auto MemoryCard::reset() -> void {
   state = State::Idle;
+  _active = false;
 }
 
 auto MemoryCard::acknowledge() -> bool {

--- a/ares/ps1/peripheral/memory-card/memory-card.hpp
+++ b/ares/ps1/peripheral/memory-card/memory-card.hpp
@@ -40,5 +40,5 @@ struct MemoryCard : PeripheralDevice {
   u8  checksum = 0;
   u8  response = 0;
   u16 address = 0;
-  bool _active;
+  bool _active = false;
 };


### PR DESCRIPTION
Discovered using Clang's undefined behavior sanitizer which detects non-0/1 values in bools.