### PR TITLE
Enable/Disable N64 Expansion Pak

### DIFF
--- a/ares/n64/rdram/debugger.cpp
+++ b/ares/n64/rdram/debugger.cpp
@@ -1,6 +1,11 @@
 auto RDRAM::Debugger::load(Node::Object parent) -> void {
   memory.ram = parent->append<Node::Debugger::Memory>("RDRAM");
-  memory.ram->setSize(4_MiB + 4_MiB);
+  if(!system.expansionPak) {
+    memory.ram->setSize(4_MiB); 
+  } else {
+    memory.ram->setSize(4_MiB + 4_MiB);
+  }
+  
   memory.ram->setRead([&](u32 address) -> u8 {
     return rdram.ram.read<Byte>(address);
   });

--- a/ares/n64/rdram/rdram.cpp
+++ b/ares/n64/rdram/rdram.cpp
@@ -10,11 +10,15 @@ RDRAM rdram;
 auto RDRAM::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("RDRAM");
 
-  //4_MiB internal
-  //4_MiB expansion pak
-  ram.allocate(4_MiB + 4_MiB);
-
-  debugger.load(node);
+  if(!system.expansionPak) {
+    //4MB internal
+    ram.allocate(4_MiB); 
+  } else {
+    //4MB internal + 4MB expansion pak
+    ram.allocate(4_MiB + 4_MiB);
+  }
+  
+  debugger.load(node);                                                                                            
 }
 
 auto RDRAM::unload() -> void {

--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -32,6 +32,7 @@ auto option(string name, string value) -> bool {
   vulkan.outputUpscale = vulkan.supersampleScanout ? 1 : vulkan.internalUpscale;
   #endif
   if(name == "Homebrew Mode") system.homebrewMode = value.boolean();
+  if(name == "Expansion Pak") system.expansionPak = value.boolean();
   return true;
 }
 

--- a/ares/n64/system/system.hpp
+++ b/ares/n64/system/system.hpp
@@ -2,6 +2,7 @@ struct System {
   Node::System node;
   VFS::Pak pak;
   bool homebrewMode = false;
+  bool expansionPak = true;
 
   enum class Region : u32 { NTSC, PAL };
 

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -102,6 +102,7 @@ auto Nintendo64::load() -> bool {
   ares::Nintendo64::option("Disable Video Interface Processing", settings.video.disableVideoInterfaceProcessing);
   ares::Nintendo64::option("Weave Deinterlacing", settings.video.weaveDeinterlacing);
   ares::Nintendo64::option("Homebrew Mode", settings.general.homebrewMode);
+  ares::Nintendo64::option("Expansion Pak", settings.nintendo64.expansionPak);
 
   if(!ares::Nintendo64::load(root, {"[Nintendo] ", name, " (", region, ")"})) return false;
 

--- a/desktop-ui/emulator/nintendo-64dd.cpp
+++ b/desktop-ui/emulator/nintendo-64dd.cpp
@@ -79,6 +79,7 @@ auto Nintendo64DD::load() -> bool {
   ares::Nintendo64::option("Disable Video Interface Processing", settings.video.disableVideoInterfaceProcessing);
   ares::Nintendo64::option("Weave Deinterlacing", settings.video.weaveDeinterlacing);
   ares::Nintendo64::option("Homebrew Mode", settings.general.homebrewMode);
+  ares::Nintendo64::option("Expansion Pak", settings.nintendo64.expansionPak);
 
   if(!ares::Nintendo64::load(root, {"[Nintendo] Nintendo 64DD (", region, ")"})) return false;
 

--- a/desktop-ui/settings/options.cpp
+++ b/desktop-ui/settings/options.cpp
@@ -2,29 +2,40 @@ auto OptionSettings::construct() -> void {
   setCollapsible();
   setVisible(false);
 
+  commonSettingsLabel.setText("Emulator Options").setFont(Font().setBold());
+
   rewind.setText("Rewind").setChecked(settings.general.rewind).onToggle([&] {
     settings.general.rewind = rewind.checked();
     program.rewindReset();
   }).doToggle();
-  rewindLayout.setAlignment(1);
+  rewindLayout.setAlignment(1).setPadding(12_sx, 0);
       rewindHint.setText("Allows you to reverse time via the rewind hotkey").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
   runAhead.setText("Run-Ahead").setEnabled(co_serializable()).setChecked(settings.general.runAhead && co_serializable()).onToggle([&] {
     settings.general.runAhead = runAhead.checked() && co_serializable();
     program.runAheadUpdate();
   });
-  runAheadLayout.setAlignment(1);
+  runAheadLayout.setAlignment(1).setPadding(12_sx, 0);
       runAheadHint.setText("Removes one frame of input lag, but doubles system requirements").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
   autoSaveMemory.setText("Auto-Save Memory Periodically").setChecked(settings.general.autoSaveMemory).onToggle([&] {
     settings.general.autoSaveMemory = autoSaveMemory.checked();
   });
-  autoSaveMemoryLayout.setAlignment(1);
+  autoSaveMemoryLayout.setAlignment(1).setPadding(12_sx, 0);
       autoSaveMemoryHint.setText("Helps safeguard game saves from being lost").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
   homebrewMode.setText("Homebrew Development Mode").setChecked(settings.general.homebrewMode).onToggle([&] {
     settings.general.homebrewMode = homebrewMode.checked();
   });
-  homebrewModeLayout.setAlignment(1);
+  homebrewModeLayout.setAlignment(1).setPadding(12_sx, 0);
       homebrewModeHint.setText("Activate core-specific features to help homebrew developers").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
+  nintendo64SettingsLabel.setText("Nintendo 64 Settings").setFont(Font().setBold());
+
+  nintendo64ExpansionPakOption.setText("4MB Expansion Pak").setChecked(settings.nintendo64.expansionPak).onToggle([&] {
+    settings.nintendo64.expansionPak = nintendo64ExpansionPakOption.checked();
+  });
+  nintendo64ExpansionPakLayout.setAlignment(1).setPadding(12_sx, 0);
+      nintendo64ExpansionPakHint.setText("Enable/Disable the 4MB Expansion Pak").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+  
 }

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -116,6 +116,8 @@ auto Settings::process(bool load) -> void {
   bind(boolean, "DebugServer/Enabled", debugServer.enabled);
   bind(boolean, "DebugServer/UseIPv4", debugServer.useIPv4);
 
+  bind(boolean, "Nintendo64/ExpansionPak", nintendo64.expansionPak);
+
   for(u32 index : range(9)) {
     string name = {"Recent/Game-", 1 + index};
     bind(string, name, recent.game[index]);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -96,6 +96,10 @@ struct Settings : Markup::Node {
     bool enabled = false; // if enabled, server starts with ares
     bool useIPv4 = false; // forces IPv4 over IPv6
   } debugServer;
+
+  struct Nintendo64 {
+    bool expansionPak = true;
+  } nintendo64;
 };
 
 struct VideoSettings : VerticalLayout {
@@ -230,18 +234,23 @@ struct EmulatorSettings : VerticalLayout {
 
 struct OptionSettings : VerticalLayout {
   auto construct() -> void;
-  HorizontalLayout rewindLayout{this, Size{~0, 0}, 5};
-    CheckLabel rewind{&rewindLayout, Size{0, 0}, 5};
-    Label rewindHint{&rewindLayout, Size{~0, 0}};
-  HorizontalLayout runAheadLayout{this, Size{~0, 0}, 5};
-    CheckLabel runAhead{&runAheadLayout, Size{0, 0}, 5};
-    Label runAheadHint{&runAheadLayout, Size{~0, 0}};
-  HorizontalLayout autoSaveMemoryLayout{this, Size{~0, 0}, 5};
-    CheckLabel autoSaveMemory{&autoSaveMemoryLayout, Size{0, 0}, 5};
-    Label autoSaveMemoryHint{&autoSaveMemoryLayout, Size{~0, 0}};
-  HorizontalLayout homebrewModeLayout{this, Size{~0, 0}, 5};
-    CheckLabel homebrewMode{&homebrewModeLayout, Size{0, 0}, 5};
-    Label homebrewModeHint{&homebrewModeLayout, Size{~0, 0}};
+  Label commonSettingsLabel{this, Size{~0, 0}, 5};
+    HorizontalLayout rewindLayout{this, Size{~0, 0}, 5};
+      CheckLabel rewind{&rewindLayout, Size{0, 0}, 5};
+      Label rewindHint{&rewindLayout, Size{~0, 0}};
+    HorizontalLayout runAheadLayout{this, Size{~0, 0}, 5};
+      CheckLabel runAhead{&runAheadLayout, Size{0, 0}, 5};
+      Label runAheadHint{&runAheadLayout, Size{~0, 0}};
+    HorizontalLayout autoSaveMemoryLayout{this, Size{~0, 0}, 5};
+      CheckLabel autoSaveMemory{&autoSaveMemoryLayout, Size{0, 0}, 5};
+      Label autoSaveMemoryHint{&autoSaveMemoryLayout, Size{~0, 0}};
+    HorizontalLayout homebrewModeLayout{this, Size{~0, 0}, 5};
+      CheckLabel homebrewMode{&homebrewModeLayout, Size{0, 0}, 5};
+      Label homebrewModeHint{&homebrewModeLayout, Size{~0, 0}};
+  Label nintendo64SettingsLabel{this, Size{~0, 0}, 5};
+    HorizontalLayout nintendo64ExpansionPakLayout{this, Size{~0, 0}, 5};
+      CheckLabel nintendo64ExpansionPakOption{&nintendo64ExpansionPakLayout, Size{0, 0}, 5};
+      Label nintendo64ExpansionPakHint{&nintendo64ExpansionPakLayout, Size{0, 0}};
 };
 
 struct FirmwareSettings : VerticalLayout {


### PR DESCRIPTION
Add ability to enable/disable N64 4MB expansion pak. 

Similarly to the video settings window, I've added a Nintendo 64 specific section in the options window, which was mostly empty. Existing options fall under a generic "Emulator Options" section. Seems like a reasonable place to add a few console specific options. 

Addresses issue: https://github.com/ares-emulator/ares/issues/939