### PR TITLE
ruby: add SDL to macOS

### DIFF
--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -19,6 +19,7 @@ ifeq ($(ruby),)
     ruby += video.cgl
     ruby += audio.openal
     ruby += input.quartz #input.carbon
+    ruby += input.sdl
   else ifeq ($(platform),linux)
     pkg_check = $(if $(shell pkg-config $1 && echo 1),$2)
     ruby += video.glx video.glx2 video.xshm

--- a/ruby/input/mouse/gcmouse.cpp
+++ b/ruby/input/mouse/gcmouse.cpp
@@ -1,0 +1,32 @@
+#pragma once
+
+struct InputMouseGC {
+  Input& input;
+  InputMouseGC(Input& input) : input(input) {}
+
+  uintptr handle = 0;
+  bool mouseAcquired = false;
+
+  struct Mouse {
+  } ms;
+
+  auto acquired() -> bool {
+    return false;
+  }
+
+  auto acquire() -> bool {
+    return false;
+  }
+
+  auto release() -> bool {
+    return true;
+  }
+    
+  auto poll(vector<shared_pointer<HID::Device>>& devices) -> void {}
+
+  auto initialize(uintptr handle) -> bool {
+    return true;
+  }
+
+  auto terminate() -> void {}
+};

--- a/ruby/input/sdl.cpp
+++ b/ruby/input/sdl.cpp
@@ -6,7 +6,7 @@
 #include "mouse/rawinput.cpp"
 #elif defined(PLATFORM_MACOS)
 #include "keyboard/quartz.cpp"
-#include "joypad/iokit.cpp"
+#include "mouse/gcmouse.cpp"
 #else
 #include <sys/ipc.h>
 #include <sys/shm.h>
@@ -88,7 +88,7 @@ private:
   InputMouseRawInput mouse;
 #elif defined(PLATFORM_MACOS)
   InputKeyboardQuartz keyboard;
-  InputJoypadIOKit joypad;
+  InputMouseGC mouse;
 #else
   InputKeyboardXlib keyboard;
   InputMouseXlib mouse;


### PR DESCRIPTION
### Description
Up to this point, SDL as an input library has not been present in macOS builds. The plumbing was already in place for macOS to make use of SDL, but SDL was not actually linked. This PR rectifies that. Seemingly unnecessary references to the IOKit joypad are also removed from `sdl.cpp`.

To facilitate adding SDL to ruby for macOS, a stubbed out macOS mouse driver, `gcmouse.cpp`, has been added, to avoid needing to make numerous modifications to `sdl.cpp` to work around mouse-related code.
### Motivation
The legacy macOS input uses raw values from IOKit, which are not available for all supported controllers, and where present, are uncalibrated and generally not ideal. SDL's input support is much more advanced comparatively, properly handling and interpolating input from a wide variety of controllers where raw IOKit input values aren't sufficient. This should resolve a number of situations where ares won't recognize input from controllers connected to macOS machines, among other macOS input-related issues.

### Discussion
I am not super well-acquainted with ares's code and build system, and it's entirely probable that I missed something here or went about this not-quite-correctly; I did so as straightforwardly as possible and may have missed something, for example fallbacks if SDL is not present at build-time; I am not sure if this is currently handled. I encourage any and all edits from maintainers if I broke something or went about something incorrectly.

### Testing?
Tested locally on my Apple Silicon machine on macOS Sonoma. SDL can now be selected and used successfully as an input driver for all supported connected controllers.