### PR TITLE
desktop-ui: destroy timers on system unload

### DIFF
--- a/desktop-ui/emulator/emulator.hpp
+++ b/desktop-ui/emulator/emulator.hpp
@@ -13,7 +13,7 @@ struct Emulator {
   auto load(const string& location) -> bool;
   auto load(shared_pointer<mia::Pak> pak, string& path) -> string;
   auto loadFirmware(const Firmware&) -> shared_pointer<vfs::file>;
-  auto unload() -> void;
+  virtual auto unload() -> void;
   auto refresh() -> void;
   auto setBoolean(const string& name, bool value) -> bool;
   auto setOverscan(bool value) -> bool;

--- a/desktop-ui/emulator/mega-cd-32x.cpp
+++ b/desktop-ui/emulator/mega-cd-32x.cpp
@@ -2,11 +2,12 @@ struct MegaCD32X : Emulator {
   MegaCD32X();
   auto load() -> bool override;
   auto load(Menu) -> void override;
+  auto unload() -> void override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
 
   u32 regionID = 0;
-  Timer discTrayTimer;
+  sTimer discTrayTimer;
 };
 
 MegaCD32X::MegaCD32X() {
@@ -84,6 +85,8 @@ auto MegaCD32X::load() -> bool {
     }
   }
 
+  discTrayTimer = Timer{};
+
   return true;
 }
 
@@ -101,8 +104,8 @@ auto MegaCD32X::load(Menu menu) -> void {
     }
 
     //give the emulator core a few seconds to notice an empty drive state before reconnecting
-    discTrayTimer.onActivate([&] {
-      discTrayTimer.setEnabled(false);
+    discTrayTimer->onActivate([&] {
+      discTrayTimer->setEnabled(false);
       auto tray = root->find<ares::Node::Port>("Mega CD/Disc Tray");
       tray->allocate();
       tray->connect();
@@ -110,6 +113,10 @@ auto MegaCD32X::load(Menu menu) -> void {
   });
 }
 
+auto MegaCD32X::unload() -> void {
+  Emulator::unload();
+  discTrayTimer.reset();
+}
 
 auto MegaCD32X::save() -> bool {
   root->save();

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -2,6 +2,7 @@ struct Nintendo64 : Emulator {
   Nintendo64();
   auto load() -> bool override;
   auto load(Menu) -> void override;
+  auto unload() -> void override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
 
@@ -9,7 +10,7 @@ struct Nintendo64 : Emulator {
   shared_pointer<mia::Pak> disk;
   shared_pointer<mia::Pak> gb;
   u32 regionID = 0;
-  Timer diskInsertTimer;
+  sTimer diskInsertTimer;
 };
 
 Nintendo64::Nintendo64() {
@@ -162,6 +163,8 @@ auto Nintendo64::load() -> bool {
     }
   }
 
+  diskInsertTimer = Timer{};
+
   return true;
 }
 
@@ -179,14 +182,19 @@ auto Nintendo64::load(Menu menu) -> void {
       }
 
       //give the emulator core a few seconds to notice an empty drive state before reconnecting
-      diskInsertTimer.onActivate([&] {
-        diskInsertTimer.setEnabled(false);
+      diskInsertTimer->onActivate([&] {
+        diskInsertTimer->setEnabled(false);
         auto drive = root->find<ares::Node::Port>("Nintendo 64DD/Disk Drive");
         drive->allocate();
         drive->connect();
       }).setInterval(3000).setEnabled();
     });
   }
+}
+
+auto Nintendo64::unload() -> void {
+  Emulator::unload();
+  diskInsertTimer.reset();
 }
 
 auto Nintendo64::save() -> bool {


### PR DESCRIPTION
Fix two issues caused by disc swap timers:
1. Crash on exit in certain build configurations
2. Crash on system unload shortly after disc swap

Because these timers were simply members of Emulator derived classes (which are in turn owned by a global variable), they were being destructed after main() along with other static lifetime objects. This was problematic because hiro also has global state that the timer implementation depends on, at least on Windows. Whether this manifested in a crash depended on a few factors, object destruction order among them (which is at the mercy of the linker).

The second crash would reliably reproduce simply by initiating a disc swap and unloading the emulated system (such as by closing the emulator) within the next 3 seconds.