### PR TITLE
fc: use hkrom for mmc6

### DIFF
--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -250,9 +250,15 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     break;
 
   case   4:
-    s += "  board:  HVC-TLROM\n";
-    s += "    chip type=MMC3B\n";
-    if(!iNes2) prgram = 8192;
+    if (submapper == 1) {
+      s += "  board:  HVC-HKROM\n";
+      s += "    chip type=MMC6\n";
+      prgram = 1024;
+    } else {
+      s += "  board:  HVC-TLROM\n";
+      s += "    chip type=MMC3B\n";
+      if(!iNes2) prgram = 8192;
+    }
     break;
 
   case   5:


### PR DESCRIPTION
MMC3 and MMC6 share the same mapper in the iNES format. To disambiguate MMC6 from the MMC3 mapper the NES 2.0 submapper 004:1 should be used:

https://www.nesdev.org/wiki/MMC6

Code for using the MMC6 was actually commented in mia/medium/famicom.cpp up to commit bed4ce3659a92e, where it was deleted. This commit reintroduces this code to use it with the NES 2.0 submapper 004:1. This adds compatibility with the games "StarTropics" and "Zoda's Revenge: StarTropics II".