### PR TITLE
build: enable strict standards conformance with cl (msvc)

### DIFF
--- a/hiro/core/widget/table-view.cpp
+++ b/hiro/core/widget/table-view.cpp
@@ -264,8 +264,8 @@ auto mTableView::sort() -> type& {
   }
   auto sorted = state.items;
   sorted.sort([&](auto& lhs, auto& rhs) {
-    string x = offset < lhs->cellCount() ? lhs->state.cells[offset]->state.text : "";
-    string y = offset < rhs->cellCount() ? rhs->state.cells[offset]->state.text : "";
+    string x = offset < lhs->cellCount() ? lhs->state.cells[offset]->state.text : ""_s;
+    string y = offset < rhs->cellCount() ? rhs->state.cells[offset]->state.text : ""_s;
     if(sorting == Sort::Ascending ) return string::icompare(x, y) < 0;
     if(sorting == Sort::Descending) return string::icompare(y, x) < 0;
     return false;  //unreachable

--- a/hiro/extension/name-dialog.cpp
+++ b/hiro/extension/name-dialog.cpp
@@ -58,7 +58,7 @@ auto NameDialog::show(string mode, string name) -> string {
   setTitle(state.title);
   if(!state.title && mode == "Create") setTitle("Create");
   if(!state.title && mode == "Rename") setTitle({"Rename ", name});
-  textLabel.setText(state.text ? state.text : "Enter a name:");
+  textLabel.setText(state.text ? state.text : "Enter a name:"_s);
   if(state.icon) {
     image icon{state.icon};
     icon.scale(16_sx, 16_sy);

--- a/hiro/windows/font.cpp
+++ b/hiro/windows/font.cpp
@@ -22,7 +22,7 @@ auto pFont::family(const string& family) -> string {
   if(family == Font::Sans ) return "Tahoma";
   if(family == Font::Serif) return "Georgia";
   if(family == Font::Mono ) return "Lucida Console";
-  return family ? family : "Tahoma";
+  return family ? family : "Tahoma"_s;
 }
 
 auto pFont::create(const Font& font) -> HFONT {

--- a/hiro/windows/status-bar.cpp
+++ b/hiro/windows/status-bar.cpp
@@ -33,7 +33,7 @@ auto pStatusBar::setFont(const Font&) -> void {
   SendMessage(hwnd, WM_SETFONT, (WPARAM)hfont, 0);
 
   auto& text = state().text;
-  auto height = font.size(text ? text : " ").height();
+  auto height = font.size(text ? text : " "_s).height();
   SendMessage(hwnd, SB_SETMINHEIGHT, (WPARAM)height, 0);
 
   if(auto parent = _parent()) {

--- a/hiro/windows/tool-tip.cpp
+++ b/hiro/windows/tool-tip.cpp
@@ -111,7 +111,7 @@ auto pToolTip::show() -> void {
   tracking.x = position.x, tracking.y = position.y;
 
   position.y += 18;
-  auto textSize = pFont::size(Font(), text ? text : " ");
+  auto textSize = pFont::size(Font(), text ? text : " "_s);
   size.cx = 12 + textSize.width();
   size.cy = 12 + textSize.height();
 

--- a/hiro/windows/widget/check-label.cpp
+++ b/hiro/windows/widget/check-label.cpp
@@ -18,7 +18,7 @@ auto pCheckLabel::destruct() -> void {
 }
 
 auto pCheckLabel::minimumSize() const -> Size {
-  auto size = pFont::size(self().font(true), state().text ? state().text : " ");
+  auto size = pFont::size(self().font(true), state().text ? state().text : " "_s);
   return {size.width() + 20_sx, size.height() + 4_sy};
 }
 

--- a/hiro/windows/widget/label.cpp
+++ b/hiro/windows/widget/label.cpp
@@ -14,7 +14,7 @@ auto pLabel::destruct() -> void {
 }
 
 auto pLabel::minimumSize() const -> Size {
-  auto size = pFont::size(self().font(true), state().text ? state().text : " ");
+  auto size = pFont::size(self().font(true), state().text ? state().text : " "_s);
   return {size.width(), size.height()};
 }
 

--- a/hiro/windows/widget/line-edit.cpp
+++ b/hiro/windows/widget/line-edit.cpp
@@ -20,7 +20,7 @@ auto pLineEdit::destruct() -> void {
 }
 
 auto pLineEdit::minimumSize() const -> Size {
-  auto size = pFont::size(hfont, state().text ? state().text : " ");
+  auto size = pFont::size(hfont, state().text ? state().text : " "_s);
   return {size.width() + 12, size.height() + 10};
 }
 

--- a/hiro/windows/widget/radio-label.cpp
+++ b/hiro/windows/widget/radio-label.cpp
@@ -18,7 +18,7 @@ auto pRadioLabel::destruct() -> void {
 }
 
 auto pRadioLabel::minimumSize() const -> Size {
-  auto size = pFont::size(self().font(true), state().text ? state().text : " ");
+  auto size = pFont::size(self().font(true), state().text ? state().text : " "_s);
   return {size.width() + 20_sx, size.height() + 4_sy};
 }
 

--- a/hiro/windows/window.cpp
+++ b/hiro/windows/window.cpp
@@ -416,7 +416,7 @@ auto pWindow::_statusHeight() const -> s32 {
   if(auto& statusBar = state().statusBar) {
     if(statusBar->visible()) {
       auto& text = statusBar->state.text;
-      height = statusBar->font(true).size(text ? text : " ").height();
+      height = statusBar->font(true).size(text ? text : " "_s).height();
       height = max(height, minimumStatusHeight);
     }
   }

--- a/mia/medium/super-famicom.cpp
+++ b/mia/medium/super-famicom.cpp
@@ -452,7 +452,7 @@ auto SuperFamicom::region() const -> string {
     if(E == 0x11) region = {"AUS"};
   }
 
-  return region ? region : "NTSC";
+  return region ? region : "NTSC"_s;
 }
 
 auto SuperFamicom::videoRegion() const -> string {

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -119,7 +119,7 @@ endif
 ifeq ($(cl),true)
   flags.c      = -TC -std:c11
   flags.cpp    = -TP -std:c++17 -EHsc
-  flags       += -nologo -W2 -Fd$(object.path)/ 
+  flags       += -nologo -permissive- -W2 -Fd$(object.path)/
   options     += -nologo $(if $(findstring clang,$(compiler)),-fuse-ld=lld) -link
 else
   flags.c      = -x c -std=c11

--- a/nall/image/multifactor.hpp
+++ b/nall/image/multifactor.hpp
@@ -3,24 +3,24 @@
 namespace nall {
 
 inline multiFactorImage::multiFactorImage(const multiFactorImage& source) {
-  (*this) = source;
+  operator=(source);
 }
 
 inline multiFactorImage::multiFactorImage(multiFactorImage&& source) {
-  operator=(std::forward<multiFactorImage>(source));
+  operator=(std::move(source));
 }
 
 inline multiFactorImage::multiFactorImage(const image& lowDPI, const image& highDPI) {
-  (*(image*)this) = lowDPI;
+  image::operator=(lowDPI);
   _highDPI = highDPI;
 }
 
 inline multiFactorImage::multiFactorImage(const image& source) {
-    (*(image*)this) = source;
+  image::operator=(source);
 }
 
 inline multiFactorImage::multiFactorImage(image&& source) {
-    operator=(std::forward<multiFactorImage>(source));
+  image::operator=(std::move(source));
 }
 
 inline multiFactorImage::multiFactorImage() {
@@ -32,7 +32,7 @@ inline multiFactorImage::~multiFactorImage() {
 inline auto multiFactorImage::operator=(const multiFactorImage& source) -> multiFactorImage& {
   if(this == &source) return *this;
   
-  (*(image*)this) = source;
+  image::operator=(source);
   _highDPI = source._highDPI;
 
   return *this;
@@ -41,15 +41,15 @@ inline auto multiFactorImage::operator=(const multiFactorImage& source) -> multi
 inline auto multiFactorImage::operator=(multiFactorImage&& source) -> multiFactorImage& {
   if(this == &source) return *this;
 
-  (*(image*)this) = source;
-  _highDPI = source._highDPI;
+  image::operator=(std::move(source));
+  _highDPI = std::move(source._highDPI);
 
   return *this;
 }
 
 inline auto multiFactorImage::operator==(const multiFactorImage& source) const -> bool {
-  if((const image&)*this != (const image&)source) return false;
-  return _highDPI != source._highDPI;
+  if(image::operator!=(source)) return false;
+  return _highDPI == source._highDPI;
 }
 
 inline auto multiFactorImage::operator!=(const multiFactorImage& source) const -> bool {

--- a/nall/string/pascal.hpp
+++ b/nall/string/pascal.hpp
@@ -33,7 +33,7 @@ struct string_pascal {
 
   explicit operator bool() const { return _data; }
   operator const char*() const { return _data ? _data + sizeof(u32) : nullptr; }
-  operator string() const { return _data ? string{_data + sizeof(u32)} : ""; }
+  operator string() const { return _data ? string{_data + sizeof(u32)} : ""_s; }
 
   auto operator=(const string_pascal& source) -> type& {
     if(this == &source) return *this;


### PR DESCRIPTION
From the MSVC docs: "You can use the /permissive- compiler option to specify standards-conforming compiler behavior. This option disables permissive behaviors, and sets the /Zc compiler options for strict conformance."

While generally a positive thing, this does make MSVC stricter than GCC/Clang in some cases. A couple of things popped out:

- nall::multiFactorImage had a busted constructor. I fixed this and did some other cleanup while I was at it.
- nall::string has an implicit conversion operator to const char*. This is honestly really ugly and creates ambiguity and allows for all kinds of surprising silent conversions. Unfortunately, fixing that (by making it explicit) will require touching hundreds of lines of code so I opted not to deal with it now. Instead I fixed the much smaller number of ambigous cases relating to string literals.