### PR TITLE
ci: build resiliency tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         program:
         - ares
@@ -77,6 +78,7 @@ jobs:
         sudo apt-get install libsdl2-dev libgtk-3-dev libao-dev libopenal-dev
     - name: "macOS: Import Certificate"
       if: runner.os == 'macOS' && github.event_name != 'pull_request'
+      continue-on-error: ${{ github.repository != 'ares-emulator/ares' }}
       uses: wpilibsuite/import-signing-certificate@2ac4f44d28045073d23153256efbb4c4b2d8aa22    # Don't use rolling branch for security reasons
       with:
         certificate-data: ${{ secrets.MACOS_CERTIFICATE_DATA }}
@@ -130,6 +132,7 @@ jobs:
         timestampUrl: 'http://timestamp.digicert.com' 
     - name: "macOS: notarize"
       if: runner.os == 'macOS' && github.event_name != 'pull_request'
+      continue-on-error: ${{ github.repository != 'ares-emulator/ares' }}
       run: |
         ditto -c -k --keepParent desktop-ui/out/ares.app /tmp/ares.zip
         xcrun notarytool submit /tmp/ares.zip --apple-id "$MACOS_NOTARIZATION_USERNAME" --password "$MACOS_NOTARIZATION_PASSWORD" --team-id "$MACOS_NOTARIZATION_TEAMID" --wait


### PR DESCRIPTION
Disable "fast fail" so jobs will run to completion even if others fail. The workflow as a whole will still fail, but the jobs that succeed will produce downloadable artifacts.

Secondly, allow the "macOS: Import Certificate" step to fail on forks. This allows CI to function on forks without any other setup, though the produced macOS builds won't run actually run unless you re-sign them.