### PR TITLE
hiro: prevent exception originating from appkit

### DIFF
--- a/hiro/cocoa/application.cpp
+++ b/hiro/cocoa/application.cpp
@@ -52,7 +52,8 @@ auto pApplication::run() -> void {
     //[[NSRunLoop currentRunLoop] addTimer:applicationTimer forMode:NSEventTrackingRunLoopMode];
   }
   [[NSUserDefaults standardUserDefaults] registerDefaults:@{
-    @"NSTreatUnknownArgumentsAsOpen": @NO
+    //@"NO" is not a mistake; the value really needs to be a string
+    @"NSTreatUnknownArgumentsAsOpen": @"NO"
   }];
 
   @autoreleasepool {


### PR DESCRIPTION
As noted in the Chromium source, the value for NSTreatUnknownArgumentsAsOpen needs to be of type string despite being a boolean setting.

If the type is boolean, AppKit throws an exception (which is caught), but if unwinding fails (observed on some arm64 systems in certain build configurations when ares is compiled with LTO and -fomit-frame-pointer) it terminates the whole application.

I've confirmed the behavior the original commit was designed to correct is still fixed with this change.