### PR TITLE
n64: improve SI emulation

### DIFF
--- a/ares/n64/si/dma.cpp
+++ b/ares/n64/si/dma.cpp
@@ -1,6 +1,8 @@
 auto SI::dmaRead() -> void {
   pif.dmaRead(io.readAddress, io.dramAddress);
   io.dmaBusy = 0;
+  io.pchState = 0;
+  io.dmaState = 0;
   io.interrupt = 1;
   mi.raise(MI::IRQ::SI);
 }
@@ -8,6 +10,8 @@ auto SI::dmaRead() -> void {
 auto SI::dmaWrite() -> void {
   pif.dmaWrite(io.writeAddress, io.dramAddress);
   io.dmaBusy = 0;
+  io.pchState = 0;
+  io.dmaState = 0;
   io.interrupt = 1;
   mi.raise(MI::IRQ::SI);
 }


### PR DESCRIPTION
In addition to approximating the correct values in SI STATUS fields, this commit also fixes a bug: I/O writes to PIF RAM do trigger an interrupt just like DMA does.