### PR TITLE
hiro: add cursor auto-hide

### DIFF
--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -15,6 +15,11 @@ Presentation::Presentation() {
 
   settingsMenu.setText("Settings");
   videoSizeMenu.setText("Size").setIcon(Icon::Emblem::Image);
+  
+  bool hideCursorImplemented = false;
+#if defined(PLATFORM_MACOS)
+  hideCursorImplemented = true;
+#endif
 
   //generate size menu
   u32 multipliers = 5;
@@ -95,6 +100,14 @@ Presentation::Presentation() {
   muteAudioSetting.setText("Mute Audio").setChecked(settings.audio.mute).onToggle([&] {
     settings.audio.mute = muteAudioSetting.checked();
   });
+  autoHideCursorSetting.setText("Auto-Hide Cursor").setChecked(settings.general.autoHideCursor).onToggle([&] {
+    settings.general.autoHideCursor = autoHideCursorSetting.checked();
+    settingsWindow.optionSettings.autoHideCursorOption.setChecked(settings.general.autoHideCursor);
+    presentation.setHidesCursor(settings.general.autoHideCursor);
+  });
+  if(!hideCursorImplemented) {
+    autoHideCursorSetting.setVisible(false);
+  }
   showStatusBarSetting.setText("Show Status Bar").setChecked(settings.general.showStatusBar).onToggle([&] {
     settings.general.showStatusBar = showStatusBarSetting.checked();
     if(!showStatusBarSetting.checked()) {
@@ -226,6 +239,8 @@ Presentation::Presentation() {
       program.load(emulator, filename);
     }
   });
+
+  setHidesCursor(settings.general.autoHideCursor);
 
   iconLayout.setCollapsible();
 

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -39,6 +39,7 @@ struct Presentation : Window {
         Group preferRegionGroup{&preferNTSCU, &preferNTSCJ, &preferPAL};
       MenuSeparator groupSettingsSeparatpr{&settingsMenu};
       MenuCheckItem muteAudioSetting{&settingsMenu};
+      MenuCheckItem autoHideCursorSetting{&settingsMenu};
       MenuCheckItem showStatusBarSetting{&settingsMenu};
       MenuSeparator audioSettingsSeparator{&settingsMenu};
       MenuItem videoSettingsAction{&settingsMenu};

--- a/desktop-ui/settings/options.cpp
+++ b/desktop-ui/settings/options.cpp
@@ -1,6 +1,10 @@
 auto OptionSettings::construct() -> void {
   setCollapsible();
   setVisible(false);
+  bool hideCursorImplemented = false;
+#if defined(PLATFORM_MACOS)
+  hideCursorImplemented = true;
+#endif
 
   commonSettingsLabel.setText("Emulator Options").setFont(Font().setBold());
 
@@ -37,5 +41,15 @@ auto OptionSettings::construct() -> void {
   });
   nintendo64ExpansionPakLayout.setAlignment(1).setPadding(12_sx, 0);
       nintendo64ExpansionPakHint.setText("Enable/Disable the 4MB Expansion Pak").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+      
+  miscellaneousSettingsLabel.setVisible(hideCursorImplemented).setText("Miscellaneous").setFont(Font().setBold());
+  
+  autoHideCursorOption.setText("Auto-Hide Cursor").setVisible(hideCursorImplemented).setChecked(settings.general.autoHideCursor).onToggle([&] {
+    settings.general.autoHideCursor = autoHideCursorOption.checked();
+    presentation.setHidesCursor(settings.general.autoHideCursor);
+    presentation.autoHideCursorSetting.setChecked(settings.general.autoHideCursor);
+  });
+  autoHideCursorLayout.setAlignment(1).setPadding(12_sx, 0);
+      autoHideCursorHint.setVisible(hideCursorImplemented).setText("Hide the mouse cursor when idle over the game window").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
   
 }

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -100,6 +100,7 @@ auto Settings::process(bool load) -> void {
   bind(boolean, "General/RunAhead", general.runAhead);
   bind(boolean, "General/AutoSaveMemory", general.autoSaveMemory);
   bind(boolean, "General/HomebrewMode", general.homebrewMode);
+  bind(boolean, "General/AutoHideCursor", general.autoHideCursor);
 
   bind(natural, "Rewind/Length", rewind.length);
   bind(natural, "Rewind/Frequency", rewind.frequency);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -66,6 +66,7 @@ struct Settings : Markup::Node {
     bool runAhead = false;
     bool autoSaveMemory = true;
     bool homebrewMode = false;
+    bool autoHideCursor = true;
   } general;
 
   struct Rewind {
@@ -251,6 +252,10 @@ struct OptionSettings : VerticalLayout {
     HorizontalLayout nintendo64ExpansionPakLayout{this, Size{~0, 0}, 5};
       CheckLabel nintendo64ExpansionPakOption{&nintendo64ExpansionPakLayout, Size{0, 0}, 5};
       Label nintendo64ExpansionPakHint{&nintendo64ExpansionPakLayout, Size{0, 0}};
+  Label miscellaneousSettingsLabel{this, Size{~0, 0}, 5};
+    HorizontalLayout autoHideCursorLayout{this, Size{~0, 0}, 5};
+      CheckLabel autoHideCursorOption{&autoHideCursorLayout, Size{0, 0}, 5};
+      Label autoHideCursorHint{&autoHideCursorLayout, Size{0,0}};
 };
 
 struct FirmwareSettings : VerticalLayout {

--- a/hiro/cocoa/window.hpp
+++ b/hiro/cocoa/window.hpp
@@ -3,10 +3,14 @@
 @interface CocoaWindow : NSWindow <NSWindowDelegate> {
 @public
   hiro::mWindow* window;
+  bool hidesCursor;
+  bool cursorIsInWindow;
+  NSTimer* hideCursorTimer;
   NSMenu* menuBar;
   NSMenu* rootMenu;
   NSMenuItem* disableGatekeeper;
   NSTextField* statusBar;
+  NSTrackingArea* trackingArea;
 }
 -(id) initWith:(hiro::mWindow&)window;
 -(BOOL) canBecomeKeyWindow;
@@ -14,6 +18,9 @@
 -(void) windowDidBecomeMain:(NSNotification*)notification;
 -(void) windowDidMove:(NSNotification*)notification;
 -(void) windowDidResize:(NSNotification*)notification;
+-(void) mouseEntered:(NSEvent*)theEvent;
+-(void) mouseExited:(NSEvent*)theEvent;
+-(void) setHidesCursor:(bool)hidesCursor;
 -(BOOL) windowShouldClose:(id)sender;
 -(NSDragOperation) draggingEntered:(id<NSDraggingInfo>)sender;
 -(BOOL) performDragOperation:(id<NSDraggingInfo>)sender;
@@ -23,6 +30,7 @@
 -(void) menuDisableGatekeeper;
 -(void) menuQuit;
 -(NSTextField*) statusBar;
+-(void) hideCursor:(NSTimer*)timer;
 @end
 
 namespace hiro {
@@ -55,7 +63,8 @@ struct pWindow : pObject {
   auto setTitle(const string& text) -> void;
   auto setAssociatedFile(const string& filename) -> void;
   auto setVisible(bool visible) -> void;
-
+  auto setHidesCursor(bool hidesCursor) -> void;
+  
   auto moveEvent() -> void;
   auto sizeEvent() -> void;
   auto statusBarHeight() -> u32;

--- a/hiro/core/shared.hpp
+++ b/hiro/core/shared.hpp
@@ -934,6 +934,7 @@ struct Window : sWindow {
   auto remove(sStatusBar statusBar) { return self().remove(statusBar), *this; }
   auto reset() { return self().reset(), *this; }
   auto resizable() const { return self().resizable(); }
+  auto hidesCursor() const { return self().hidesCursor(); }
   auto setAlignment(Alignment alignment = Alignment::Center) { return self().setAlignment(alignment), *this; }
   auto setAlignment(sWindow relativeTo, Alignment alignment = Alignment::Center) { return self().setAlignment(relativeTo, alignment), *this; }
   auto setBackgroundColor(Color color = {}) { return self().setBackgroundColor(color), *this; }
@@ -953,6 +954,7 @@ struct Window : sWindow {
   auto setPosition(Position position) { return self().setPosition(position), *this; }
   auto setPosition(sWindow relativeTo, Position position) { return self().setPosition(relativeTo, position), *this; }
   auto setResizable(bool resizable = true) { return self().setResizable(resizable), *this; }
+  auto setHidesCursor(bool hidesCursor = true) { return self().setHidesCursor(hidesCursor), *this; }
   auto setSize(Size size) { return self().setSize(size), *this; }
   auto setTitle(const string& title = "") { return self().setTitle(title), *this; }
   auto setAssociatedFile(const string& filename = "") { return self().setAssociatedFile(filename), *this; }

--- a/hiro/core/window.cpp
+++ b/hiro/core/window.cpp
@@ -187,6 +187,10 @@ auto mWindow::resizable() const -> bool {
   return state.resizable;
 }
 
+auto mWindow::hidesCursor() const -> bool {
+  return state.hidesCursor;
+}
+
 auto mWindow::setAlignment(Alignment alignment) -> type& {
   auto workspace = Monitor::workspace();
   auto geometry = frameGeometry();
@@ -346,6 +350,12 @@ auto mWindow::setPosition(sWindow relativeTo, Position position) -> type& {
 auto mWindow::setResizable(bool resizable) -> type& {
   state.resizable = resizable;
   signal(setResizable, resizable);
+  return *this;
+}
+
+auto mWindow::setHidesCursor(bool hidesCursor) -> type& {
+  state.hidesCursor = hidesCursor;
+  signal(setHidesCursor, hidesCursor);
   return *this;
 }
 

--- a/hiro/core/window.hpp
+++ b/hiro/core/window.hpp
@@ -39,6 +39,7 @@ struct mWindow : mObject {
   auto remove(sStatusBar statusBar) -> type&;
   auto reset() -> type& override;
   auto resizable() const -> bool;
+  auto hidesCursor() const -> bool;
   auto setAlignment(Alignment = Alignment::Center) -> type&;
   auto setAlignment(sWindow relativeTo, Alignment = Alignment::Center) -> type&;
   auto setBackgroundColor(Color color = {}) -> type&;
@@ -58,6 +59,7 @@ struct mWindow : mObject {
   auto setPosition(Position) -> type&;
   auto setPosition(sWindow relativeTo, Position) -> type&;
   auto setResizable(bool resizable = true) -> type&;
+  auto setHidesCursor(bool hidesCursor = true) -> type&;
   auto setSize(Size size) -> type&;
   auto setTitle(const string& title = "") -> type&;
   auto setAssociatedFile(const string& filename = "") -> type&;
@@ -89,6 +91,7 @@ struct mWindow : mObject {
     sSizable sizable;
     sStatusBar statusBar;
     string title;
+    bool hidesCursor;
   } state;
 
   auto destruct() -> void override;


### PR DESCRIPTION
### Description
Adds a cursor auto-hide option for when the cursor has been idle for at least two seconds and is over the game window, and the application is focused. Currently only implemented via the Cocoa UI on macOS in hiro.

To `hiro/core/window`, the `hidesCursor` stored property is added, along with a setter, so a window knows whether it should use the auto-hide behavior. To `desktop-ui/settings/settings`, the `autoHideCursor` property is added to `general`, and a corresponding option has been added under a new Miscellaneous header under "Options" in the Configuration window. An option is also added to the main menu bar via `desktop-ui/presentation/presentation.cpp` and state there is kept in sync with the Configuration window option.

<img width="300" alt="Screenshot 2023-12-05 at 6 03 44 PM" src="https://github.com/ares-emulator/ares/assets/6864788/a1825c3b-47c3-4107-9727-0e49cf3bcce0">
<img width="500" alt="Screenshot 2023-12-05 at 12 57 11 PM" src="https://github.com/ares-emulator/ares/assets/6864788/59c4c157-02ad-4c36-b1b8-a6125c652be2">


Toggling the option calls out to specifically the presentation window, calling `setHidesCursor()`. Correspondly, during initialization, the option only is referenced when starting up the presentation window (`desktop-ui/presentation/presentation.cpp:230`), as other windows should never auto-hide the cursor. 

On the concrete implementation side, in Cocoa, `hidesCursor` defaults to `false` (`hiro/cocoa/window.cpp:9`).
> [!IMPORTANT]
> Future implementations for other UIs should initialize `hidesCursor` in the concrete `window.cpp` implementation as `false`, so the cursor is never hidden over non-game windows.

The Cocoa implementation is fairly straightforward; on window initialization, an `NSTimer` is added to the run loop that ticks every second and calls `hideCursor()`, and an `NSTrackingArea` is created for the bounds of the window on every size event. `hideCursor()` hides the cursor if `hidesCursor` is true, at least 2 seconds idle have elapsed, and the cursor is within the tracking area for the window. Cursor presence in the window is tracked with `-(void)mouseEntered:(NSEvent *)` and `-(void)mouseExited:(NSEvent *)` and the `cursorIsInWindow` property. Cursor is hidden simply via `[NSCursor setHiddenUntilMouseMoves:YES];`

### Motivation
Hiding the mouse cursor when it falls idle over the game window is typical for most games and emulators, and is probably behavior that users will generally want.

### Discussion / Possible Issues
Currently, the option is only implemented on macOS, and so the configuration window and menu bar options are currently hidden behind a simple `#ifdef PLATFORM_MACOS`. I am not sure if I will be able to effectively test this for other platforms and UIs since my only machine is Apple Silicon (though I will try), so I wanted to go ahead and get this in flight for review as is just in case.

In terms of UI/UX, I am not sure if the current location is the best place for the option to live in the Configuration window. Currently, the option lives both there as well as the menu bar. I considered only having the option in the menu bar as well, which might fit better. Currently there are no other options in ares that are settable both via the menu bar as well as the Configuration window. I will of course defer to maintainers' thoughts on this.