### PR TITLE
build: remove -fomit-frame-pointer

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -171,7 +171,7 @@ else ifeq ($(build),optimized)
   ifeq ($(cl),true)
     flags += -O2
   else
-    flags += -O3 -fomit-frame-pointer
+    flags += -O3
   endif
   flags += -DBUILD_OPTIMIZED
 else


### PR DESCRIPTION
This option is usually enabled by default by GCC/Clang with -O1 and above. This is not true on some targets like macOS/arm64, and there we are better off deferring to the compiler anyway.

This became an issue because Xcode 15 shipped with a new linker that, at least when LTO is enabled, appears to mess up metadata that is used to unwind the stack during exception handling. Without a frame pointer to fall back on, unwinding fails completely and causes ares to terminate.