### PR TITLE
build: take care of some macOS build warnings

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -284,7 +284,7 @@ endif
 
 # macos settings
 ifeq ($(platform),macos)
-  flags   += -stdlib=libc++ -mmacosx-version-min=10.9 -Wno-auto-var-id -fobjc-arc
+  flags   += -mmacosx-version-min=10.9 -Wno-auto-var-id -Wno-deprecated-declarations -fobjc-arc
   options += -lc++ -lobjc -mmacosx-version-min=10.9
   # allow mprotect() on dynamic recompiler code blocks
   options += -Wl,-segprot,__DATA,rwx,rw


### PR DESCRIPTION
- remove -stdlib=libc++ as it caused warnings when applied to C files and has been the default on macOS for something like a decade
- add -Wno-deprecated-declarations to the command line to silence warnings about things like sprintf in thirdparty