### PR TITLE
nall: define new type traits

### DIFF
--- a/nall/serializer.hpp
+++ b/nall/serializer.hpp
@@ -76,11 +76,10 @@ struct serializer {
   }
 
   template<typename T> auto operator()(T& value) -> serializer& {
-    constexpr bool integral = is_integral_v<T> || is_same_v<T, u128>;
-    static_assert(has_serialize_v<T> || integral || is_floating_point_v<T>);
+    static_assert(has_serialize_v<T> || is_integral_v<T> || is_floating_point_v<T>);
     if constexpr(has_serialize_v<T>) {
       value.serialize(*this);
-    } else if constexpr(integral) {
+    } else if constexpr(is_integral_v<T>) {
       integer(value);
     } else if constexpr(is_floating_point_v<T>) {
       real(value);

--- a/nall/traits.hpp
+++ b/nall/traits.hpp
@@ -24,16 +24,10 @@ namespace nall {
   using std::is_base_of;
   using std::is_base_of_v;
   using std::is_function;
-  using std::is_integral;
-  using std::is_integral_v;
   using std::is_pointer;
   using std::is_pointer_v;
   using std::is_same;
   using std::is_same_v;
-  using std::is_signed;
-  using std::is_signed_v;
-  using std::is_unsigned;
-  using std::is_unsigned_v;
   using std::nullptr_t;
   using std::remove_extent;
   using std::remove_extent_t;
@@ -41,13 +35,22 @@ namespace nall {
   using std::remove_reference_t;
   using std::swap;
   using std::true_type;
-}
 
-namespace std {
+  //directly specializing std traits would result in undefined behavior
+  template<typename T> struct is_integral : std::is_integral<T> {};
+  template<typename T> struct is_signed   : std::is_signed  <T> {};
+  template<typename T> struct is_unsigned : std::is_unsigned<T> {};
+
+  template<typename T> inline constexpr bool is_integral_v = is_integral<T>::value;
+  template<typename T> inline constexpr bool is_signed_v   = is_signed  <T>::value;
+  template<typename T> inline constexpr bool is_unsigned_v = is_unsigned<T>::value;
+
+  //defined in arithmetic.hpp when unavailable as a builtin
+  template<> struct is_integral<u128> : true_type {};
+  template<> struct is_unsigned<u128> : true_type {};
+
   #if defined(__SIZEOF_INT128__)
   template<> struct is_integral<s128> : true_type {};
-  template<> struct is_integral<u128> : true_type {};
-  template<> struct is_signed<s128> : true_type {};
-  template<> struct is_unsigned<u128> : true_type {};
+  template<> struct is_signed  <s128> : true_type {};
   #endif
 }


### PR DESCRIPTION
Instead of directly specializing std traits classes (which would result in undefined behavior) define our own traits classes that inherit from the std types.

This allows us to remove a hack in the serializer class and paves the way for building ares with Qt on Windows.