### PR TITLE
Mega Mouse support for 32X + CD

### DIFF
--- a/desktop-ui/emulator/mega-32x.cpp
+++ b/desktop-ui/emulator/mega-32x.cpp
@@ -30,6 +30,15 @@ Mega32X::Mega32X() {
     device.digital("Start", virtualPorts[id].pad.start);
     port.append(device); }
 
+  { InputDevice device{"Mega Mouse"};
+    device.relative("X",      virtualPorts[id].mouse.x);
+    device.relative("Y",      virtualPorts[id].mouse.y);
+    device.digital ("Left",   virtualPorts[id].mouse.left);
+    device.digital ("Right",  virtualPorts[id].mouse.right);
+    device.digital ("Middle", virtualPorts[id].mouse.middle);
+    device.digital ("Start",  virtualPorts[id].mouse.extra);
+    port.append(device); }
+
     ports.append(port);
   }
 }

--- a/desktop-ui/emulator/mega-cd-32x.cpp
+++ b/desktop-ui/emulator/mega-cd-32x.cpp
@@ -32,6 +32,15 @@ MegaCD32X::MegaCD32X() {
     device.digital("Start", virtualPorts[id].pad.start);
     port.append(device); }
 
+  { InputDevice device{"Mega Mouse"};
+    device.relative("X",      virtualPorts[id].mouse.x);
+    device.relative("Y",      virtualPorts[id].mouse.y);
+    device.digital ("Left",   virtualPorts[id].mouse.left);
+    device.digital ("Right",  virtualPorts[id].mouse.right);
+    device.digital ("Middle", virtualPorts[id].mouse.middle);
+    device.digital ("Start",  virtualPorts[id].mouse.extra);
+    port.append(device); }
+
     ports.append(port);
   }
 }


### PR DESCRIPTION
Doom Resurrection patch version 3.0 (currently at version 3.1) added support for the Mega Mouse, as well as making use of Mega CD hardware if available. When I added mouse support for the Mega CD, the patch for Doom Resurrection was at version 2.2, and since there was no licensed 32X software that supported the Mega Mouse I declined to add support at the time. But leave it to homebrew, especially one as comprehensive as this patch to add support. 

This adds Mega Mouse support for both the 32X and 32X/CD combo, so it is now available for all Mega * consoles.