### PR TITLE
build: improve pkg-config support on windows

### DIFF
--- a/desktop-ui/GNUmakefile
+++ b/desktop-ui/GNUmakefile
@@ -69,8 +69,8 @@ $(object.path)/desktop-ui-presentation.o: $(desktop-ui.path)/presentation/presen
 $(object.path)/desktop-ui-settings.o: $(desktop-ui.path)/settings/settings.cpp
 $(object.path)/desktop-ui-tools.o: $(desktop-ui.path)/tools/tools.cpp
 
-all.objects := $(libco.objects) $(sljit.objects) $(libchdr.objects) $(tzxfile.objects) $(ymfm.objects) $(nall.objects) $(ruby.objects) $(hiro.objects) $(ares.objects) $(mia.objects) $(desktop-ui.objects)
-all.options := $(libco.options) $(sljit.options) $(libchdr.options) $(tzxfile.options) $(ymfm.options) $(nall.options) $(ruby.options) $(hiro.options) $(ares.options) $(mia.options) $(desktop-ui.options) $(options)
+all.objects :=            $(libco.objects) $(sljit.objects) $(libchdr.objects) $(tzxfile.objects) $(ymfm.objects) $(nall.objects) $(ruby.objects) $(hiro.objects) $(ares.objects) $(mia.objects) $(desktop-ui.objects)
+all.options := $(options) $(libco.options) $(sljit.options) $(libchdr.options) $(tzxfile.options) $(ymfm.options) $(nall.options) $(ruby.options) $(hiro.options) $(ares.options) $(mia.options) $(desktop-ui.options)
 
 $(all.objects): | $(object.path)
 

--- a/hiro/GNUmakefile
+++ b/hiro/GNUmakefile
@@ -13,15 +13,17 @@ ifeq ($(platform),windows)
       $(error hiro does not support static linking against $(hiro) on Windows)
     endif
 
+    hiro.flags = $(flags.cpp) $(if $(findstring g++,$(compiler)),-Wno-deprecated-declarations)
+
     ifeq ($(hiro),gtk2)
-      hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell $(pkg_config) --cflags gtk+-2.0) -Wno-deprecated-declarations
+      hiro.flags  += -DHIRO_GTK=2 $(shell $(pkg_config) --cflags gtk+-2.0)
       hiro.options = $(shell $(pkg_config) --libs gtk+-2.0)
     else ifeq ($(hiro),gtk3)
-      hiro.flags   = $(flags.cpp) -DHIRO_GTK=3 $(shell $(pkg_config) --cflags gtk+-3.0) -Wno-deprecated-declarations
+      hiro.flags  += -DHIRO_GTK=3 $(shell $(pkg_config) --cflags gtk+-3.0)
       hiro.options = $(shell $(pkg_config) --libs gtk+-3.0)
     else ifeq ($(hiro),qt5)
       moc = $(shell $(pkg_config) --variable=host_bins Qt5Core)/moc
-      hiro.flags   = $(flags.cpp) -DHIRO_QT=5 $(shell $(pkg_config) --cflags Qt5Core Qt5Gui Qt5Widgets) -Wno-deprecated-declarations
+      hiro.flags  += -DHIRO_QT=5 $(shell $(pkg_config) --cflags Qt5Core Qt5Gui Qt5Widgets)
       hiro.options = $(shell $(pkg_config) --libs Qt5Core Qt5Gui Qt5Widgets)
     else
       $(error unrecognized hiro backend $(hiro))

--- a/hiro/GNUmakefile
+++ b/hiro/GNUmakefile
@@ -1,5 +1,3 @@
-PKG_CONFIG ?= pkg-config
-
 ifeq ($(platform),windows)
   ifeq ($(hiro),)
     hiro := windows
@@ -16,15 +14,15 @@ ifeq ($(platform),windows)
     endif
 
     ifeq ($(hiro),gtk2)
-      hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell $(PKG_CONFIG) --cflags gtk+-2.0) -Wno-deprecated-declarations
-      hiro.options = $(shell $(PKG_CONFIG) --libs gtk+-2.0)
+      hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell $(pkg_config) --cflags gtk+-2.0) -Wno-deprecated-declarations
+      hiro.options = $(shell $(pkg_config) --libs gtk+-2.0)
     else ifeq ($(hiro),gtk3)
-      hiro.flags   = $(flags.cpp) -DHIRO_GTK=3 $(shell $(PKG_CONFIG) --cflags gtk+-3.0) -Wno-deprecated-declarations
-      hiro.options = $(shell $(PKG_CONFIG) --libs gtk+-3.0)
+      hiro.flags   = $(flags.cpp) -DHIRO_GTK=3 $(shell $(pkg_config) --cflags gtk+-3.0) -Wno-deprecated-declarations
+      hiro.options = $(shell $(pkg_config) --libs gtk+-3.0)
     else ifeq ($(hiro),qt5)
-      moc = $(shell $(PKG_CONFIG) --variable=host_bins Qt5Core)/moc
-      hiro.flags   = $(flags.cpp) -DHIRO_QT=5 $(shell $(PKG_CONFIG) --cflags Qt5Core Qt5Gui Qt5Widgets) -Wno-deprecated-declarations
-      hiro.options = $(shell $(PKG_CONFIG) --libs Qt5Core Qt5Gui Qt5Widgets)
+      moc = $(shell $(pkg_config) --variable=host_bins Qt5Core)/moc
+      hiro.flags   = $(flags.cpp) -DHIRO_QT=5 $(shell $(pkg_config) --cflags Qt5Core Qt5Gui Qt5Widgets) -Wno-deprecated-declarations
+      hiro.options = $(shell $(pkg_config) --libs Qt5Core Qt5Gui Qt5Widgets)
     else
       $(error unrecognized hiro backend $(hiro))
     endif
@@ -50,27 +48,27 @@ ifneq ($(filter $(platform),linux bsd),)
   endif
 
   ifeq ($(hiro),gtk2)
-    hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell $(PKG_CONFIG) --cflags gtk+-2.0) -Wno-deprecated-declarations
-    hiro.options = -L/usr/local/lib -lX11 $(shell $(PKG_CONFIG) --libs gtk+-2.0)
+    hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell $(pkg_config) --cflags gtk+-2.0) -Wno-deprecated-declarations
+    hiro.options = -L/usr/local/lib -lX11 $(shell $(pkg_config) --libs gtk+-2.0)
   else ifeq ($(hiro),gtk2-se)
     flags       += -DHiro_SourceEdit
-    hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell $(PKG_CONFIG) --cflags gtk+-2.0 gtksourceview-2.0) -Wno-deprecated-declarations
-    hiro.options = -L/usr/local/lib -lX11 $(shell $(PKG_CONFIG) --libs gtk+-2.0 gtksourceview-2.0)
+    hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell $(pkg_config) --cflags gtk+-2.0 gtksourceview-2.0) -Wno-deprecated-declarations
+    hiro.options = -L/usr/local/lib -lX11 $(shell $(pkg_config) --libs gtk+-2.0 gtksourceview-2.0)
   else ifeq ($(hiro),gtk3)
-    hiro.flags   = $(flags.cpp) -DHIRO_GTK=3 $(shell $(PKG_CONFIG) --cflags gtk+-3.0) -Wno-deprecated-declarations
-    hiro.options = -L/usr/local/lib -lX11 $(shell $(PKG_CONFIG) --libs gtk+-3.0)
+    hiro.flags   = $(flags.cpp) -DHIRO_GTK=3 $(shell $(pkg_config) --cflags gtk+-3.0) -Wno-deprecated-declarations
+    hiro.options = -L/usr/local/lib -lX11 $(shell $(pkg_config) --libs gtk+-3.0)
   else ifeq ($(hiro),gtk3-se)
     flags       += -DHiro_SourceEdit
-    hiro.flags   = $(flags.cpp) -DHIRO_GTK=3 $(shell $(PKG_CONFIG) --cflags gtk+-3.0 gtksourceview-3.0) -Wno-deprecated-declarations
-    hiro.options = -L/usr/local/lib -lX11 $(shell $(PKG_CONFIG) --libs gtk+-3.0 gtksourceview-3.0)
+    hiro.flags   = $(flags.cpp) -DHIRO_GTK=3 $(shell $(pkg_config) --cflags gtk+-3.0 gtksourceview-3.0) -Wno-deprecated-declarations
+    hiro.options = -L/usr/local/lib -lX11 $(shell $(pkg_config) --libs gtk+-3.0 gtksourceview-3.0)
   else ifeq ($(hiro),qt4)
     moc = /usr/local/lib/qt4/bin/moc
-    hiro.flags   = $(flags.cpp) -DHIRO_QT=4 $(shell $(PKG_CONFIG) --cflags QtCore QtGui)
-    hiro.options = -L/usr/local/lib -lX11 $(shell $(PKG_CONFIG) --libs QtCore QtGui)
+    hiro.flags   = $(flags.cpp) -DHIRO_QT=4 $(shell $(pkg_config) --cflags QtCore QtGui)
+    hiro.options = -L/usr/local/lib -lX11 $(shell $(pkg_config) --libs QtCore QtGui)
   else ifeq ($(hiro),qt5)
-    moc = $(shell $(PKG_CONFIG) --variable=host_bins Qt5Core)/moc
-    hiro.flags   = $(flags.cpp) -DHIRO_QT=5 -fPIC $(shell $(PKG_CONFIG) --cflags Qt5Core Qt5Gui Qt5Widgets)
-    hiro.options = -L/usr/local/lib -lX11 $(shell $(PKG_CONFIG) --libs Qt5Core Qt5Gui Qt5Widgets)
+    moc = $(shell $(pkg_config) --variable=host_bins Qt5Core)/moc
+    hiro.flags   = $(flags.cpp) -DHIRO_QT=5 -fPIC $(shell $(pkg_config) --cflags Qt5Core Qt5Gui Qt5Widgets)
+    hiro.options = -L/usr/local/lib -lX11 $(shell $(pkg_config) --libs Qt5Core Qt5Gui Qt5Widgets)
   else
     $(error unrecognized hiro backend $(hiro))
   endif

--- a/hiro/gtk/browser-window.cpp
+++ b/hiro/gtk/browser-window.cpp
@@ -19,7 +19,7 @@ auto pBrowserWindow::directory(BrowserWindow::State& state) -> string {
   string name;
 
   GtkWidget* dialog = gtk_file_chooser_dialog_new(
-    state.title ? state.title : "Select Directory",
+    state.title ? state.title : "Select Directory"_s,
     state.parent && state.parent->self() ? GTK_WINDOW(state.parent->self()->widget) : (GtkWindow*)nullptr,
     GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
     GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
@@ -44,7 +44,7 @@ auto pBrowserWindow::open(BrowserWindow::State& state) -> string {
   string name;
 
   GtkWidget* dialog = gtk_file_chooser_dialog_new(
-    state.title ? state.title : "Open File",
+    state.title ? state.title : "Open File"_s,
     state.parent && state.parent->self() ? GTK_WINDOW(state.parent->self()->widget) : (GtkWindow*)nullptr,
     GTK_FILE_CHOOSER_ACTION_OPEN,
     GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
@@ -69,7 +69,7 @@ auto pBrowserWindow::save(BrowserWindow::State& state) -> string {
   string name;
 
   GtkWidget* dialog = gtk_file_chooser_dialog_new(
-    state.title ? state.title : "Save File",
+    state.title ? state.title : "Save File"_s,
     state.parent && state.parent->self() ? GTK_WINDOW(state.parent->self()->widget) : (GtkWindow*)nullptr,
     GTK_FILE_CHOOSER_ACTION_SAVE,
     GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,

--- a/hiro/gtk/font.cpp
+++ b/hiro/gtk/font.cpp
@@ -26,12 +26,12 @@ auto pFont::family(const string& family) -> string {
   if(family == Font::Sans ) return "Tahoma";
   if(family == Font::Serif) return "Georgia";
   if(family == Font::Mono ) return "Lucida Console";
-  return family ? family : "Tahoma";
+  return family ? family : "Tahoma"_s;
   #elif defined(DISPLAY_XORG)
   if(family == Font::Sans ) return "Sans";
   if(family == Font::Serif) return "Serif";
   if(family == Font::Mono ) return "Monospace";
-  return family ? family : "Sans";
+  return family ? family : "Sans"_s;
   #else
   return family;
   #endif

--- a/hiro/gtk/window.cpp
+++ b/hiro/gtk/window.cpp
@@ -417,7 +417,7 @@ auto pWindow::setResizable(bool resizable) -> void {
 }
 
 auto pWindow::setTitle(const string& title) -> void {
-  gtk_window_set_title(GTK_WINDOW(widget), title ? title : " ");
+  gtk_window_set_title(GTK_WINDOW(widget), title ? title : " "_s);
 }
 
 auto pWindow::setVisible(bool visible) -> void {

--- a/hiro/qt/platform.cpp
+++ b/hiro/qt/platform.cpp
@@ -1,8 +1,12 @@
+#if defined(COMPILER_CLANG)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#endif
 #include "qt.hpp"
 #include "qt.moc"
+#if defined(COMPILER_CLANG)
 #pragma clang diagnostic pop
+#endif
 #include "platform.hpp"
 
 #include "utility.cpp"

--- a/hiro/qt/widget/button.cpp
+++ b/hiro/qt/widget/button.cpp
@@ -21,7 +21,7 @@ auto pButton::destruct() -> void {
 }
 
 auto pButton::minimumSize() const -> Size {
-  auto size = pFont::size(qtWidget->font(), state().text ? state().text : " ");
+  auto size = pFont::size(qtWidget->font(), state().text ? state().text : " "_s);
 
   if(state().orientation == Orientation::Horizontal) {
     size.setWidth(size.width() + state().icon.width());

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -265,7 +265,14 @@ ifeq ($(platform),windows)
     flags += -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS
   endif
   options += $(call lib,ws2_32 ole32 shell32 shlwapi advapi32)
-  options += $(if $(findstring g++,$(compiler)),-mthreads $(if $(filter-out true,$(static)),,-static))
+  options += $(if $(findstring g++,$(compiler)),-mthreads)
+  ifeq ($(cl),true)
+    flags += $(if $(filter-out true,$(static)),-MD,-MT)
+  else ifeq ($(msvc),true)
+    flags += -fms-runtime-lib=$(if $(filter-out true,$(static)),dll,static)
+  else
+    options += $(if $(filter-out true,$(static)),,-static)
+  endif
   ifeq ($(console),true)
     flags += -DSUBSYTEM_CONSOLE
     options += $(if $(findstring g++,$(compiler)),-mconsole)

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -318,6 +318,22 @@ ifeq ($(threaded),true)
   endif
 endif
 
+# pkg-config/pkgconf detection
+PKG_CONFIG ?= pkg-config
+ifeq ($(shell echo ^^),^)
+  PKG_CONFIG_VERSION := $(shell $(PKG_CONFIG) --version 2> NUL)
+else
+  PKG_CONFIG_VERSION := $(shell $(PKG_CONFIG) --version 2> /dev/null)
+endif
+
+pkg_config :=
+ifneq ($(PKG_CONFIG_VERSION),)
+  pkg_config := $(PKG_CONFIG)
+  ifeq ($(cl),true)
+    pkg_config += --msvc-syntax
+  endif
+endif
+
 # paths
 ifeq ($(object.path),)
   object.path := obj

--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -7,11 +7,10 @@ ifeq ($(ruby),)
     ruby += audio.wasapi audio.xaudio2 audio.directsound audio.waveout #audio.asio
     ruby += input.windows
 
-  ifeq ($(call which,pkg-config),)
+  ifeq ($(pkg_config),)
     # TODO: Check presence of libSDL
   else
-    # If we're in a posix shell, use pkg-config/pkg-check
-    pkg_check = $(if $(shell pkg-config $1 && echo 1),$2)
+    pkg_check = $(if $(shell $(pkg_config) $1 && echo 1),$2)
     ruby += $(call pkg_check,sdl2,input.sdl)
     ruby += $(call pkg_check,sdl2,audio.sdl)
   endif
@@ -20,7 +19,7 @@ ifeq ($(ruby),)
     ruby += audio.openal
     ruby += input.quartz #input.carbon
   else ifeq ($(platform),linux)
-    pkg_check = $(if $(shell pkg-config $1 && echo 1),$2)
+    pkg_check = $(if $(shell $(pkg_config) $1 && echo 1),$2)
     ruby += video.glx video.glx2 video.xshm
     ruby += $(call pkg_check,xv,video.xvideo)
     ruby += audio.oss audio.alsa
@@ -33,7 +32,7 @@ ifeq ($(ruby),)
     ruby += $(call pkg_check,sdl2,input.sdl)
     ruby += $(call pkg_check,sdl2,audio.sdl)
   else ifeq ($(platform),bsd)
-    pkg_check = $(if $(shell pkg-config $1 && echo 1),$2)
+    pkg_check = $(if $(shell $(pkg_config) $1 && echo 1),$2)
     ruby += video.glx video.glx2 video.xshm
     ruby += $(call pkg_check,xv,video.xvideo)
     ruby += audio.oss
@@ -54,11 +53,11 @@ else
 endif
 
 ruby.flags += $(foreach c,$(subst .,_,$(call strupper,$(ruby))),-D$c)
-ifeq ($(call which,pkg-config),)
+ifeq ($(pkg_config),)
   # TODO: add SDL2 cflags
 else
-  ruby.flags += $(if $(findstring input.sdl,$(ruby)),$(shell pkg-config sdl2 --cflags))
-  ruby.flags += $(if $(findstring audio.sdl,$(ruby)),$(shell pkg-config sdl2 --cflags))
+  ruby.flags += $(if $(findstring input.sdl,$(ruby)),$(shell $(pkg_config) sdl2 --cflags))
+  ruby.flags += $(if $(findstring audio.sdl,$(ruby)),$(shell $(pkg_config) sdl2 --cflags))
 endif
 
 ruby.options :=
@@ -79,15 +78,15 @@ ruby.options += $(if $(findstring audio.waveout,$(ruby)),$(call lib,winmm))
 ruby.options += $(if $(findstring audio.xaudio2,$(ruby)),$(call lib,ole32))
 
 ifeq ($(platform),windows)
-  ifeq ($(call which,pkg-config),)
+  ifeq ($(pkg_config),)
     # TODO: add SDL2 ldflags
   else
-    ruby.options += $(if $(findstring input.sdl,$(ruby)),$(shell pkg-config sdl2 --libs --static))
-    ruby.options += $(if $(findstring audio.sdl,$(ruby)),$(shell pkg-config sdl2 --libs --static))
+    ruby.options += $(if $(findstring input.sdl,$(ruby)),$(shell $(pkg_config) sdl2 --libs --static))
+    ruby.options += $(if $(findstring audio.sdl,$(ruby)),$(shell $(pkg_config) sdl2 --libs --static))
   endif
 else
-  ruby.options += $(if $(findstring input.sdl,$(ruby)),$(shell pkg-config sdl2 --libs))
-  ruby.options += $(if $(findstring audio.sdl,$(ruby)),$(shell pkg-config sdl2 --libs))
+  ruby.options += $(if $(findstring input.sdl,$(ruby)),$(shell $(pkg_config) sdl2 --libs))
+  ruby.options += $(if $(findstring audio.sdl,$(ruby)),$(shell $(pkg_config) sdl2 --libs))
 endif
 
 ruby.options += $(if $(findstring input.udev,$(ruby)),-ludev)


### PR DESCRIPTION
Allow ares to be more easily built against external dependencies on Windows outside of MSYS2 and using the MSVC ABI.

For example, dependencies can now acquired via vcpkg by installing the relevant packages (pkgconf, gtk3, qt5, sdl2) and setting up the environment appropriately before building.

```
CMD:
set PKG_CONFIG=C:\src\vcpkg\installed\x64-windows\tools\pkgconf\pkgconf.exe
set PKG_CONFIG_PATH=C:\src\vcpkg\installed\x64-windows\lib\pkgconfig

Bash:
export PKG_CONFIG=/c/src/vcpkg/installed/x64-windows/tools/pkgconf/pkgconf.exe
export PKG_CONFIG_PATH=/c/src/vcpkg/installed/x64-windows/lib/pkgconfig
```

Changes:
- hiro: fix building against gtk/qt with cl
- build: improve pkg-config detection and use with cl
- nall: support dynamic crt with clang-msvc/cl