### PR TITLE
nall: ensure utf-8 string encoding in cl builds

### DIFF
--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -2,11 +2,7 @@
 namespace Instances { Instance<Presentation> presentation; }
 Presentation& presentation = Instances::presentation();
 
-#if defined(PLATFORM_MACOS)
 #define ELLIPSIS "\u2026"
-#else
-#define ELLIPSIS " ..."
-#endif
 
 Presentation::Presentation() {
   loadMenu.setText("Load");

--- a/desktop-ui/settings/paths.cpp
+++ b/desktop-ui/settings/paths.cpp
@@ -1,8 +1,4 @@
-#if defined(PLATFORM_MACOS)
 #define ELLIPSIS "\u2026"
-#else
-#define ELLIPSIS " ..."
-#endif
 
 auto PathSettings::construct() -> void {
   setCollapsible();

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -119,7 +119,7 @@ endif
 ifeq ($(cl),true)
   flags.c      = -TC -std:c11
   flags.cpp    = -TP -std:c++17 -EHsc
-  flags       += -nologo -permissive- -W2 -Fd$(object.path)/
+  flags       += -nologo -permissive- -utf-8 -W2 -Fd$(object.path)/
   options     += -nologo $(if $(findstring clang,$(compiler)),-fuse-ld=lld) -link
 else
   flags.c      = -x c -std=c11


### PR DESCRIPTION
As a bonus, use the Unicode ellipsis character in the ares UI on all platforms instead of just macOS. In addition to looking nicer, it will make regressions in this area very obvious.