### PR TITLE
md: various i/o port improvements

### DIFF
--- a/ares/md/controller/control-pad/control-pad.cpp
+++ b/ares/md/controller/control-pad/control-pad.cpp
@@ -11,9 +11,7 @@ ControlPad::ControlPad(Node::Port parent) {
   start = node->append<Node::Input::Button>("Start");
 }
 
-auto ControlPad::readData() -> n8 {
-  n6 data;
-
+auto ControlPad::poll() -> void {
   platform->input(up);
   platform->input(down);
   platform->input(left);
@@ -34,6 +32,10 @@ auto ControlPad::readData() -> n8 {
   } else if(!xHold) {
     xHold = 1, swap(leftLatch, rightLatch);
   }
+}
+
+auto ControlPad::readData() -> Data {
+  n6 data;
 
   if(select == 0) {
     data.bit(0) = upLatch;
@@ -51,10 +53,9 @@ auto ControlPad::readData() -> n8 {
   }
 
   data = ~data;
-  return latch << 7 | select << 6 | data;
+  return {data, 0x3f};
 }
 
 auto ControlPad::writeData(n8 data) -> void {
   select = data.bit(6);
-  latch = data.bit(7);
 }

--- a/ares/md/controller/control-pad/control-pad.hpp
+++ b/ares/md/controller/control-pad/control-pad.hpp
@@ -10,12 +10,12 @@ struct ControlPad : Controller {
 
   ControlPad(Node::Port);
 
-  auto readData() -> n8 override;
+  auto poll() -> void override;
+  auto readData() -> Data override;
   auto writeData(n8 data) -> void override;
 
 private:
   n1 select = 1;
-  n1 latch;
 
   b1 yHold;
   b1 upLatch;

--- a/ares/md/controller/controller.hpp
+++ b/ares/md/controller/controller.hpp
@@ -17,9 +17,15 @@
 struct Controller {
   Node::Peripheral node;
 
+  struct Data {
+    n8 value;
+    n8 mask;
+  };
+
   virtual ~Controller() = default;
 
-  virtual auto readData() -> n8 { return 0xff; }
+  virtual auto poll() -> void {}
+  virtual auto readData() -> Data { return {0x7f, 0x7f}; }
   virtual auto writeData(n8 data) -> void {}
 };
 

--- a/ares/md/controller/fighting-pad/fighting-pad.hpp
+++ b/ares/md/controller/fighting-pad/fighting-pad.hpp
@@ -15,12 +15,12 @@ struct FightingPad : Controller, Thread {
   FightingPad(Node::Port);
   ~FightingPad();
   auto main() -> void;
-  auto readData() -> n8 override;
+  auto poll() -> void override;
+  auto readData() -> Data override;
   auto writeData(n8 data) -> void override;
 
 private:
   n1  select = 1;
-  n1  latch;
   n3  counter;
   n32 timeout;
 

--- a/ares/md/controller/mega-mouse/mega-mouse.hpp
+++ b/ares/md/controller/mega-mouse/mega-mouse.hpp
@@ -10,14 +10,13 @@ struct MegaMouse : Controller, Thread {
   ~MegaMouse();
 
   auto main() -> void;
-  auto readData() -> n8 override;
+  auto readData() -> Data override;
   auto writeData(n8 data) -> void override;
 
 private:
   n1  th = 1;
   n1  tr = 1;
   n1  tl = 1;
-  n1  latch;
   n8  index = 0;
   n4  status[10];
   s16 maxspeed = 255;

--- a/ares/md/controller/port.cpp
+++ b/ares/md/controller/port.cpp
@@ -29,10 +29,21 @@ auto ControllerPort::allocate(string name) -> Node::Peripheral {
   return {};
 }
 
+auto ControllerPort::update() -> void {
+  auto [inputData, inputMask] = device ? device->readData() : Controller::Data{0x7f, 0x7f};
+  n8 outputMask = 0x80 | control;
+  n8 prevLines = dataLines;
+  dataLines = inputData & inputMask | dataLines & ~inputMask;
+  dataLines = dataLatch & outputMask | dataLines & ~outputMask;
+  //todo: gradually pull up floating lines
+  if(device && prevLines != dataLines) return device->writeData(dataLines);
+}
+
 auto ControllerPort::power(bool reset) -> void {
   if(!reset) {
     control        = 0x00;
     dataLatch      = 0x7f;
+    dataLines      = 0x7f;
     serialControl  = 0x00;
     serialTxBuffer = 0xff;
     serialRxBuffer = 0x00;
@@ -42,6 +53,7 @@ auto ControllerPort::power(bool reset) -> void {
 auto ControllerPort::serialize(serializer& s) -> void {
   s(control);
   s(dataLatch);
+  s(dataLines);
   s(serialControl);
   s(serialTxBuffer);
   s(serialRxBuffer);

--- a/ares/md/system/serialization.cpp
+++ b/ares/md/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v133.1";
+static const string SerializerVersion = "v134";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
General fixes:
- model data lines separately from output data latches
- update data lines after control register writes
- distinguish between driven and floating data lines
- remove redundant data latch state from devices
- separate host input polling from data line synthesis

6 button/fighting pad fixes:
- reset timeout only on TH 0->1 transitions
- remain in last phase until timeout (don't wrap)
- read back C/B button state along with M/X/Y/Z

Mega mouse:
- remove erroneous thread synchronize on attach which could crash ares

Affected titles:
- Decap Attack (MD)
- Trouble Shooter/Battle Mania (MD)
- WWF Raw (32X)