### PR TITLE
gba: unmapped i/o fixes

### DIFF
--- a/ares/gba/apu/io.cpp
+++ b/ares/gba/apu/io.cpp
@@ -21,6 +21,10 @@ auto APU::readIO(n32 address) -> n8 {
   case 0x0400'0068: return square2.read(1);
   case 0x0400'0069: return square2.read(2);
 
+  //zero
+  case 0x0400'006a: return 0x00;
+  case 0x0400'006b: return 0x00;
+
   //NR23, NR24
   case 0x0400'006c: return square2.read(3);
   case 0x0400'006d: return square2.read(4);

--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -126,9 +126,9 @@ auto CPU::power() -> void {
   for(u32 n = 0x100; n <= 0x10f; n++) bus.io[n] = this;  //Timers
   for(u32 n = 0x120; n <= 0x12b; n++) bus.io[n] = this;  //Serial
   for(u32 n = 0x130; n <= 0x133; n++) bus.io[n] = this;  //Keypad
-  for(u32 n = 0x134; n <= 0x159; n++) bus.io[n] = this;  //Serial
-  for(u32 n = 0x200; n <= 0x209; n++) bus.io[n] = this;  //System
-  for(u32 n = 0x300; n <= 0x301; n++) bus.io[n] = this;  //System
+  for(u32 n = 0x134; n <= 0x15b; n++) bus.io[n] = this;  //Serial
+  for(u32 n = 0x200; n <= 0x20b; n++) bus.io[n] = this;  //System
+  for(u32 n = 0x300; n <= 0x303; n++) bus.io[n] = this;  //System
   //0x080-0x083 mirrored via gba/memory/memory.cpp        //System
 }
 

--- a/ares/gba/cpu/io.cpp
+++ b/ares/gba/cpu/io.cpp
@@ -144,6 +144,10 @@ auto CPU::readIO(n32 address) -> n8 {
     joybus.siIRQEnable << 0
   | joybus.mode        << 6
   );
+  
+  //zero
+  case 0x0400'0136: return 0;
+  case 0x0400'0137: return 0;
 
   //JOYCNT
   case 0x0400'0140: return (
@@ -201,14 +205,26 @@ auto CPU::readIO(n32 address) -> n8 {
   | wait.prefetch << 6
   | wait.gameType << 7
   );
+  
+  //zero
+  case 0x0400'0206: return 0;
+  case 0x0400'0207: return 0;
 
   //IME
   case 0x0400'0208: return irq.ime;
-  case 0x0400'0209: return 0;
+  case 0x0400'0209: return 0x0;
+  
+  //zero
+  case 0x0400'020a: return 0;
+  case 0x0400'020b: return 0;
 
   //POSTFLG + HALTCNT
   case 0x0400'0300: return context.booted;
-  case 0x0400'0301: return 0;
+  case 0x0400'0301: return 0x0;
+  
+  //zero
+  case 0x0400'0302: return 0;
+  case 0x0400'0303: return 0;
 
   //MEMCNT_L
   case 0x0400'0800: return (

--- a/ares/gba/cpu/io.cpp
+++ b/ares/gba/cpu/io.cpp
@@ -212,7 +212,7 @@ auto CPU::readIO(n32 address) -> n8 {
 
   //IME
   case 0x0400'0208: return irq.ime;
-  case 0x0400'0209: return 0x0;
+  case 0x0400'0209: return 0;
   
   //zero
   case 0x0400'020a: return 0;
@@ -220,7 +220,7 @@ auto CPU::readIO(n32 address) -> n8 {
 
   //POSTFLG + HALTCNT
   case 0x0400'0300: return context.booted;
-  case 0x0400'0301: return 0x0;
+  case 0x0400'0301: return 0;
   
   //zero
   case 0x0400'0302: return 0;


### PR DESCRIPTION
Some unmapped I/O registers on the GBA always return 0 when read. This pull request implements the required behaviour on six registers that previously used open bus behaviour instead, allowing ares to pass all remaining I/O read tests in the mGBA test suite.