### PR TITLE
build: add macOS SDL to thirdparty, add .dylib to bundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         keychain-password: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
     - name: Checkout source code
       uses: actions/checkout@v2
-    - name: "macOS: recover cache"
+    - name: "macOS: recover MoltenVK cache"
       if: runner.os == 'macOS'
       uses: actions/cache@v3
       env:
@@ -95,12 +95,23 @@ jobs:
       with:
           path: thirdparty/MoltenVK/MoltenVK
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('thirdparty/MoltenVK/HEAD') }}
+    - name: "macOS: recover SDL cache"
+      if: runner.os == 'macOS'
+      uses: actions/cache@v3
+      env:
+          cache-name: sdl
+      with:
+          path: thirdparty/SDL/SDL
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('thirdparty/SDL/HEAD') }}
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'
       run: |
-        brew install make ninja sdl2
+        brew install make ninja cmake
         pip install --no-input setuptools
         echo "MAKE=gmake" >> $GITHUB_ENV
+        pushd thirdparty/SDL
+        ./build-SDL.sh
+        popd
         pushd thirdparty/MoltenVK
         ./build-moltenvk.sh
         popd
@@ -114,7 +125,7 @@ jobs:
       run: ${MAKE:-make} -j4 -C desktop-ui build=optimized local=false compiler="${{ matrix.platform.compiler }}" windres="${{ matrix.platform.windres }}"
     - name: "macOS: Make universal app"
       if: runner.os == 'macOS'
-      run: scripts/macos-make-universal.sh build=optimized local=false sdl2=false
+      run: scripts/macos-make-universal.sh build=optimized local=false
       env:
         MAKEFLAGS: -j3
         MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}

--- a/ares/GNUmakefile
+++ b/ares/GNUmakefile
@@ -13,10 +13,6 @@ ares.objects := ares ares-fixed-allocator
 $(object.path)/ares.o: $(ares.path)/ares/ares.cpp
 $(object.path)/ares-fixed-allocator.o: $(ares.path)/ares/memory/fixed-allocator.cpp
 
-ifeq ($(platform),macos)
-  ares.dylibs :=
-endif
-
 ifeq ($(vulkan),true)
   flags += -DVULKAN
 endif

--- a/desktop-ui/GNUmakefile
+++ b/desktop-ui/GNUmakefile
@@ -22,6 +22,10 @@ ifneq ($(filter $(arch),x86 amd64),)
   endif
 endif
 
+ifeq ($(platform),macos)
+  ares.dylibs :=
+endif
+
 libco.path := ../libco
 include $(libco.path)/GNUmakefile
 

--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -21,6 +21,11 @@ ifeq ($(ruby),)
     ruby += audio.openal
     ruby += input.quartz #input.carbon
     ifeq ($(sdl2),true)
+      macsdl = ../thirdparty/SDL/libSDL2-2.0.0.dylib
+      ares.dylibs += $(macsdl)
+      ifeq ($(wildcard $(macsdl)),)
+        $(error Tried to compile ruby for macOS with SDL2 linked, but no SDL2 library was found. Compile it with thirdparty/SDL/build-sdl.sh, or disable SDL by compiling ares with sdl2=false)
+      endif
       ruby += input.sdl
     endif
   else ifeq ($(platform),linux)

--- a/thirdparty/SDL/HEAD
+++ b/thirdparty/SDL/HEAD
@@ -1,0 +1,1 @@
+15ead9a40d09a1eb9972215cceac2bf29c9b77f6

--- a/thirdparty/SDL/build-sdl.sh
+++ b/thirdparty/SDL/build-sdl.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ ! -d "SDL" ]; then
+    git clone https://github.com/libsdl-org/SDL.git -b SDL2
+else
+    git -C SDL fetch
+fi
+git -C SDL reset --hard "$(cat HEAD)"
+mkdir -p SDL/build
+pushd SDL/build
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+cmake .. "-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64" \
+          -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11
+cmake --build .
+sudo cmake --install .
+sudo xcode-select -s /Applications/Xcode_14.2.app/Contents/Developer
+popd
+cp SDL/build/libSDL2-2.0.0.dylib .


### PR DESCRIPTION
### Description

Adds SDL (properly) to Mac builds.

This time, it has been added as a fully fledged optional dependency in `thirdparty`, à la MoltenVK, and built from source before ares. We build from source because brew installations are both single-architecture and not fully portable.

The .dylib is copied inside the app bundle when linking, at the same stage as MoltenVK.

The initialization of `ares.dylibs` has been moved from ares's Makefile to the `desktop-ui` Makefile so that it's initialized when building ruby, which it wasn't previously.

The SDL build is also added to CI, with the same caching methods as used for MVK.

### Relevant Details

`HEAD` points at SDL 2.28.5 currently, which is the most recent stable release. This should probably be periodically incremented as appropriate.

~~SDL is currently built with the macOS deployment target of 10.13. While SDL's minimum supported macOS version is 10.11, ares CI is using Xcode 14.2, which has a minimum deployment target of 10.13. I am currently testing to see if I can get the deployment target lower without breaking other parts of ares's CI.~~ resolved, per below; SDL supporting 10.11 is built + bundled.

### Testing

This has been tested to build properly locally and via GitHub CI. The .dylib is packaged inside the bundle correctly and SDL functions correctly in my testing, even if the user does not have SDL installed elsewhere on their system.

This is seeking tests from other Mac users, especially on older operating systems, to verify that SDL works correctly there.