### PR TITLE
Correct prefetch order for M68000 ASR instruction

### DIFF
--- a/ares/component/processor/m68000/instructions.cpp
+++ b/ares/component/processor/m68000/instructions.cpp
@@ -197,9 +197,9 @@ template<u32 Size> auto M68000::instructionASR(n4 count, DataRegister with) -> v
 
 template<u32 Size> auto M68000::instructionASR(DataRegister from, DataRegister with) -> void {
   auto count = read<Long>(from) & 63;
+  prefetch();
   idle((Size != Long ? 2 : 4) + count * 2);
   auto result = ASR<Size>(read<Size>(with), count);
-  prefetch();
   write<Size>(with, result);
 }
 


### PR DESCRIPTION
Originally found by vmicka72, so credits to them. Documented as issue: https://github.com/ares-emulator/ares/issues/1275 and confirmed by TascoDLX.

Since it is easy and straightforward, no sense in letting it hang around. 