### PR TITLE
macOS: Add minimum macOS version and copyright to ares.plist

### DIFF
--- a/desktop-ui/resource/ares.plist
+++ b/desktop-ui/resource/ares.plist
@@ -18,6 +18,10 @@
   <true/>
   <key>NSSupportsAutomaticGraphicsSwitching</key>
   <true/>
+  <key>LSMinimumSystemVersion</key>
+  <string>10.9</string>
+  <key>NSHumanReadableCopyright</key>
+  <string>Copyright © ares Team and Contributors.</string>
   <key>CFBundleDocumentTypes</key>
   <array>
     <dict>


### PR DESCRIPTION
Added the minimum macOS version key, but kept it at 10.9 which is what macOS currently reports it as. 
Now that the key is here, it will be easier to update it in the future. 

Also added the copyright line attributing the ares team and contributors.