### PR TITLE
n64: improve PIF HLE emulation by reducing latency

### DIFF
--- a/ares/n64/pif/io.cpp
+++ b/ares/n64/pif/io.cpp
@@ -23,7 +23,8 @@ auto PIF::readWord(u32 address) -> u32 {
 
 auto PIF::writeWord(u32 address, u32 data) -> void {
   writeInt(address, data);  
-  return intA(Write, Size4);
+  intA(Write, Size4);
+  mainHLE();
 }
 
 auto PIF::dmaRead(u32 address, u32 ramAddress) -> void {
@@ -40,4 +41,5 @@ auto PIF::dmaWrite(u32 address, u32 ramAddress) -> void {
     writeInt(address + offset, data);
   }
   intA(Write, Size64);
+  mainHLE();
 }


### PR DESCRIPTION
When doing PIF HLE emulation, we run the HLE state machine just once per frame. This is OK in general, but there can be a few situations where this can cause PIF to miss one command from CPU. For instance, a ROM might send the PIF boot termination command (0x8) and then shortly after issue a SI DMA to identify controllers. If the two happen within the same frame, our HLE emulation would miss the boot termination command.

This commit updates the HLE state machine also after each write to PIF RAM.