### PR TITLE
n64: support ROMs bigger than 63.9375 MiB

### DIFF
--- a/ares/n64/cartridge/cartridge.cpp
+++ b/ares/n64/cartridge/cartridge.cpp
@@ -47,10 +47,12 @@ auto Cartridge::connect() -> void {
 
   rtc.load();
 
-  isviewer.ram.allocate(64_KiB);
-  isviewer.tracer = node->append<Node::Debugger::Tracer::Notification>("ISViewer", "Cartridge");
-  isviewer.tracer->setAutoLineBreak(false);
-  isviewer.tracer->setTerminal(true);
+  if(rom.size <= 0x03fe'ffff && system.homebrewMode) {
+    isviewer.ram.allocate(64_KiB);
+    isviewer.tracer = node->append<Node::Debugger::Tracer::Notification>("ISViewer", "Cartridge");
+    isviewer.tracer->setAutoLineBreak(false);
+    isviewer.tracer->setTerminal(true);
+  }
 
   debugger.load(node);
 

--- a/ares/n64/cartridge/cartridge.hpp
+++ b/ares/n64/cartridge/cartridge.hpp
@@ -42,6 +42,8 @@ struct Cartridge {
     Memory::Writable ram;  //unserialized
     Node::Debugger::Tracer::Notification tracer;
 
+    auto enabled() -> bool { return ram.size; }
+
     //isviewer.cpp
     auto messageChar(char c) -> void;
     auto readHalf(u32 address) -> u16;


### PR DESCRIPTION
Currently, the n64 core is limited to ROMs whose size is 63.9375 MiB (also known as 64 MiB - 64 KiB). The reason is twofold: first, only 64 MiB are actually mapped in the PI bus; second, the last 64 KiB are shadowed by the ISViewer debugging device.

ISViewer addresses sit in the last 64 KiB of the 64th MiB, so when the ROM is larger than that (for instance, it is exactly 64 MiB), we should simply disable ISViewer. In the long run, there will be a better debugging solution which doesn't sit in the PI address space anyway.

Moreover, N64 supports basically ROM of unlimited size, there is no 64 MiB limit. This commit also allows that by simply mapping the whole ROM into the PI address bus, whatever the actual size is.