### PR TITLE
macOS: various UI fixes

### DIFF
--- a/desktop-ui/tools/tracer.cpp
+++ b/desktop-ui/tools/tracer.cpp
@@ -3,8 +3,8 @@ auto TraceLogger::construct() -> void {
   setVisible(false);
 
   tracerLabel.setText("Trace Logger").setFont(Font().setBold());
-  tracerList.onToggle([&](auto cell) {
-    if(auto item = tracerList.selected()) {
+  tracerList.onToggle([&](TableViewCell cell) {
+    if(auto item = cell.parent()) {
       if(auto tracer = item.attribute<ares::Node::Debugger::Tracer::Tracer>("tracer")) {
         if(cell.offset() == 1) tracer->setPrefix(cell.checked());
         if(cell.offset() == 2) tracer->setTerminal(cell.checked());

--- a/hiro/cocoa/widget/line-edit.cpp
+++ b/hiro/cocoa/widget/line-edit.cpp
@@ -56,11 +56,11 @@ auto pLineEdit::setEditable(bool editable) -> void {
 }
 
 auto pLineEdit::setForegroundColor(SystemColor color) -> void {
-  [[(CocoaLineEdit*)cocoaView cell] setTextColor: NSMakeColor(color)?: NSMakeColor(hiro::SystemColor::Text)];
+  [[(CocoaLineEdit*)cocoaView cell] setTextColor: NSMakeColor(color)];
 }
 
 auto pLineEdit::setForegroundColor(Color color) -> void {
-  [[(CocoaLineEdit*)cocoaView cell] setTextColor: NSMakeColor(color)?: NSMakeColor(hiro::SystemColor::Text)];
+  [[(CocoaLineEdit*)cocoaView cell] setTextColor: color ? NSMakeColor(color) : NSMakeColor(hiro::SystemColor::Text)];
 }
 
 auto pLineEdit::setText(const string& text) -> void {


### PR DESCRIPTION
Some issues I noticed while playing with this on macOS. Took a bit of a deep dive and attempted to fix them up:
- changing the tracer settings did not seem to change what was logged. seems to be the row isn't selected when the `onToggle` callback is called. solution was to instead use the toggled `cell` to get the row its in. this caused some C++ template issues but removing the `auto` fixes them all (the alternative being adding `template` to a few method calls, I should add I'm not a C++ programmer so from my limited understanding this was the best solution)
- text in text fields were invisible. this was due to `setForegroundColor` in the macOS backend not properly handling a 0,0,0,0 color. changed to perform the ternary on the `Color` rather than the `NSColor` (`SystemColor` did not support the ternary)

merry christmas :)