### PR TITLE
nall: add support for LoongArch architecture

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -99,6 +99,8 @@ else
     machine := arm64
   else ifneq ($(filter arm-% armv7-%,$(machine_str)),)
     machine := arm32
+  else ifneq ($(filter loong64-% loongarch64-%,$(machine_str)),)
+  machine := loong64
   else ifneq ($(filter powerpc64-% powerpc64le-%,$(machine_str)),)
     machine := ppc64
   else ifneq ($(filter riscv64-%,$(machine_str)),)

--- a/nall/intrinsics.hpp
+++ b/nall/intrinsics.hpp
@@ -190,6 +190,7 @@ namespace nall {
     static constexpr bool amd64 = 0;
     static constexpr bool arm64 = 0;
     static constexpr bool arm32 = 0;
+    static constexpr bool loong64 = 0;
     static constexpr bool ppc64 = 0;
     static constexpr bool ppc32 = 0;
     static constexpr bool rv64  = 0;
@@ -205,6 +206,7 @@ namespace nall {
     static constexpr bool amd64 = 1;
     static constexpr bool arm64 = 0;
     static constexpr bool arm32 = 0;
+    static constexpr bool loong64 = 0;
     static constexpr bool ppc64 = 0;
     static constexpr bool ppc32 = 0;
     static constexpr bool rv64  = 0;
@@ -220,6 +222,7 @@ namespace nall {
     static constexpr bool amd64 = 0;
     static constexpr bool arm64 = 1;
     static constexpr bool arm32 = 0;
+    static constexpr bool loong64 = 0;
     static constexpr bool ppc64 = 0;
     static constexpr bool ppc32 = 0;
     static constexpr bool rv64  = 0;
@@ -232,6 +235,20 @@ namespace nall {
     static constexpr bool amd64 = 0;
     static constexpr bool arm64 = 0;
     static constexpr bool arm32 = 1;
+    static constexpr bool loong64 = 0;
+    static constexpr bool ppc64 = 0;
+    static constexpr bool ppc32 = 0;
+    static constexpr bool rv64  = 0;
+    static constexpr bool rv32  = 0;
+  };
+#elif defined(__loongarch64)
+  #define ARCHITECTURE_LOONG64
+  struct Architecture {
+    static constexpr bool x86   = 0;
+    static constexpr bool amd64 = 0;
+    static constexpr bool arm64 = 0;
+    static constexpr bool arm32 = 0;
+    static constexpr bool loong64 = 1;
     static constexpr bool ppc64 = 0;
     static constexpr bool ppc32 = 0;
     static constexpr bool rv64  = 0;
@@ -244,6 +261,7 @@ namespace nall {
     static constexpr bool amd64 = 0;
     static constexpr bool arm64 = 0;
     static constexpr bool arm32 = 0;
+    static constexpr bool loong64 = 0;
     static constexpr bool ppc64 = 1;
     static constexpr bool ppc32 = 0;
     static constexpr bool rv64  = 0;
@@ -256,6 +274,7 @@ namespace nall {
     static constexpr bool amd64 = 0;
     static constexpr bool arm64 = 0;
     static constexpr bool arm32 = 0;
+    static constexpr bool loong64 = 0;
     static constexpr bool ppc64 = 0;
     static constexpr bool ppc32 = 1;
     static constexpr bool rv64  = 0;
@@ -268,6 +287,7 @@ namespace nall {
     static constexpr bool amd64 = 0;
     static constexpr bool arm64 = 0;
     static constexpr bool arm32 = 0;
+    static constexpr bool loong64 = 0;
     static constexpr bool ppc64 = 0;
     static constexpr bool ppc32 = 0;
     static constexpr bool rv64  = 1;
@@ -280,6 +300,7 @@ namespace nall {
     static constexpr bool amd64 = 0;
     static constexpr bool arm64 = 0;
     static constexpr bool arm32 = 0;
+    static constexpr bool loong64 = 0;
     static constexpr bool ppc64 = 0;
     static constexpr bool ppc32 = 0;
     static constexpr bool rv64  = 0;

--- a/nall/recompiler/generic/generic.hpp
+++ b/nall/recompiler/generic/generic.hpp
@@ -3,7 +3,7 @@
 #if defined(SLJIT)
 namespace nall::recompiler {
   struct generic {
-    static constexpr bool supported = Architecture::amd64 | Architecture::arm64 | Architecture::ppc64 | Architecture::rv64;
+    static constexpr bool supported = Architecture::amd64 | Architecture::arm64 | Architecture::loong64 | Architecture::ppc64 | Architecture::rv64;
 
     bump_allocator& allocator;
     sljit_compiler* compiler = nullptr;


### PR DESCRIPTION
Compiling ares project failed in the my local loongarch64 environment.
There are 2 architecture-related errors are reported, for examples,
```
Q1: unknown arch, please specify manually.
root@localhost:/home/remine/ares/git/ares# make -j4
make[1]: Entering directory “/home/remine/ares/git/ares/desktop-ui”
../nall/GNUmakefile:137: *** unknown arch, please specify manually.。 停止。
make[1]: Leaving directory “/home/remine/ares/git/ares/desktop-ui”

Q2：error "unable to detect architecture".
In file included from ../nall/platform.hpp:3,
                 from ../thirdparty/sljitAllocator.cpp:3:
../nall/intrinsics.hpp:289:4: error: #error "unable to detect architecture"
  289 |   #error "unable to detect architecture"
      |    ^~~~~
```
Please review. 
If you have any questions, you can contact me at any time.