### PR TITLE
arm7tdmi: Improved ldmia and stmia timings in Thumb mode

### DIFF
--- a/ares/component/processor/arm7tdmi/instructions-thumb.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-thumb.cpp
@@ -126,17 +126,23 @@ auto ARM7TDMI::thumbInstructionMoveMultiple
 (n8 list, n3 n, n1 mode) -> void {
   n32 rn = r(n);
 
+  u32 sequential = Nonsequential;
   for(u32 m : range(8)) {
     if(!list.bit(m)) continue;
     switch(mode) {
-    case 0: write(Word | Nonsequential, rn, r(m)); break;  //STMIA
-    case 1: r(m) = read(Word | Nonsequential, rn); break;  //LDMIA
+    case 0: write(Word | sequential, rn, r(m)); break;  //STMIA
+    case 1: r(m) = read(Word | sequential, rn); break;  //LDMIA
     }
     rn += 4;
+    sequential = Sequential;
   }
 
   if(mode == 0 || !list.bit(n)) r(n) = rn;
-  if(mode == 1) idle();
+  if(mode == 1) {
+    idle();
+  } else {
+    pipeline.nonsequential = true;
+  }
 }
 
 auto ARM7TDMI::thumbInstructionMoveRegisterOffset


### PR DESCRIPTION
ARM and Thumb mode variants of the ldmia and stmia instructions use a shared pattern of sequential and nonsequential memory accesses. The correct pattern was already implemented in ARM mode, and this PR applies the same pattern to Thumb mode, making the timings of these instructions more accurate.