### PR TITLE
arm7tdmi: fix additional instructions that require offset when reading PC

### DIFF
--- a/ares/component/processor/arm7tdmi/arm7tdmi.hpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.hpp
@@ -62,7 +62,7 @@ struct ARM7TDMI {
   auto thumbInitialize() -> void;
 
   //instructions-arm.cpp
-  auto armALU(n4 mode, n4 target, n4 source, n32 data) -> void;
+  auto armALU(n4 mode, n4 target, n32 source, n32 data) -> void;
   auto armMoveToStatus(n4 field, n1 source, n32 data) -> void;
 
   auto armInstructionBranch(i24, n1) -> void;


### PR DESCRIPTION
Depending on which cycle they read values from registers, instructions will read a different PC value. This is handled in ares by adding an offset to the program counter (r15) value in affected cases. This PR applies the offset in a few instructions that are affected by this behaviour, but were previously not covered.