### PR TITLE
n64: implement undocumented accesses in FPU half-mode

### DIFF
--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -652,7 +652,7 @@ struct CPU : Thread {
 
     struct Coprocessor {
       static constexpr u8 revision = 0x00;
-      static constexpr u8 implementation = 0x0b;
+      static constexpr u8 implementation = 0x0a;
     } coprocessor;
 
     struct ControlStatus {
@@ -688,6 +688,8 @@ struct CPU : Thread {
   float_env fenv;
 
   template<typename T> auto fgr(u32) -> T&;
+  template<typename T> auto fgr_src(u32) -> T&;
+  template<typename T> auto fgr_dest(u32) -> T&;
   auto getControlRegisterFPU(n5) -> u32;
   auto setControlRegisterFPU(n5, n32) -> void;
   template<bool CVT> auto checkFPUExceptions() -> bool;

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -687,9 +687,9 @@ struct CPU : Thread {
   //interpreter-fpu.cpp
   float_env fenv;
 
-  template<typename T> auto fgr(u32) -> T&;
-  template<typename T> auto fgr_src(u32) -> T&;
-  template<typename T> auto fgr_dest(u32) -> T&;
+  template<typename T> auto fgr_t(u32) -> T&;
+  template<typename T> auto fgr_s(u32) -> T&;
+  template<typename T> auto fgr_d(u32) -> T&;
   auto getControlRegisterFPU(n5) -> u32;
   auto setControlRegisterFPU(n5, n32) -> void;
   template<bool CVT> auto checkFPUExceptions() -> bool;

--- a/ares/n64/cpu/interpreter-fpu.cpp
+++ b/ares/n64/cpu/interpreter-fpu.cpp
@@ -7,7 +7,7 @@ auto CPU::FPU::setFloatingPointMode(bool mode) -> void {
   }
 }
 
-template<> auto CPU::fgr<s32>(u32 index) -> s32& {
+template<> auto CPU::fgr_t<s32>(u32 index) -> s32& {
   if(scc.status.floatingPointMode) {
     return fpu.r[index].s32;
   } else if(index & 1) {
@@ -17,7 +17,7 @@ template<> auto CPU::fgr<s32>(u32 index) -> s32& {
   }
 }
 
-template<> auto CPU::fgr_src<s32>(u32 index) -> s32& {
+template<> auto CPU::fgr_s<s32>(u32 index) -> s32& {
   if(scc.status.floatingPointMode) {
     return fpu.r[index].s32;
   } else {
@@ -25,25 +25,25 @@ template<> auto CPU::fgr_src<s32>(u32 index) -> s32& {
   }
 }
 
-template<> auto CPU::fgr_dest<s32>(u32 index) -> s32& {
+template<> auto CPU::fgr_d<s32>(u32 index) -> s32& {
   fpu.r[index].s32h = 0;
   return fpu.r[index].s32;
 }
 
-template<> auto CPU::fgr<u32>(u32 index) -> u32& {
-  return (u32&)fgr<s32>(index);
+template<> auto CPU::fgr_t<u32>(u32 index) -> u32& {
+  return (u32&)fgr_t<s32>(index);
 }
 
-template<> auto CPU::fgr<f32>(u32 index) -> f32& {
+template<> auto CPU::fgr_t<f32>(u32 index) -> f32& {
   return fpu.r[index].f32;
 }
 
-template<> auto CPU::fgr_dest<f32>(u32 index) -> f32& {
+template<> auto CPU::fgr_d<f32>(u32 index) -> f32& {
   fpu.r[index].f32h = 0;
   return fpu.r[index].f32;
 }
 
-template<> auto CPU::fgr_src<f32>(u32 index) -> f32& {
+template<> auto CPU::fgr_s<f32>(u32 index) -> f32& {
   if(scc.status.floatingPointMode) {
     return fpu.r[index].f32;
   } else {
@@ -51,7 +51,7 @@ template<> auto CPU::fgr_src<f32>(u32 index) -> f32& {
   }
 }
 
-template<> auto CPU::fgr<s64>(u32 index) -> s64& {
+template<> auto CPU::fgr_t<s64>(u32 index) -> s64& {
   if(scc.status.floatingPointMode) {
     return fpu.r[index].s64;
   } else {
@@ -59,31 +59,31 @@ template<> auto CPU::fgr<s64>(u32 index) -> s64& {
   }
 }
 
-template<> auto CPU::fgr_dest<s64>(u32 index) -> s64& {
+template<> auto CPU::fgr_d<s64>(u32 index) -> s64& {
   return fpu.r[index].s64;
 }
 
-template<> auto CPU::fgr_src<s64>(u32 index) -> s64& {
-  return fgr<s64>(index);
+template<> auto CPU::fgr_s<s64>(u32 index) -> s64& {
+  return fgr_t<s64>(index);
 }
 
-template<> auto CPU::fgr<u64>(u32 index) -> u64& {
-  return (u64&)fgr<s64>(index);
+template<> auto CPU::fgr_t<u64>(u32 index) -> u64& {
+  return (u64&)fgr_t<s64>(index);
 }
 
-template<> auto CPU::fgr_src<u64>(u32 index) -> u64& {
-  return fgr<u64>(index);
+template<> auto CPU::fgr_s<u64>(u32 index) -> u64& {
+  return fgr_t<u64>(index);
 }
 
-template<> auto CPU::fgr<f64>(u32 index) -> f64& {
+template<> auto CPU::fgr_t<f64>(u32 index) -> f64& {
   return fpu.r[index].f64;
 }
 
-template<> auto CPU::fgr_dest<f64>(u32 index) -> f64& {
-  return fgr<f64>(index);
+template<> auto CPU::fgr_d<f64>(u32 index) -> f64& {
+  return fgr_t<f64>(index);
 }
 
-template<> auto CPU::fgr_src<f64>(u32 index) -> f64& {
+template<> auto CPU::fgr_s<f64>(u32 index) -> f64& {
   if(scc.status.floatingPointMode) {
     return fpu.r[index].f64;
   } else {
@@ -404,9 +404,9 @@ auto CPU::fpuCheckInputConv<s64>(f64& f) -> bool {
 }
 
 #define CF fpu.csr.compare
-#define FD(type) fgr_dest<type>(fd)
-#define FS(type) fgr_src<type>(fs)
-#define FT(type) fgr<type>(ft)
+#define FD(type) fgr_d<type>(fd)
+#define FS(type) fgr_s<type>(fs)
+#define FT(type) fgr_t<type>(ft)
 
 auto CPU::BC1(bool value, bool likely, s16 imm) -> void {
   if(!fpuCheckStart()) return;

--- a/ares/n64/cpu/interpreter-fpu.cpp
+++ b/ares/n64/cpu/interpreter-fpu.cpp
@@ -250,8 +250,9 @@ auto CPU::checkFPUExceptions() -> bool {
 
 #define CHECK_FPE_IMPL(type, res, operation, convert) \
   fenv.clearExcept(); \
-  type res = [&]() noinline -> type { return operation; }(); \
-  if (checkFPUExceptions<convert>()) return;
+  volatile type v##res = [&]() noinline -> type { return operation; }(); \
+  if (checkFPUExceptions<convert>()) return; \
+  type res = v##res;
 
 #define CHECK_FPE(type, res, operation)      CHECK_FPE_IMPL(type, res, operation, false)
 #define CHECK_FPE_CONV(type, res, operation) CHECK_FPE_IMPL(type, res, operation, true)

--- a/ares/n64/pi/bus.hpp
+++ b/ares/n64/pi/bus.hpp
@@ -2,6 +2,7 @@ inline auto PI::readWord(u32 address, Thread& thread) -> u32 {
   if(address <= 0x046f'ffff) return ioRead(address);
 
   if (unlikely(io.ioBusy)) {
+    debug(unusual, "[PI::readWord] PI read to 0x", hex(address, 8L), " will not behave as expected because PI writing is in progress");
     thread.step(writeForceFinish() * 2);
     return io.busLatch;
   }


### PR DESCRIPTION
Fixes most of the remaining failures in n64-systemtest