### PR TITLE
nall: correctly handle TCP peer disconnections in tcp-socket.cpp

### DIFF
--- a/nall/gdb/server.cpp
+++ b/nall/gdb/server.cpp
@@ -427,7 +427,6 @@ namespace nall::GDB {
 
     if(requestDisconnect) {
       requestDisconnect = false;
-      printf("GDB ending session, disconnecting client\n");
       if(!noAckMode) {
         sendText("+");
       }
@@ -500,11 +499,13 @@ namespace nall::GDB {
   }
 
   auto Server::onConnect() -> void {
+    printf("GDB client connected\n");
     resetClientData();
     hasActiveClient = true;
   }
 
   auto Server::onDisconnect() -> void {
+    printf("GDB client disconnected\n");
     hadHandshake = false;
     resetClientData();
   }

--- a/nall/tcptext/tcp-socket.cpp
+++ b/nall/tcptext/tcp-socket.cpp
@@ -212,7 +212,7 @@ NALL_HEADER_INLINE auto Socket::open(u32 port, bool useIPv4) -> bool {
 
     while(!stopServer) 
     {
-      if(fdClient < 0) {
+      if(fdClient < 0 || wantKickClient) {
         std::this_thread::sleep_for(std::chrono::milliseconds(CLIENT_SLEEP_MS));
         continue;
       }
@@ -227,6 +227,13 @@ NALL_HEADER_INLINE auto Socket::open(u32 port, bool useIPv4) -> bool {
 
         if constexpr(TCP_LOG_MESSAGES) {
           printf("%.4f | TCP <: [%d]: %.*s ([%d]: %.*s)\n", (f64)chrono::millisecond() / 1000.0, length, length, (char*)receiveBuffer.data(), length, length, (char*)packet);
+        }
+      } else if(length == 0) {
+        disconnectClient();
+      } else {
+        if (errno != EAGAIN) {
+          printf("TCP server: error receiving data from client: %s\n", strerror(errno));
+          disconnectClient();
         }
       }
     }


### PR DESCRIPTION
Currently, when a client disconnects, the server in Ares fails to notice and to call the onDisconnect hook, which in turns cause the server to stop responding (it won't accept a new client, and will never receive more data from the disconnected one).

This commit fixes it by correctly handling the recv() return code to detect peer disconnections (return value 0) and any other kind of error (return value < 0).