### PR TITLE
gba: improve save type detection for homebrew

### DIFF
--- a/mia/medium/game-boy-advance.cpp
+++ b/mia/medium/game-boy-advance.cpp
@@ -71,16 +71,7 @@ auto GameBoyAdvance::analyze(vector<u8>& rom) -> string {
   for(auto& identifier : identifiers) {
     for(s32 n : range(rom.size() - 16)) {
       if(!memory::compare(&rom[n], identifier.data(), identifier.size())) {
-        auto p = (const char*)&rom[n + identifier.size()];
-        if(p[0] >= '0' && p[0] <= '9'
-        && p[1] >= '0' && p[1] <= '9'
-        && p[2] >= '0' && p[2] <= '9'
-        ) {
-          char text[16];
-          memory::copy(text, &rom[n], identifier.size() + 3);
-          text[identifier.size() + 3] = 0;
-          if(!list.find(text)) list.append(text);
-        }
+        if(!list.find(identifier.data())) list.append(identifier.data());
       }
     }
   }


### PR DESCRIPTION
Commercial GBA games contain strings in the ROM that correspond to a save type (e.g. SRAM, flash memory, EEPROM), followed by 3 digits. These strings are used by ares to detect what save type to use. However, when running [jsmolka's SRAM and flash memory save tests](https://github.com/jsmolka/gba-tests/tree/master/save), ares does not detect a save type, since the programs lack the 3 digits at the end of the save type string. This PR ignores the trailing digits during save type detection, since it's likely that many other homebrew programs are affected by the same issue ([GBATEK even advises developers to not add digits when including save type strings](https://problemkaputt.de/gbatek-gba-cart-backup-ids.htm)).