### PR TITLE
nall: make gdb server accept only one connection at a time.

### DIFF
--- a/nall/tcptext/tcp-socket.hpp
+++ b/nall/tcptext/tcp-socket.hpp
@@ -27,7 +27,7 @@ class Socket {
 
     auto disconnectClient() -> void;
 
-    auto isStarted() const -> bool { return fdServer >= 0; }
+    auto isStarted() const -> bool { return serverRunning; }
     auto hasClient() const -> bool { return fdClient >= 0; }
 
     auto getURL(u32 port, bool useIPv4) const -> string;


### PR DESCRIPTION
This closes the socket server after each successful connection so that new connections are immediately refused. Before, given that the server socket was always in listen mode, one additional connection could always be estabilished at the TCP level, even though the server wouldn't accept it right away.