### PR TITLE
n64: reenable isviewer even outside of homebrew mode

### DIFF
--- a/ares/n64/cartridge/cartridge.cpp
+++ b/ares/n64/cartridge/cartridge.cpp
@@ -47,7 +47,7 @@ auto Cartridge::connect() -> void {
 
   rtc.load();
 
-  if(rom.size <= 0x03fe'ffff && system.homebrewMode) {
+  if(rom.size <= 0x03fe'ffff) {
     isviewer.ram.allocate(64_KiB);
     isviewer.tracer = node->append<Node::Debugger::Tracer::Notification>("ISViewer", "Cartridge");
     isviewer.tracer->setAutoLineBreak(false);

--- a/ares/n64/pi/bus.hpp
+++ b/ares/n64/pi/bus.hpp
@@ -98,8 +98,6 @@ inline auto PI::busWrite(u32 address, u32 data) -> void {
     if(cartridge.isviewer.enabled()) {
       writeForceFinish(); //Debugging channel for homebrew, be gentle
       return cartridge.isviewer.write<Size>(address, data);      
-    } else if (!system.homebrewMode) {
-      debug(unhandled, "[PI::busWrite] attempt to write to ISViewer: enable homebrew mode in settings to enable ISViewer emulation");
     } else {
       debug(unhandled, "[PI::busWrite] attempt to write to ISViewer: ROM is too big so ISViewer is disabled");
     }


### PR DESCRIPTION
ISViewer is currently gated by the homebrew mode flag. It seems like this is not ideal for rom hackers because they would still need a way to log but homebrew mode is too verbose for them and hide the ISViewer messages in streams of actual problems in game code that they don't intend to fix. So restore ISViewer functionality without homebrew mode.