### PR TITLE
Fixup *nix SDL info and makefile indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ ares supports additional audio drivers besides the ALSA drivers included above. 
 By default, GTK3 is used, but support for GTK2 is available. You will need to install the additional package `libgtk2.0-dev` as well as specifying the command line option `hiro=gtk2` at compile time.
 
 ###### SDL2 for input
-If you would like to use SDL for input, you will need to install the following the `libsdl2-dev` and `libsdl2-0.0` packages and perform a clean build of ares. You should then be able to select SDL for input in the Settings > Drivers menu.   
+If you would like to use SDL for input (e.g. for using a controller), you will need to install the `libsdl2-dev` and `libsdl2-2.0-0` packages and perform a clean build of ares.
+You should then be able to select SDL for input in the Settings > Drivers menu.
 
 ##### Building with clang
 

--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -7,15 +7,15 @@ ifeq ($(ruby),)
     ruby += audio.wasapi audio.xaudio2 audio.directsound audio.waveout #audio.asio
     ruby += input.windows
 
-  ifeq ($(pkg_config),)
-    # TODO: Check presence of libSDL
-  else
-    pkg_check = $(if $(shell $(pkg_config) $1 && echo 1),$2)
-    ifeq ($(sdl2),true)
-      ruby += $(call pkg_check,sdl2,input.sdl)
-      ruby += $(call pkg_check,sdl2,audio.sdl)
+    ifeq ($(pkg_config),)
+      # TODO: Check presence of libSDL
+    else
+      pkg_check = $(if $(shell $(pkg_config) $1 && echo 1),$2)
+      ifeq ($(sdl2),true)
+        ruby += $(call pkg_check,sdl2,input.sdl)
+        ruby += $(call pkg_check,sdl2,audio.sdl)
+      endif
     endif
-  endif
   else ifeq ($(platform),macos)
     ruby += video.cgl
     ruby += audio.openal


### PR DESCRIPTION
The readme references `libsdl2-0.0` which does not exist: https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libsdl2-0.0&searchon=names

I'm not sure it's even useful mentioning `libsdl2-2.0-0` since `libsdl2-dev` depends on it. Maybe for distributing ares you would then know people have to install `libsdl2-2.0-0` I guess

Also added a note that SDL2 input allows using a controller on *nix as I haven't seen that documented anywhere

And I fixed a random makefile indentation issue that messed with my head.