### PR TITLE
gba: improve horizontal sprite mosaic

### DIFF
--- a/ares/gba/ppu/object.cpp
+++ b/ares/gba/ppu/object.cpp
@@ -56,12 +56,12 @@ auto PPU::Objects::scanline(u32 y) -> void {
           }
         } else if(!buffer[bx].enable || object.priority < buffer[bx].priority) {
           buffer[bx].priority = object.priority;  //updated regardless of transparency
+          buffer[bx].mosaic = object.mosaic;  //updated regardless of transparency
           if(color) {
             if(object.colors == 0) color = object.palette * 16 + color;
             buffer[bx].enable = true;
             buffer[bx].color = ppu.pram[256 + color];
             buffer[bx].translucent = object.mode == 1;
-            buffer[bx].mosaic = object.mosaic;
           }
         }
       }
@@ -80,12 +80,15 @@ auto PPU::Objects::run(u32 x, u32 y) -> void {
   }
 
   output = buffer[x];
-
+  
   //horizontal mosaic
-  if(!output.mosaic || ++mosaicOffset >= 1 + io.mosaicWidth) {
+  if(mosaicOffset >= 1 + io.mosaicWidth) {
     mosaicOffset = 0;
     mosaic = output;
+  } else if(!mosaic.mosaic || !output.mosaic) {
+    mosaic = output;
   }
+  mosaicOffset++;
 }
 
 auto PPU::Objects::power() -> void {


### PR DESCRIPTION
Addresses a few cases where the current horizontal sprite mosaic implementation is incorrect:

- Transparent pixels should be affected by horizontal sprite mosaic effects
- If the latched pixel does not have the sprite mosaic effect enabled, the next pixel should always be latched
- Mosaic offset should not be reset to 0 at the start of a new horizontal mosaic effect

Accounting for these cases improves visual accuracy of sprite mosaic effects. This is easily visible in test cases such as [sprite-hmosaic.gba](https://github.com/nba-emu/hw-test/tree/master/ppu/sprite-hmosaic), and [Tonc's mosaic demo](https://www.coranac.com/projects/#tonc) (mos_demo.gba, from tonc-bin.zip v1.4.2).