### PR TITLE
Continue if xcode-select fails building SDL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: Build
 on:
-  push:
-    branches: [ master ]
-    tags: [ 'v*' ]
-  pull_request:
-    branches: [ master ]
+  push
 jobs:
   build:
     strategy:

--- a/thirdparty/SDL/build-sdl.sh
+++ b/thirdparty/SDL/build-sdl.sh
@@ -9,11 +9,15 @@ fi
 git -C SDL reset --hard "$(cat HEAD)"
 mkdir -p SDL/build
 pushd SDL/build
-sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+if [ -n "${GITHUB_ACTIONS+1}" ]; then
+    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+fi
 cmake .. "-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64" \
           -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11
 cmake --build .
-sudo cmake --install .
-sudo xcode-select -s /Applications/Xcode_14.2.app/Contents/Developer
+#sudo cmake --install .
+if [ -n "${GITHUB_ACTIONS+1}" ]; then
+    sudo xcode-select -s /Applications/Xcode_14.2.app/Contents/Developer
+fi
 popd
 cp SDL/build/libSDL2-2.0.0.dylib .


### PR DESCRIPTION
The `build-SDL.sh` script I added was not fit for local builds because it selects specific Xcode builds that are only normally present on CI machines. This PR changes the script to continue if those commands fail, allowing `./buildSDL.sh` to work without modifications for users building locally.