### PR TITLE
n64: revert previous commit (add HLE RDRAM initialization)

### DIFF
--- a/ares/n64/ri/ri.cpp
+++ b/ares/n64/ri/ri.cpp
@@ -25,6 +25,10 @@ auto RI::power(bool reset) -> void {
     io.config  = 0x40;
     io.select  = 0x14;
     io.refresh = 0x0006'3634;
+
+    //store RDRAM size result into memory
+    rdram.ram.write<Word>(0x318, rdram.ram.size, "IPL3");  //CIC-NUS-6102
+    rdram.ram.write<Word>(0x3f0, rdram.ram.size, "IPL3");  //CIC-NUS-6105
   }
 }
 


### PR DESCRIPTION
This is actually still required as we still skip RDRAM initialization anyway and proprietary IPL3 doesn't initialize the RAM size in this case.