### PR TITLE
gba: timer 0 count-up bit cannot be set

### DIFF
--- a/ares/gba/cpu/io.cpp
+++ b/ares/gba/cpu/io.cpp
@@ -309,9 +309,10 @@ auto CPU::writeIO(n32 address, n8 data) -> void {
     bool enable = timer().enable;
 
     timer().frequency = data.bit(0,1);
-    timer().cascade   = data.bit(2);
     timer().irq       = data.bit(6);
     timer().enable    = data.bit(7);
+
+    if(address != 0x0400'0102) timer().cascade = data.bit(2);
 
     if(!enable && timer().enable) {  //0->1 transition
       timer().pending = true;


### PR DESCRIPTION
The count-up bit for timer 0 cannot be set on hardware ([test ROM](https://github.com/png183/gba-tests/blob/master/timer/timer_check_count_up_presence.gba)). This PR implements said behaviour in ares, preventing timer 0 from incorrectly halting if this bit is written.