### PR TITLE
Make macOS SDL build portable, build script runnable locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ obj-amd64/
 obj-arm64/
 out-amd64/
 out-arm64/
+thirdparty/SDL/SDL
+thirdparty/SDL/libSDL2-2.0.0.dylib

--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -26,6 +26,7 @@ ifeq ($(ruby),)
       ifeq ($(wildcard $(macsdl)),)
         $(error Tried to compile ruby for macOS with SDL2 linked, but no SDL2 library was found. Compile it with thirdparty/SDL/build-sdl.sh, or disable SDL by compiling ares with sdl2=false)
       endif
+      flags += -DMACOS_COMPILED_SDL
       ruby += audio.sdl
       ruby += input.sdl
     endif
@@ -63,6 +64,9 @@ endif
 
 ifeq ($(platform),macos)
   ruby.flags := $(flags.objcpp)
+  ifeq ($(sdl2),true)
+    ruby.flags += -I ../thirdparty/SDL/SDL/include/
+  endif
 else
   ruby.flags := $(flags.cpp)
 endif
@@ -71,7 +75,7 @@ ruby.flags += -I../thirdparty
 ruby.flags += $(foreach c,$(subst .,_,$(call strupper,$(ruby))),-D$c)
 ifeq ($(pkg_config),)
   # TODO: add SDL2 cflags
-else
+else ifeq ($(wildcard $(macsdl)),)
   ruby.flags += $(if $(findstring input.sdl,$(ruby)),$(shell $(pkg_config) sdl2 --cflags))
   ruby.flags += $(if $(findstring audio.sdl,$(ruby)),$(shell $(pkg_config) sdl2 --cflags))
 endif
@@ -100,7 +104,7 @@ ifeq ($(platform),windows)
     ruby.options += $(if $(findstring input.sdl,$(ruby)),$(shell $(pkg_config) sdl2 --libs --static))
     ruby.options += $(if $(findstring audio.sdl,$(ruby)),$(shell $(pkg_config) sdl2 --libs --static))
   endif
-else
+else ifeq ($(wildcard $(macsdl)),)
   ruby.options += $(if $(findstring input.sdl,$(ruby)),$(shell $(pkg_config) sdl2 --libs))
   ruby.options += $(if $(findstring audio.sdl,$(ruby)),$(shell $(pkg_config) sdl2 --libs))
 endif
@@ -116,6 +120,9 @@ endif
 ifeq ($(platform),macos)
   ruby.options += -framework IOKit
   ruby.options += $(if $(findstring audio.openal,$(ruby)),-framework OpenAL)
+  ifeq ($(sdl2),true)
+    ruby.options += -L../thirdparty/SDL/ -lSDL2-2.0.0
+  endif
 endif
 
 ifeq ($(platform),linux)

--- a/ruby/audio/sdl.cpp
+++ b/ruby/audio/sdl.cpp
@@ -1,4 +1,8 @@
+#if defined(MACOS_COMPILED_SDL)
+#include "SDL.h"
+#else
 #include <SDL2/SDL.h>
+#endif
 
 struct AudioSDL : AudioDriver {
   AudioSDL& self = *this;

--- a/ruby/input/sdl.cpp
+++ b/ruby/input/sdl.cpp
@@ -1,4 +1,8 @@
+#if defined(MACOS_COMPILED_SDL)
+#include "SDL.h"
+#else
 #include <SDL2/SDL.h>
+#endif
 
 #if defined(PLATFORM_WINDOWS)
 #include "shared/rawinput.cpp"

--- a/thirdparty/SDL/build-sdl.sh
+++ b/thirdparty/SDL/build-sdl.sh
@@ -9,11 +9,18 @@ fi
 git -C SDL reset --hard "$(cat HEAD)"
 mkdir -p SDL/build
 pushd SDL/build
-sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+
+if [ -n "${GITHUB_ACTIONS+1}" ]; then
+    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+    echo "Set Xcode version in order to target macOS 10.11 when building SDL."
+fi
 cmake .. "-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64" \
           -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11
 cmake --build .
-sudo cmake --install .
-sudo xcode-select -s /Applications/Xcode_14.2.app/Contents/Developer
+
+if [ -n "${GITHUB_ACTIONS+1}" ]; then
+    sudo xcode-select -s /Applications/Xcode_14.2.app/Contents/Developer
+    echo "Set Xcode to 14.2 to continue build."
+fi
 popd
 cp SDL/build/libSDL2-2.0.0.dylib .


### PR DESCRIPTION
Resubmission of https://github.com/ares-emulator/ares/pull/1389 with improvements.

Now the SDL build script will not call `xcode-select`, which can have undesired effects on the user build environment, unless it is on CI (detected with the `$GITHUB_ACTIONS` env var).

It will also not call ``cmake --install .``, which would previously replace the user's SDL installation.

This second change required some minor changes to ruby's makefile. We now include the header directory from the cloned SDL source, and inform the linker correctly of the location of the SDL .dylib.

Also added the cloned SDL repository and .dylib to the .gitignore for easier development workflow.

To ensure compatibility with https://github.com/ares-emulator/ares/pull/1390, the `MACOS_COMPILED_SDL` flag is added so we can include the proper "SDL.h" header for compiled builds and `<SDL2/SDL.h>` header for system builds.