### PR TITLE
Borderless Mode (Windows)

### DIFF
--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -64,6 +64,10 @@ auto nall::main(Arguments arguments) -> void {
     return settings.paths.saves;
   });
 
+#if defined(PLATFORM_WINDOWS)
+  u32 SettingsGeneralsBorderless = 0;
+#endif 
+
   if(arguments.take("--fullscreen")) {
     program.startFullScreen = true;
   }
@@ -112,11 +116,14 @@ auto nall::main(Arguments arguments) -> void {
     print("  --terminal           Create new terminal window\n");
 #endif
     print("  --fullscreen         Start in full screen mode\n");
+#if defined(PLATFORM_WINDOWS)	
+    print("  --no/--Borderless    Disable/Enable Borderless Window");
+#endif	
     print("  --system name        Specify the system name\n");
     print("  --shader name        Specify the name of the shader to use\n");
     print("  --setting name=value Specify a value for a setting\n");
     print("  --dump-all-settings  Show a list of all existing settings and exit\n");
-    print("  --no-file-prompt     Do not prompt to load (optional) additional roms (eg: 64DD)\n");
+    print("  --no-file-prompt     Do not prompt to load (optional) additional roms (eg: 64DD)\n");	
     print("\n");
     print("Available Systems:\n");
     print("  ");
@@ -126,7 +133,19 @@ auto nall::main(Arguments arguments) -> void {
     print("\n");
     return;
   }
-
+  
+#if defined(PLATFORM_WINDOWS)	
+    // Randloses Fenster Commandline --------- BEGIN
+    if (argument == "--noBorderless") {
+        settings.general.sBorderless = false;
+		SettingsGeneralsBorderless = 1;
+    }	
+    if (argument == "--Borderless") {
+        settings.general.sBorderless = true;
+		SettingsGeneralsBorderless = 2;
+    }
+#endif
+	
   if(arguments.take("--dump-all-settings")) {
     function<void(const Markup::Node&, string)> dump;
     dump = [&](const Markup::Node& node, string prefix) -> void {
@@ -144,6 +163,17 @@ auto nall::main(Arguments arguments) -> void {
     if(file::exists(argument)) program.startGameLoad.append(argument);
   }
 
+#if defined(PLATFORM_WINDOWS)	
+ /* Force and Change Settings By Commandline */
+  if ( SettingsGeneralsBorderless > 0)
+  {
+	  if ( SettingsGeneralsBorderless == 1)
+		   settings.general.sBorderless = false;
+	   
+	  if ( SettingsGeneralsBorderless == 2)	   
+		   settings.general.sBorderless = true;
+  }
+#endif  
   Instances::presentation.construct();
   Instances::settingsWindow.construct();
   Instances::toolsWindow.construct();

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -64,10 +64,6 @@ auto nall::main(Arguments arguments) -> void {
     return settings.paths.saves;
   });
 
-#if defined(PLATFORM_WINDOWS)
-  u32 SettingsGeneralsBorderless = 0;
-#endif 
-
   if(arguments.take("--fullscreen")) {
     program.startFullScreen = true;
   }
@@ -123,7 +119,7 @@ auto nall::main(Arguments arguments) -> void {
     print("  --shader name        Specify the name of the shader to use\n");
     print("  --setting name=value Specify a value for a setting\n");
     print("  --dump-all-settings  Show a list of all existing settings and exit\n");
-    print("  --no-file-prompt     Do not prompt to load (optional) additional roms (eg: 64DD)\n");	
+    print("  --no-file-prompt     Do not prompt to load (optional) additional roms (eg: 64DD)\n");
     print("\n");
     print("Available Systems:\n");
     print("  ");
@@ -135,17 +131,14 @@ auto nall::main(Arguments arguments) -> void {
   }
   
 #if defined(PLATFORM_WINDOWS)	
-    // Randloses Fenster Commandline --------- BEGIN
-    if (arguments.take("--noBorderless")) {
-        settings.general.sBorderless = false;
-		SettingsGeneralsBorderless = 1;
-    }	
-    if (arguments.take("--Borderless")) {
-        settings.general.sBorderless = true;
-		SettingsGeneralsBorderless = 2;
+    if(arguments.take("--noBorderless")) {
+        settings.general.borderless = false;
+    }
+    if(arguments.take("--Borderless")) {
+        settings.general.borderless = true;
     }
 #endif
-	
+
   if(arguments.take("--dump-all-settings")) {
     function<void(const Markup::Node&, string)> dump;
     dump = [&](const Markup::Node& node, string prefix) -> void {
@@ -163,17 +156,6 @@ auto nall::main(Arguments arguments) -> void {
     if(file::exists(argument)) program.startGameLoad.append(argument);
   }
 
-#if defined(PLATFORM_WINDOWS)	
- /* Force and Change Settings By Commandline */
-  if ( SettingsGeneralsBorderless > 0)
-  {
-	  if ( SettingsGeneralsBorderless == 1)
-		   settings.general.sBorderless = false;
-	   
-	  if ( SettingsGeneralsBorderless == 2)	   
-		   settings.general.sBorderless = true;
-  }
-#endif  
   Instances::presentation.construct();
   Instances::settingsWindow.construct();
   Instances::toolsWindow.construct();

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -136,11 +136,11 @@ auto nall::main(Arguments arguments) -> void {
   
 #if defined(PLATFORM_WINDOWS)	
     // Randloses Fenster Commandline --------- BEGIN
-    if (argument == "--noBorderless") {
+    if (arguments.take("--noBorderless")) {
         settings.general.sBorderless = false;
 		SettingsGeneralsBorderless = 1;
     }	
-    if (argument == "--Borderless") {
+    if (arguments.take("--Borderless")) {
         settings.general.sBorderless = true;
 		SettingsGeneralsBorderless = 2;
     }

--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -139,6 +139,13 @@ auto InputManager::createHotkeys() -> void {
     if(!emulator) return;
     if(settings.audio.volume >= (f64)(0.1)) settings.audio.volume -= (f64)(0.1);
   }));
+
+#if defined(PLATFORM_WINDOWS)  
+  hotkeys.append(InputHotkey("Fork Borderless Window").onPress([&] {
+      program.UpdateBorderless();
+	  settings.save(); /* Marty Shepard Speichert aktuell die gewählten Einstellung*/
+  }));  
+#endif
 }
 
 auto InputManager::pollHotkeys() -> void {

--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -140,11 +140,10 @@ auto InputManager::createHotkeys() -> void {
     if(settings.audio.volume >= (f64)(0.1)) settings.audio.volume -= (f64)(0.1);
   }));
 
-#if defined(PLATFORM_WINDOWS)  
-  hotkeys.append(InputHotkey("Fork Borderless Window").onPress([&] {
-      program.UpdateBorderless();
-	  settings.save();
-  }));  
+#if defined(PLATFORM_WINDOWS)
+  hotkeys.append(InputHotkey("Toggle Borderless Window").onPress([&] {
+    program.updateBorderless();
+  }));
 #endif
 }
 

--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -143,7 +143,7 @@ auto InputManager::createHotkeys() -> void {
 #if defined(PLATFORM_WINDOWS)  
   hotkeys.append(InputHotkey("Fork Borderless Window").onPress([&] {
       program.UpdateBorderless();
-	  settings.save(); /* Marty Shepard Speichert aktuell die gewählten Einstellung*/
+	  settings.save();
   }));  
 #endif
 }

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -101,7 +101,6 @@ Presentation::Presentation() {
     if(visible()) resizeWindow();
   }).doToggle();
 #if defined(PLATFORM_WINDOWS)    
-   //------------------------- Marty Shepard Borderless Begin 
   showBorderlessSetting.setText("Borderless Window").setChecked(settings.general.sBorderless).onToggle([&] {
       settings.general.sBorderless = showBorderlessSetting.checked();
       if (!showBorderlessSetting.checked()) {
@@ -111,9 +110,8 @@ Presentation::Presentation() {
         Window::setBorderless(true);
       }
       if (visible()) resizeWindow();
-	  settings.save(); /* Marty Shepard Speichert aktuell die gewählten Einstellung*/	  
+	  settings.save();
       }).doToggle();
-	//------------------------- Shepard Borderless END
 #endif
   videoSettingsAction.setText("Video" ELLIPSIS).setIcon(Icon::Device::Display).onActivate([&] {
     settingsWindow.show("Video");

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -100,6 +100,21 @@ Presentation::Presentation() {
     }
     if(visible()) resizeWindow();
   }).doToggle();
+#if defined(PLATFORM_WINDOWS)    
+   //------------------------- Marty Shepard Borderless Begin 
+  showBorderlessSetting.setText("Borderless Window").setChecked(settings.general.sBorderless).onToggle([&] {
+      settings.general.sBorderless = showBorderlessSetting.checked();
+      if (!showBorderlessSetting.checked()) {
+		Window::setBorderless(false);  	  
+      }
+      else {
+        Window::setBorderless(true);
+      }
+      if (visible()) resizeWindow();
+	  settings.save(); /* Marty Shepard Speichert aktuell die gewählten Einstellung*/	  
+      }).doToggle();
+	//------------------------- Shepard Borderless END
+#endif
   videoSettingsAction.setText("Video" ELLIPSIS).setIcon(Icon::Device::Display).onActivate([&] {
     settingsWindow.show("Video");
   });

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -101,17 +101,15 @@ Presentation::Presentation() {
     if(visible()) resizeWindow();
   }).doToggle();
 #if defined(PLATFORM_WINDOWS)    
-  showBorderlessSetting.setText("Borderless Window").setChecked(settings.general.sBorderless).onToggle([&] {
-      settings.general.sBorderless = showBorderlessSetting.checked();
-      if (!showBorderlessSetting.checked()) {
-		Window::setBorderless(false);  	  
-      }
-      else {
-        Window::setBorderless(true);
-      }
-      if (visible()) resizeWindow();
-	  settings.save();
-      }).doToggle();
+  showBorderlessSetting.setText("Borderless Window").setChecked(settings.general.borderless).onToggle([&] {
+    settings.general.borderless = showBorderlessSetting.checked();
+    if(!showBorderlessSetting.checked()) {
+      Window::setBorderless(false);
+    }else{
+      Window::setBorderless(true);
+    }
+    if(visible()) resizeWindow();
+  }).doToggle();
 #endif
   videoSettingsAction.setText("Video" ELLIPSIS).setIcon(Icon::Device::Display).onActivate([&] {
     settingsWindow.show("Video");

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -41,7 +41,7 @@ struct Presentation : Window {
       MenuCheckItem muteAudioSetting{&settingsMenu};
       MenuCheckItem showStatusBarSetting{&settingsMenu};
 #if defined(PLATFORM_WINDOWS)  	  
-      MenuCheckItem showBorderlessSetting{&settingsMenu};	// Marty Shepard Show/Hide Borderless 	  
+      MenuCheckItem showBorderlessSetting{&settingsMenu};
 #endif	  
       MenuSeparator audioSettingsSeparator{&settingsMenu};
       MenuItem videoSettingsAction{&settingsMenu};

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -40,6 +40,9 @@ struct Presentation : Window {
       MenuSeparator groupSettingsSeparatpr{&settingsMenu};
       MenuCheckItem muteAudioSetting{&settingsMenu};
       MenuCheckItem showStatusBarSetting{&settingsMenu};
+#if defined(PLATFORM_WINDOWS)  	  
+      MenuCheckItem showBorderlessSetting{&settingsMenu};	// Marty Shepard Show/Hide Borderless 	  
+#endif	  
       MenuSeparator audioSettingsSeparator{&settingsMenu};
       MenuItem videoSettingsAction{&settingsMenu};
       MenuItem audioSettingsAction{&settingsMenu};

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -31,7 +31,7 @@ struct Program : ares::Platform {
   auto updateMessage() -> void;
   auto showMessage(const string&) -> void;
 #if defined(PLATFORM_WINDOWS)    
-  auto UpdateBorderless() -> void;  			//------------------------- Marty Shepard Borderless  
+  auto UpdateBorderless() -> void;
 #endif
 
   //utility.cpp

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -30,6 +30,9 @@ struct Program : ares::Platform {
   //status.cpp
   auto updateMessage() -> void;
   auto showMessage(const string&) -> void;
+#if defined(PLATFORM_WINDOWS)    
+  auto UpdateBorderless() -> void;  			//------------------------- Marty Shepard Borderless  
+#endif
 
   //utility.cpp
   auto pause(bool) -> void;

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -31,7 +31,7 @@ struct Program : ares::Platform {
   auto updateMessage() -> void;
   auto showMessage(const string&) -> void;
 #if defined(PLATFORM_WINDOWS)    
-  auto UpdateBorderless() -> void;
+  auto updateBorderless() -> void;
 #endif
 
   //utility.cpp

--- a/desktop-ui/program/status.cpp
+++ b/desktop-ui/program/status.cpp
@@ -28,3 +28,21 @@ auto Program::showMessage(const string& text) -> void {
   messages.append({chrono::millisecond(), text});
   printf("%s\n", (const char*)text);
 }
+#if defined(PLATFORM_WINDOWS)    
+//------------------------- Marty2Life Borderless BEG
+auto Program::UpdateBorderless()  -> void {
+	    
+	if (settings.general.sBorderless == true){
+        settings.general.sBorderless = false;
+        presentation.Window::setBorderless(false);        
+        presentation.showBorderlessSetting.setChecked(false);
+    }
+    else {
+        settings.general.sBorderless = true;
+        presentation.Window::setBorderless(true);  
+        presentation.showBorderlessSetting.setChecked(true);
+    }
+    if (presentation.visible()) presentation.resizeWindow();   
+}
+//------------------------- Marty2Life Borderless END
+#endif

--- a/desktop-ui/program/status.cpp
+++ b/desktop-ui/program/status.cpp
@@ -29,7 +29,6 @@ auto Program::showMessage(const string& text) -> void {
   printf("%s\n", (const char*)text);
 }
 #if defined(PLATFORM_WINDOWS)    
-//------------------------- Marty2Life Borderless BEG
 auto Program::UpdateBorderless()  -> void {
 	    
 	if (settings.general.sBorderless == true){
@@ -44,5 +43,4 @@ auto Program::UpdateBorderless()  -> void {
     }
     if (presentation.visible()) presentation.resizeWindow();   
 }
-//------------------------- Marty2Life Borderless END
 #endif

--- a/desktop-ui/program/status.cpp
+++ b/desktop-ui/program/status.cpp
@@ -28,19 +28,17 @@ auto Program::showMessage(const string& text) -> void {
   messages.append({chrono::millisecond(), text});
   printf("%s\n", (const char*)text);
 }
-#if defined(PLATFORM_WINDOWS)    
-auto Program::UpdateBorderless()  -> void {
-	    
-	if (settings.general.sBorderless == true){
-        settings.general.sBorderless = false;
-        presentation.Window::setBorderless(false);        
-        presentation.showBorderlessSetting.setChecked(false);
-    }
-    else {
-        settings.general.sBorderless = true;
-        presentation.Window::setBorderless(true);  
-        presentation.showBorderlessSetting.setChecked(true);
-    }
-    if (presentation.visible()) presentation.resizeWindow();   
+#if defined(PLATFORM_WINDOWS)
+auto Program::updateBorderless() -> void {
+  bool state = settings.general.borderless ? false : true;
+  if(!state){
+    presentation.Window::setBorderless(false);
+    presentation.showBorderlessSetting.setChecked(false);
+  } else {
+    presentation.Window::setBorderless(true);
+    presentation.showBorderlessSetting.setChecked(true);
+  }
+  settings.general.borderless  = state;
+  if(presentation.visible()) presentation.resizeWindow();
 }
 #endif

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -101,7 +101,7 @@ auto Settings::process(bool load) -> void {
   bind(boolean, "General/AutoSaveMemory", general.autoSaveMemory);
   bind(boolean, "General/HomebrewMode", general.homebrewMode);
 #if defined(PLATFORM_WINDOWS)    
-  bind(boolean, "General/Borderless", general.sBorderless);  // Marty Shepard Borderless
+  bind(boolean, "General/Borderless", general.sBorderless);
 #endif  
 
   bind(natural, "Rewind/Length", rewind.length);

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -100,9 +100,9 @@ auto Settings::process(bool load) -> void {
   bind(boolean, "General/RunAhead", general.runAhead);
   bind(boolean, "General/AutoSaveMemory", general.autoSaveMemory);
   bind(boolean, "General/HomebrewMode", general.homebrewMode);
-#if defined(PLATFORM_WINDOWS)    
-  bind(boolean, "General/Borderless", general.sBorderless);
-#endif  
+#if defined(PLATFORM_WINDOWS)
+  bind(boolean, "General/Borderless", general.borderless);
+#endif
 
   bind(natural, "Rewind/Length", rewind.length);
   bind(natural, "Rewind/Frequency", rewind.frequency);

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -100,6 +100,9 @@ auto Settings::process(bool load) -> void {
   bind(boolean, "General/RunAhead", general.runAhead);
   bind(boolean, "General/AutoSaveMemory", general.autoSaveMemory);
   bind(boolean, "General/HomebrewMode", general.homebrewMode);
+#if defined(PLATFORM_WINDOWS)    
+  bind(boolean, "General/Borderless", general.sBorderless);  // Marty Shepard Borderless
+#endif  
 
   bind(natural, "Rewind/Length", rewind.length);
   bind(natural, "Rewind/Frequency", rewind.frequency);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -66,6 +66,9 @@ struct Settings : Markup::Node {
     bool runAhead = false;
     bool autoSaveMemory = true;
     bool homebrewMode = false;
+#if defined(PLATFORM_WINDOWS)    	
+	bool sBorderless = false;           // Marty Shepard Borderless
+#endif
   } general;
 
   struct Rewind {

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -67,7 +67,7 @@ struct Settings : Markup::Node {
     bool autoSaveMemory = true;
     bool homebrewMode = false;
 #if defined(PLATFORM_WINDOWS)    	
-	bool sBorderless = false;           // Marty Shepard Borderless
+	bool sBorderless = false;
 #endif
   } general;
 

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -66,8 +66,8 @@ struct Settings : Markup::Node {
     bool runAhead = false;
     bool autoSaveMemory = true;
     bool homebrewMode = false;
-#if defined(PLATFORM_WINDOWS)    	
-	bool sBorderless = false;
+#if defined(PLATFORM_WINDOWS)
+    bool borderless = false;
 #endif
   } general;
 

--- a/hiro/core/shared.hpp
+++ b/hiro/core/shared.hpp
@@ -905,6 +905,7 @@ struct Window : sWindow {
   auto append(sStatusBar statusBar) { return self().append(statusBar), *this; }
   auto backgroundColor() const { return self().backgroundColor(); }
   auto dismissable() const { return self().dismissable(); }
+  auto borderless() const { return self().borderless(); }  						/* Marty Shepard Borderless */    
   auto doClose() const { return self().doClose(); }
   auto doDrop(vector<string> names) const { return self().doDrop(names); }
   auto doKeyPress(s32 key) const { return self().doKeyPress(key); }
@@ -937,6 +938,7 @@ struct Window : sWindow {
   auto setAlignment(Alignment alignment = Alignment::Center) { return self().setAlignment(alignment), *this; }
   auto setAlignment(sWindow relativeTo, Alignment alignment = Alignment::Center) { return self().setAlignment(relativeTo, alignment), *this; }
   auto setBackgroundColor(Color color = {}) { return self().setBackgroundColor(color), *this; }
+  auto setBorderless(bool borderless = true) { return self().setBorderless(borderless), *this; }			/* Marty Shepard Borderless */	  
   auto setDismissable(bool dismissable = true) { return self().setDismissable(dismissable), *this; }
   auto setDroppable(bool droppable = true) { return self().setDroppable(droppable), *this; }
   auto setFrameGeometry(Geometry geometry) { return self().setFrameGeometry(geometry), *this; }

--- a/hiro/core/shared.hpp
+++ b/hiro/core/shared.hpp
@@ -904,8 +904,8 @@ struct Window : sWindow {
   auto append(sSizable sizable) { return self().append(sizable), *this; }
   auto append(sStatusBar statusBar) { return self().append(statusBar), *this; }
   auto backgroundColor() const { return self().backgroundColor(); }
+  auto borderless() const { return self().borderless(); }  
   auto dismissable() const { return self().dismissable(); }
-  auto borderless() const { return self().borderless(); }  						/* Marty Shepard Borderless */    
   auto doClose() const { return self().doClose(); }
   auto doDrop(vector<string> names) const { return self().doDrop(names); }
   auto doKeyPress(s32 key) const { return self().doKeyPress(key); }
@@ -938,7 +938,7 @@ struct Window : sWindow {
   auto setAlignment(Alignment alignment = Alignment::Center) { return self().setAlignment(alignment), *this; }
   auto setAlignment(sWindow relativeTo, Alignment alignment = Alignment::Center) { return self().setAlignment(relativeTo, alignment), *this; }
   auto setBackgroundColor(Color color = {}) { return self().setBackgroundColor(color), *this; }
-  auto setBorderless(bool borderless = true) { return self().setBorderless(borderless), *this; }			/* Marty Shepard Borderless */	  
+  auto setBorderless(bool borderless = true) { return self().setBorderless(borderless), *this; }
   auto setDismissable(bool dismissable = true) { return self().setDismissable(dismissable), *this; }
   auto setDroppable(bool droppable = true) { return self().setDroppable(droppable), *this; }
   auto setFrameGeometry(Geometry geometry) { return self().setFrameGeometry(geometry), *this; }

--- a/hiro/core/window.cpp
+++ b/hiro/core/window.cpp
@@ -388,7 +388,7 @@ auto mWindow::statusBar() const -> StatusBar {
 auto mWindow::title() const -> string {
   return state.title;
 }
-/* Marty Shepard Borderless BEG */
+
 auto mWindow::borderless() const -> bool {
   return state.borderless;
 }
@@ -398,5 +398,5 @@ auto mWindow::setBorderless(bool borderless) -> type& {
   signal(setBorderless, borderless);
   return *this;
 }
-/* Marty Shepard Borderless END */
+
 #endif

--- a/hiro/core/window.cpp
+++ b/hiro/core/window.cpp
@@ -388,5 +388,15 @@ auto mWindow::statusBar() const -> StatusBar {
 auto mWindow::title() const -> string {
   return state.title;
 }
+/* Marty Shepard Borderless BEG */
+auto mWindow::borderless() const -> bool {
+  return state.borderless;
+}
 
+auto mWindow::setBorderless(bool borderless) -> type& {
+  state.borderless = borderless;
+  signal(setBorderless, borderless);
+  return *this;
+}
+/* Marty Shepard Borderless END */
 #endif

--- a/hiro/core/window.hpp
+++ b/hiro/core/window.hpp
@@ -10,6 +10,7 @@ struct mWindow : mObject {
   auto append(sStatusBar statusBar) -> type&;
   auto backgroundColor() const -> Color;
   auto dismissable() const -> bool;
+  auto borderless() const -> bool;							/* Marty Shepard Borderless */    
   auto doClose() const -> void;
   auto doDrop(vector<string>) const -> void;
   auto doKeyPress(s32) const -> void;
@@ -43,6 +44,7 @@ struct mWindow : mObject {
   auto setAlignment(sWindow relativeTo, Alignment = Alignment::Center) -> type&;
   auto setBackgroundColor(Color color = {}) -> type&;
   auto setDismissable(bool dismissable = true) -> type&;
+  auto setBorderless(bool borderless = true) -> type&;  		/* Marty Shepard Borderless */    
   auto setDroppable(bool droppable = true) -> type&;
   auto setFrameGeometry(Geometry geometry) -> type&;
   auto setFramePosition(Position position) -> type&;
@@ -65,11 +67,14 @@ struct mWindow : mObject {
   auto sizable() const -> Sizable;
   auto statusBar() const -> StatusBar;
   auto title() const -> string;
+  
+
 
 //private:
   struct State {
     Color backgroundColor;
     bool dismissable = false;
+	bool borderless = false;								/* Marty Shepard Borderless */  	
     bool droppable = false;
     bool fullScreen = false;
     Geometry geometry = {128, 128, 256, 256};

--- a/hiro/core/window.hpp
+++ b/hiro/core/window.hpp
@@ -9,8 +9,8 @@ struct mWindow : mObject {
   auto append(sSizable sizable) -> type&;
   auto append(sStatusBar statusBar) -> type&;
   auto backgroundColor() const -> Color;
+  auto borderless() const -> bool;  
   auto dismissable() const -> bool;
-  auto borderless() const -> bool;							/* Marty Shepard Borderless */    
   auto doClose() const -> void;
   auto doDrop(vector<string>) const -> void;
   auto doKeyPress(s32) const -> void;
@@ -43,8 +43,8 @@ struct mWindow : mObject {
   auto setAlignment(Alignment = Alignment::Center) -> type&;
   auto setAlignment(sWindow relativeTo, Alignment = Alignment::Center) -> type&;
   auto setBackgroundColor(Color color = {}) -> type&;
+  auto setBorderless(bool borderless = true) -> type&;  
   auto setDismissable(bool dismissable = true) -> type&;
-  auto setBorderless(bool borderless = true) -> type&;  		/* Marty Shepard Borderless */    
   auto setDroppable(bool droppable = true) -> type&;
   auto setFrameGeometry(Geometry geometry) -> type&;
   auto setFramePosition(Position position) -> type&;
@@ -73,8 +73,8 @@ struct mWindow : mObject {
 //private:
   struct State {
     Color backgroundColor;
-    bool dismissable = false;
-	bool borderless = false;								/* Marty Shepard Borderless */  	
+	bool borderless = false; 	
+    bool dismissable = false;	
     bool droppable = false;
     bool fullScreen = false;
     Geometry geometry = {128, 128, 256, 256};

--- a/hiro/core/window.hpp
+++ b/hiro/core/window.hpp
@@ -67,13 +67,11 @@ struct mWindow : mObject {
   auto sizable() const -> Sizable;
   auto statusBar() const -> StatusBar;
   auto title() const -> string;
-  
-
 
 //private:
   struct State {
     Color backgroundColor;
-	bool borderless = false; 	
+    bool borderless = false;
     bool dismissable = false;	
     bool droppable = false;
     bool fullScreen = false;

--- a/hiro/windows/window.cpp
+++ b/hiro/windows/window.cpp
@@ -86,7 +86,13 @@ auto pWindow::frameMargin(s32 width) const -> Geometry {
     SendMessage(hwnd, WM_NCCALCSIZE, (WPARAM)false, (LPARAM)&rcTemp);
     //adjust our previous calculation to compensate for menu wrapping
     rc.bottom += rcTemp.top;
-  }
+  } else {
+  /* Marty Shephard Borderless BEG */
+    if (bBorderLess){
+	  rc.bottom = 458; // TODO Hardcoded ...
+    }
+  }  
+  /* Marty Shephard Borderless END */	  
   auto& efb = state().fullScreen ? settings.efbPopup : !state().resizable ? settings.efbFixed : settings.efbResizable;
   return {
     abs(rc.left) - efb.x,
@@ -422,9 +428,12 @@ auto pWindow::_statusHeight() const -> s32 {
   }
   return height;
 }
-/* Marty Shepard Borderless Beg */
+/* Marty Shephard Borderless Beg */
 
 enum class Style : DWORD {
+	windowed			= WS_OVERLAPPEDWINDOW	| WS_THICKFRAME	| WS_CAPTION 	| WS_SYSMENU 	| WS_MINIMIZEBOX 	| WS_MAXIMIZEBOX,
+    aero_borderless	= WS_POPUP			| WS_THICKFRAME	| WS_CAPTION 	| WS_SYSMENU 	| WS_MAXIMIZEBOX 	| WS_MINIMIZEBOX,
+    basic_borderless	= WS_POPUP			| WS_THICKFRAME	| WS_SYSMENU 	| WS_MAXIMIZEBOX 	| WS_MINIMIZEBOX,
 	FixedStyle		= WS_SYSMENU 		| WS_CAPTION 	| WS_MINIMIZEBOX 	| WS_BORDER 		| WS_CLIPCHILDREN,
 	ResizableStyle	= WS_SYSMENU 		| WS_CAPTION 	| WS_MINIMIZEBOX 	| WS_MAXIMIZEBOX 	| WS_THICKFRAME 	| WS_CLIPCHILDREN,
 	Marty_Borderless	= WS_POPUP			| WS_VISIBLE 	| WS_CLIPSIBLINGS ,		
@@ -465,7 +474,7 @@ auto pWindow::setBorderless(bool borderless) -> void {
         ::ShowWindow(hwnd, SW_SHOW);		        	
     }
 }
-/* Marty Shepard Borderless END */
+/* Marty Shephard Borderless END */
 }
 
 #endif

--- a/hiro/windows/window.cpp
+++ b/hiro/windows/window.cpp
@@ -87,12 +87,10 @@ auto pWindow::frameMargin(s32 width) const -> Geometry {
     //adjust our previous calculation to compensate for menu wrapping
     rc.bottom += rcTemp.top;
   } else {
-  /* Marty Shephard Borderless BEG */
     if (bBorderLess){
 	  rc.bottom = 458; // TODO Hardcoded ...
     }
-  }  
-  /* Marty Shephard Borderless END */	  
+  }   
   auto& efb = state().fullScreen ? settings.efbPopup : !state().resizable ? settings.efbFixed : settings.efbResizable;
   return {
     abs(rc.left) - efb.x,
@@ -428,8 +426,6 @@ auto pWindow::_statusHeight() const -> s32 {
   }
   return height;
 }
-/* Marty Shephard Borderless Beg */
-
 enum class Style : DWORD {
 	windowed			= WS_OVERLAPPEDWINDOW	| WS_THICKFRAME	| WS_CAPTION 	| WS_SYSMENU 	| WS_MINIMIZEBOX 	| WS_MAXIMIZEBOX,
     aero_borderless	= WS_POPUP			| WS_THICKFRAME	| WS_CAPTION 	| WS_SYSMENU 	| WS_MAXIMIZEBOX 	| WS_MINIMIZEBOX,
@@ -465,16 +461,13 @@ auto pWindow::setBorderless(bool borderless) -> void {
 	
 	if (new_style != old_style) {
         ::SetWindowLongPtrW(hwnd, GWL_STYLE, static_cast<LONG>(new_style));
-
-        /* when switching between borderless and windowed, restore appropriate shadow state	*/
+		
         set_shadow(hwnd, true && (new_style != Style::ResizableStyle));
-
-        /* redraw frame */
+		
         ::SetWindowPos(hwnd, nullptr, 0, 0, 0, 0, SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE);
         ::ShowWindow(hwnd, SW_SHOW);		        	
     }
 }
-/* Marty Shephard Borderless END */
 }
 
 #endif

--- a/hiro/windows/window.cpp
+++ b/hiro/windows/window.cpp
@@ -19,6 +19,7 @@ static auto CALLBACK Window_windowProc(HWND hwnd, UINT msg, WPARAM wparam, LPARA
 static constexpr u32 PopupStyle = WS_POPUP | WS_CLIPCHILDREN;
 static constexpr u32 FixedStyle = WS_SYSMENU | WS_CAPTION | WS_MINIMIZEBOX | WS_BORDER | WS_CLIPCHILDREN;
 static constexpr u32 ResizableStyle = WS_SYSMENU | WS_CAPTION | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_THICKFRAME | WS_CLIPCHILDREN;
+static constexpr u32 BorderlessStyle = WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS;
 
 u32 pWindow::minimumStatusHeight = 0;
 
@@ -86,11 +87,7 @@ auto pWindow::frameMargin(s32 width) const -> Geometry {
     SendMessage(hwnd, WM_NCCALCSIZE, (WPARAM)false, (LPARAM)&rcTemp);
     //adjust our previous calculation to compensate for menu wrapping
     rc.bottom += rcTemp.top;
-  } else {
-    if (bBorderLess){
-	  rc.bottom = 458; // TODO Hardcoded ...
-    }
-  }   
+  }
   auto& efb = state().fullScreen ? settings.efbPopup : !state().resizable ? settings.efbFixed : settings.efbResizable;
   return {
     abs(rc.left) - efb.x,
@@ -426,47 +423,15 @@ auto pWindow::_statusHeight() const -> s32 {
   }
   return height;
 }
-enum class Style : DWORD {
-	windowed			= WS_OVERLAPPEDWINDOW	| WS_THICKFRAME	| WS_CAPTION 	| WS_SYSMENU 	| WS_MINIMIZEBOX 	| WS_MAXIMIZEBOX,
-    aero_borderless	= WS_POPUP			| WS_THICKFRAME	| WS_CAPTION 	| WS_SYSMENU 	| WS_MAXIMIZEBOX 	| WS_MINIMIZEBOX,
-    basic_borderless	= WS_POPUP			| WS_THICKFRAME	| WS_SYSMENU 	| WS_MAXIMIZEBOX 	| WS_MINIMIZEBOX,
-	FixedStyle		= WS_SYSMENU 		| WS_CAPTION 	| WS_MINIMIZEBOX 	| WS_BORDER 		| WS_CLIPCHILDREN,
-	ResizableStyle	= WS_SYSMENU 		| WS_CAPTION 	| WS_MINIMIZEBOX 	| WS_MAXIMIZEBOX 	| WS_THICKFRAME 	| WS_CLIPCHILDREN,
-	Marty_Borderless	= WS_POPUP			| WS_VISIBLE 	| WS_CLIPSIBLINGS ,		
-};
 
-auto composition_enabled() -> bool {
-	BOOL composition_enabled = FALSE;
-    bool success = ::DwmIsCompositionEnabled(&composition_enabled) == S_OK;
-    return composition_enabled && success;
-}
-	
-auto set_shadow(HWND handle, bool enabled) -> void {
-	if (composition_enabled()) {
-		static const MARGINS shadow_state[2]{ { 0,0,0,0 },{ 1,1,1,1 } };
-        ::DwmExtendFrameIntoClientArea(handle, &shadow_state[enabled]);
-    }
-}
-	
-auto select_borderless_style() -> Style {
-	return composition_enabled() ? Style::aero_borderless : Style::basic_borderless;
-}
-	
 auto pWindow::setBorderless(bool borderless) -> void {
-	
-	bBorderLess = borderless;
-			
-	Style new_style = (borderless) ? Style::Marty_Borderless : Style::ResizableStyle;
-	Style old_style = static_cast<Style>(::GetWindowLongPtrW(hwnd, GWL_STYLE));
-	
-	if (new_style != old_style) {
-        ::SetWindowLongPtrW(hwnd, GWL_STYLE, static_cast<LONG>(new_style));
-		
-        set_shadow(hwnd, true && (new_style != Style::ResizableStyle));
-		
-        ::SetWindowPos(hwnd, nullptr, 0, 0, 0, 0, SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE);
-        ::ShowWindow(hwnd, SW_SHOW);		        	
-    }
+  DWORD newframeStyle = (borderless) ? BorderlessStyle : ResizableStyle;
+  DWORD oldframeStyle = static_cast<LONG>(GetWindowLongPtrW(hwnd, GWL_STYLE));
+  if (newframeStyle != oldframeStyle) {
+    SetWindowLongPtrW(hwnd, GWL_STYLE, static_cast<LONG>(newframeStyle));
+    SetWindowPos(hwnd, nullptr, 0, 0, 0, 0, SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE);
+    ShowWindow(hwnd, SW_SHOW);
+  }
 }
 }
 

--- a/hiro/windows/window.hpp
+++ b/hiro/windows/window.hpp
@@ -36,8 +36,6 @@ struct pWindow : pObject {
   auto setTitle(string text) -> void;
   auto setVisible(bool visible) -> void override;
 
-  auto setBorderless(bool borderless) -> void;		/* Marty Shepard Borderless */
-  
   auto modalIncrement() -> void;
   auto modalDecrement() -> void;
   auto windowProc(HWND, UINT, WPARAM, LPARAM) -> maybe<LRESULT>;
@@ -54,6 +52,9 @@ struct pWindow : pObject {
   COLORREF hbrushColor = 0;
   Geometry windowedGeometry{128, 128, 256, 256};
   bool focus = false;
+  
+  auto setBorderless(bool borderless) -> void;		/* Marty Shepard Borderless */  
+  bool bBorderLess = false;						/* Marty Shepard Borderless */
 };
 
 }

--- a/hiro/windows/window.hpp
+++ b/hiro/windows/window.hpp
@@ -36,7 +36,7 @@ struct pWindow : pObject {
   auto setResizable(bool resizable) -> void;
   auto setTitle(string text) -> void;
   auto setVisible(bool visible) -> void override;   
-  
+
   auto modalIncrement() -> void;
   auto modalDecrement() -> void;
   auto windowProc(HWND, UINT, WPARAM, LPARAM) -> maybe<LRESULT>;
@@ -52,11 +52,7 @@ struct pWindow : pObject {
   HBRUSH hbrush = nullptr;
   COLORREF hbrushColor = 0;
   Geometry windowedGeometry{128, 128, 256, 256};
-  bool bBorderLess = false;  
   bool focus = false;
-  
-
-
 };
 
 }

--- a/hiro/windows/window.hpp
+++ b/hiro/windows/window.hpp
@@ -36,6 +36,8 @@ struct pWindow : pObject {
   auto setTitle(string text) -> void;
   auto setVisible(bool visible) -> void override;
 
+  auto setBorderless(bool borderless) -> void;		/* Marty Shepard Borderless */
+  
   auto modalIncrement() -> void;
   auto modalDecrement() -> void;
   auto windowProc(HWND, UINT, WPARAM, LPARAM) -> maybe<LRESULT>;

--- a/hiro/windows/window.hpp
+++ b/hiro/windows/window.hpp
@@ -20,6 +20,7 @@ struct pWindow : pObject {
   auto remove(sSizable sizable) -> void;
   auto remove(sStatusBar statusBar) -> void;
   auto setBackgroundColor(Color color) -> void;
+  auto setBorderless(bool borderless) -> void;   
   auto setDismissable(bool dismissable) -> void;
   auto setDroppable(bool droppable) -> void;
   auto setEnabled(bool enabled) -> void override;
@@ -34,8 +35,8 @@ struct pWindow : pObject {
   auto setModal(bool modal) -> void;
   auto setResizable(bool resizable) -> void;
   auto setTitle(string text) -> void;
-  auto setVisible(bool visible) -> void override;
-
+  auto setVisible(bool visible) -> void override;   
+  
   auto modalIncrement() -> void;
   auto modalDecrement() -> void;
   auto windowProc(HWND, UINT, WPARAM, LPARAM) -> maybe<LRESULT>;
@@ -51,10 +52,11 @@ struct pWindow : pObject {
   HBRUSH hbrush = nullptr;
   COLORREF hbrushColor = 0;
   Geometry windowedGeometry{128, 128, 256, 256};
+  bool bBorderLess = false;  
   bool focus = false;
   
-  auto setBorderless(bool borderless) -> void;		/* Marty Shepard Borderless */  
-  bool bBorderLess = false;						/* Marty Shepard Borderless */
+
+
 };
 
 }


### PR DESCRIPTION
Hello, i have added a Borderless mode for  the Windows version.

I only use Ares in window desktop mode with shaders and bezels but the frame around the window was bothering me and I still use Windows 7.

Can be activated via the command line (--noBorderless/ --Borderless) or via the menu. or via Hotkey.

Might be useful for some users. :)

I have no technical knowledge of Linux or Mac APIs.

![](https://github.com/ares-emulator/ares/assets/8560193/c68d68e5-afa5-4963-b082-86fb5eff3d73)

greetings
Edit: I use Msys2
g++.exe (Rev1, Built by MSYS2 project) 11.3.0 under Windows 7