### PR TITLE
n64: fix corner case in FPU exception handling

### DIFF
--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -700,8 +700,10 @@ struct CPU : Thread {
   auto fpeInvalidOperation() -> bool;
   auto fpeUnimplemented() -> bool;
   auto fpuCheckStart() -> bool;
-  auto fpuCheckInput(f32& f) -> bool;
-  auto fpuCheckInput(f64& f) -> bool;
+  template <typename T>
+  auto fpuCheckInput(T& f) -> bool;
+  template <typename T>
+  auto fpuCheckInputs(T& f1, T& f2) -> bool;
   auto fpuCheckOutput(f32& f) -> bool;
   auto fpuCheckOutput(f64& f) -> bool;
   auto fpuClearCause() -> void;


### PR DESCRIPTION
Ares checked each of the two input arguments to three-ops functions separately, but this is not correct. Conditions causing unimplemented operation on either input (sNAN, subnormal) take precedence on conditions causing invalid operation on either input (qNAN).

After this fix, Ares passes n64-systemtest COP1 stress test.