### PR TITLE
wdc65816: emulate (direct,X) wraparound bug in emulation mode

### DIFF
--- a/ares/component/processor/wdc65816/instructions-read.cpp
+++ b/ares/component/processor/wdc65816/instructions-read.cpp
@@ -113,8 +113,8 @@ auto WDC65816::instructionIndexedIndirectRead8(alu8 op) -> void {
   U.l = fetch();
   idle2();
   idle();
-  V.l = readDirect(U.l + X.w + 0);
-  V.h = readDirect(U.l + X.w + 1);
+  V.l = readDirectX(U.l + X.w, 0);
+  V.h = readDirectX(U.l + X.w, 1);
 L W.l = readBank(V.w + 0);
   alu(W.l);
 }
@@ -123,8 +123,8 @@ auto WDC65816::instructionIndexedIndirectRead16(alu16 op) -> void {
   U.l = fetch();
   idle2();
   idle();
-  V.l = readDirect(U.l + X.w + 0);
-  V.h = readDirect(U.l + X.w + 1);
+  V.l = readDirectX(U.l + X.w, 0);
+  V.h = readDirectX(U.l + X.w, 1);
   W.l = readBank(V.w + 0);
 L W.h = readBank(V.w + 1);
   alu(W.w);

--- a/ares/component/processor/wdc65816/instructions-write.cpp
+++ b/ares/component/processor/wdc65816/instructions-write.cpp
@@ -90,8 +90,8 @@ auto WDC65816::instructionIndexedIndirectWrite8() -> void {
   U.l = fetch();
   idle2();
   idle();
-  V.l = readDirect(U.l + X.w + 0);
-  V.h = readDirect(U.l + X.w + 1);
+  V.l = readDirectX(U.l + X.w, 0);
+  V.h = readDirectX(U.l + X.w, 1);
 L writeBank(V.w + 0, A.l);
 }
 
@@ -99,8 +99,8 @@ auto WDC65816::instructionIndexedIndirectWrite16() -> void {
   U.l = fetch();
   idle2();
   idle();
-  V.l = readDirect(U.l + X.w + 0);
-  V.h = readDirect(U.l + X.w + 1);
+  V.l = readDirectX(U.l + X.w, 0);
+  V.h = readDirectX(U.l + X.w, 1);
   writeBank(V.w + 0, A.l);
 L writeBank(V.w + 1, A.h);
 }

--- a/ares/component/processor/wdc65816/memory.cpp
+++ b/ares/component/processor/wdc65816/memory.cpp
@@ -59,6 +59,13 @@ inline auto WDC65816::writeDirect(u32 address, n8 data) -> void {
   write(n16(D.w + address), data);
 }
 
+inline auto WDC65816::readDirectX(u32 address, u32 offset) -> n8 {
+  // The (direct,X) addressing mode has a bug in which the high byte is
+  // wrapped within the page if E = 1 and D&0xFF != 0.
+  if(EF && D.l) return read(((D.w + address) & 0xffff00) | n8(D.w + address + offset));
+  else return readDirect(address + offset);
+}
+
 inline auto WDC65816::readDirectN(u32 address) -> n8 {
   return read(n16(D.w + address));
 }

--- a/ares/component/processor/wdc65816/wdc65816.hpp
+++ b/ares/component/processor/wdc65816/wdc65816.hpp
@@ -64,6 +64,7 @@ struct WDC65816 {
   auto pullN() -> n8;
   auto pushN(n8 data) -> void;
   auto readDirect(u32 address) -> n8;
+  auto readDirectX(u32 address, u32 offset) -> n8;
   auto writeDirect(u32 address, n8 data) -> void;
   auto readDirectN(u32 address) -> n8;
   auto readBank(u32 address) -> n8;


### PR DESCRIPTION
See https://github.com/gilyon/snes-tests/tree/main/cputest for more details. This makes the relevant tests (and thus entirety of) `cputest-full.sfc` pass.