### PR TITLE
UI fix-ups for macOS

### DIFF
--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -78,12 +78,12 @@ struct Presentation : Window {
   VerticalLayout layout{this};
     HorizontalLayout viewportLayout{&layout, Size{~0, ~0}, 0};
       Viewport viewport{&viewportLayout, Size{~0, ~0}, 0};
-      VerticalLayout iconLayout{&viewportLayout, Size{128, ~0}, 0};
-        Canvas iconSpacer{&iconLayout, Size{128, ~0}, 0};
-        HorizontalLayout iconHorizontal{&iconLayout, Size{128, 128}, 0};
-          Canvas iconCanvas{&iconHorizontal, Size{112, 128}, 0};
+      VerticalLayout iconLayout{&viewportLayout, Size{144, ~0}, 0};
+        Canvas iconSpacer{&iconLayout, Size{144, ~0}, 0};
+        HorizontalLayout iconHorizontal{&iconLayout, Size{144, 128}, 0};
+          Canvas iconCanvas{&iconHorizontal, Size{128, 128}, 0};
           Canvas iconPadding{&iconHorizontal, Size{16, 128}, 0};
-        Canvas iconBottom{&iconLayout, Size{128, 10}, 0};
+        Canvas iconBottom{&iconLayout, Size{144, 10}, 0};
     HorizontalLayout statusLayout{&layout, Size{~0, StatusHeight}, 0};
       Label spacerLeft{&statusLayout, Size{8, ~0}, 0};
       Label statusLeft{&statusLayout, Size{~0, ~0}, 0};

--- a/hiro/cocoa/widget/canvas.cpp
+++ b/hiro/cocoa/widget/canvas.cpp
@@ -11,6 +11,7 @@
     ];
     [self addTrackingArea:area];
   }
+  self.clipsToBounds = true;
   return self;
 }
 

--- a/hiro/cocoa/widget/label.cpp
+++ b/hiro/cocoa/widget/label.cpp
@@ -9,6 +9,7 @@
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {
     label = &labelReference;
   }
+  self.clipsToBounds = true;
   return self;
 }
 

--- a/hiro/cocoa/widget/viewport.cpp
+++ b/hiro/cocoa/widget/viewport.cpp
@@ -6,6 +6,7 @@
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {
     viewport = &viewportReference;
   }
+  self.clipsToBounds = true;
   return self;
 }
 


### PR DESCRIPTION
### Status Bar 

When building with the macOS SDK included with macOS Sonoma, ares has had a regression involving an overly large status bar that rendered over the game viewport, causing confusion as well as being tricky to debug.

It turns out that this was due to a breaking change in AppKit in macOS 14 where an `NSView`'s `dirtyRect` was no longer clipped to its bounds by default. In short, a view's `dirtyRect` is now often much larger than its `bounds` if `clipsToBounds` is not defined explicitly. This creates problems in views that draw by calling `NSFillRect` on the dirtyRect, a common pattern, as it will fill a rect that is much larger than the actual bounds.

This PR sets the `clipsToBounds` property for NSView to `true` for views in ares that draw by filling `dirtyRect`. Accordingly these views' `dirtyRect` will now always be the same size as their `bounds`. 

This was true of `canvas.cpp`, `viewport.cpp`, and `label.cpp`. To avoid making the change overly broad, and to enable macOS to perform whatever optimizations it wants to perform, other view types are left alone.

### Splash Screen

This PR also addresses logo clipping issues in macOS on the splash screen. The dimensions for the logo on the splash screen, as defined, seemed to be a bit off previously, with the square logo rendering into a non-square canvas area. For whatever reason, this only clipped the logo rendering on macOS. The size and padding are adjusted slightly by this PR. It should not result in regressions on other platforms, but should be tested to make sure.

> [!IMPORTANT]  
> Pwease test on Windows and Linux to make sure the splash screen looks OK.

macOS screenshot of adjusted splash screen and fixed status bar, built with Xcode 15: 
<img width="1072" alt="Screenshot 2024-03-02 at 1 43 20 AM" src="https://github.com/ares-emulator/ares/assets/6864788/83504592-03dd-4881-8f3d-0db1fb771f44">
