### PR TITLE
hiro: Expose clipsToBounds for macOS SDKs below 14

### DIFF
--- a/hiro/cocoa/widget/canvas.hpp
+++ b/hiro/cocoa/widget/canvas.hpp
@@ -4,6 +4,7 @@
 @public
   hiro::mCanvas* canvas;
 }
+@property BOOL clipsToBounds;
 -(id) initWith:(hiro::mCanvas&)canvas;
 -(void) resetCursorRects;
 -(NSDragOperation) draggingEntered:(id<NSDraggingInfo>)sender;

--- a/hiro/cocoa/widget/label.hpp
+++ b/hiro/cocoa/widget/label.hpp
@@ -4,6 +4,7 @@
 @public
   hiro::mLabel* label;
 }
+@property BOOL clipsToBounds;
 -(id) initWith:(hiro::mLabel&)label;
 -(void) resetCursorRects;
 -(void) drawRect:(NSRect)dirtyRect;

--- a/hiro/cocoa/widget/viewport.hpp
+++ b/hiro/cocoa/widget/viewport.hpp
@@ -4,6 +4,7 @@
 @public
   hiro::mViewport* viewport;
 }
+@property BOOL clipsToBounds;
 -(id) initWith:(hiro::mViewport&)viewport;
 -(void) resetCursorRects;
 -(void) drawRect:(NSRect)rect;


### PR DESCRIPTION
Fixes CI failing to build after #1412.

`clipsToBounds` is available as far back as 10.9 but not exposed until 14.0, so we have to expose it manually if we're building on an earlier SDK.

In future, ares should of course be built with the current SDK, but should support building with earlier SDKs.

