### PR TITLE
Disable link-time optimization for debug builds

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -155,6 +155,7 @@ endif
 # build optimization levels
 ifeq ($(build),debug)
   symbols = true
+  lto = false
   ifeq ($(cl),true)
     flags += -Od
   else


### PR DESCRIPTION
For some reason, on macOS, debug symbols do not seem to be available for lldb if link-time optimization is enabled. I do not know exactly why that's the case, but it seems safe and without downsides to just disable LTO if we're doing a debug build.