### PR TITLE
Make Alt+Tab work correctly when in fullscreen

### DIFF
--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -145,7 +145,7 @@ auto InputManager::pollHotkeys() -> void {
   if(Application::modal()) return;
 
   if(!driverSettings.inputDefocusAllow.checked()) {
-    if (!presentation.focused() && !ruby::video.fullScreen()) return;
+    if (!presentation.focused()) return;
   }
 
   for(auto& hotkey : hotkeys) {

--- a/desktop-ui/program/platform.cpp
+++ b/desktop-ui/program/platform.cpp
@@ -173,7 +173,7 @@ auto Program::audio(ares::Node::Audio::Stream node) -> void {
 
 auto Program::input(ares::Node::Input::Input node) -> void {
   if(!driverSettings.inputDefocusAllow.checked()) {
-    if(!ruby::video.fullScreen() && !presentation.focused()) {
+    if(!presentation.focused()) {
       //treat the input as not being active
       if(auto button = node->cast<ares::Node::Input::Button>()) button->setValue(0);
       if(auto axis = node->cast<ares::Node::Input::Axis>()) axis->setValue(0);

--- a/desktop-ui/program/program.cpp
+++ b/desktop-ui/program/program.cpp
@@ -51,7 +51,7 @@ auto Program::main() -> void {
   inputManager.poll();
   inputManager.pollHotkeys();
 
-  bool defocused = driverSettings.inputDefocusPause.checked() && !ruby::video.fullScreen() && !presentation.focused();
+  bool defocused = driverSettings.inputDefocusPause.checked() && !presentation.focused();
   if(emulator && defocused) message.text = "Paused";
 
   if(settings.debugServer.enabled) {

--- a/ruby/video/direct3d9.cpp
+++ b/ruby/video/direct3d9.cpp
@@ -257,9 +257,9 @@ private:
     }
 
     if(self.fullScreen) {
-      _context = _window = CreateWindowEx(WS_EX_TOPMOST, L"VideoDirect3D9_Window", L"", WS_VISIBLE | WS_POPUP,
+      _context = _window = CreateWindowEx(WS_EX_NOACTIVATE, L"VideoDirect3D9_Window", L"", WS_VISIBLE | WS_POPUP | WS_DISABLED,
         _monitorX, _monitorY, _monitorWidth, _monitorHeight,
-        nullptr, nullptr, GetModuleHandle(0), nullptr);
+        (HWND)self.context, nullptr, GetModuleHandle(0), nullptr);
     } else {
       _context = (HWND)self.context;
     }

--- a/ruby/video/gdi.cpp
+++ b/ruby/video/gdi.cpp
@@ -115,9 +115,9 @@ private:
     _monitorHeight = monitor.height;
 
     if(self.fullScreen) {
-      _context = _window = CreateWindowEx(WS_EX_TOPMOST, L"VideoGDI_Window", L"", WS_VISIBLE | WS_POPUP,
+      _context = _window = CreateWindowEx(WS_EX_NOACTIVATE, L"VideoGDI_Window", L"", WS_VISIBLE | WS_POPUP | WS_DISABLED,
         _monitorX, _monitorY, _monitorWidth, _monitorHeight,
-        nullptr, nullptr, GetModuleHandle(0), nullptr);
+        (HWND)self.context, nullptr, GetModuleHandle(0), nullptr);
     } else {
       _context = (HWND)self.context;
     }

--- a/ruby/video/wgl.cpp
+++ b/ruby/video/wgl.cpp
@@ -152,9 +152,9 @@ private:
     _monitorHeight = monitor.height;
 
     if(self.fullScreen) {
-      _context = _window = CreateWindowEx(WS_EX_TOPMOST, L"VideoOpenGL32_Window", L"", WS_VISIBLE | WS_POPUP,
+      _context = _window = CreateWindowEx(WS_EX_NOACTIVATE, L"VideoOpenGL32_Window", L"", WS_VISIBLE | WS_POPUP | WS_DISABLED,
         _monitorX, _monitorY, _monitorWidth, _monitorHeight,
-        nullptr, nullptr, GetModuleHandle(0), nullptr);
+        (HWND)self.context, nullptr, GetModuleHandle(0), nullptr);
     } else {
       _context = (HWND)self.context;
     }


### PR DESCRIPTION
Using WS_EX_TOPMOST on a fullscreen window prevents Alt+Tab from switching to any different window. This is a bit of an annoyance as it ruins the point of Alt+Tab, especially in the case of a non-exclusive mode being set. It however is very very bad in any case ares hangs, and thus prevents being able to switch to Task Manager to actually kill ares. This means the average user could potentially run into a situation requiring them sign out or shutdown their PC, and thus potentially lose data in other apps.

It also happens to be the case that if the user attempts to Alt+Tab while in exclusive fullscreen, ares will hang for whatever reason. This commit doesn't fix that hang, but it does at least allow the user to Alt+Tab out of the situation.

Note that the windows are being set with WS_DISABLED more to avoid what I believe is a Windows bug. Normally WS_EX_NOACTIVATE should prevent clicking on the window from actually activating the window. However, if you were to Alt+Tab to some other window, then have that other window being shunk so ares ends up shown, you can proceed to click on the ares window, and it will actually activate that window. This thus takes focus away from ares' presentation window with generally no way to give it focus (assuming inputs get blocked). WS_DISABLED prevents mouse input from working on the fullscreen window (which it normally doesn't do anything due to WS_EX_NOACTIVATE, only in the weird case I laid out does it do something)

Also this commit likely breaks macOS/Linux (haven't tested / can't test those), probably need to check for focus differently depending on platform defines?