### PR TITLE
ruby: Add SDL audio for macOS

### DIFF
--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -26,6 +26,7 @@ ifeq ($(ruby),)
       ifeq ($(wildcard $(macsdl)),)
         $(error Tried to compile ruby for macOS with SDL2 linked, but no SDL2 library was found. Compile it with thirdparty/SDL/build-sdl.sh, or disable SDL by compiling ares with sdl2=false)
       endif
+      ruby += audio.sdl
       ruby += input.sdl
     endif
   else ifeq ($(platform),linux)


### PR DESCRIPTION
Exposes the option to use SDL's audio backend on macOS. The wiring for this is already fully present, just needs to be added to builds.

Good to have another option for Mac audio for anyone having issues with the OpenAL backend.

Tested locally and verified to work in the Metal dev branch.