### PR TITLE
gba: reading 32-bit ARM instruction from prefetch buffer takes 1 cycle

### DIFF
--- a/ares/gba/cpu/bus.cpp
+++ b/ares/gba/cpu/bus.cpp
@@ -12,6 +12,7 @@ auto CPU::get(u32 mode, n32 address) -> n32 {
   } else if(address & 0x0800'0000) {
     if(mode & Prefetch && wait.prefetch) {
       prefetchSync(address);
+      prefetchStep(1);
       word = prefetchRead();
       if(mode & Word) word |= prefetchRead() << 16;
     } else {

--- a/ares/gba/cpu/prefetch.cpp
+++ b/ares/gba/cpu/prefetch.cpp
@@ -25,7 +25,6 @@ auto CPU::prefetchReset() -> void {
 
 auto CPU::prefetchRead() -> n16 {
   if(prefetch.empty()) prefetchStep(prefetch.wait);
-  else prefetchStep(1);
 
   if(prefetch.full()) prefetch.wait = _wait(Half | Sequential, prefetch.load);
 


### PR DESCRIPTION
When an instruction is already present in the prefetch buffer, fetching the instruction should take only one cycle in both ARM and Thumb modes. Currently, ares uses 1 cycle for each halfword read from the prefetch buffer, which is correct for Thumb but not ARM. Fixing this discrepancy allows ares to pass 1890/2020 of the timing tests in the mGBA test suite (up from 1760/2020).