### PR TITLE
ares/screen: Reduce excessive polling for new frames

### DIFF
--- a/ares/ares/node/video/screen.cpp
+++ b/ares/ares/node/video/screen.cpp
@@ -25,7 +25,7 @@ Screen::~Screen() {
 
 auto Screen::main(uintptr_t) -> void {
   while(!_kill) {
-    usleep(1);
+    usleep(1000);
     if(_frame) {
       refresh();
       _frame = false;


### PR DESCRIPTION
ares currently polls every microsecond in a dedicated thread looking for new frames. This is excessively often, and uses a large amount of processing power.

There is probably a more elegant way to handle this polling, but changing the polling to happen every millisecond instead of every microsecond seems like a reasonable start.

In my testing, this change reduces ares' CPU use by 25-30%, without adversely impacting performance in any way. 

This change should be tested on other platforms to make sure there are no adverse effects that might not be accounted for.