### PR TITLE
ruby: Add Metal display backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.moc
 *.user
+*.xcuserdata
 .vs/
 .vscode/
 .idea/
@@ -12,3 +13,6 @@ out-amd64/
 out-arm64/
 thirdparty/SDL/SDL
 thirdparty/SDL/libSDL2-2.0.0.dylib
+macos-xcode/
+.swiftpm
+*.xcodeproj

--- a/desktop-ui/GNUmakefile
+++ b/desktop-ui/GNUmakefile
@@ -129,6 +129,7 @@ endif
 	cp resource/$(name).plist $(output.path)/$(name).app/Contents/Info.plist
 	$(call mkdir,$(output.path)/$(name).app/Contents/Resources/Shaders/)
 	$(call mkdir,$(output.path)/$(name).app/Contents/Resources/Database/)
+	cp ../ruby/video/metal/Shaders.metal $(output.path)/$(name).app/Contents/Resources/Shaders/Shaders.metal
 	$(call rcopy,$(thirdparty.path)/slang-shaders/*,$(output.path)/$(name).app/Contents/Resources/Shaders/)
 	$(call rcopy,$(mia.path)/Database/*,$(output.path)/$(name).app/Contents/Resources/Database/)
 	sips -s format icns resource/$(name).png --out $(output.path)/$(name).app/Contents/Resources/$(name).icns

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -594,7 +594,7 @@ auto Presentation::loadShaders() -> void {
 
   auto location = locate("Shaders/");
 
-  if(ruby::video.driver() == "OpenGL 3.2") {
+  if(ruby::video.hasShader()) {
     auto files = directory::files(location, "*.slangp");
     for(auto file : files) {
       MenuCheckItem item{&videoShaderMenu};

--- a/desktop-ui/resource/Shaders.metal
+++ b/desktop-ui/resource/Shaders.metal
@@ -1,0 +1,82 @@
+//
+//  Shaders.metal
+//  ares
+//
+//  Created by jcm on 2024-03-07.
+//
+
+#include <metal_stdlib>
+
+#include "ShaderTypes.h"
+
+using namespace metal;
+
+// Vertex shader outputs and fragment shader inputs
+struct RasterizerData
+{
+    // The [[position]] attribute of this member indicates that this value
+    // is the clip space position of the vertex when this structure is
+    // returned from the vertex function.
+    float4 position [[position]];
+
+    // Since this member does not have a special attribute, the rasterizer
+    // interpolates its value with the values of the other triangle vertices
+    // and then passes the interpolated value to the fragment shader for each
+    // fragment in the triangle.
+    float2 textureCoordinate;
+};
+
+vertex RasterizerData
+vertexShader(uint vertexID [[vertex_id]],
+             constant AAPLVertex *vertices [[buffer(AAPLVertexInputIndexVertices)]],
+             constant vector_uint2 *viewportSizePointer [[buffer(AAPLVertexInputIndexViewportSize)]])
+{
+    RasterizerData out;
+
+    // Index into the array of positions to get the current vertex.
+    // The positions are specified in pixel dimensions (i.e. a value of 100
+    // is 100 pixels from the origin).
+    float2 pixelSpacePosition = vertices[vertexID].position.xy;
+
+    // Get the viewport size and cast to float.
+    vector_float2 viewportSize = vector_float2(*viewportSizePointer);
+    
+
+    // To convert from positions in pixel space to positions in clip-space,
+    //  divide the pixel coordinates by half the size of the viewport.
+    out.position = vector_float4(0.0, 0.0, 0.0, 1.0);
+    out.position.xy = pixelSpacePosition / (viewportSize / 2.0);
+
+    // Pass the input color directly to the rasterizer.
+    out.textureCoordinate = vertices[vertexID].textureCoordinate;
+
+    return out;
+}
+
+fragment float4
+samplingShader(RasterizerData in [[stage_in]],
+               texture2d<half> colorTexture [[ texture(AAPLTextureIndexBaseColor) ]])
+{
+    constexpr sampler textureSampler (mag_filter::nearest,
+                                      min_filter::nearest);
+
+    // Sample the texture to obtain a color
+    const half4 colorSample = colorTexture.sample(textureSampler, in.textureCoordinate);
+
+    // return the color of the texture
+    return float4(colorSample);
+}
+
+fragment float4
+drawableSamplingShader(RasterizerData in [[stage_in]],
+               texture2d<half> colorTexture [[ texture(AAPLTextureIndexBaseColor) ]])
+{
+    constexpr sampler textureSampler (mag_filter::linear,
+                                      min_filter::linear);
+
+    // Sample the texture to obtain a color
+    const half4 colorSample = colorTexture.sample(textureSampler, in.textureCoordinate);
+
+    // return the color of the texture
+    return float4(colorSample);
+}

--- a/desktop-ui/settings/drivers.cpp
+++ b/desktop-ui/settings/drivers.cpp
@@ -39,6 +39,12 @@ auto DriverSettings::construct() -> void {
     settings.video.flush = videoFlushToggle.checked();
     ruby::video.setFlush(settings.video.flush);
   });
+#if defined(PLATFORM_MACOS)
+  videoColorSpaceToggle.setText("Force sRGB").onToggle([&] {
+    settings.video.forceSRGB = videoColorSpaceToggle.checked();
+    ruby::video.setForceSRGB(settings.video.forceSRGB);
+  });
+#endif
 
   audioLabel.setText("Audio").setFont(Font().setBold());
   audioDriverList.onChange([&] {
@@ -147,6 +153,9 @@ auto DriverSettings::videoRefresh() -> void {
   videoFormatList.setEnabled(0 && videoFormatList.itemCount() > 1);
   videoExclusiveToggle.setChecked(ruby::video.exclusive()).setEnabled(ruby::video.hasExclusive());
   videoBlockingToggle.setChecked(ruby::video.blocking()).setEnabled(ruby::video.hasBlocking());
+#if defined(PLATFORM_MACOS)
+  videoColorSpaceToggle.setChecked(ruby::video.forceSRGB()).setEnabled(ruby::video.hasForceSRGB());
+#endif
   videoFlushToggle.setChecked(ruby::video.flush()).setEnabled(ruby::video.hasFlush());
   VerticalLayout::resize();
 }

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -56,6 +56,7 @@ auto Settings::process(bool load) -> void {
   bind(string,  "Video/Format", video.format);
   bind(boolean, "Video/Exclusive", video.exclusive);
   bind(boolean, "Video/Blocking", video.blocking);
+  bind(boolean, "Video/PresentSRGB", video.forceSRGB);
   bind(boolean, "Video/Flush", video.flush);
   bind(string,  "Video/Shader", video.shader);
   bind(natural, "Video/Multiplier", video.multiplier);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -11,6 +11,7 @@ struct Settings : Markup::Node {
     string format;
     bool exclusive = false;
     bool blocking = false;
+    bool forceSRGB = false;
     bool flush = false;
     string shader = "None";
     u32 multiplier = 2;
@@ -334,6 +335,9 @@ struct DriverSettings : VerticalLayout {
     CheckLabel videoExclusiveToggle{&videoToggleLayout, Size{0, 0}};
     CheckLabel videoBlockingToggle{&videoToggleLayout, Size{0, 0}};
     CheckLabel videoFlushToggle{&videoToggleLayout, Size{0, 0}};
+#if defined(PLATFORM_MACOS)
+    CheckLabel videoColorSpaceToggle{&videoToggleLayout, Size{0, 0}};
+#endif
   //
   Label audioLabel{this, Size{~0, 0}, 5};
   HorizontalLayout audioDriverLayout{this, Size{~0, 0}};

--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -20,6 +20,7 @@ ifeq ($(ruby),)
     ruby += video.cgl
     ruby += audio.openal
     ruby += input.quartz #input.carbon
+    ruby += video.metal
     ifeq ($(sdl2),true)
       macsdl = ../thirdparty/SDL/libSDL2-2.0.0.dylib
       ares.dylibs += $(macsdl)
@@ -118,6 +119,8 @@ ifeq ($(platform),windows)
 endif
 
 ifeq ($(platform),macos)
+  ruby.options += -framework Metal
+  ruby.options += -framework MetalKit
   ruby.options += -framework IOKit
   ruby.options += $(if $(findstring audio.openal,$(ruby)),-framework OpenAL)
   ifeq ($(sdl2),true)

--- a/ruby/video/cgl.cpp
+++ b/ruby/video/cgl.cpp
@@ -36,6 +36,7 @@ struct VideoCGL : VideoDriver, OpenGL {
   auto hasFullScreen() -> bool override { return true; }
   auto hasContext() -> bool override { return true; }
   auto hasBlocking() -> bool override { return true; }
+  auto hasForceSRGB() -> bool override { return false; }
   auto hasFlush() -> bool override { return true; }
   auto hasShader() -> bool override { return true; }
 

--- a/ruby/video/metal/ShaderTypes.h
+++ b/ruby/video/metal/ShaderTypes.h
@@ -1,0 +1,30 @@
+/*
+See LICENSE folder for this sample’s licensing information.
+
+Abstract:
+Header containing types and enum constants shared between Metal shaders and C/ObjC source
+*/
+#include <simd/simd.h>
+
+// Buffer index values shared between shader and C code to ensure Metal shader buffer inputs
+// match Metal API buffer set calls.
+typedef enum MetalVertexInputIndex
+{
+    MetalVertexInputIndexVertices     = 0,
+    MetalVertexInputIndexViewportSize = 1,
+} MetalVertexInputIndex;
+
+typedef enum MetalTextureIndex
+{
+    MetalTextureIndexBaseColor = 0,
+} MetalTextureIndex;
+
+//  This structure defines the layout of vertices sent to the vertex
+//  shader. This header is shared between the .metal shader and C code, to guarantee that
+//  the layout of the vertex array in the C code matches the layout that the .metal
+//  vertex shader expects.
+typedef struct
+{
+    vector_float2 position;
+    vector_float2 textureCoordinate;
+} MetalVertex;

--- a/ruby/video/metal/Shaders.metal
+++ b/ruby/video/metal/Shaders.metal
@@ -1,0 +1,109 @@
+//
+//  Shaders.metal
+//  ares
+//
+//  Created by jcm on 2024-03-07.
+//
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+// Buffer index values shared between shader and C code to ensure Metal shader buffer inputs
+// match Metal API buffer set calls.
+typedef enum MetalVertexInputIndex
+{
+    MetalVertexInputIndexVertices     = 0,
+    MetalVertexInputIndexViewportSize = 1,
+} MetalVertexInputIndex;
+
+typedef enum MetalTextureIndex
+{
+    MetalTextureIndexBaseColor = 0,
+} MetalTextureIndex;
+
+//  This structure defines the layout of vertices sent to the vertex
+//  shader. This header is shared between the .metal shader and C code, to guarantee that
+//  the layout of the vertex array in the C code matches the layout that the .metal
+//  vertex shader expects.
+typedef struct
+{
+    vector_float2 position;
+    vector_float2 textureCoordinate;
+} MetalVertex;
+
+using namespace metal;
+
+// Vertex shader outputs and fragment shader inputs
+struct RasterizerData
+{
+    // The [[position]] attribute of this member indicates that this value
+    // is the clip space position of the vertex when this structure is
+    // returned from the vertex function.
+    float4 position [[position]];
+
+    // Since this member does not have a special attribute, the rasterizer
+    // interpolates its value with the values of the other triangle vertices
+    // and then passes the interpolated value to the fragment shader for each
+    // fragment in the triangle.
+    float2 textureCoordinate;
+};
+
+vertex RasterizerData
+vertexShader(uint vertexID [[vertex_id]],
+             constant MetalVertex *vertices [[buffer(MetalVertexInputIndexVertices)]],
+             constant vector_uint2 *viewportSizePointer [[buffer(MetalVertexInputIndexViewportSize)]])
+{
+    RasterizerData out;
+
+    // Index into the array of positions to get the current vertex.
+    // The positions are specified in pixel dimensions (i.e. a value of 100
+    // is 100 pixels from the origin).
+    float2 pixelSpacePosition = vertices[vertexID].position.xy;
+
+    // Get the viewport size and cast to float.
+    vector_float2 viewportSize = vector_float2(*viewportSizePointer);
+    
+
+    // To convert from positions in pixel space to positions in clip-space,
+    //  divide the pixel coordinates by half the size of the viewport.
+    out.position = vector_float4(0.0, 0.0, 0.0, 1.0);
+    out.position.xy = pixelSpacePosition / (viewportSize / 2.0);
+
+    // Pass the input color directly to the rasterizer.
+    out.textureCoordinate = vertices[vertexID].textureCoordinate;
+
+    return out;
+}
+
+fragment float4
+samplingShader(RasterizerData in [[stage_in]],
+               texture2d<half> colorTexture [[ texture(MetalTextureIndexBaseColor) ]])
+{
+    constexpr sampler textureSampler (mag_filter::nearest,
+                                      min_filter::nearest);
+
+    // Sample the texture to obtain a color
+    const half4 colorSample = colorTexture.sample(textureSampler, in.textureCoordinate);
+
+    // return the color of the texture
+    return float4(colorSample);
+}
+
+fragment float4
+drawableSamplingShader(RasterizerData in [[stage_in]],
+               texture2d<half> colorTexture [[ texture(MetalTextureIndexBaseColor) ]])
+{
+    // We use this shader to sample the intermediate texture onto the screen texture;
+    // both textures are identical in size. Despite that, if we use nearest neighbor
+    // filtering, we end up with significant interference patterns at some scales,
+    // probably due to float rounding lower down in the system, if I were to guess.
+    // Linear filtering solves this problem. We could also blit, probably.
+    constexpr sampler textureSampler (mag_filter::linear,
+                                      min_filter::linear);
+
+    // Sample the texture to obtain a color
+    const half4 colorSample = colorTexture.sample(textureSampler, in.textureCoordinate);
+
+    // return the color of the texture
+    return float4(colorSample);
+}

--- a/ruby/video/metal/metal.cpp
+++ b/ruby/video/metal/metal.cpp
@@ -1,0 +1,547 @@
+//
+//  metal.cpp
+//  ares
+//
+//  Created by jcm on 3/4/24.
+//
+
+#include "metal.hpp"
+
+struct VideoMetal;
+
+@interface RubyVideoMetal : MTKView <MTKViewDelegate> {
+@public
+  VideoMetal* video;
+}
+-(id) initWith:(VideoMetal*)video frame:(NSRect)frame device:(id<MTLDevice>)metalDevice;
+-(void) mtkView:(MTKView *)view drawableSizeWillChange:(CGSize) size;
+-(BOOL) acceptsFirstResponder;
+@end
+
+@interface RubyWindowMetal : NSWindow <NSWindowDelegate> {
+@public
+  VideoMetal* video;
+}
+-(id) initWith:(VideoMetal*)video;
+-(BOOL) canBecomeKeyWindow;
+-(BOOL) canBecomeMainWindow;
+@end
+
+struct VideoMetal : VideoDriver, Metal {
+  VideoMetal& self = *this;
+  VideoMetal(Video& super) : VideoDriver(super) {}
+  ~VideoMetal() { terminate(); }
+
+  auto create() -> bool override {
+    return initialize();
+  }
+
+  auto driver() -> string override { return "Metal"; }
+  auto ready() -> bool override { return _ready; }
+
+  auto hasFullScreen() -> bool override { return false; }
+  auto hasContext() -> bool override { return true; }
+  auto hasBlocking() -> bool override {
+    if (@available(macOS 10.15.4, *)) {
+      return !isVRRSupported();
+    } else {
+      return false;
+    }
+  }
+  auto hasForceSRGB() -> bool override { return true; }
+  auto hasFlush() -> bool override { return true; }
+  auto hasShader() -> bool override { return true; }
+
+  auto setFullScreen(bool fullScreen) -> bool override {
+    return initialize();
+  }
+
+  auto setContext(uintptr context) -> bool override {
+    return initialize();
+  }
+
+  auto setBlocking(bool blocking) -> bool override {
+    _blocking = blocking;
+    updatePresentInterval();
+    return true;
+  }
+  
+  auto setForceSRGB(bool forceSRGB) -> bool override {
+    if (forceSRGB) {
+      view.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
+    } else {
+      view.colorspace = view.window.screen.colorSpace.CGColorSpace;
+    }
+  }
+
+  auto setFlush(bool flush) -> bool override {
+    _flush = flush;
+    return true;
+  }
+  
+  auto hintRefreshRate(double refreshRate) -> void {
+    _refreshRateHint = refreshRate;
+    updatePresentInterval();
+  }
+  
+  auto isVRRSupported() -> bool {
+    if (@available(macOS 12.0, *)) {
+      NSTimeInterval minInterval = view.window.screen.minimumRefreshInterval;
+      NSTimeInterval maxInterval = view.window.screen.maximumRefreshInterval;
+      return minInterval != maxInterval;
+    } else {
+      return false;
+    }
+  }
+  
+  auto updatePresentInterval() -> void {
+    if (!isVRRSupported()) {
+      CGDirectDisplayID displayID = CGMainDisplayID();
+      CGDisplayModeRef displayMode = CGDisplayCopyDisplayMode(displayID);
+      CFTimeInterval refreshRate = CGDisplayModeGetRefreshRate(displayMode);
+      _presentInterval = (1.0 / refreshRate);
+    } else {
+      if (@available(macOS 12.0, *)) {
+        CFTimeInterval minimumInterval = view.window.screen.minimumRefreshInterval;
+        if (_refreshRateHint != 0) {
+          _presentInterval = (1.0 / _refreshRateHint);
+        } else {
+          _presentInterval = minimumInterval;
+        }
+      }
+    }
+  }
+
+  auto setShader(string pathname) -> bool override {
+    if (_filterChain != NULL) {
+      _libra.mtl_filter_chain_free(&_filterChain);
+    }
+
+    if (_preset != NULL) {
+      _libra.preset_free(&_preset);
+    }
+    
+    if (pathname == "Blur") return true;
+    
+    if (_libra.preset_create(pathname.data(), &_preset) != NULL) {
+      print(string{"Metal: Failed to load shader: ", pathname, "\n"});
+      return false;
+    }
+    
+    if (_libra.mtl_filter_chain_create(&_preset, _commandQueue, nil, &_filterChain) != NULL) {
+      print(string{"Metal: Failed to create filter chain for: ", pathname, "\n"});
+      return false;
+    };
+    return true;
+  }
+
+  auto focused() -> bool override {
+    return true;
+  }
+
+  auto clear() -> void override {}
+
+  auto size(u32& width, u32& height) -> void override {
+    if ((_viewWidth == width && _viewHeight == height) && (_viewWidth != 0 && _viewHeight != 0)) { return; }
+    auto area = [view convertRectToBacking:[view bounds]];
+    width = area.size.width;
+    height = area.size.height;
+    auto newSize = CGSize();
+    newSize.width = width;
+    newSize.height = height;
+    view.drawableSize = newSize;
+    
+    _viewWidth = width;
+    _viewHeight = height;
+    
+    _outputX = (width - outputWidth) / 2;
+    _outputY = (height - outputHeight) / 2;
+  }
+
+  auto acquire(u32*& data, u32& pitch, u32 width, u32 height) -> bool override {
+    if (sourceWidth != width || sourceHeight != height) {
+      
+      sourceWidth = width, sourceHeight = height;
+      
+      if (buffer) {
+        delete[] buffer;
+        buffer = nullptr;
+      }
+      
+      buffer = new u32[width * height]();
+      
+      MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor new];
+      textureDescriptor.pixelFormat = MTLPixelFormatBGRA8Unorm;
+      textureDescriptor.width = sourceWidth;
+      textureDescriptor.height = sourceHeight;
+      textureDescriptor.usage = MTLTextureUsageRenderTarget|MTLTextureUsageShaderRead;
+      
+      _sourceTexture = [_device newTextureWithDescriptor:textureDescriptor];
+      
+      bytesPerRow = sourceWidth * sizeof(u32);
+      if (bytesPerRow < 16) bytesPerRow = 16;
+      
+    }
+    pitch = sourceWidth * sizeof(u32);
+    return data = buffer;
+  }
+
+  auto release() -> void override {}
+  
+  auto resizeOutputBuffers(u32 width, u32 height) {
+    outputWidth = width;
+    outputHeight = height;
+    
+    float widthfloat = (float)width;
+    float heightfloat = (float)height;
+    
+    MetalVertex vertices[] =
+    {
+      // Pixel positions, Texture coordinates
+      { {  widthfloat / 2,  -heightfloat / 2 },  { 1.f, 1.f } },
+      { { -widthfloat / 2,  -heightfloat / 2 },  { 0.f, 1.f } },
+      { { -widthfloat / 2,   heightfloat / 2 },  { 0.f, 0.f } },
+      
+      { {  widthfloat / 2,  -heightfloat / 2 },  { 1.f, 1.f } },
+      { { -widthfloat / 2,   heightfloat / 2 },  { 0.f, 0.f } },
+      { {  widthfloat / 2,   heightfloat / 2 },  { 1.f, 0.f } },
+    };
+    
+    _vertexBuffer = [_device newBufferWithBytes:vertices length:sizeof(vertices) options:MTLResourceStorageModeShared];
+    
+    MTLTextureDescriptor *texDescriptor = [MTLTextureDescriptor new];
+    texDescriptor.textureType = MTLTextureType2D;
+    texDescriptor.width = width;
+    texDescriptor.height = height;
+    texDescriptor.pixelFormat = MTLPixelFormatBGRA8Unorm;
+    texDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
+    
+    _renderTargetTexture = [_device newTextureWithDescriptor:texDescriptor];
+    
+    _viewportSize.x = width;
+    _viewportSize.y = height;
+
+    _libraViewport.width = (uint32_t) width;
+    _libraViewport.height = (uint32_t) height;
+    _libraViewport.x = 0;
+    _libraViewport.y = 0;
+    
+    _outputX = (_viewWidth - width) / 2;
+    _outputY = (_viewHeight - height) / 2;
+  }
+
+  auto output(u32 width, u32 height) -> void override {
+    /// Uses two render passes (plus librashader's render passes). The first render pass samples the source texture,
+    /// consisting of the pixel buffer from the emulator, onto a texture the same size as our eventual output,
+    /// `_renderTargetTexture`. Then it calls into librashader, which performs postprocessing onto the same
+    /// output texture. Then for the second render pass here, we composite the output texture within ares's viewport.
+    /// We need this last pass because librashader expects the viewport to be the same size as the output texture,
+    /// which is not the case for ares.
+    
+    //can we do this outside of the output function?
+    if (width != outputWidth || height != outputHeight) {
+      resizeOutputBuffers(width, height);
+    }
+    
+    @autoreleasepool {
+      
+      dispatch_semaphore_wait(_semaphore, DISPATCH_TIME_FOREVER);
+      
+      id<MTLCommandBuffer> commandBuffer = [_commandQueue commandBuffer];
+      
+      if (commandBuffer != nil) {
+        __block dispatch_semaphore_t block_sema = _semaphore;
+        
+        [commandBuffer addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
+         dispatch_semaphore_signal(block_sema);
+        }];
+        
+        _renderToTextureRenderPassDescriptor.colorAttachments[0].texture = _renderTargetTexture;
+        
+        if (_renderToTextureRenderPassDescriptor != nil) {
+          
+          id<MTLRenderCommandEncoder> renderEncoder = [commandBuffer renderCommandEncoderWithDescriptor:_renderToTextureRenderPassDescriptor];
+          
+          _renderToTextureRenderPassDescriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
+          
+          [_sourceTexture replaceRegion:MTLRegionMake2D(0, 0, sourceWidth, sourceHeight) mipmapLevel:0 withBytes:buffer bytesPerRow:bytesPerRow];
+          
+          [renderEncoder setRenderPipelineState:_renderToTextureRenderPipeline];
+          
+          [renderEncoder setViewport:(MTLViewport){0, 0, (double)width, (double)height, -1.0, 1.0}];
+          
+          [renderEncoder setVertexBuffer:_vertexBuffer
+                                  offset:0
+                                 atIndex:0];
+          
+          [renderEncoder setVertexBytes:&_viewportSize
+                                 length:sizeof(_viewportSize)
+                                atIndex:MetalVertexInputIndexViewportSize];
+          
+          [renderEncoder setFragmentTexture:_sourceTexture atIndex:0];
+          
+          [renderEncoder drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:6];
+          
+          [renderEncoder endEncoding];
+          
+          if (_filterChain) {
+            _libra.mtl_filter_chain_frame(&_filterChain, commandBuffer, frameCount++, _sourceTexture, _libraViewport, _renderTargetTexture, nil, nil);
+          }
+          
+          MTLRenderPassDescriptor *drawableRenderPassDescriptor = view.currentRenderPassDescriptor;
+          
+          drawableRenderPassDescriptor.colorAttachments[0].loadAction = MTLLoadActionClear;
+          
+          if (drawableRenderPassDescriptor != nil) {
+            
+            id<MTLRenderCommandEncoder> renderEncoder = [commandBuffer renderCommandEncoderWithDescriptor:drawableRenderPassDescriptor];
+            
+            [renderEncoder setRenderPipelineState:_drawableRenderPipeline];
+            
+            [renderEncoder setViewport:(MTLViewport){_outputX, _outputY, (double)width, (double)height, -1.0, 1.0}];
+            
+            [renderEncoder setVertexBuffer:_vertexBuffer
+                                    offset:0
+                                   atIndex:0];
+            
+            [renderEncoder setVertexBytes:&_viewportSize
+                                   length:sizeof(_viewportSize)
+                                  atIndex:MetalVertexInputIndexViewportSize];
+            
+            [renderEncoder setFragmentTexture:_renderTargetTexture atIndex:0];
+            
+            [renderEncoder drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:6];
+            
+            [renderEncoder endEncoding];
+            
+            id<CAMetalDrawable> drawable = view.currentDrawable;
+            
+            if (drawable != nil) {
+              
+              if (_blocking) {
+                
+                [commandBuffer presentDrawable:drawable afterMinimumDuration:_presentInterval];
+                
+              } else {
+                
+                [commandBuffer presentDrawable:drawable];
+                
+              }
+              
+              [view draw];
+              
+            }
+          }
+          
+          [commandBuffer commit];
+          
+          if (_flush) {
+            [commandBuffer waitUntilCompleted];
+          }
+        }
+      }
+    }
+  }
+
+private:
+  auto initialize() -> bool {
+    terminate();
+    if (!self.fullScreen && !self.context) return false;
+
+    auto context = self.fullScreen ? [window contentView] : (__bridge NSView*)(void *)self.context;
+    auto size = [context frame].size;
+    
+    NSError *error = nil;
+    
+    _device = MTLCreateSystemDefaultDevice();
+    _commandQueue = [_device newCommandQueue];
+    
+    _semaphore = dispatch_semaphore_create(kMaxBuffersInFlight);
+
+    _renderToTextureRenderPassDescriptor = [MTLRenderPassDescriptor new];
+
+    _renderToTextureRenderPassDescriptor.colorAttachments[0].texture = _renderTargetTexture;
+    _renderToTextureRenderPassDescriptor.colorAttachments[0].loadAction = MTLLoadActionClear;
+    _renderToTextureRenderPassDescriptor.colorAttachments[0].clearColor = MTLClearColorMake(0, 0, 0, 1);
+    _renderToTextureRenderPassDescriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
+    
+    ///We compile shaders at runtime so we do not need to add the `xcrun` Metal compiler toolchain to the ares build process.
+    ///Metal frame capture does not get along with runtime-compiled shaders in my testing, however. If you are debugging ares
+    ///and need GPU captures, you should compile shaders with debug symbols offline, then instantiate the shader library by
+    ///directly referencing a compiled `.metallib` file, rather than the following instantiation flow. You will also need to alter
+    ///the `desktop-ui` Makefile such that it copies the `.metallib` into the bundle, rather than only the `Shaders.metal`
+    ///source.
+
+    NSString *bundleResourcePath = [NSBundle mainBundle].resourcePath;
+    const string& fileComponent = "/Shaders/Shaders.metal";
+    NSString *shaderFilePath = [bundleResourcePath stringByAppendingString: [[NSString new] initWithUTF8String:fileComponent]];
+    
+    NSString *shaderLibrarySource = [NSString stringWithContentsOfFile:shaderFilePath encoding:NSUTF8StringEncoding error: &error];
+    
+    if (shaderLibrarySource == nil) {
+      NSLog(@"%@",error);
+      return false;
+    }
+    
+    _library = [_device newLibraryWithSource: shaderLibrarySource options: [MTLCompileOptions alloc] error:&error];
+    
+    if (_library == nil) {
+      NSLog(@"%@",error);
+      return false;
+    }
+    
+    MTLRenderPipelineDescriptor *pipelineStateDescriptor = [MTLRenderPipelineDescriptor new];
+    
+    // Set up pipeline for rendering to the offscreen texture. Reuse the
+    // descriptor and change properties that differ.
+    pipelineStateDescriptor.label = @"Offscreen Render Pipeline";
+    pipelineStateDescriptor.sampleCount = 1;
+    pipelineStateDescriptor.vertexFunction = [_library newFunctionWithName:@"vertexShader"];
+    pipelineStateDescriptor.fragmentFunction = [_library newFunctionWithName:@"samplingShader"];
+    pipelineStateDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+    _renderToTextureRenderPipeline = [_device newRenderPipelineStateWithDescriptor:pipelineStateDescriptor error:&error];
+    
+    if (_renderToTextureRenderPipeline == nil) {
+      NSLog(@"%@",error);
+      return false;
+    }
+    
+    pipelineStateDescriptor.label = @"Drawable Render Pipeline";
+    pipelineStateDescriptor.sampleCount = 1;
+    pipelineStateDescriptor.vertexFunction = [_library newFunctionWithName:@"vertexShader"];
+    pipelineStateDescriptor.fragmentFunction = [_library newFunctionWithName:@"drawableSamplingShader"];
+    pipelineStateDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+    _drawableRenderPipeline = [_device newRenderPipelineStateWithDescriptor:pipelineStateDescriptor error:&error];
+    
+    if (_drawableRenderPipeline == nil) {
+      NSLog(@"%@",error);
+      return false;
+    }
+    
+    auto frame = NSMakeRect(0, 0, size.width, size.height);
+    view = [[RubyVideoMetal alloc] initWith:this frame:frame device:_device];
+    [context addSubview:view];
+    [[view window] makeFirstResponder:view];
+    bool forceSRGB = self.forceSRGB;
+    self.setForceSRGB(forceSRGB);
+    view.autoresizingMask = NSViewWidthSizable|NSViewHeightSizable;
+
+    _commandQueue = [_device newCommandQueue];
+
+    _libra = librashader_load_instance();
+    if (!_libra.instance_loaded) {
+      print("Metal: Failed to load librashader: shaders will be disabled\n");
+    }
+    
+    setShader(self.shader);
+    
+    _blocking = self.blocking;
+    
+    initialized = true;
+    return _ready = true;
+  }
+
+  auto terminate() -> void {
+    _ready = false;
+    
+    _commandQueue = nullptr;
+    _library = nullptr;
+
+    _vertexBuffer = nullptr;
+    _sourceTexture = nullptr;
+    _mtlVertexDescriptor = nullptr;
+    
+    _renderToTextureRenderPassDescriptor = nullptr;
+    _renderTargetTexture = nullptr;
+    _renderToTextureRenderPipeline = nullptr;
+    
+    _drawableRenderPipeline = nullptr;
+    
+    if (_filterChain) {
+      _libra.mtl_filter_chain_free(&_filterChain);
+    }
+    _device = nullptr;
+
+    if (view) {
+      [view removeFromSuperview];
+      view = nil;
+    }
+
+    if (window) {
+      [window toggleFullScreen:nil];
+      [window setCollectionBehavior:NSWindowCollectionBehaviorDefault];
+      [window close];
+      window = nil;
+    }
+  }
+
+  RubyVideoMetal* view = nullptr;
+  RubyWindowMetal* window = nullptr;
+
+  bool _ready = false;
+  std::recursive_mutex mutex;
+};
+
+@implementation RubyVideoMetal : MTKView
+
+-(id) initWith:(VideoMetal*)videoPointer frame:(NSRect)frame device:(id<MTLDevice>)metalDevice {
+  if (self = [super initWithFrame:frame device:metalDevice]) {
+    video = videoPointer;
+  }
+  self.enableSetNeedsDisplay = NO;
+  self.paused = YES;
+  
+  //below is the delegate path; currently not used but likely will be used in future.
+  
+  //self.enableSetNeedsDisplay = YES;
+  //self.paused = NO;
+  //[self setDelegate:self];
+  
+  return self;
+}
+
+-(void) drawInMTKView:(MTKView *)view {
+  //currently not used
+  //video->alternateDrawPath();
+}
+
+-(void) mtkView:(MTKView *)view drawableSizeWillChange:(CGSize) size {
+  
+}
+
+-(BOOL) acceptsFirstResponder {
+  return YES;
+}
+
+-(void) keyDown:(NSEvent*)event {
+}
+
+-(void) keyUp:(NSEvent*)event {
+}
+
+@end
+
+@implementation RubyWindowMetal : NSWindow
+
+-(id) initWith:(VideoMetal*)videoPointer {
+  auto primaryRect = [[[NSScreen screens] objectAtIndex:0] frame];
+  if (self = [super initWithContentRect:primaryRect styleMask:0 backing:NSBackingStoreBuffered defer:YES]) {
+    video = videoPointer;
+    [self setDelegate:self];
+    [self setReleasedWhenClosed:NO];
+    [self setAcceptsMouseMovedEvents:YES];
+    [self setTitle:@""];
+    [self makeKeyAndOrderFront:nil];
+  }
+  return self;
+}
+
+-(BOOL) canBecomeKeyWindow {
+  return YES;
+}
+
+-(BOOL) canBecomeMainWindow {
+  return YES;
+}
+
+@end

--- a/ruby/video/metal/metal.hpp
+++ b/ruby/video/metal/metal.hpp
@@ -1,0 +1,71 @@
+//
+//  metal.hpp
+//  ares
+//
+//  Created by jcm on 3/4/24.
+//
+
+#include <Metal/Metal.h>
+#include <MetalKit/MetalKit.h>
+
+#include "librashader_ld.h"
+#include "ShaderTypes.h"
+
+struct Metal;
+
+static const NSUInteger kMaxBuffersInFlight = 3;
+
+struct Metal {
+  auto setShader(const string& pathname) -> void;
+  auto clear() -> void;
+  auto output() -> void;
+  auto initialize(const string& shader) -> bool;
+  auto terminate() -> void;
+  auto refreshRateHint(double refreshRate) -> void;
+  
+  auto size(u32 width, u32 height) -> void;
+  auto release() -> void;
+  auto render(u32 sourceWidth, u32 sourceHeight, u32 targetX, u32 targetY, u32 targetWidth, u32 targetHeight) -> void;
+  
+  u32 *buffer = nullptr;
+  
+  u32 sourceWidth = 0;
+  u32 sourceHeight = 0;
+  u32 bytesPerRow = 0;
+  
+  u32 outputWidth = 0;
+  u32 outputHeight = 0;
+  double _outputX = 0;
+  double _outputY = 0;
+  
+  CGFloat _viewWidth = 0;
+  CGFloat _viewHeight = 0;
+  vector_uint2 _viewportSize;
+  
+  double _presentInterval = .016;
+  u32 frameCount = 0;
+  double _refreshRateHint = 60;
+  
+  bool _blocking = false;
+  bool _flush = false;
+  
+  id<MTLDevice> _device;
+  id<MTLCommandQueue> _commandQueue;
+  id<MTLLibrary> _library;
+  dispatch_semaphore_t _semaphore;
+  
+  id<MTLBuffer> _vertexBuffer;
+  id<MTLTexture> _sourceTexture;
+  MTLVertexDescriptor *_mtlVertexDescriptor;
+  
+  MTLRenderPassDescriptor *_renderToTextureRenderPassDescriptor;
+  id<MTLRenderPipelineState> _renderToTextureRenderPipeline;
+  id<MTLRenderPipelineState> _drawableRenderPipeline;
+  id<MTLTexture> _renderTargetTexture;
+  
+  libra_instance_t _libra;
+  libra_shader_preset_t _preset;
+  libra_mtl_filter_chain_t _filterChain;
+  libra_viewport_t _libraViewport;
+  bool initialized = false;
+};

--- a/ruby/video/video.cpp
+++ b/ruby/video/video.cpp
@@ -26,6 +26,10 @@
   #include <ruby/video/xvideo.cpp>
 #endif
 
+#if defined(VIDEO_METAL)
+  #include <ruby/video/metal/metal.cpp>
+#endif
+
 namespace ruby {
 
 auto Video::setFullScreen(bool fullScreen) -> bool {
@@ -65,6 +69,14 @@ auto Video::setBlocking(bool blocking) -> bool {
   if(instance->blocking == blocking) return true;
   if(!instance->hasBlocking()) return false;
   if(!instance->setBlocking(instance->blocking = blocking)) return false;
+  return true;
+}
+
+auto Video::setForceSRGB(bool forceSRGB) -> bool {
+  lock_guard<recursive_mutex> lock(mutex);
+  if(instance->forceSRGB == forceSRGB) return true;
+  if(!instance->hasForceSRGB()) return false;
+  if(!instance->setForceSRGB(instance->forceSRGB = forceSRGB)) return false;
   return true;
 }
 
@@ -179,6 +191,10 @@ auto Video::create(string driver) -> bool {
   #if defined(VIDEO_XVIDEO)
   if(driver == "XVideo") self.instance = new VideoXVideo(*this);
   #endif
+  
+  #if defined(VIDEO_METAL)
+  if(driver == "Metal") self.instance = new VideoMetal(*this);
+  #endif
 
   if(!self.instance) self.instance = new VideoDriver(*this);
 
@@ -215,6 +231,10 @@ auto Video::hasDrivers() -> vector<string> {
   #if defined(VIDEO_XSHM)
   "XShm",
   #endif
+    
+  #if defined(VIDEO_METAL)
+    "Metal",
+  #endif
 
   "None"};
 }
@@ -234,6 +254,8 @@ auto Video::optimalDriver() -> string {
   return "XVideo";
   #elif defined(VIDEO_XSHM)
   return "XShm";
+  #elif defined(VIDEO_Metal)
+  return "Metal";
   #else
   return "None";
   #endif
@@ -254,6 +276,8 @@ auto Video::safestDriver() -> string {
   return "XVideo";
   #elif defined(VIDEO_GLX)
   return "OpenGL 3.2";
+  #elif defined(VIDEO_Metal)
+  return "Metal";
   #else
   return "None";
   #endif

--- a/ruby/video/video.hpp
+++ b/ruby/video/video.hpp
@@ -13,6 +13,7 @@ struct VideoDriver {
   virtual auto hasExclusive() -> bool { return false; }
   virtual auto hasContext() -> bool { return false; }
   virtual auto hasBlocking() -> bool { return false; }
+  virtual auto hasForceSRGB() -> bool { return false; }
   virtual auto hasFlush() -> bool { return false; }
   virtual auto hasFormats() -> vector<string> { return {"ARGB24"}; }
   virtual auto hasShader() -> bool { return false; }
@@ -24,6 +25,7 @@ struct VideoDriver {
   virtual auto setExclusive(bool exclusive) -> bool { return true; }
   virtual auto setContext(uintptr context) -> bool { return true; }
   virtual auto setBlocking(bool blocking) -> bool { return true; }
+  virtual auto setForceSRGB(bool forceSRGB) -> bool { return true; }
   virtual auto setFlush(bool flush) -> bool { return true; }
   virtual auto setFormat(string format) -> bool { return true; }
   virtual auto setShader(string shader) -> bool { return true; }
@@ -45,6 +47,7 @@ protected:
   bool exclusive = false;
   uintptr context = 0;
   bool blocking = false;
+  bool forceSRGB = false;
   bool flush = false;
   string format = "ARGB24";
   string shader = "Blur";
@@ -85,6 +88,7 @@ struct Video {
   auto hasExclusive() -> bool { return instance->hasExclusive(); }
   auto hasContext() -> bool { return instance->hasContext(); }
   auto hasBlocking() -> bool { return instance->hasBlocking(); }
+  auto hasForceSRGB() -> bool { return instance->hasForceSRGB(); }
   auto hasFlush() -> bool { return instance->hasFlush(); }
   auto hasFormats() -> vector<string> { return instance->hasFormats(); }
   auto hasShader() -> bool { return instance->hasShader(); }
@@ -96,6 +100,7 @@ struct Video {
   auto exclusive() -> bool { return instance->exclusive; }
   auto context() -> uintptr { return instance->context; }
   auto blocking() -> bool { return instance->blocking; }
+  auto forceSRGB() -> bool { return instance->forceSRGB; }
   auto flush() -> bool { return instance->flush; }
   auto format() -> string { return instance->format; }
   auto shader() -> string { return instance->shader; }
@@ -105,6 +110,7 @@ struct Video {
   auto setExclusive(bool exclusive) -> bool;
   auto setContext(uintptr context) -> bool;
   auto setBlocking(bool blocking) -> bool;
+  auto setForceSRGB(bool forceSRGB) -> bool;
   auto setFlush(bool flush) -> bool;
   auto setFormat(string format) -> bool;
   auto setShader(string shader) -> bool;

--- a/ruby/video/xshm.cpp
+++ b/ruby/video/xshm.cpp
@@ -24,7 +24,7 @@ struct VideoXShm : VideoDriver {
   auto hasFullScreen() -> bool override { return true; }
   auto hasMonitor() -> bool override { return true; }
   auto hasContext() -> bool override { return true; }
-  auto hasShader() -> bool override { return true; }
+  auto hasShader() -> bool override { return false; }
 
   auto setFullScreen(bool fullScreen) -> bool override { return initialize(); }
   auto setMonitor(string monitor) -> bool override { return initialize(); }

--- a/thirdparty/librashader/include/librashader_ld.h
+++ b/thirdparty/librashader/include/librashader_ld.h
@@ -37,9 +37,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define LIBRA_RUNTIME_D3D12
 #endif
 
-// #if (defined(__APPLE__) && defined(__OBJC__))
-// #define LIBRA_RUNTIME_METAL
-// #endif
+#if (defined(__APPLE__) && defined(__OBJC__))
+#define LIBRA_RUNTIME_METAL
+#endif
 
 #if defined(_WIN32)
 #include <windows.h>


### PR DESCRIPTION
This PR adds a Metal display backend to ares.

<img width="1482" alt="Screenshot 2024-03-31 at 7 02 40 PM" src="https://github.com/ares-emulator/ares/assets/6864788/48718f19-9916-491b-8301-c16b95f95c19">

*ares N64 core on a 60Hz P3 display. Shader: "crt-maximus-royale".*

## Context

With ares's recent introduction of librashader, ares users have enjoyed access to the sizable library of shaders in the slang format, such as those used by the RetroArch frontend. Simultaneously, up to now, the CGL OpenGL backend shipped by ares for Mac users has offered enough functionality to do the (relatively) simple job of an ares display backend; display software-rendered frame buffers and pace them appropriately.

librashader's advanced postprocessing, however, has asked a bit more of the display backend, and in the case of OpenGL, has laid bare various deficiencies in macOS's OpenGL driver. These deficiencies can kneecap ares's librashader support on macOS with compiler errors and broken shader behavior.

Rather than chase down these errors and try to work around what is fundamentally a broken driver shipped by Apple, we take advantage of librashader's native Metal support by adding a Metal backend to ares. This greatly increases baseline shader compatibility, with the added benefit of documentation and greater platform debugging information when issues arise. The Metal backend will also generally future-proof ares on macOS, with OpenGL's uncertain future on macOS.

## Basics

The first iteration of this Metal driver mostly offers feature parity with the OpenGL driver. More advanced features, particularly in the realm of frame pacing on ProMotion displays, will arrive in future iterations. The priority with this PR is to start getting the driver in the hands of users with basic features and greater librashader compatibility.

Host refresh rate sync is still a work in progress and in this iteration will only be enabled for users above 10.15.4 on non-VRR displays (discussed more below).

Explicit sRGB color matching is offered as a new option for those on wide gamut displays (by default, the Metal driver will map to the native color space, conforming to OpenGL driver behavior). This option is only exposed on macOS, since other operating systems lack per-surface color matching.

<img width="400" alt="Screenshot 2024-03-31 at 6 37 38 PM" src="https://github.com/ares-emulator/ares/assets/6864788/e177a256-bba2-4a02-ad5b-9ad84cb09740">
<img width="400" alt="Screenshot 2024-03-31 at 6 37 46 PM" src="https://github.com/ares-emulator/ares/assets/6864788/dd517394-e97e-40f6-98de-4562d62bda98">

*Left: ares presenting in Display P3. Right: ares presenting more accurately in sRGB with "Force sRGB" enabled. Shader: crt-hyllian.*

A simple vertex and fragment shader are compiled at runtime, so we avoid the need to add another compiler toolchain to the ares build process. There is unfortunately some code duplicated at present; `metal.cpp` and `Shaders.metal` both include types defined in `ShaderTypes.h`, but we also need to place `Shaders.metal` inside the .app bundle for runtime compilation, making for awkward `#include`s. Presently, we just bundle a copy of `Shaders.metal` appended with `ShaderTypes.h`, inside `desktop-ui/resource`. This will be cleaned up in future work.

The driver's draw implementation itself is fairly simple; one render pass renders to an offscreen texture, librashader performs its work on that offscreen texture, and a second ares Metal render pass composites the finished texture inside ares's viewport. Since we do not use `MTKViewDelegate`, our output function finishes with a `[view draw]` call and the system presents at the earliest opportunity. 

## Details

When it came to the details of implementing this driver, there were some nontrivial issues encountered. Some of these will need solving in separate PRs before this driver is feature-complete.

### ares vs. VRR

Users on fixed refresh rate displays should enjoy good frame pacing with this driver. Unfortunately, users of more recent Mac machines with "ProMotion" refresh rates will not have an ideal experience in terms of pacing. To understand why, we need to take a brief detour into how ares works and then discuss some current limitations with ares's macOS integration.

In ares "synchronize to audio" mode, ares creates and delivers video frames as audio frames are created. This means that the video frame timing is completely dependent on when exactly the audio driver processes audio frames. For display modes with a refresh rate at or close to the core refresh rate, this is mostly no problem; the system seems to naturally present frames in a FIFO-esque fashion, and every once in awhile the system will just drop or duplicate a frame if two or no draw calls fall within one refresh interval.

For recent more advanced Mac displays with "up to 120Hz" refresh rate, the story is more complicated. We have to explicitly tell the system when we want it to draw the frame once available. It is tempting to answer "now"; after all, if our audio timings are correct, then video frames should be generated precisely when they need to be shown. Unfortunately, in higher latency modes of OpenAL or with SDL audio in general on macOS, audio frames are processed in large batches. That means that we end up emitting several video frames in quick succession at 8ms intervals on a 120Hz display, then waiting as long as 75ms for a new batch of audio (and thus video) frames:

<img width="265" alt="Screenshot 2024-03-31 at 4 55 25 PM" src="https://github.com/ares-emulator/ares/assets/6864788/69f887a0-8ded-4f47-ac4c-4cf2b58283a7">
<img width="265" alt="Screenshot 2024-03-31 at 4 55 35 PM" src="https://github.com/ares-emulator/ares/assets/6864788/2f7a417a-0378-44b5-b0c0-f894542c0371">
<img width="265" alt="Screenshot 2024-03-31 at 4 55 56 PM" src="https://github.com/ares-emulator/ares/assets/6864788/13b471d9-3e77-45cd-baf4-0d786ae83e22">

*VRR macOS frame pacing across audio driver settings in v0.1 of the Metal driver. The graph in blue shows frame present intervals over time; the values in red show the minimum and maximum present intervals over the graph duration.*

If we do not answer "now," we have to decide when to present. Unfortunately, currently, there is not a satisfying way to answer that question. Core refresh rates vary somewhat widely, sometimes during runtime, and there is no mechanism in ares by which to inform the graphics driver of a core's desired refresh rate.

We could elect to just duplicate the behavior for a fixed display refresh rate and pick, e.g. 60 Hz, but unfortunately even that option is not available, because we currently have no way of receiving callbacks when a frame is actually presented. Why not `CAMetalDisplayLink` or even `MTKViewDelegate` you ask? Well...

### ares vs. macOS

For most of its cores, ares performs much of its work on a single dedicated main thread that blocks for audio and video presentation to drive hardware-accurate timing. Unfortunately, all of this work occurs on the macOS main thread, with lots of blocking and CPU-intensive activity. This interferes with the macOS application run loop's ability to perform its callbacks and call out to observers.

In practice, this means that if we try to employ delegates that interface with macOS, that could send a callback when a frame is presented, or tell ares the exact moment a frame needs to be presented, these system delegates cannot actually make these calls in time in between ares's main thread activity; upwards of 50% of `MTKViewDelegate` callbacks are lost, for example.

This means that tools like `MTKViewDelegate` or `CAMetalDisplayLink` that would help us solve the frame pacing problem are, unfortunately, useless to us. We cannot leverage these tools as ares is currently architected.

To get around these issues, we will need one of: less main thread blocking, so delegates can interface with ares on the main thread, or an audio driver with a processing tolerance that falls within the display's minimum refresh interval. Our best bet for now is to emit frames to the system within ares's main thread work as they come available, let the system draw them as it will, and hope that our audio driver is doing a good job pacing them.

In practice, for Metal driver users on VRR displays you cannot set to a fixed rate, this means you should use the OpenAL driver, and set the latency to the lowest value possible.

## Future Work

The future for the Metal driver in ares takes us down a few different paths.

The main issue at present is making macOS system delegates work well with ares, which is the ideal path forward. Ideally, we could move all of the emulation-intensive work off of the main thread in macOS and into a high priority dedicated thread, reserving the main thread for actual UI and rendering, giving the system plenty of overhead with which to communicate.

For the future of VRR in ares, it would be good to create a mechanism to tell the graphics driver what refresh rate the core wants to present at. This would be one way to pace draw calls appropriately in the absence of reliable feedback from the system about the state of the display.

It has gone without mentioning so far due to the other issues, but long term, it would also be good for ares or librashader to have some way of utilizing the entire viewport for shaders; currently, shaders are limited to the output width and height area rather than the entire window view size. This is limiting for "bezel"-style shaders that want to use the entire screen in fullscreen, for example.

