### PR TITLE
ws: emulate 32KB SRAM for "8KB" cartridges

### DIFF
--- a/mia/medium/wonderswan.cpp
+++ b/mia/medium/wonderswan.cpp
@@ -84,7 +84,7 @@ auto WonderSwan::analyze(vector<u8>& rom) -> string {
   string ramType;
   u32 ramSize = 0;
   switch(metadata[11]) {
-  case 0x01: ramType = "RAM";    ramSize =    8_KiB; break;
+  case 0x01: ramType = "RAM";    ramSize =   32_KiB; break;
   case 0x02: ramType = "RAM";    ramSize =   32_KiB; break;
   case 0x03: ramType = "RAM";    ramSize =  128_KiB; break;
   case 0x04: ramType = "RAM";    ramSize =  256_KiB; break;


### PR DESCRIPTION
Based on [ototo2009's PCB scans](http://blog-imgs-131-origin.fc2.com/o/t/o/ototo2009/WS-2019-12b.html), I have verified that every single cartridge that uses the value `0x01` for its save type in the ROM header actually comes with 256 Kbit (or 32 KB) of SRAM.

In addition, WonderSwan ROM chips tend to use the notation of `MHxxMyySzzzz` for a cartridge with `xx` megabits of ROM, `yy` kilobits of SRAM (or `yyE` for EEPROM), and the ROM data ID `zzzz`. All of the cartridges in question appear to use `256S`.

As such, it seems to me that Ares should similarly emulate 32KB of save data for all such cartridges. It seems that this actually fixes a game, for once.