### PR TITLE
UI: update shader location when initializing

### DIFF
--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -633,7 +633,7 @@ auto Presentation::loadShaders() -> void {
     string existingShader = settings.video.shader;
 
     if(!program.startShader.imatch("None")) {
-        settings.video.shader = {location, program.startShader, ".slangp"};
+        settings.video.shader = {locate(shadersBaseDirectory), program.startShader, ".slangp"};
     } else {
         settings.video.shader = program.startShader;
     }


### PR DESCRIPTION
Fix an error when cherry picking changes from a local branch for #1438. Use the new variable for the base shaders directory when loading the program start shader. Unbreak the build.