### PR TITLE
fix(apu): fix apu framecounter

### DIFF
--- a/ares/fc/apu/apu.hpp
+++ b/ares/fc/apu/apu.hpp
@@ -135,21 +135,47 @@ struct APU {
   } dmc;
 
   struct FrameCounter {
-    static constexpr u16 NtscPeriod = 14915;  //~(21.477MHz / 6 / 240hz)
+    enum mode: u8 { Freq60Hz = 0, Freq48Hz = 1 };
+
+    auto rate() const -> u32 { return Region::PAL() ? 16 : 12; }
+    auto getPeriod() const -> u16 {
+      return Region::PAL() ? periodPAL[mode][step] : periodNTSC[mode][step];
+    }
+
+    auto main() -> void;
+    auto power(bool reset) -> void;
+    auto write(n8 data) -> void;
 
     //serialization.cpp
     auto serialize(serializer&) -> void;
 
+    n1  irqInhibit;
+    n1  mode;
+    n1  newMode;
+
     n1  irqPending;
-    n2  mode;
-    n2  counter;
-    i32 divider = 1;
-  } frame;
+    n3  step;
+    n16 counter;
+
+    bool odd;
+    bool delay;
+    n3   delayCounter;
+
+    constexpr static u16 periodNTSC[2][6] = {
+      { 7457, 7456, 7458, 7457,    1, 1, },
+      { 7457, 7456, 7458, 7458, 7452, 1, },
+    };
+    constexpr static u16 periodPAL[2][6] = {
+      { 8313, 8314, 8312, 8313,    1, 1, },
+      { 8313, 8314, 8312, 8320, 8312, 1,},
+    };
+  };
 
   //apu.cpp
-  auto clockFrameCounter() -> void;
-  auto clockFrameCounterDivider() -> void;
+  auto clockQuarterFrame() -> void;
+  auto clockHalfFrame() -> void;
 
+  FrameCounter frame;
   n5 enabledChannels;
 
 //unserialized:

--- a/ares/fc/apu/apu.hpp
+++ b/ares/fc/apu/apu.hpp
@@ -137,7 +137,6 @@ struct APU {
   struct FrameCounter {
     enum mode: u8 { Freq60Hz = 0, Freq48Hz = 1 };
 
-    auto rate() const -> u32 { return Region::PAL() ? 16 : 12; }
     auto getPeriod() const -> u16 {
       return Region::PAL() ? periodPAL[mode][step] : periodNTSC[mode][step];
     }

--- a/ares/fc/apu/framecounter.cpp
+++ b/ares/fc/apu/framecounter.cpp
@@ -1,0 +1,78 @@
+auto APU::FrameCounter::main() -> void {
+  --counter;
+  odd = !odd;
+
+  if (delay && --delayCounter == 0) {
+    delay = false;
+    mode = newMode;
+    step = 0;
+    counter = getPeriod();
+    if (mode == Freq48Hz) {
+      apu.clockHalfFrame();
+    }
+  }
+
+  if (counter != 0)
+    return;
+
+  switch(step) {
+    case 0:
+      step = 1;
+      apu.clockQuarterFrame();
+      break;
+    case 1:
+      step = 2;
+      apu.clockHalfFrame();
+      break;
+    case 2:
+      step = 3;
+      apu.clockQuarterFrame();
+      break;
+    case 3:
+      step = 4;
+      if (mode == Freq60Hz && irqInhibit == 0)
+        irqPending = 1;
+      break;
+    case 4:
+      step = 5;
+      apu.clockHalfFrame();
+      if (mode == Freq60Hz && irqInhibit == 0)
+        irqPending = 1;
+      break;
+    case 5:
+      step = 0;
+      if (mode == Freq60Hz && irqInhibit == 0)
+        irqPending = 1;
+      break;
+  }
+
+  counter = periodNTSC[mode][counter];
+}
+
+auto APU::FrameCounter::power(bool reset) -> void {
+  irqInhibit = 0;
+  if (!reset) mode = Freq60Hz;
+  newMode = mode;
+
+  irqPending = 0;
+  step = 0;
+  counter = getPeriod();
+
+  odd = true;
+  delay = true;
+  delayCounter = 3;
+}
+
+auto APU::FrameCounter::write(n8 data) -> void {
+  newMode = data.bit(7);
+  delay = true;
+  // If the write occurs during an APU cycle,
+  // the effects occur 3 CPU cycles after the
+  // $4017 write cycle, and if the write occurs
+  // between APU cycles, the effects occurs 4 CPU
+  // cycles after the write cycle.
+  delayCounter = odd ? 4 : 3;
+
+  irqInhibit = data.bit(6);
+  if (irqInhibit) irqPending = 0;
+}

--- a/ares/fc/apu/serialization.cpp
+++ b/ares/fc/apu/serialization.cpp
@@ -76,8 +76,15 @@ auto APU::DMC::serialize(serializer& s) -> void {
 }
 
 auto APU::FrameCounter::serialize(serializer& s) -> void {
-  s(irqPending);
+  s(irqInhibit);
   s(mode);
+  s(newMode);
+
+  s(irqPending);
+  s(step);
   s(counter);
-  s(divider);
+
+  s(odd);
+  s(delay);
+  s(delayCounter);
 }

--- a/ares/fc/cartridge/board/hvc-exrom.cpp
+++ b/ares/fc/cartridge/board/hvc-exrom.cpp
@@ -163,8 +163,6 @@ struct HVC_ExROM : Interface {  //MMC5
       pulse1.envelope.clock();
       pulse2.clockLength();
       pulse2.envelope.clock();
-      // frameDivider += APU::FrameCounter::NtscPeriod;
-      // todo: fix the apu frame counter divider period
       frameDivider += 14915; // ~(21.477MHz / 6 / 240hz)
     }
 

--- a/ares/fc/cartridge/board/hvc-exrom.cpp
+++ b/ares/fc/cartridge/board/hvc-exrom.cpp
@@ -163,7 +163,9 @@ struct HVC_ExROM : Interface {  //MMC5
       pulse1.envelope.clock();
       pulse2.clockLength();
       pulse2.envelope.clock();
-      frameDivider += APU::FrameCounter::NtscPeriod;
+      // frameDivider += APU::FrameCounter::NtscPeriod;
+      // todo: fix the apu frame counter divider period
+      frameDivider += 14915; // ~(21.477MHz / 6 / 240hz)
     }
 
     i32 output = 0;


### PR DESCRIPTION
  detail:
    1. Improve the emulational accuracy of apu framecounter
    2. pass the apu_test/4-jitter.nes

  todo:
    1. Does apu need to emulate blocking_write_4017?

  question:
    1. A white screen will appear when running blargg_apu_2005.07.30/04.clock_jitter.nes