### PR TITLE
macOS: Implement mouse driver

### DIFF
--- a/hiro/cocoa/widget/table-view.cpp
+++ b/hiro/cocoa/widget/table-view.cpp
@@ -159,24 +159,21 @@
 }
 
 -(NSMenu*) menuForEvent:(NSEvent*)event {
-  //macOS doesn't set focus to right-clicked items, but this is neccesary for context menus:
-  //todo: select the current column as well so that doContext(cell) works correctly
-  NSInteger row = [self rowAtPoint:[self convertPoint:event.locationInWindow fromView:nil]];
-  if(row >= 0 && ![self isRowSelected:row]) {
+  NSPoint localPoint = [self convertPoint:event.locationInWindow fromView:nil];
+  NSInteger row = [self rowAtPoint:localPoint];
+  NSInteger column = [self columnAtPoint:localPoint];
+
+
+  if (row >= 0 && ![self isRowSelected:row]) {
     [self selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
   }
 
-#if 0 // breaks the build
-  s32 row = [content clickedRow];
-  if(row >= 0 && _row < tableView->state.items.size()) {
-    s32 column = [content clickedColumn];
-    if(column >= 0 && column < tableView->state.columns.size()) {
-      auto item = tableView->state.items[row];
-      auto cell = item->cell(column);
-      tableView->doContext(cell);
-    }
+  if(column >= 0 && column < tableView->state.columns.size()) {
+    auto item = tableView->state.items[row];
+    auto cell = item->cell(column);
+    tableView->doContext(cell);
   }
-#endif
+
   return nil;
 }
 

--- a/ruby/input/mouse/gcmouse.cpp
+++ b/ruby/input/mouse/gcmouse.cpp
@@ -5,26 +5,63 @@ struct InputMouseGC {
   InputMouseGC(Input& input) : input(input) {}
 
   uintptr handle = 0;
-  bool mouseAcquired = false;
 
-  struct Mouse {
-  } ms;
+  shared_pointer<HID::Mouse> hid{new HID::Mouse};
 
   auto acquired() -> bool {
-    return false;
+    return true;
   }
 
   auto acquire() -> bool {
-    return false;
+    // ms.mouse = [GCMouse current];
+    return acquired();
   }
 
   auto release() -> bool {
     return true;
   }
+
+  auto assign(u32 groupID, u32 inputID, s16 value) -> void {
+    auto& group = hid->group(groupID);
+    if(group.input(inputID).value() == value) return;
+    input.doChange(hid, groupID, inputID, group.input(inputID).value(), value);
+    group.input(inputID).setValue(value);
+  }
     
-  auto poll(vector<shared_pointer<HID::Device>>& devices) -> void {}
+  auto poll(vector<shared_pointer<HID::Device>>& devices) -> void {
+    NSUInteger mouseButtons = [NSEvent pressedMouseButtons];
+    NSPoint mouseLocation = [NSEvent mouseLocation];
+    NSWindow* window = [NSApp mainWindow];
+    NSPoint windowLocation = [window convertPointFromScreen:mouseLocation];
+
+    assign(HID::Mouse::GroupID::Button, 0, mouseButtons & 0x1);
+    assign(HID::Mouse::GroupID::Button, 1, mouseButtons & 0x4);
+    assign(HID::Mouse::GroupID::Button, 2, mouseButtons & 0x2);
+
+    assign(HID::Mouse::GroupID::Axis, 0, windowLocation.x);
+    assign(HID::Mouse::GroupID::Axis, 1, windowLocation.y);
+
+    NSLog(@"Mouse Location - X: %f, Y: %f", windowLocation.x, windowLocation.y);
+
+    devices.append(hid);
+  }
+
 
   auto initialize(uintptr handle) -> bool {
+    hid->setVendorID(HID::Mouse::GenericVendorID);
+    hid->setProductID(HID::Mouse::GenericProductID);
+    hid->setPathID(0);
+
+    hid->axes().append("X");
+    hid->axes().append("Y");
+    // hid->axes().append("Z");
+
+    hid->buttons().append("Left");
+    hid->buttons().append("Middle");
+    hid->buttons().append("Right");
+    hid->buttons().append("Up");
+    hid->buttons().append("Down");
+
     return true;
   }
 

--- a/ruby/input/mouse/nsmouse.cpp
+++ b/ruby/input/mouse/nsmouse.cpp
@@ -7,17 +7,21 @@ struct InputMouseNS {
   uintptr handle = 0;
 
   shared_pointer<HID::Mouse> hid{new HID::Mouse};
+  bool hidden = false;
 
   auto acquired() -> bool {
-    // do this in intialize
-    return true;
+    return hidden;
   }
 
   auto acquire() -> bool {
+    [NSCursor hide];
+    hidden = true;
     return acquired();
   }
 
   auto release() -> bool {
+    [NSCursor unhide];
+    hidden = false;
     return true;
   }
 

--- a/ruby/input/mouse/nsmouse.cpp
+++ b/ruby/input/mouse/nsmouse.cpp
@@ -1,19 +1,19 @@
 #pragma once
 
-struct InputMouseGC {
+struct InputMouseNS {
   Input& input;
-  InputMouseGC(Input& input) : input(input) {}
+  InputMouseNS(Input& input) : input(input) {}
 
   uintptr handle = 0;
 
   shared_pointer<HID::Mouse> hid{new HID::Mouse};
 
   auto acquired() -> bool {
+    // do this in intialize
     return true;
   }
 
   auto acquire() -> bool {
-    // ms.mouse = [GCMouse current];
     return acquired();
   }
 
@@ -38,10 +38,10 @@ struct InputMouseGC {
     assign(HID::Mouse::GroupID::Button, 1, mouseButtons & 0x4);
     assign(HID::Mouse::GroupID::Button, 2, mouseButtons & 0x2);
 
-    assign(HID::Mouse::GroupID::Axis, 0, windowLocation.x);
-    assign(HID::Mouse::GroupID::Axis, 1, windowLocation.y);
+    assign(HID::Mouse::GroupID::Axis, 0, mouseLocation.x);
+    assign(HID::Mouse::GroupID::Axis, 1, mouseLocation.y);
 
-    NSLog(@"Mouse Location - X: %f, Y: %f", windowLocation.x, windowLocation.y);
+    // NSLog(@"Mouse Location - X: %f, Y: %f", windowLocation.x, windowLocation.y);
 
     devices.append(hid);
   }
@@ -54,13 +54,10 @@ struct InputMouseGC {
 
     hid->axes().append("X");
     hid->axes().append("Y");
-    // hid->axes().append("Z");
 
     hid->buttons().append("Left");
     hid->buttons().append("Middle");
     hid->buttons().append("Right");
-    hid->buttons().append("Up");
-    hid->buttons().append("Down");
 
     return true;
   }

--- a/ruby/input/sdl.cpp
+++ b/ruby/input/sdl.cpp
@@ -10,7 +10,7 @@
 #include "mouse/rawinput.cpp"
 #elif defined(PLATFORM_MACOS)
 #include "keyboard/quartz.cpp"
-#include "mouse/gcmouse.cpp"
+#include "mouse/nsmouse.cpp"
 #else
 #include <sys/ipc.h>
 #include <sys/shm.h>
@@ -92,7 +92,7 @@ private:
   InputMouseRawInput mouse;
 #elif defined(PLATFORM_MACOS)
   InputKeyboardQuartz keyboard;
-  InputMouseGC mouse;
+  InputMouseNS mouse;
 #else
   InputKeyboardXlib keyboard;
   InputMouseXlib mouse;


### PR DESCRIPTION
There are a few ways to get mouse position: GCMouse and using NSEvent.

GCMouse is newer and better, it reports mouse movement in raw x/y deltas which is exactly what we need. The issue is that it expects you to set up handlers for the movement events , but I couldn't figure out a way to do that with the existing `poll()` paradigm where it passes the device into the function. Ideally I'd be able to do `assign(HID::Mouse::GroupID::Axis, 0, deltaX);` directly in the event handler.

The other advantage to GCMouse is that we can use `CGAssociateMouseAndMouseCursorPosition` and then we don't have to worry about moving the hidden cursor over built in UI (such as the dock).

This implementation uses regular NSEvent for mouse data which works pretty well with the current poll() paradigm. I had difficulty handing mouse centering/zeroing so I left it out. It works pretty well both full screen and windowed but it is possible to accidentally click the dock.

Open to feedback so please let me know what you think! I'd love to get GCMouse working.

Demo:
https://www.youtube.com/watch?v=UwPyVNWP5hM