### PR TITLE
gba: last cycle of prefetcher cannot be interrupted

### DIFF
--- a/ares/gba/cpu/prefetch.cpp
+++ b/ares/gba/cpu/prefetch.cpp
@@ -1,6 +1,8 @@
 auto CPU::prefetchSync(n32 address) -> void {
   if(address == prefetch.addr) return;
 
+  if(prefetch.wait == 1) step(1);
+
   prefetch.addr = address;
   prefetch.load = address;
   prefetch.wait = _wait(Half | Nonsequential, prefetch.load);
@@ -8,7 +10,7 @@ auto CPU::prefetchSync(n32 address) -> void {
 
 auto CPU::prefetchStep(u32 clocks) -> void {
   step(clocks);
-  if(!wait.prefetch || context.dmaActive) return;
+  if(!wait.prefetch || context.dmaActive || (prefetch.addr == 0)) return;
 
   while(!prefetch.full() && clocks--) {
     if(--prefetch.wait) continue;
@@ -19,8 +21,11 @@ auto CPU::prefetchStep(u32 clocks) -> void {
 }
 
 auto CPU::prefetchReset() -> void {
+  if(prefetch.wait == 1) step(1);
+
   prefetch.addr = 0;
   prefetch.load = 0;
+  prefetch.wait = 0;
 }
 
 auto CPU::prefetchRead() -> n16 {


### PR DESCRIPTION
If the prefetcher is interrupted with 1 cycle left in its fetching operation, run the final cycle regardless. Improves mGBA test suite timings from 1890/2020 to 1904/2020, and passes a [test in the AGBEEG Aging Cartridge dedicated to this prefetcher edge case](https://github.com/zaydlang/AGBEEG-Aging-Cartridge/blob/master/documentation/cartridge/rom_access_during_prefetch.md).