### PR TITLE
fix windows tcp timeout

### DIFF
--- a/nall/tcptext/tcp-socket.cpp
+++ b/nall/tcptext/tcp-socket.cpp
@@ -244,7 +244,11 @@ NALL_HEADER_INLINE auto Socket::open(u32 port, bool useIPv4) -> bool {
       } else if(length == 0) {
         disconnectClient();
       } else {
+        #if defined(PLATFORM_WINDOWS)
+        if (WSAGetLastError() != WSAETIMEDOUT) {
+        #else
         if (errno != EAGAIN) {
+        #endif
           printf("TCP server: error receiving data from client: %s\n", strerror(errno));
           disconnectClient();
         }


### PR DESCRIPTION
Gotta love questionable platform differences. On Windows the old code causes a disconnect after recv times out in 1 second, because errno will always be 0. [Windows does not use errno, or EAGAIN](https://learn.microsoft.com/en-us/windows/win32/winsock/error-codes-errno-h-errno-and-wsagetlasterror-2).
Now when the platform is windows [WSAGetLastError](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-wsagetlasterror) is checked for [WSAETIMEDOUT](https://learn.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2).

I could maybe do some more improvements in the file, (probably in another PR) but I don't know what the project is interested in.
I did not address other uses of errno in the file.
I also did not switch from strerror, which windows does not use, to [FormatMessage](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessage).