### PR TITLE
gba: improve handling of SRAM/Flash bus

### DIFF
--- a/ares/gba/cartridge/memory.hpp
+++ b/ares/gba/cartridge/memory.hpp
@@ -15,8 +15,8 @@ struct MROM {
 
 struct SRAM {
   //sram.cpp
-  auto read(u32 mode, n32 address) -> n32;
-  auto write(u32 mode, n32 address, n32 word) -> void;
+  auto read(n32 address) -> n8;
+  auto write(n32 address, n32 word) -> void;
 
   //serialization.cpp
   auto serialize(serializer&) -> void;

--- a/ares/gba/cartridge/sram.cpp
+++ b/ares/gba/cartridge/sram.cpp
@@ -1,10 +1,7 @@
-auto Cartridge::SRAM::read(u32 mode, n32 address) -> n32 {
-  n32 word = data[address & mask];
-  word |= word <<  8;
-  word |= word << 16;
-  return word;
+auto Cartridge::SRAM::read(n32 address) -> n8 {
+  return data[address & mask];
 }
 
-auto Cartridge::SRAM::write(u32 mode, n32 address, n32 word) -> void {
+auto Cartridge::SRAM::write(n32 address, n32 word) -> void {
   data[address & mask] = word;
 }


### PR DESCRIPTION
This PR accounts for using 16- or 32-bit accesses in the cartridge backup region, which has an 8-bit bus, and accounts for reading from said region when no SRAM or flash memory is present. Passes all of [jsmolka's save tests](https://github.com/jsmolka/gba-tests/tree/master/save).