### PR TITLE
n64: Unload and save before reset() on gamepad and disk

### DIFF
--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -193,11 +193,12 @@ auto Nintendo64::load(Menu menu) -> void {
 }
 
 auto Nintendo64::unload() -> void {
+  Emulator::unload();
+
   gamepad.reset();
   disk.reset();
   gb.reset();
 
-  Emulator::unload();
   diskInsertTimer.reset();
 }
 


### PR DESCRIPTION
https://github.com/ares-emulator/ares/commit/7ad14ff6bfbd7a67fa6670101ef8a30bfa030e5e inadvertently made it so that .pak saves (and other save data) are not properly persisted to disk when unloading the n64 core. This PR resolves that, calling `unload()`, which itself calls `save()`, before resetting the gamepad and other memory.