### PR TITLE
ruby: improve clear() in Metal to prevent possible shader crash

### DIFF
--- a/ruby/video/metal/metal.cpp
+++ b/ruby/video/metal/metal.cpp
@@ -165,8 +165,16 @@ struct VideoMetal : VideoDriver, Metal {
   }
 
   auto clear() -> void override {
-    //force a resize of the framebuffer to clear it, then output one pixel
-    output(1, 1);
+    dispatch_sync(_renderQueue, ^{
+      id<MTLCommandBuffer> commandBuffer = [_commandQueue commandBuffer];
+      MTLRenderPassDescriptor *drawableRenderPassDescriptor = view.currentRenderPassDescriptor;
+      id<MTLRenderCommandEncoder> renderEncoder = [commandBuffer renderCommandEncoderWithDescriptor:drawableRenderPassDescriptor];
+      [renderEncoder endEncoding];
+      id<CAMetalDrawable> drawable = view.currentDrawable;
+      [commandBuffer presentDrawable:drawable];
+      [view draw];
+      [commandBuffer commit];
+    });
   }
 
   auto size(u32& width, u32& height) -> void override {


### PR DESCRIPTION
clear() in Metal was implemented by outputting a (1, 1) sized output buffer. This was very quick and dirty though generally worked.

With librashader introduced in the render output chain, outputting a (1, 1) sized buffer can sometimes, depending on the shader, introduce an intermediate pass that involves a (0, 0) sized MTLTexture, which can lead to assertion failures and possible crashes.

This PR adds an actual clear() implementation that just does a blank render pass. the clear color on the drawable is already defined during initialization so we do not need to redefine it here.

librashader issue: https://github.com/SnowflakePowered/librashader/issues/78