### PR TITLE
CI: Fix macOS build name errors for release action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,9 +213,10 @@ jobs:
         bindir="${GITHUB_WORKSPACE}/bin"
 
         # Hack: Workaround for GitHub artifacts losing attributes.
-        chmod +x ${bindir}/ares-macos/ares.app/Contents/MacOS/ares
+        chmod +x ${bindir}/ares-macos-latest/ares.app/Contents/MacOS/ares
+        chmod +x ${bindir}/ares-macos-compat/ares.app/Contents/MacOS/ares
 
-        for package in windows windows-msvc-arm64 macos
+        for package in windows windows-msvc-arm64 macos-latest macos-compat
         do
           mkdir "${package}"
           cd "${package}"
@@ -315,10 +316,14 @@ jobs:
       uses: actions/upload-release-asset@v1
       env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' }
       with: { upload_url: '${{ env.UPLOAD_URL }}', asset_path: 'ares-windows-msvc-arm64.zip', asset_name: 'ares-windows-msvc-arm64.zip', asset_content_type: 'application/zip' }      
-    - name: Upload ares-macos
+    - name: Upload ares-macos-latest
       uses: actions/upload-release-asset@v1
       env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' }
-      with: { upload_url: '${{ env.UPLOAD_URL }}', asset_path: 'ares-macos.zip', asset_name: 'ares-macos.zip', asset_content_type: 'application/zip' }
+      with: { upload_url: '${{ env.UPLOAD_URL }}', asset_path: 'ares-macos-latest.zip', asset_name: 'ares-macos-latest.zip', asset_content_type: 'application/zip' }
+    - name: Upload ares-macos-compat
+      uses: actions/upload-release-asset@v1
+      env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' }
+      with: { upload_url: '${{ env.UPLOAD_URL }}', asset_path: 'ares-macos-compat.zip', asset_name: 'ares-macos-compat.zip', asset_content_type: 'application/zip' }
 #  - name: Upload ares-ubuntu
 #      uses: actions/upload-release-asset@v1
 #      env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' }


### PR DESCRIPTION
#1463 renamed the `macos` build to `macos-latest` and introduced `macos-compat`. We need to address the rename in the release workflow. I believe this PR accounts for every use of the package name. Also adds macos-compat to the release (for now).