### PR TITLE
CI: Update upload-artifact and download-artifact to use v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
         MACOS_NOTARIZATION_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}
         MACOS_NOTARIZATION_TEAMID: ${{ secrets.MACOS_NOTARIZATION_TEAMID }}
     - name: Upload
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.program }}-${{ matrix.platform.name }}
         path: desktop-ui/out/*
@@ -197,7 +197,7 @@ jobs:
       with:
         path: 'src'
     - name: Download Artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         path: 'bin'
     - name: Package Artifacts


### PR DESCRIPTION
- v2 will be unavailable from the end of June 2024
- v4 can be up to 98% faster than previous versions according to [Github's notification](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

This PR only changes the version number, and I'm submitting it to see if it works. 
It is possible that further changes are necessary, as there were some [breaking changes](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes), but I don't think any of them apply to ares. 

Testing: 
- See if CI passes
- See if warnings regarding using v2 of `upload-artifact` and `download-artifact` are gone (There will still be other warnings regarding `checkout` and `cache`)
- (Optional) Compare times for the tasks using `upload-artifact` and `download-artifact` with previous CI runs