### PR TITLE
Disable run ahead for 64DD, fixes load failures

### DIFF
--- a/desktop-ui/program/utility.cpp
+++ b/desktop-ui/program/utility.cpp
@@ -28,6 +28,7 @@ auto Program::runAheadUpdate() -> void {
   if(!emulator) return;
   if(emulator->name == "Game Boy Advance") runAhead = false;  //crashes immediately
   if(emulator->name == "Nintendo 64") runAhead = false;  //too demanding
+  if(emulator->name == "Nintendo 64DD") runAhead = false;  //too demanding
   if(emulator->name == "PlayStation") runAhead = false;  //too demanding
 }
 


### PR DESCRIPTION
Turns out the problem some folks experienced trying to load 64DD games was due to run ahead not being disabled by default. An exception for this system has been added.