### PR TITLE
CI: Update cache and checkout to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
         keychain-name: ares-macos-keychain
         keychain-password: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install Windows Dependencies
       if: runner.os == 'Windows'
       run: |
@@ -193,7 +193,7 @@ jobs:
     needs:
     - build
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         path: 'src'
     - name: Download Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
         fi
     - name: "macOS: recover MoltenVK cache"
       if: runner.os == 'macOS'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
           cache-name: moltenvk
       with:


### PR DESCRIPTION
- Updates `checkout` from v2 to v4
- Updates `cache` from v3 to v4

Reasons for change: 
- Checkout@v2 runs on node 12, which has been [discontinued](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/)
- Checkout@v3 runs on node 16 and has also reached its [end of life](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), so skip it entirely. 
- Cache@v3 runs on node 16 as well, so update to v4 for the same reason.

Testing: 
- Ensure CI passes
- Check that warnings regarding `checkout` and `cache` are gone