### PR TITLE
nall: fix Wcast-user-defined warning

### DIFF
--- a/nall/primitives/bit-field.hpp
+++ b/nall/primitives/bit-field.hpp
@@ -25,7 +25,7 @@ template<s32 Precision, s32 Index> struct BitField<Precision, Index> {
     return *this;
   }
 
-  template<typename T> BitField(T* source) : target((type&)*source) {
+  template<typename T> BitField(T* source) : target(reinterpret_cast<type&>(*source)) {
     static_assert(sizeof(T) == sizeof(type));
   }
 

--- a/nall/primitives/bit-range.hpp
+++ b/nall/primitives/bit-range.hpp
@@ -27,7 +27,7 @@ template<s32 Precision, s32 Lo, s32 Hi> struct BitRange {
     return *this;
   }
 
-  template<typename T> BitRange(T* source) : target((type&)*source) {
+  template<typename T> BitRange(T* source) : target(reinterpret_cast<type&>(*source)) {
     static_assert(sizeof(T) == sizeof(type));
   }
 

--- a/nall/string/markup/bml.hpp
+++ b/nall/string/markup/bml.hpp
@@ -150,7 +150,7 @@ inline auto unserialize(const string& markup, string_view spacing = {}) -> Marku
   } catch(const char* error) {
     node.reset();
   }
-  return (Markup::SharedNode&)node;
+  return Markup::SharedNode(node);
 }
 
 inline auto serialize(const Markup::Node& node, string_view spacing = {}, u32 depth = 0) -> string {

--- a/nall/string/markup/xml.hpp
+++ b/nall/string/markup/xml.hpp
@@ -213,7 +213,7 @@ inline auto unserialize(const string& markup) -> Markup::Node {
   } catch(const char* error) {
     node.reset();
   }
-  return (Markup::SharedNode&)node;
+  return Markup::SharedNode(node);
 }
 
 }


### PR DESCRIPTION
Compiling with GCC 14.1 in MSYS2 caused a lot of warnings of the `-Wcast-user-defined` variety. This PR adresses that.

Note: This PR does not address https://github.com/ares-emulator/ares/issues/1399 . Those warnings happen at the link stage, they don't seem to be GCC-only (since issue OP also reports them with clang), and they don't appear at lower optimization settings (I tested `build=debug` and `build=stable` which compiled cleanly).