### PR TITLE
Resize target buffer when IPS patch extends beyond original source size

### DIFF
--- a/nall/ips.hpp
+++ b/nall/ips.hpp
@@ -41,7 +41,9 @@ inline auto apply(array_view<u8> source, array_view<u8> patch, maybe<string&> re
         u32 offset = readOffset();
         u32 length = readLength();
 
-        if(target.size() < offset + length) error("Invalid IPS patch file");
+        if(target.size() < offset + length) { 
+            target.resize(target.size() + ((u64)(offset + length) - target.size()), 0); 
+        }
 
         if (length == 0) {
             length = readLength();

--- a/nall/ips.hpp
+++ b/nall/ips.hpp
@@ -40,15 +40,20 @@ inline auto apply(array_view<u8> source, array_view<u8> patch, maybe<string&> re
     while (patchOffset < patchSize - 3) {
         u32 offset = readOffset();
         u32 length = readLength();
+        bool rleRecord = false;
+
+        if (length == 0) {
+            length = readLength();
+            rleRecord = true;
+        }
 
         if(target.size() < offset + length) { 
             target.resize(target.size() + ((u64)(offset + length) - target.size()), 0); 
         }
 
-        if (length == 0) {
-            length = readLength();
+        if(rleRecord) {
             u8 data = read();
-            for(u32 i : range(length)) write(offset + i, data);
+            for (u32 i : range(length)) write(offset + i, data);
         } else {
             for (u32 i : range(length)) write(offset + i, read());
         }


### PR DESCRIPTION
For IPS patches that extend the original ROM beyond its initial size, we will now resize the target buffer when patches extend the size of the original. 

Originally found testing out the Shin Megami Tensei patch by Orden (https://www.romhacking.net/translations/2616/), which will now work correctly.