### PR TITLE
gba: improve BIOS open bus edge case handling

### DIFF
--- a/ares/gba/system/system.hpp
+++ b/ares/gba/system/system.hpp
@@ -4,6 +4,7 @@ struct BIOS {
   //bios.cpp
   auto load(Node::Object) -> void;
   auto unload() -> void;
+  auto readROM(n25 address) -> n32;
   auto read(u32 mode, n25 address) -> n32;
   auto write(u32 mode, n25 address, n32 word) -> void;
   auto serialize(serializer&) -> void;


### PR DESCRIPTION
This PR improves handling of BIOS open bus edge cases that previously were handled incorrectly, such as unaligned 8-bit and 16-bit accesses, and cases where the last value read from BIOS was not a 32-bit value.