### PR TITLE
gba: synchronize CPU with other components more frequently

### DIFF
--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -81,10 +81,10 @@ auto CPU::step(u32 clocks) -> void {
   }
 
   #if defined(PROFILE_PERFORMANCE)
-  //20% speedup by only synchronizing other components every 64 clock cycles
+  //10-20% speedup by only synchronizing other components every 16 clock cycles
   static u32 counter = 0;
   counter += clocks;
-  if(counter < 64) return;
+  if(counter < 16) return;
   clocks = counter;
   counter = 0;
   #endif


### PR DESCRIPTION
Reduces the synchronization interval between the GBA CPU and other components from 64 to 16 cycles, which significantly improves PPU timings in the performance profile. These PPU timing improvements can be observed in [status-irq-dma.gba](https://github.com/nba-emu/hw-test/tree/master/ppu/status-irq-dma), which now frequently gets results within a few cycles of the correct values in situations which were previously off by dozens of cycles. While this does impact performance by ~5-10%, in my testing this is still faster than versions from before [commit b145f0f](https://github.com/ares-emulator/ares/commit/b145f0f000c4e0ddedf25a62cdcfe713deea1f6a).