### PR TITLE
n64: fix macOS build

### DIFF
--- a/ares/n64/vulkan/parallel-rdp/util/thread_name.cpp
+++ b/ares/n64/vulkan/parallel-rdp/util/thread_name.cpp
@@ -22,7 +22,7 @@
 
 #include "thread_name.hpp"
 
-#ifdef __linux__
+#if !defined(_WIN32)
 #include <pthread.h>
 #else
 #define WIN32_LEAN_AND_MEAN
@@ -34,9 +34,11 @@ namespace Util
 {
 void set_current_thread_name(const char *name)
 {
-#ifdef __linux__
+#if defined(__linux__)
 	pthread_setname_np(pthread_self(), name);
-#else
+#elif defined(__APPLE__)
+  pthread_setname_np(name);
+#elif defined(_WIN32)
 	using PFN_SetThreadDescription = HRESULT (WINAPI *)(HANDLE, PCWSTR);
 	auto module = GetModuleHandleA("kernel32.dll");
 	PFN_SetThreadDescription SetThreadDescription = module ? reinterpret_cast<PFN_SetThreadDescription>(


### PR DESCRIPTION
The paraLLEl-RDP build was broken on macOS because of a change from February to Granite in regarding platform ifdefs for pthreads.

A PR that applies a fix has been opened [upstream](https://github.com/Themaister/Granite/pull/131), but until an upstream fix lands, this PR will unbreak the build for ares without needing to roll back the recent paraLLEl-RDP update entirely.