### PR TITLE
ruby: Add source frame scaling via `screen` functions

### DIFF
--- a/ares/ares/node/video/screen.cpp
+++ b/ares/ares/node/video/screen.cpp
@@ -104,6 +104,7 @@ auto Screen::setScale(f64 scaleX, f64 scaleY) -> void {
   lock_guard<recursive_mutex> lock(_mutex);
   _scaleX = scaleX;
   _scaleY = scaleY;
+  platform->setScale(scaleX, scaleY);
 }
 
 auto Screen::setAspect(f64 aspectX, f64 aspectY) -> void {
@@ -160,6 +161,7 @@ auto Screen::setProgressive(bool progressiveDouble) -> void {
   _interlace = false;
   _progressive = true;
   _progressiveDouble = progressiveDouble;
+  platform->setProgressive(progressiveDouble);
 }
 
 auto Screen::setInterlace(bool interlaceField) -> void {
@@ -167,6 +169,7 @@ auto Screen::setInterlace(bool interlaceField) -> void {
   _progressive = false;
   _interlace = true;
   _interlaceField = interlaceField;
+  platform->setInterlace(interlaceField);
 }
 
 auto Screen::attach(Node::Video::Sprite sprite) -> void {

--- a/ares/ares/platform.hpp
+++ b/ares/ares/platform.hpp
@@ -19,6 +19,9 @@ struct Platform {
   virtual auto status(string_view message) -> void {}
   virtual auto video(Node::Video::Screen, const u32* data, u32 pitch, u32 width, u32 height) -> void {}
   virtual auto refreshRateHint(double refreshRate) -> void {}
+  virtual auto setScale(f64 scaleX, f64 scaleY) -> void {}
+  virtual auto setInterlace(bool interlaceField) -> void {}
+  virtual auto setProgressive(bool progressivedouble) -> void {}
   virtual auto audio(Node::Audio::Stream) -> void {}
   virtual auto input(Node::Input::Input) -> void {}
   virtual auto cheat(u32 addr) -> maybe<u32> { return nothing; }

--- a/desktop-ui/program/platform.cpp
+++ b/desktop-ui/program/platform.cpp
@@ -136,6 +136,18 @@ auto Program::refreshRateHint(double refreshRate) -> void {
   ruby::video.refreshRateHint(refreshRate);
 }
 
+auto Program::setScale(f64 scaleX, f64 scaleY) -> void {
+  ruby::video.setScale(scaleX, scaleY);
+}
+
+auto Program::setInterlace(bool interlaceField) -> void {
+  ruby::video.setInterlace(interlaceField);
+}
+
+auto Program::setProgressive(bool progressiveDouble) -> void {
+  ruby::video.setProgressive(progressiveDouble);
+}
+
 auto Program::audio(ares::Node::Audio::Stream node) -> void {
   if(!streams) return;
 

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -12,6 +12,9 @@ struct Program : ares::Platform {
   auto status(string_view message) -> void override;
   auto video(ares::Node::Video::Screen, const u32* data, u32 pitch, u32 width, u32 height) -> void override;
   auto refreshRateHint(double refreshRate) -> void override;
+  auto setScale(f64 scaleX, f64 scaleY) -> void override;
+  auto setInterlace(bool interlaceField) -> void override;
+  auto setProgressive(bool progressiveDouble) -> void override;
   auto audio(ares::Node::Audio::Stream) -> void override;
   auto input(ares::Node::Input::Input) -> void override;
   auto cheat(u32 address) -> maybe<u32> override;

--- a/ruby/video/metal/metal.cpp
+++ b/ruby/video/metal/metal.cpp
@@ -251,7 +251,9 @@ struct VideoMetal : VideoDriver, Metal {
     if (scaleX != _scaleX || scaleY != scaleY) {
       _scaleX = scaleX;
       _scaleY = scaleY;
-      resizeSourceBuffers();
+      dispatch_async(_renderQueue, ^{
+        resizeSourceBuffers();
+      });
     }
   }
   
@@ -259,14 +261,18 @@ struct VideoMetal : VideoDriver, Metal {
     if (_interlace) return;
     _interlace = true;
     _progressive = false;
-    resizeSourceBuffers();
+    dispatch_async(_renderQueue, ^{
+      resizeSourceBuffers();
+    });
   }
   
   auto setProgressive(bool progressiveDouble) -> void override {
     if (_progressive) return;
     _interlace = false;
     _progressive = true;
-    resizeSourceBuffers();
+    dispatch_async(_renderQueue, ^{
+      resizeSourceBuffers();
+    });
   }
 
   auto acquire(u32*& data, u32& pitch, u32 width, u32 height) -> bool override {
@@ -283,8 +289,10 @@ struct VideoMetal : VideoDriver, Metal {
       
       bytesPerRow = sourceWidth * sizeof(u32);
       if (bytesPerRow < 16) bytesPerRow = 16;
-        
-      resizeSourceBuffers();
+      
+      dispatch_async(_renderQueue, ^{
+        resizeSourceBuffers();
+      });
     }
     pitch = sourceWidth * sizeof(u32);
     return data = buffer;

--- a/ruby/video/metal/metal.cpp
+++ b/ruby/video/metal/metal.cpp
@@ -210,6 +210,64 @@ struct VideoMetal : VideoDriver, Metal {
     _outputX = (width - outputWidth) / 2;
     _outputY = (height - outputHeight) / 2;
   }
+  
+  auto resizeSourceBuffers() {
+    for (int i = 0; i < kMaxSourceBuffersInFlight; i++) {
+      if (sourceWidth < 1 || sourceHeight < 1) {
+        _sourceTextures[i] = nullptr;
+        continue;
+      }
+      MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor new];
+      textureDescriptor.pixelFormat = MTLPixelFormatBGRA8Unorm;
+      textureDescriptor.width = sourceWidth;
+      textureDescriptor.height = sourceHeight;
+      textureDescriptor.usage = MTLTextureUsageRenderTarget|MTLTextureUsageShaderRead;
+      
+      _sourceTextures[i] = [_device newTextureWithDescriptor:textureDescriptor];
+    }
+    
+    f64 newWidth = sourceWidth * _scaleX;
+    f64 newHeight = sourceHeight * _scaleY;
+    if (_interlace) {
+      newHeight = sourceHeight;
+    }
+    for (int i = 0; i < kMaxSourceBuffersInFlight; i++) {
+      if (newWidth < 1 || newHeight < 1) {
+        _finalSourceTextures[i] = nullptr;
+        continue;
+      }
+      MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor new];
+      textureDescriptor.pixelFormat = MTLPixelFormatBGRA8Unorm;
+      textureDescriptor.width = newWidth;
+      textureDescriptor.height = newHeight;
+      textureDescriptor.usage = MTLTextureUsageRenderTarget|MTLTextureUsageShaderRead;
+      
+      _finalSourceTextures[i] = [_device newTextureWithDescriptor:textureDescriptor];
+    }
+    NSLog(@"Resized final source textures to %lf, %lf", newWidth, newHeight);
+  }
+	
+  auto setScale(f64 scaleX, f64 scaleY) -> void override {
+    if (scaleX != _scaleX || scaleY != scaleY) {
+      _scaleX = scaleX;
+      _scaleY = scaleY;
+      resizeSourceBuffers();
+    }
+  }
+  
+  auto setInterlace(bool interlaceField) -> void override {
+    if (_interlace) return;
+    _interlace = true;
+    _progressive = false;
+    resizeSourceBuffers();
+  }
+  
+  auto setProgressive(bool progressiveDouble) -> void override {
+    if (_progressive) return;
+    _interlace = false;
+    _progressive = true;
+    resizeSourceBuffers();
+  }
 
   auto acquire(u32*& data, u32& pitch, u32 width, u32 height) -> bool override {
     if (sourceWidth != width || sourceHeight != height) {
@@ -226,20 +284,7 @@ struct VideoMetal : VideoDriver, Metal {
       bytesPerRow = sourceWidth * sizeof(u32);
       if (bytesPerRow < 16) bytesPerRow = 16;
         
-      for (int i = 0; i < kMaxSourceBuffersInFlight; i++) {
-        if (sourceWidth < 1 || sourceHeight < 1) {
-          _sourceTextures[i] = nullptr;
-          continue;
-        }
-        MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor new];
-        textureDescriptor.pixelFormat = MTLPixelFormatBGRA8Unorm;
-        textureDescriptor.width = sourceWidth;
-        textureDescriptor.height = sourceHeight;
-        textureDescriptor.usage = MTLTextureUsageRenderTarget|MTLTextureUsageShaderRead;
-        
-        _sourceTextures[i] = [_device newTextureWithDescriptor:textureDescriptor];
-      }
-      
+      resizeSourceBuffers();
     }
     pitch = sourceWidth * sizeof(u32);
     return data = buffer;
@@ -312,6 +357,7 @@ struct VideoMetal : VideoDriver, Metal {
       auto index = frameCount % kMaxSourceBuffersInFlight;
       
       auto sourceTexture = _sourceTextures[index];
+      auto finalSourceTexture = _finalSourceTextures[index];
       
       [sourceTexture replaceRegion:MTLRegionMake2D(0, 0, sourceWidth, sourceHeight) mipmapLevel:0 withBytes:buffer bytesPerRow:bytesPerRow];
       
@@ -325,18 +371,18 @@ struct VideoMetal : VideoDriver, Metal {
       /// assurances that we won't block the emulation thread in the worst case system conditions.
       if ((_blocking && !_vrrIsSupported) || !_threaded) {
         dispatch_sync(_renderQueue, ^{
-          outputHelper(width, height, sourceTexture);
+          outputHelper(width, height, sourceTexture, finalSourceTexture);
         });
       } else {
         dispatch_async(_renderQueue, ^{
-          outputHelper(width, height, sourceTexture);
+          outputHelper(width, height, sourceTexture, finalSourceTexture);
         });
       }
     }
   }
 
 private:
-  auto outputHelper(u32 width, u32 height, id<MTLTexture> sourceTexture) -> void {
+  auto outputHelper(u32 width, u32 height, id<MTLTexture> sourceTexture, id<MTLTexture> finalSourceTexture) -> void {
     /// Uses two render passes (plus librashader's render passes). The first render pass samples the source texture,
     /// consisting of the pixel buffer from the emulator, onto a texture the same size as our eventual output,
     /// `_renderTargetTexture`. Then it calls into librashader, which performs postprocessing onto the same
@@ -355,7 +401,7 @@ private:
        dispatch_semaphore_signal(block_sema);
       }];
       
-      _renderToTextureRenderPassDescriptor.colorAttachments[0].texture = _renderTargetTexture;
+      _renderToTextureRenderPassDescriptor.colorAttachments[0].texture = finalSourceTexture;
       
       if (_renderToTextureRenderPassDescriptor != nil) {
         
@@ -365,7 +411,7 @@ private:
         
         [renderEncoder setRenderPipelineState:_renderToTextureRenderPipeline];
         
-        [renderEncoder setViewport:(MTLViewport){0, 0, (double)width, (double)height, -1.0, 1.0}];
+        [renderEncoder setViewport:(MTLViewport){0, 0, (double)finalSourceTexture.width, (double)finalSourceTexture.height, -1.0, 1.0}];
         
         [renderEncoder setVertexBuffer:_vertexBuffer
                                 offset:0
@@ -382,7 +428,36 @@ private:
         [renderEncoder endEncoding];
         
         if (_filterChain) {
-          _libra.mtl_filter_chain_frame(&_filterChain, commandBuffer, frameCount, sourceTexture, _libraViewport, _renderTargetTexture, nil, nil);
+          _libra.mtl_filter_chain_frame(&_filterChain, commandBuffer, frameCount, finalSourceTexture, _libraViewport, _renderTargetTexture, nil, nil);
+        } else {
+          
+          _renderToTextureRenderPassDescriptor.colorAttachments[0].texture = _renderTargetTexture;
+          
+          if (_renderToTextureRenderPassDescriptor != nil) {
+            
+            id<MTLRenderCommandEncoder> renderEncoder = [commandBuffer renderCommandEncoderWithDescriptor:_renderToTextureRenderPassDescriptor];
+            
+            _renderToTextureRenderPassDescriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
+            
+            [renderEncoder setRenderPipelineState:_renderToTextureRenderPipeline];
+            
+            [renderEncoder setViewport:(MTLViewport){0, 0, (double)width, (double)height, -1.0, 1.0}];
+            
+            [renderEncoder setVertexBuffer:_vertexBuffer
+                                    offset:0
+                                   atIndex:0];
+            
+            [renderEncoder setVertexBytes:&_viewportSize
+                                   length:sizeof(_viewportSize)
+                                  atIndex:MetalVertexInputIndexViewportSize];
+            
+            [renderEncoder setFragmentTexture:finalSourceTexture atIndex:0];
+            
+            [renderEncoder drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:6];
+            
+            [renderEncoder endEncoding];
+            
+          }
         }
         
         //this call will block the current thread/queue if a drawable is not yet available

--- a/ruby/video/metal/metal.hpp
+++ b/ruby/video/metal/metal.hpp
@@ -45,6 +45,10 @@ struct Metal {
   auto initialize(const string& shader) -> bool;
   auto terminate() -> void;
   auto refreshRateHint(double refreshRate) -> void;
+  auto setScale(f64 scaleX, f64 scaleY) -> void;
+  auto setInterlace(bool interlaceField) -> void;
+  auto setProgressive(bool progressiveDouble) -> void;
+  auto resizeSourceBuffers() -> void;
   
   auto size(u32 width, u32 height) -> void;
   auto release() -> void;
@@ -54,6 +58,8 @@ struct Metal {
   
   u32 sourceWidth = 0;
   u32 sourceHeight = 0;
+  f64 _scaleX = 1;
+  f64 _scaleY = 1;
   u32 bytesPerRow = 0;
   
   u32 outputWidth = 0;
@@ -61,6 +67,9 @@ struct Metal {
   double _outputX = 0;
   double _outputY = 0;
   u32 depth = 0;
+  
+  bool _interlace = false;
+  bool _progressive = false;
   
   dispatch_queue_t _renderQueue = nullptr;
   
@@ -89,6 +98,7 @@ struct Metal {
   
   id<MTLBuffer> _vertexBuffer;
   id<MTLTexture> _sourceTextures[kMaxSourceBuffersInFlight];
+  id<MTLTexture> _finalSourceTextures[kMaxSourceBuffersInFlight];
   MTLVertexDescriptor *_mtlVertexDescriptor;
   
   MTLRenderPassDescriptor *_renderToTextureRenderPassDescriptor;

--- a/ruby/video/video.cpp
+++ b/ruby/video/video.cpp
@@ -113,6 +113,21 @@ auto Video::refreshRateHint(double refreshRate) -> void {
   instance->refreshRateHint(refreshRate);
 }
 
+auto Video::setScale(f64 scaleX, f64 scaleY) -> void {
+  lock_guard<recursive_mutex> lock(mutex);
+  instance->setScale(scaleX, scaleY);
+}
+
+auto Video::setInterlace(bool interlaceField) -> void {
+  lock_guard<recursive_mutex> lock(mutex);
+  instance->setInterlace(interlaceField);
+}
+
+auto Video::setProgressive(bool progressiveDouble) -> void {
+  lock_guard<recursive_mutex> lock(mutex);
+  instance->setProgressive(progressiveDouble);
+}
+
 //
 
 auto Video::focused() -> bool {

--- a/ruby/video/video.hpp
+++ b/ruby/video/video.hpp
@@ -34,6 +34,9 @@ struct VideoDriver {
   virtual auto setFormat(string format) -> bool { return true; }
   virtual auto setShader(string shader) -> bool { return true; }
   virtual auto refreshRateHint(double refreshRate) -> void {}
+  virtual auto setScale(f64 scaleX, f64 scaleY) -> void {}
+  virtual auto setInterlace(bool interlaceField) -> void {}
+  virtual auto setProgressive(bool progressiveDouble) -> void {}
 
   virtual auto focused() -> bool { return true; }
   virtual auto clear() -> void {}
@@ -129,6 +132,9 @@ struct Video {
   auto setFormat(string format) -> bool;
   auto setShader(string shader) -> bool;
   auto refreshRateHint(double refreshRate) -> void;
+  auto setScale(f64 scaleX, f64 scaleY) -> void;
+  auto setInterlace(bool interlaceField) -> void;
+  auto setProgressive(bool progressiveDouble) -> void;
 
   auto focused() -> bool;
   auto clear() -> void;


### PR DESCRIPTION
(Marked as draft pending some further testing and any feedback)

This PR exposes several methods in `screen` to the video backend in `ruby`, in order to resolve certain libretro shader scaling issues, and downscale source frame buffers as appropriate to improve shader performance.

### Background

ares's current rendering strategy, broadly, is to render frames on the CPU one at a time before sending them to the video backend. The frames sent to the video backend can have many duplicated pixels present, as a shortcut to account for cases where frames contain scanlines with different pixel clocks. Unless we scale these buffers down to the appropriate size before sending them to librashader, we can introduce artifacts, cause incorrect shader behavior, or even [crash](https://github.com/SnowflakePowered/librashader/issues/79) if we cause a shader to create an overly large texture.

By allowing `screen`'s `setScale`, `setInterlace` and `setProgressive` methods to call into the video backend, we can signal that ruby should scale down the framebuffers appropriately before sending them to shaders. This is (in theory of course) more efficient than performing this scaling on the CPU, and more streamlined logically in terms of making the video backend responsible for the final frame buffer creation.

### Proof of concept

To test this approach, I added rudimentary implementations of these functions for the Metal backend. These methods basically do the following in a separate render pass, prior to shader passes:
* In terms of width, simply always scale the framebuffer to the largest pixel width.
* In terms of height, if we are in the progressive mode and the framebuffer is doubling identical lines, scale down.
* If we're in the interlaced mode and lines are doubled, don't scale down, because a frame larger in height than a deinterlaced frame often acts as a signal for shaders that we are outputting interlaced video.

This approach is basic and may need refinement, but is a solid improvement on existing behavior in my testing.

### Future work

(Disclaimer; not trying to speak for maintainers here; just thinking out loud):

Per conversations on the ares Discord, it seems as though ares may in the future move toward a renderer that leans more heavily on the video backend, perhaps similar to the approach taken by something like CLK, where the core generates a video signal, and the display backend is entirely responsible for synthesizing that signal into frames. This could have numerous advantages in terms of accuracy, performance and latency.

While not terribly significant, this PR could be considered a small step in this direction, as it moves some of the work generating the final source frame from the CPU to the GPU/display backend.

This does, however, also mean that for other video backends to achieve parity with Metal in terms of framebuffer scaling, they will need to implement `setScale`, `setInterlace` and `setProgressive` themselves in some fashion.

### Examples

`crt/crt-maximus-royale.slangp` used here, not because it is my favorite shader but because it seems to detect interlacing changes on the fly, and also creates very large textures.

SNES 240p, first with PR then without PR:

<img width="400" alt="Screenshot 2024-05-29 at 12 51 36 AM" src="https://github.com/ares-emulator/ares/assets/6864788/df30249e-c2a4-4db1-8c92-ea8157cd0093">
<img width="400" alt="Screenshot 2024-05-29 at 12 54 21 AM" src="https://github.com/ares-emulator/ares/assets/6864788/05860e9a-c417-4d21-ab1e-48c257fe6a90">

Sega 32x at combined 320/256 pixel width, first with PR then without PR:

<img width="400" alt="Screenshot 2024-05-29 at 12 51 36 AM" src="https://github.com/ares-emulator/ares/assets/6864788/49303fe2-8626-4211-8615-45f222ae7806">
<img width="400" alt="Screenshot 2024-05-29 at 12 54 21 AM" src="https://github.com/ares-emulator/ares/assets/6864788/12c3b670-12bf-4ec4-adad-b5c8915d1bee">

Sonic 2 switching from interlaced to progressive during runtime (works both ways) (crashes without PR):

<img width="400" alt="Screenshot 2024-05-29 at 12 54 21 AM" src="https://github.com/ares-emulator/ares/assets/6864788/3b609ec9-3a04-45e0-b6c5-5ffeb8a61959">
