### PR TITLE
n64: poll gdb more frequently

### DIFF
--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -37,6 +37,17 @@ auto CPU::main() -> void {
   }
 
   vi.refreshed = false;
+  queue.remove(Queue::GDB_Poll);
+  if(GDB::server.hasClient()) {
+    queue.insert(Queue::GDB_Poll, (93750000*2)/60/240);
+  }
+}
+
+auto CPU::gdbPoll() -> void {
+  if(GDB::server.hasClient()) {
+    GDB::server.updateLoop();
+    queue.insert(Queue::GDB_Poll, (93750000*2)/60/240);
+  }
 }
 
 auto CPU::synchronize() -> void {
@@ -68,6 +79,7 @@ auto CPU::synchronize() -> void {
     case Queue::DD_MECHA_Response:  return dd.mechaResponse();
     case Queue::DD_BM_Request:  return dd.bmRequest();
     case Queue::DD_Motor_Mode:  return dd.motorChange();
+    case Queue::GDB_Poll:      return cpu.gdbPoll();
     }
   });
 

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -35,6 +35,8 @@ struct CPU : Thread {
   auto main() -> void;
   auto synchronize() -> void;
 
+  auto gdbPoll() -> void;
+
   auto instruction() -> void;
   auto instructionPrologue(u32 instruction) -> void;
   auto instructionEpilogue() -> s32;

--- a/ares/n64/n64.hpp
+++ b/ares/n64/n64.hpp
@@ -73,6 +73,7 @@ namespace ares::Nintendo64 {
       DD_MECHA_Response,
       DD_BM_Request,
       DD_Motor_Mode,
+      GDB_Poll,
     };
   };
   extern Queue queue;

--- a/nall/gdb/server.cpp
+++ b/nall/gdb/server.cpp
@@ -505,7 +505,8 @@ namespace nall::GDB {
   }
 
   auto Server::onDisconnect() -> void {
-    printf("GDB client disconnected\n");
+    if (hasActiveClient)
+      printf("GDB client disconnected\n");
     hadHandshake = false;
     resetClientData();
   }


### PR DESCRIPTION
Currently, gdb is polled once per frame, which seems enough for interactive usage. Some ROM hacks would like to use the gdb interface to provide additional emulation-only features such as online multiplayer, but that requires a faster turnaround.

A quick solution is to poll gdb more frequently within the n64 core. This patch does that once per screen line, approximately. Notice that the poll is only scheduled and run if there is a gdb client connected so it should not cause any performance impact on normal users.