### PR TITLE
UI: Initialize all video options correctly on driver settings update

### DIFF
--- a/desktop-ui/program/drivers.cpp
+++ b/desktop-ui/program/drivers.cpp
@@ -7,6 +7,9 @@ auto Program::videoDriverUpdate() -> void {
   ruby::video.setBlocking(settings.video.blocking);
   ruby::video.setFlush(settings.video.flush);
   ruby::video.setShader(settings.video.shader);
+  ruby::video.setForceSRGB(settings.video.forceSRGB);
+  ruby::video.setThreadedRenderer(settings.video.threadedRenderer);
+  ruby::video.setNativeFullScreen(settings.video.nativeFullScreen);
 
   if(!ruby::video.ready()) {
     MessageDialog().setText({"Failed to initialize ", settings.video.driver, " video driver."}).setAlignment(presentation).error();

--- a/ruby/video/metal/metal.cpp
+++ b/ruby/video/metal/metal.cpp
@@ -576,13 +576,9 @@ private:
     view = [[RubyVideoMetal alloc] initWith:this frame:frame device:_device];
     [context addSubview:view];
     [[view window] makeFirstResponder:view];
-    bool forceSRGB = self.forceSRGB;
-    self.setForceSRGB(forceSRGB);
     view.autoresizingMask = NSViewWidthSizable|NSViewHeightSizable;
     
-    _threaded = self.threadedRenderer;
-    _blocking = self.blocking;
-    setNativeFullScreen(self.nativeFullScreen);
+    //driver settings like sync, flush, threaded renderer, etc. will be initialized later
 
     _libra = librashader_load_instance();
     if (!_libra.instance_loaded) {


### PR DESCRIPTION
Just a small fix to account for the new video settings in Metal; the threaded renderer, native fullscreen behavior and color space option. These options were not fully persistent because the `videoDriverUpdate` function (run on startup, among other times) did not account for them. They would be set correctly in `settings.bml` and the settings object, but would never actually be set correctly on the driver struct.