### PR TITLE
Support default device in WASAPI driver

### DIFF
--- a/desktop-ui/resource/ares.Manifest
+++ b/desktop-ui/resource/ares.Manifest
@@ -6,6 +6,18 @@
       <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>
     </dependentAssembly>
   </dependency>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+      <application>
+          <!-- Windows 10 and Windows 11 -->
+          <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+          <!-- Windows 8.1 -->
+          <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+          <!-- Windows 8 -->
+          <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+          <!-- Windows 7 -->
+          <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      </application>
+  </compatibility>
   <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
     <asmv3:windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>


### PR DESCRIPTION
The WASAPI sound driver now supports a "Default" audio output device:
<img src="https://github.com/ares-emulator/ares/assets/27514983/fbf358d6-41e7-478d-8a76-fc86790d7774" width="650" />

This uses the [Automatic Stream Routing](https://learn.microsoft.com/en-us/windows/win32/coreaudio/automatic-stream-routing) API that was introduced in Windows 10. A runtime check was added to ensure that the feature does not appear on older versions of Windows.

I did some limited testing and found the feature to work without issues.

Closes https://github.com/ares-emulator/ares/issues/1514