### PR TITLE
gba: improve video capture DMA

### DIFF
--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -141,7 +141,11 @@ auto PPU::main() -> void {
   step(226);
   io.hblank = 0;
   if(++io.vcounter == 228) io.vcounter = 0;
-  if(io.vcounter > 1 && io.vcounter < 162) cpu.dmaHDMA();
+  if(io.vcounter == 162) {
+    if(videoCapture) cpu.dma[3].enable = 0;
+    videoCapture = !videoCapture && cpu.dma[3].timingMode == 3 && cpu.dma[3].enable;
+  }
+  if(io.vcounter >= 2 && io.vcounter < 162 && videoCapture) cpu.dmaHDMA();
 }
 
 auto PPU::frame() -> void {

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -255,6 +255,8 @@ private:
     i16 pc;
     i16 pd;
   } objectParam[32];
+  
+  n1 videoCapture = 0;
 };
 
 extern PPU ppu;

--- a/ares/gba/ppu/serialization.cpp
+++ b/ares/gba/ppu/serialization.cpp
@@ -16,6 +16,8 @@ auto PPU::serialize(serializer& s) -> void {
   s(io.vcompare);
   s(io.vcounter);
 
+  s(videoCapture);
+
   s(Background::IO::mode);
   s(Background::IO::frame);
   s(Background::IO::mosaicWidth);

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v138";
+static const string SerializerVersion = "v138.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Video capture DMAs should run only if the mode was enabled on scanline 162 of the previous frame, and should clear the DMA enable bit once complete.