### PR TITLE
Add sha256 hash to manifest for 2600 and CV

### DIFF
--- a/mia/medium/atari-2600.cpp
+++ b/mia/medium/atari-2600.cpp
@@ -90,6 +90,7 @@ auto Atari2600::analyze(vector<u8>& rom, string location) -> string {
   s +={"  name:   ", Medium::name(location), "\n"};
   s +={"  title:  ", Medium::name(location), "\n"};
   s +={"  region: ", region, "\n"};  //database required to detect region
+  s +={"  sha256: ", sha256, "\n"};
   s +={"  board:  ", board, "\n"};
   s += "    memory\n";
   s += "      type: ROM\n";

--- a/mia/medium/colecovision.cpp
+++ b/mia/medium/colecovision.cpp
@@ -60,6 +60,7 @@ auto ColecoVision::analyze(vector<u8>& rom) -> string {
   s +={"  name:  ", Medium::name(location), "\n"};
   s +={"  title: ", Medium::name(location), "\n"};
   s += "  region: NTSC, PAL\n";  //database required to detect region
+  s +={"  sha256: ", hash, "\n"};
   s +={"  board:  ", board, "\n"};
   s += "    memory\n";
   s += "      type: ROM\n";


### PR DESCRIPTION
Testing some games on Coleco Vision & Atari 2600 and noticed that the SHA256 ROM hash was missing from the manifest for these two, which I have now added.