### PR TITLE
Accept unh extension for unheadered NES roms

### DIFF
--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -1,6 +1,6 @@
 struct Famicom : Cartridge {
   auto name() -> string override { return "Famicom"; }
-  auto extensions() -> vector<string> override { return {"fc", "nes", "unf", "unif"}; }
+  auto extensions() -> vector<string> override { return {"fc", "nes", "unf", "unif", "unh"}; }
   auto load(string location) -> bool override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& data) -> string;


### PR DESCRIPTION
No-Intro uses the unh extension for un-headered NES roms. Accept this as a valid extension for the famicom core.