### PR TITLE
CI: Update wpilibsuite signing action for macOS 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
     - name: "macOS: Import Certificate"
       if: runner.os == 'macOS' && github.event_name != 'pull_request'
       continue-on-error: ${{ github.repository != 'ares-emulator/ares' }}
-      uses: wpilibsuite/import-signing-certificate@2ac4f44d28045073d23153256efbb4c4b2d8aa22    # Don't use rolling branch for security reasons
+      uses: wpilibsuite/import-signing-certificate@9e858a4e87d254c4f1d39632ff810d78ee061302    # Don't use rolling branch for security reasons
       with:
         certificate-data: ${{ secrets.MACOS_CERTIFICATE_DATA }}
         certificate-passphrase: ${{ secrets.MACOS_CERTIFICATE_PASSPHRASE }}


### PR DESCRIPTION
This updates the [import signing certificate](https://github.com/wpilibsuite/import-signing-certificate) to the latest version. 
It should silence several warnings in the actions builds. 

Since this is security related, it needs to be thoroughly reviewed.  

I noticed that the wpilibsuite repo does not get updated very often, sometimes years between commits. Since this is security related, it might be an idea to switch to an alternative tool that's updated more often. 
There are a few options including [Apple Actions](https://github.com/Apple-Actions/import-codesign-certs) which looks like it's kept up to date on a regular basis. 