### PR TITLE
Exclude more logic when compiling with librashader=false

### DIFF
--- a/desktop-ui/GNUmakefile
+++ b/desktop-ui/GNUmakefile
@@ -7,7 +7,13 @@ sdl2 := true
 local := true
 lto := true
 librashader	:= true
-flags += -I. -I.. -I../ares -I../thirdparty -I../thirdparty/librashader/include -DMIA_LIBRARY
+flags += -I. -I.. -I../ares -I../thirdparty -DMIA_LIBRARY
+
+ifeq ($(librashader), true)
+  flags += -I../thirdparty/librashader/include
+else
+  flags += -DNO_LIBRASHADER
+endif
 
 nall.path := ../nall
 include $(nall.path)/GNUmakefile
@@ -37,13 +43,15 @@ tzxfile.path := $(thirdparty.path)/TZXFile
 ymfm.path := $(thirdparty.path)/ymfm
 include $(thirdparty.path)/GNUmakefile
 
-ifeq ($(platform),macos)
-	librashader.path := $(thirdparty.path)/librashader/target/optimized/librashader.dylib
-else ifeq ($(platform), windows)
-  ifneq ($(wildcard $(thirdparty.path)/librashader/target/aarch64-pc-windows-msvc/optimized/librashader.dll),)
-	librashader.path := $(thirdparty.path)/librashader/target/aarch64-pc-windows-msvc/optimized/librashader.dll
-  else
-	librashader.path := $(thirdparty.path)/librashader/target/optimized/librashader.dll
+ifeq ($(librashader), true)
+  ifeq ($(platform),macos)
+    librashader.path := $(thirdparty.path)/librashader/target/optimized/librashader.dylib
+  else ifeq ($(platform), windows)
+    ifneq ($(wildcard $(thirdparty.path)/librashader/target/aarch64-pc-windows-msvc/optimized/librashader.dll),)
+      librashader.path := $(thirdparty.path)/librashader/target/aarch64-pc-windows-msvc/optimized/librashader.dll
+    else
+      librashader.path := $(thirdparty.path)/librashader/target/optimized/librashader.dll
+    endif
   endif
 endif
 
@@ -92,20 +100,18 @@ $(all.objects): | $(object.path)
 
 all: output
 ifneq ($(MAKECMDGOALS),clean)
-   ifeq ($(platform),macos)
-      ifeq ($(librashader), true)
-        ifeq ($(wildcard $(librashader.path)),)
-    	  $(error Tried to compile ares for macOS with librashader enabled, but no librashader library was found. Compile it with thirdparty/librashader/build-librashader.sh, or disable librashader by compiling ares with librashader=false)
-        endif
-    	ares.dylibs += $(librashader.path)
+  ifeq ($(librashader), true)
+    ifeq ($(platform),macos)
+      ifeq ($(wildcard $(librashader.path)),)
+        $(error Tried to compile ares for macOS with librashader enabled, but no librashader library was found. Compile it with thirdparty/librashader/build-librashader.sh, or disable librashader by compiling ares with librashader=false)
       endif
-   else ifeq ($(platform), windows)
-      ifeq ($(librashader), true)
-        ifeq ($(wildcard $(librashader.path)),)
-          $(error Tried to compile ares for Windows with librashader enabled, but no librashader library was found. Compile it with thirdparty/librashader/build-librashader.sh, or disable librashader by compiling ares with librashader=false)
-        endif
+      ares.dylibs += $(librashader.path)
+    else ifeq ($(platform), windows)
+      ifeq ($(wildcard $(librashader.path)),)
+        $(error Tried to compile ares for Windows with librashader enabled, but no librashader library was found. Compile it with thirdparty/librashader/build-librashader.sh, or disable librashader by compiling ares with librashader=false)
       endif
-   endif
+    endif
+  endif
 endif
 
 output: $(all.objects) | $(output.path)

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -570,8 +570,13 @@ auto Presentation::showIcon(bool visible) -> void {
 
 auto Presentation::loadShaders() -> void {
   videoShaderMenu.reset();
-  videoShaderMenu.setEnabled(ruby::video.hasShader());
-  if(!ruby::video.hasShader()) return;
+#if !defined(NO_LIBRASHADER)
+  const auto hasShader = ruby::video.hasShader();
+#else
+  const auto hasShader = false;
+#endif
+  videoShaderMenu.setEnabled(hasShader);
+  if(!hasShader) return;
 
   Group shaders;
 

--- a/ruby/video/opengl/main.hpp
+++ b/ruby/video/opengl/main.hpp
@@ -1,9 +1,9 @@
 #if defined(PLATFORM_MACOS)
 #import <mach-o/dyld.h>
 #endif
-auto OpenGL::setShader(const string& pathname) -> void {
-  settings.reset();
 
+auto OpenGL::setShader(const string& pathname) -> void {
+#if !defined(NO_LIBRASHADER)
   format = inputFormat;
   filter = GL_NEAREST;
   wrap = GL_CLAMP_TO_BORDER;
@@ -31,6 +31,7 @@ auto OpenGL::setShader(const string& pathname) -> void {
       return;
     }
   }
+#endif
 }
 
 auto OpenGL::clear() -> void {
@@ -66,7 +67,7 @@ auto OpenGL::output() -> void {
   u32 x = (outputWidth - targetWidth) / 2;
   u32 y = (outputHeight - targetHeight) / 2;
 
-  if(_chain != NULL) {
+  if(has_shader()) {
     // Shader path: our intermediate framebuffer matches the output size
     if(!framebuffer || framebufferWidth != outputWidth || framebufferHeight != outputHeight) {
       if(framebuffer) {
@@ -122,6 +123,7 @@ auto OpenGL::initialize(const string& shader) -> bool {
   glDisable(GL_STENCIL_TEST);
   glEnable(GL_DITHER);
 
+#if !defined(NO_LIBRASHADER)
   _libra = librashader_load_instance();
   if(!_libra.instance_loaded) {
     print("OpenGL: Failed to load librashader: shaders will be disabled\n");
@@ -130,6 +132,7 @@ auto OpenGL::initialize(const string& shader) -> bool {
   if(_libra.gl_init_context(resolveSymbol) != NULL) {
     print("OpenGL: Failed to initialize librashader context: shaders will be disabled\n");
   };
+#endif
 
   setShader(shader);
   return initialized = true;

--- a/ruby/video/opengl/opengl.hpp
+++ b/ruby/video/opengl/opengl.hpp
@@ -18,7 +18,10 @@
 
 #include "bind.hpp"
 #include "utility.hpp"
-#include "librashader_ld.h"
+
+#if !defined(NO_LIBRASHADER)
+  #include "librashader_ld.h"
+#endif
 
 struct OpenGL;
 
@@ -46,9 +49,14 @@ struct OpenGLSurface : OpenGLTexture {
   GLuint framebufferHeight = 0;
   u32* buffer = nullptr;
 
+#if !defined(NO_LIBRASHADER)
   libra_instance_t _libra;
   libra_shader_preset_t _preset = NULL;
   libra_gl_filter_chain_t  _chain = NULL;
+  auto has_shader() { return _chain != NULL; };
+#else
+  auto has_shader() const { return false; };
+#endif
   u32 frameCount = 0;
 };
 
@@ -68,16 +76,6 @@ struct OpenGL : OpenGLSurface {
   u32 outputY = 0;
   u32 outputWidth = 0;
   u32 outputHeight = 0;
-  struct Setting {
-    string name;
-    string value;
-    bool operator< (const Setting& source) const { return name <  source.name; }
-    bool operator==(const Setting& source) const { return name == source.name; }
-    Setting() = default;
-    Setting(const string& name) : name(name) {}
-    Setting(const string& name, const string& value) : name(name), value(value) {}
-  };
-  set<Setting> settings;
   bool initialized = false;
 };
 

--- a/ruby/video/opengl/surface.hpp
+++ b/ruby/video/opengl/surface.hpp
@@ -22,7 +22,8 @@ auto OpenGLSurface::render(u32 sourceWidth, u32 sourceHeight, u32 targetX, u32 t
   glBindTexture(GL_TEXTURE_2D, texture);
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
-  if(_chain != NULL) {
+  if(has_shader()) {
+#if !defined(NO_LIBRASHADER)
     libra_source_image_gl_t input = {texture, format, sourceWidth, sourceHeight};
     libra_viewport_t viewport{(float)targetX, (float)targetY, targetWidth, targetHeight};
     libra_output_framebuffer_gl_t output = {framebuffer, framebufferTexture, framebufferFormat};
@@ -35,6 +36,7 @@ auto OpenGLSurface::render(u32 sourceWidth, u32 sourceHeight, u32 targetX, u32 t
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
     glBlitFramebuffer(0, framebufferHeight, framebufferWidth, 0, 0, 0, framebufferWidth, framebufferHeight, GL_COLOR_BUFFER_BIT, filter);
     glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+#endif
   } else {
     glBindFramebuffer(GL_READ_FRAMEBUFFER, framebuffer);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);


### PR DESCRIPTION
## Current configuration options wrt librashader

Building currently supports `librashader=false` (default true) to disable librashader support
Currently, it merely means not copying the library binary to the output (for the platforms that do)

## This PR

This PR defines the `NO_LIBRASHADER` cpp macro under `librashader=false`, causing shader support in ares to be more thoroughly disabled, some code is #if'd out and the Shader menu in the UI is disabled.

Also featuring tiny bits of cleanup in related parts of the Makefile and code.

Comments are welcome. I'm far from a C++ expert.

## Motivation

This was prompted to me by ares complaining in the console like

> OpenGL: Failed to load librashader: shaders will be disabled

I personally don't use shaders so I tried compiling with `librashader=false`, which didn't get rid of that warning, so here we are. I could also just #if out the warning but it didn't feel as proper.