### PR TITLE
Enforce the "C" locale for `LC_NUMERIC` (fix #1526)

### DIFF
--- a/hiro/gtk/application.cpp
+++ b/hiro/gtk/application.cpp
@@ -145,6 +145,12 @@ auto pApplication::initialize() -> void {
   char** argvp = argv;
 
   gtk_init(&argc, &argvp);
+
+  // gtk_init causes GTK to set the locale from the environment.
+  // Set the locale for LC_NUMERIC back to "C". It is expected to be "C" for
+  // the purpose of various string formatting and parsing operations.
+  setlocale(LC_NUMERIC, "C");
+
   GtkSettings* gtkSettings = gtk_settings_get_default();
 
   //allow buttons to show icons

--- a/hiro/qt/application.cpp
+++ b/hiro/qt/application.cpp
@@ -124,6 +124,11 @@ auto pApplication::initialize() -> void {
   static char** argvp = argv;
   qtApplication = new QApplication(argc, argvp);
 
+  // Creating the QApplication causes Qt to set the locale from the environment.
+  // Set the locale for LC_NUMERIC back to "C". It is expected to be "C" for
+  // the purpose of various string formatting and parsing operations.
+  setlocale(LC_NUMERIC, "C");
+
   pKeyboard::initialize();
 }
 

--- a/nall/main.cpp
+++ b/nall/main.cpp
@@ -19,8 +19,6 @@ auto main(int argc, char** argv) -> int {
   _setmode(_fileno(stderr), O_BINARY);
   #endif
 
-  setlocale(LC_NUMERIC, "C"); // Enforce 'standard' locale for numeric formatting
-
   main(Arguments{argc, argv});
 
   #if !defined(PLATFORM_WINDOWS)


### PR DESCRIPTION
Fixes #1526

The default locale in a C program is the "C" locale ( POSIX https://pubs.opengroup.org/onlinepubs/9699919799/functions/setlocale.html , C89 standard ), which we want for string-number formatting and parsing

gtk ( https://gitlab.gnome.org/GNOME/gtk/-/blob/a274a5ff4b2a2f9cf9731cdddbb456a0758fcbcc/gtk/gtkmain.c#L435 ) and Qt ( 5 https://codebrowser.dev/qt5/qtbase/src/corelib/kernel/qcoreapplication.cpp.html#597 , 6 https://codebrowser.dev/qt6/qtbase/src/corelib/kernel/qcoreapplication.cpp.html#613 ) set the locale from the environment variables instead. (by passing "" as the locale, cf `setlocale`)

This PR sets the locale for `LC_NUMERIC` back to "C" with `setlocale` after initializing gtk/Qt

I tested this with gtk, saw no problem in the GUI with a rom named `/home/dragorn421/Desktop/c'est la fête/rom de noël __  やあ！.z64`

Qt codepath is not tested