### PR TITLE
ruby: Use cleaner OpenGL render pattern, misc. CGL fixes

### DIFF
--- a/ruby/video/metal/metal.cpp
+++ b/ruby/video/metal/metal.cpp
@@ -586,6 +586,7 @@ private:
     }
     
     initialized = true;
+    setNativeFullScreen(self.nativeFullScreen);
     return _ready = true;
   }
 

--- a/ruby/video/opengl/main.hpp
+++ b/ruby/video/opengl/main.hpp
@@ -67,8 +67,8 @@ auto OpenGL::output() -> void {
   u32 y = (outputHeight - targetHeight) / 2;
 
   if(_chain != NULL) {
-    // Shader path: our intermediate framebuffer matches the output size
-    if(!framebuffer || framebufferWidth != outputWidth || framebufferHeight != outputHeight) {
+    // Shader path: our intermediate framebuffer matches the target size (final composited game area size)
+    if(!framebuffer || framebufferWidth != targetWidth || framebufferHeight != targetHeight) {
       if(framebuffer) {
         glDeleteFramebuffers(1, &framebuffer);
         framebuffer = 0;
@@ -78,7 +78,7 @@ auto OpenGL::output() -> void {
         framebufferTexture = 0;
       }
 
-      framebufferWidth = outputWidth, framebufferHeight = outputHeight;
+      framebufferWidth = targetWidth, framebufferHeight = targetHeight;
       glGenFramebuffers(1, &framebuffer);
       glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
       glGenTextures(1, &framebufferTexture);

--- a/ruby/video/opengl/surface.hpp
+++ b/ruby/video/opengl/surface.hpp
@@ -24,7 +24,7 @@ auto OpenGLSurface::render(u32 sourceWidth, u32 sourceHeight, u32 targetX, u32 t
 
   if(_chain != NULL) {
     libra_source_image_gl_t input = {texture, format, sourceWidth, sourceHeight};
-    libra_viewport_t viewport{(float)targetX, (float)targetY, targetWidth, targetHeight};
+    libra_viewport_t viewport{0, 0, targetWidth, targetHeight};
     libra_output_framebuffer_gl_t output = {framebuffer, framebufferTexture, framebufferFormat};
 
     if (auto error = _libra.gl_filter_chain_frame(&_chain, frameCount++, input, viewport, output, NULL, NULL)) {
@@ -33,7 +33,7 @@ auto OpenGLSurface::render(u32 sourceWidth, u32 sourceHeight, u32 targetX, u32 t
 
     glBindFramebuffer(GL_READ_FRAMEBUFFER, framebuffer);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-    glBlitFramebuffer(0, framebufferHeight, framebufferWidth, 0, 0, 0, framebufferWidth, framebufferHeight, GL_COLOR_BUFFER_BIT, filter);
+    glBlitFramebuffer(0, framebufferHeight, framebufferWidth, 0, targetX, targetY, framebufferWidth + targetX, framebufferHeight + targetY, GL_COLOR_BUFFER_BIT, filter);
     glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
   } else {
     glBindFramebuffer(GL_READ_FRAMEBUFFER, framebuffer);


### PR DESCRIPTION
### OpenGL rendering (all platforms)

- librashader specifies that the output viewport should be the same size as the output framebuffer texture. This was not the case for the OpenGL render code.
   * Previously, librashader under OpenGL would render onto an intermediate framebuffer sized to the "output" size (the entire window view size), rather than the "target" size (the final composited size of the game area within the output area). The `libra_viewport_t` would be sized to the target size, but the underlying buffer would be larger.
   * Now, we size the intermediate framebuffer to the "target" size, let librashader render onto it with a `libra_viewport_t` that matches that size. In the final pass we sample this buffer within an area of the "output"-sized buffer as appropriate.

This prior behavior would lead to scaling issues with shaders in the Metal backend. The same issues did not seem to be obviously present in OpenGL in my testing, but we should nevertheless probably fix this in case it is causing any of the subtle issues with shaders that have been reported, and also in case something breaks in the future as a result of not following this recommendation.

(The above is also unrelated to the scaling issues addressed by https://github.com/ares-emulator/ares/pull/1508)

### CGL fix-ups (macOS)

- Backports the native fullscreen and monitor selection options to OpenGL, and removes unnecessary custom window code from the OpenGL driver.
- Removes a seemingly unnecessary output call from `reshape` that would cause flickering during resizes.

This has been tested on macOS but should probably be tested on other platforms as well to make sure nothing breaks.