### PR TITLE
fc, ng, sg: add missing cart ram serialization

### DIFF
--- a/ares/fc/cartridge/board/hvc-nrom.cpp
+++ b/ares/fc/cartridge/board/hvc-nrom.cpp
@@ -59,6 +59,7 @@ struct HVC_NROM : Interface {
   }
 
   auto serialize(serializer& s) -> void override {
+    s(programRAM);
     s(characterRAM);
     s(mirror);
   }

--- a/ares/fc/cartridge/board/sunsoft-1.cpp
+++ b/ares/fc/cartridge/board/sunsoft-1.cpp
@@ -65,6 +65,7 @@ struct Sunsoft1 : Interface {
   }
 
   auto serialize(serializer& s) -> void override {
+    s(characterRAM);
     s(characterBank);
   }
 

--- a/ares/fc/cartridge/board/sunsoft-2.cpp
+++ b/ares/fc/cartridge/board/sunsoft-2.cpp
@@ -61,6 +61,7 @@ struct Sunsoft2 : Interface {
   }
 
   auto serialize(serializer& s) -> void override {
+    s(characterRAM);
     s(programBank);
     s(characterBank);
     s(mirror);

--- a/ares/fc/cartridge/board/sunsoft-3.cpp
+++ b/ares/fc/cartridge/board/sunsoft-3.cpp
@@ -105,6 +105,8 @@ struct Sunsoft3 : Interface {
   }
 
   auto serialize(serializer& s) -> void override {
+    s(programRAM);
+    s(characterRAM);
     s(programBank);
     s(characterBank);
     s(mirror);

--- a/ares/fc/system/serialization.cpp
+++ b/ares/fc/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v146";
+static const string SerializerVersion = "v147";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);

--- a/ares/ng/cartridge/board/jockey-gp.cpp
+++ b/ares/ng/cartridge/board/jockey-gp.cpp
@@ -61,5 +61,9 @@ struct JockeyGP : Interface {
 
   auto power() -> void override {
   }
+
+  auto serialize(serializer& s) -> void override {
+    s(ram);
+  }
 };
 

--- a/ares/ng/cartridge/serialization.cpp
+++ b/ares/ng/cartridge/serialization.cpp
@@ -1,3 +1,4 @@
 auto Cartridge::serialize(serializer& s) -> void {
+  if(board) s(*board);
   s(bank);
 }

--- a/ares/ng/system/serialization.cpp
+++ b/ares/ng/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v133.2";
+static const string SerializerVersion = "v134";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);

--- a/ares/sg/cartridge/board/taiwan-a.cpp
+++ b/ares/sg/cartridge/board/taiwan-a.cpp
@@ -44,6 +44,6 @@ struct TaiwanA : Interface {
   }
 
   auto serialize(serializer& s) -> void override {
-
+    s(ram);
   }
 };

--- a/ares/sg/cartridge/board/taiwan-b.cpp
+++ b/ares/sg/cartridge/board/taiwan-b.cpp
@@ -44,6 +44,6 @@ struct TaiwanB : Interface {
   }
 
   auto serialize(serializer& s) -> void override {
-
+    s(ram);
   }
 };

--- a/ares/sg/system/serialization.cpp
+++ b/ares/sg/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v132";
+static const string SerializerVersion = "v134";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Add missing serialization for the following boards.

fc
- HVC-NROM
- SUNSOFT-1
- SUNSOFT-2
- SUNSOFT-3

ng
- cmc50_jockeygp

sg
- Taiwan-A
- Taiwan-B