### PR TITLE
fc: add prg ram to uxrom and cnrom mappers

### DIFF
--- a/ares/fc/system/serialization.cpp
+++ b/ares/fc/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v147";
+static const string SerializerVersion = "v148";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Some homebrew/aftermarket software calls for UXROM w/ PRG (NV)RAM. The licensed title Hayauchi Super Igo pairs CNROM with SRAM.