### PR TITLE
build: detect cl target architecture

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -88,9 +88,20 @@ endif
 ifneq ($(filter cl clang-cl,$(compiler)),)
   cl := true
   msvc := true
-  machine := amd64
+endif
+
+ifneq ($(filter cl,$(compiler)),)
+  machine_str := $(shell $(compiler) 2>&1 1>NUL)
+  ifneq ($(filter x86,$(machine_str)),)
+    machine := x86
+  else ifneq ($(filter x64,$(machine_str)),)
+    machine := amd64
+  else ifneq ($(filter ARM64,$(machine_str)),)
+    machine := arm64
+  endif
 else
-  machine_str := $(shell $(compiler) -dumpmachine)
+  machine_opt := $(if $(findstring clang,$(compiler)),-print-target-triple,-dumpmachine)
+  machine_str := $(shell $(compiler) $(machine_opt))
   ifneq ($(filter i686-%,$(machine_str)),)
     machine := x86
   else ifneq ($(filter amd64-% x86_64-%,$(machine_str)),)
@@ -286,6 +297,13 @@ ifeq ($(platform),windows)
       windres := $(if $(findstring clang,$(compiler)),llvm-rc,rc)
     else
       windres := windres
+    endif
+  endif
+  ifneq ($(filter cl,$(compiler)),)
+    ifeq ($(arch),arm64)
+      # work around optimizer bug in MSVC 19.39+
+      # https://developercommunity.microsoft.com/t/ARM64-code-generation-regression/10686742#T-N10699503
+      flags += -d2lowered-bit-liveness-
     endif
   endif
 endif


### PR DESCRIPTION
Automatically detect the (clang-)cl target architecture instead of assuming amd64. Note that -print-target-triple is now used in favor of -dumpmachine for all versions of clang. This option has been around for ages in the regular clang driver but is only supported by clang-cl as of LLVM 18, which isn't yet available via the Visual Studio installer but is available through a standalone installer on GitHub.

This commit also adds a compiler flag to the command line when targeting arm64 with cl to work around an optimizer bug.