### PR TITLE
arm7tdmi, gba: prevent debugger from advancing GBA CPU clock

### DIFF
--- a/ares/component/processor/arm7tdmi/arm7tdmi.hpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.hpp
@@ -20,6 +20,7 @@ struct ARM7TDMI {
   virtual auto step(u32 clocks) -> void = 0;
   virtual auto sleep() -> void = 0;
   virtual auto get(u32 mode, n32 address) -> n32 = 0;
+  virtual auto getDebugger(u32 mode, n32 address) -> n32 { return get(mode, address); }
   virtual auto set(u32 mode, n32 address, n32 word) -> void = 0;
 
   //arm7tdmi.cpp

--- a/ares/component/processor/arm7tdmi/disassembler.cpp
+++ b/ares/component/processor/arm7tdmi/disassembler.cpp
@@ -17,12 +17,12 @@ auto ARM7TDMI::disassembleInstruction(maybe<n32> pc, maybe<boolean> thumb) -> st
 
   _pc = pc();
   if(!thumb()) {
-    n32 opcode = read(Word | Nonsequential, _pc & ~3);
+    n32 opcode = getDebugger(Word | Nonsequential, _pc & ~3);
     n12 index = (opcode & 0x0ff00000) >> 16 | (opcode & 0x000000f0) >> 4;
     _c = _conditions[opcode >> 28];
     return pad(armDisassemble[index](opcode), -40);
   } else {
-    n16 opcode = read(Half | Nonsequential, _pc & ~1);
+    n16 opcode = getDebugger(Half | Nonsequential, _pc & ~1);
     return pad(thumbDisassemble[opcode](), -40);
   }
 }
@@ -121,7 +121,7 @@ auto ARM7TDMI::armDisassembleDataRegisterShift
 auto ARM7TDMI::armDisassembleLoadImmediate
 (n8 immediate, n1 half, n4 d, n4 n, n1 writeback, n1 up, n1 pre) -> string {
   string data;
-  if(n == 15) data = {" =0x", hex(read((half ? Half : Byte) | Nonsequential,
+  if(n == 15) data = {" =0x", hex(getDebugger((half ? Half : Byte) | Nonsequential,
     _pc + 8 + (up ? +immediate : -immediate)), half ? 4L : 2L)};
 
   return {"ldr", _c, half ? "sh" : "sb", " ",
@@ -150,7 +150,7 @@ auto ARM7TDMI::armDisassembleMemorySwap
 auto ARM7TDMI::armDisassembleMoveHalfImmediate
 (n8 immediate, n4 d, n4 n, n1 mode, n1 writeback, n1 up, n1 pre) -> string {
   string data;
-  if(n == 15) data = {" =0x", hex(read(Half | Nonsequential, _pc + (up ? +immediate : -immediate)), 4L)};
+  if(n == 15) data = {" =0x", hex(getDebugger(Half | Nonsequential, _pc + (up ? +immediate : -immediate)), 4L)};
 
   return {mode ? "ldr" : "str", _c, "h ",
     _r[d], ",[", _r[n],
@@ -173,7 +173,7 @@ auto ARM7TDMI::armDisassembleMoveHalfRegister
 auto ARM7TDMI::armDisassembleMoveImmediateOffset
 (n12 immediate, n4 d, n4 n, n1 mode, n1 writeback, n1 byte, n1 up, n1 pre) -> string {
   string data;
-  if(n == 15) data = {" =0x", hex(read((byte ? Byte : Word) | Nonsequential,
+  if(n == 15) data = {" =0x", hex(getDebugger((byte ? Byte : Word) | Nonsequential,
     _pc + 8 + (up ? +immediate : -immediate)), byte ? 2L : 4L)};
   return {mode ? "ldr" : "str", _c, byte ? "b" : "", " ", _r[d], ",[", _r[n],
     pre == 0 ? "]" : "",
@@ -308,7 +308,7 @@ auto ARM7TDMI::thumbDisassembleBranchExchange
 
 auto ARM7TDMI::thumbDisassembleBranchFarPrefix
 (i11 displacementHi) -> string {
-  n11 displacementLo = read(Half | Nonsequential, (_pc & ~1) + 2);
+  n11 displacementLo = getDebugger(Half | Nonsequential, (_pc & ~1) + 2);
   i22 displacement = displacementHi << 11 | displacementLo << 0;
   n32 address = _pc + 4 + displacement * 2;
   return {"bl 0x", hex(address, 8L)};
@@ -340,7 +340,7 @@ auto ARM7TDMI::thumbDisassembleImmediate
 auto ARM7TDMI::thumbDisassembleLoadLiteral
 (n8 displacement, n3 d) -> string {
   n32 address = ((_pc + 4) & ~3) + (displacement << 2);
-  n32 data = read(Word | Nonsequential, address);
+  n32 data = getDebugger(Word | Nonsequential, address);
   return {"ldr ", _r[d], ",[pc,#0x", hex(address, 8L), "] =0x", hex(data, 8L)};
 }
 

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -57,7 +57,9 @@ struct CPU : ARM7TDMI, Thread, IO {
 
   //bus.cpp
   auto sleep() -> void override;
+  template<bool UseDebugger> auto getBus(u32 mode, n32 address) -> n32;
   auto get(u32 mode, n32 address) -> n32 override;
+  auto getDebugger(u32 mode, n32 address) -> n32 override;
   auto set(u32 mode, n32 address, n32 word) -> void override;
   auto _wait(u32 mode, n32 address) -> u32;
 


### PR DESCRIPTION
Provides a getDebugger function for the ARM debugger to read memory without advancing CPU state, fixing a bug where GBA core CPU timings were impacted by debugger use.