### PR TITLE
Improve FreeBSD compatibility

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -325,7 +325,6 @@ endif
 ifeq ($(platform),bsd)
   flags   += -I/usr/local/include
   options += -Wl,-rpath=/usr/local/lib
-  options += -Wl,-rpath=/usr/local/lib/gcc8
   options += -lstdc++ -lm
 endif
 

--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -128,12 +128,7 @@ ifeq ($(platform),macos)
   endif
 endif
 
-ifeq ($(platform),linux)
-  ruby.options += -lX11 -lXext -lXrandr
-  ruby.options += $(if $(findstring audio.openal,$(ruby)),-lopenal)
-endif
-
-ifeq ($(platform),bsd)
+ifneq ($(findstring $(platform),linux bsd),)
   ruby.options += -lX11 -lXext -lXrandr
   ruby.options += $(if $(findstring audio.openal,$(ruby)),-lopenal)
 endif

--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -51,6 +51,7 @@ ifeq ($(ruby),)
     ruby += video.glx
     ruby += $(call pkg_check,xv,video.xvideo)
     ruby += audio.oss
+    ruby += $(call pkg_check,alsa,audio.alsa)
     ruby += $(call pkg_check,openal,audio.openal)
     ruby += $(call pkg_check,libpulse,audio.pulseaudio)
     ruby += $(call pkg_check,libpulse-simple,audio.pulseaudiosimple)

--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -135,8 +135,7 @@ endif
 
 ifeq ($(platform),bsd)
   ruby.options += -lX11 -lXext -lXrandr
-  ruby.options += $(if $(findstring audio.openal,$(ruby)),-lopenal -fuse-ld=bfd)
-  # -fuse-ld=bfd: see FreeBSD bug 219089
+  ruby.options += $(if $(findstring audio.openal,$(ruby)),-lopenal)
 endif
 
 ruby.objects := $(object.path)/ruby.o

--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -33,7 +33,7 @@ ifeq ($(ruby),)
     endif
   else ifeq ($(platform),linux)
     pkg_check = $(if $(shell $(pkg_config) $1 && echo 1),$2)
-    ruby += video.glx video.xshm
+    ruby += video.glx
     ruby += $(call pkg_check,xv,video.xvideo)
     ruby += audio.oss audio.alsa
     ruby += $(call pkg_check,openal,audio.openal)
@@ -48,7 +48,7 @@ ifeq ($(ruby),)
     endif
   else ifeq ($(platform),bsd)
     pkg_check = $(if $(shell $(pkg_config) $1 && echo 1),$2)
-    ruby += video.glx video.glx2 video.xshm
+    ruby += video.glx
     ruby += $(call pkg_check,xv,video.xvideo)
     ruby += audio.oss
     ruby += $(call pkg_check,openal,audio.openal)

--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -57,6 +57,7 @@ ifeq ($(ruby),)
     ruby += $(call pkg_check,libpulse-simple,audio.pulseaudiosimple)
     ruby += $(call pkg_check,ao,audio.ao)
     ruby += input.uhid input.xlib
+    ruby += $(call pkg_check,libudev,input.udev)
     ifeq ($(sdl2),true)
       ruby += $(call pkg_check,sdl2,input.sdl)
       ruby += $(call pkg_check,sdl2,audio.sdl)

--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -31,32 +31,24 @@ ifeq ($(ruby),)
       ruby += audio.sdl
       ruby += input.sdl
     endif
-  else ifeq ($(platform),linux)
+  else ifneq ($(findstring $(platform),linux bsd),)
     pkg_check = $(if $(shell $(pkg_config) $1 && echo 1),$2)
     ruby += video.glx
     ruby += $(call pkg_check,xv,video.xvideo)
-    ruby += audio.oss audio.alsa
+    ruby += audio.oss
+    ifeq ($(platform),linux)
+      ruby += audio.alsa
+    else
+      ruby += $(call pkg_check,alsa,audio.alsa)
+    endif
     ruby += $(call pkg_check,openal,audio.openal)
     ruby += $(call pkg_check,libpulse,audio.pulseaudio)
     ruby += $(call pkg_check,libpulse-simple,audio.pulseaudiosimple)
     ruby += $(call pkg_check,ao,audio.ao)
     ruby += input.xlib
-    ruby += $(call pkg_check,libudev,input.udev)
-    ifeq ($(sdl2),true)
-      ruby += $(call pkg_check,sdl2,input.sdl)
-      ruby += $(call pkg_check,sdl2,audio.sdl)
+    ifeq ($(platform),bsd)
+      ruby += input.uhid
     endif
-  else ifeq ($(platform),bsd)
-    pkg_check = $(if $(shell $(pkg_config) $1 && echo 1),$2)
-    ruby += video.glx
-    ruby += $(call pkg_check,xv,video.xvideo)
-    ruby += audio.oss
-    ruby += $(call pkg_check,alsa,audio.alsa)
-    ruby += $(call pkg_check,openal,audio.openal)
-    ruby += $(call pkg_check,libpulse,audio.pulseaudio)
-    ruby += $(call pkg_check,libpulse-simple,audio.pulseaudiosimple)
-    ruby += $(call pkg_check,ao,audio.ao)
-    ruby += input.uhid input.xlib
     ruby += $(call pkg_check,libudev,input.udev)
     ifeq ($(sdl2),true)
       ruby += $(call pkg_check,sdl2,input.sdl)

--- a/ruby/input/udev.cpp
+++ b/ruby/input/udev.cpp
@@ -5,8 +5,12 @@
 #include <sys/poll.h>
 #include <fcntl.h>
 #include <libudev.h>
+#ifdef __FreeBSD__
+#include <dev/evdev/input.h>
+#else
 #include <linux/types.h>
 #include <linux/input.h>
+#endif
 
 #include "keyboard/xlib.cpp"
 #include "mouse/xlib.cpp"


### PR DESCRIPTION
These commits improve the compatibility with FreeBSD. Among some cosmetic changes is a commit to unbreak the build on FreeBSD and two commits adding an audio and an input backend to FreeBSD builds.

There's still a change needed to make ares completely buildable on FreeBSD:
use of `CLOCK_MONOTONIC` in `ares/n64/vulkan/parallel-rdp/util/timer.cpp`, see https://github.com/Themaister/Granite/pull/135. This change will propagate to ares if/when Granite upstream merges the PR, parallel-rdp adopts the updated Granite and ares updates its parallel-rdp.