### PR TITLE
nall: respect prefix for sharedData location on Linux/BSD

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -472,6 +472,7 @@ ifeq ($(platform),windows)
   prefix := $(subst $([space]),\$([space]),$(strip $(call strtr,$(LOCALAPPDATA),\,/)))
 else
   prefix := $(HOME)/.local
+  flags += -DARES_PREFIX="$(prefix)"
 endif
 
 # objects

--- a/nall/path.cpp
+++ b/nall/path.cpp
@@ -1,4 +1,5 @@
 #include <nall/path.hpp>
+#include <nall/stringize.hpp>
 
 #if defined(PLATFORM_WINDOWS)
   #include <shlobj.h>
@@ -143,7 +144,7 @@ NALL_HEADER_INLINE auto sharedData() -> string {
   #elif defined(PLATFORM_MACOS)
   string result = "/Library/Application Support/";
   #else
-  string result = "/usr/share/";
+  string result = stringize(ARES_PREFIX/share/);
   #endif
   if(!result) result = ".";
   if(!result.endsWith("/")) result.append("/");

--- a/nall/stringize.hpp
+++ b/nall/stringize.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+// The # preprocessing operator converts the argument into a quoted string literal.
+// In order to use this for macro parameters which need to be expanded, this must
+// be a two-level-macro call.
+
+#define stringize_(arg) #arg
+#define stringize(arg) stringize_(arg)


### PR DESCRIPTION
The hardcoded `/usr/share` for the sharedData location doesn't respect the given prefix, e.g. `~/.local` or `/usr/local`. This results in the emulator not finding the shaders or databases in case the emulator is not installed under `/usr` and the files are not found in the application or user data directory.

Now the build script defines a preprocessor constant `ARES_PREFIX` which is set to the requested prefix. With the help of the C preprocessor stringize operator, this prefix is then used as the root of the sharedData location.

Fixes https://github.com/ares-emulator/ares/issues/1179