### PR TITLE
arm7tdmi: fix reading SPSR in user and system modes

### DIFF
--- a/ares/component/processor/arm7tdmi/instructions-arm.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-arm.cpp
@@ -249,11 +249,7 @@ auto ARM7TDMI::armInstructionMoveRegisterOffset
 
 auto ARM7TDMI::armInstructionMoveToRegisterFromStatus
 (n4 d, n1 mode) -> void {
-  if(mode && (cpsr().m == PSR::USR || cpsr().m == PSR::SYS)) {
-    r(d) = cpsr();
-  } else {
-    r(d) = mode ? spsr() : cpsr();
-  }
+  r(d) = (mode && cpsr().m != PSR::USR && cpsr().m != PSR::SYS) ? spsr() : cpsr();
 }
 
 auto ARM7TDMI::armInstructionMoveToStatusFromImmediate

--- a/ares/component/processor/arm7tdmi/instructions-arm.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-arm.cpp
@@ -249,8 +249,11 @@ auto ARM7TDMI::armInstructionMoveRegisterOffset
 
 auto ARM7TDMI::armInstructionMoveToRegisterFromStatus
 (n4 d, n1 mode) -> void {
-  if(mode && (cpsr().m == PSR::USR || cpsr().m == PSR::SYS)) return;
-  r(d) = mode ? spsr() : cpsr();
+  if(mode && (cpsr().m == PSR::USR || cpsr().m == PSR::SYS)) {
+    r(d) = cpsr();
+  } else {
+    r(d) = mode ? spsr() : cpsr();
+  }
 }
 
 auto ARM7TDMI::armInstructionMoveToStatusFromImmediate


### PR DESCRIPTION
In user and system modes, attempting to read SPSR should instead read CPSR.