### PR TITLE
hiro: remove QT5 deprecation warnings

### DIFF
--- a/hiro/qt/font.cpp
+++ b/hiro/qt/font.cpp
@@ -11,7 +11,7 @@ auto pFont::size(const QFont& qtFont, const string& text) -> Size {
   s32 maxWidth = 0;
   auto lines = text.split("\n");
   for(auto& line : lines) {
-    maxWidth = max(maxWidth, metrics.width(QString::fromUtf8(line)));
+    maxWidth = max(maxWidth, metrics.boundingRect(QString::fromUtf8(line)).width());
   }
   return {maxWidth, metrics.height() * (signed)lines.size()};
 }

--- a/hiro/qt/monitor.cpp
+++ b/hiro/qt/monitor.cpp
@@ -3,7 +3,7 @@
 namespace hiro {
 
 auto pMonitor::count() -> u32 {
-  return QApplication::desktop()->screenCount();
+  return QApplication::screens().count();
 }
 
 auto pMonitor::dpi(u32 monitor) -> Position {

--- a/hiro/qt/monitor.cpp
+++ b/hiro/qt/monitor.cpp
@@ -15,7 +15,7 @@ auto pMonitor::dpi(u32 monitor) -> Position {
 }
 
 auto pMonitor::geometry(u32 monitor) -> Geometry {
-  QRect rectangle = QApplication::desktop()->screenGeometry(monitor);
+  QRect rectangle = QApplication::screens()[monitor]->geometry();
   return {rectangle.x(), rectangle.y(), rectangle.width(), rectangle.height()};
 }
 

--- a/hiro/qt/monitor.cpp
+++ b/hiro/qt/monitor.cpp
@@ -20,7 +20,7 @@ auto pMonitor::geometry(u32 monitor) -> Geometry {
 }
 
 auto pMonitor::primary() -> u32 {
-  return QApplication::desktop()->primaryScreen();
+  return max(QApplication::screens().indexOf(QApplication::primaryScreen()), 0);
 }
 
 auto pMonitor::workspace(u32 monitor) -> Geometry {

--- a/hiro/qt/mouse.cpp
+++ b/hiro/qt/mouse.cpp
@@ -11,7 +11,7 @@ auto pMouse::pressed(Mouse::Button button) -> bool {
   Qt::MouseButtons buttons = QApplication::mouseButtons();
   switch(button) {
   case Mouse::Button::Left: return buttons & Qt::LeftButton;
-  case Mouse::Button::Middle: return buttons & Qt::MidButton;
+  case Mouse::Button::Middle: return buttons & Qt::MiddleButton;
   case Mouse::Button::Right: return buttons & Qt::RightButton;
   }
   return false;

--- a/hiro/qt/widget/canvas.cpp
+++ b/hiro/qt/widget/canvas.cpp
@@ -120,7 +120,7 @@ auto QtCanvas::mouseMoveEvent(QMouseEvent* event) -> void {
 auto QtCanvas::mousePressEvent(QMouseEvent* event) -> void {
   switch(event->button()) {
   case Qt::LeftButton: p.self().doMousePress(Mouse::Button::Left); break;
-  case Qt::MidButton: p.self().doMousePress(Mouse::Button::Middle); break;
+  case Qt::MiddleButton: p.self().doMousePress(Mouse::Button::Middle); break;
   case Qt::RightButton: p.self().doMousePress(Mouse::Button::Right); break;
   }
 }
@@ -128,7 +128,7 @@ auto QtCanvas::mousePressEvent(QMouseEvent* event) -> void {
 auto QtCanvas::mouseReleaseEvent(QMouseEvent* event) -> void {
   switch(event->button()) {
   case Qt::LeftButton: p.self().doMouseRelease(Mouse::Button::Left); break;
-  case Qt::MidButton: p.self().doMouseRelease(Mouse::Button::Middle); break;
+  case Qt::MiddleButton: p.self().doMouseRelease(Mouse::Button::Middle); break;
   case Qt::RightButton: p.self().doMouseRelease(Mouse::Button::Right); break;
   }
 }

--- a/hiro/qt/widget/hex-edit.cpp
+++ b/hiro/qt/widget/hex-edit.cpp
@@ -271,8 +271,9 @@ auto QtHexEdit::keyPressEventAcknowledge(QKeyEvent* event) -> void {
 }
 
 auto QtHexEdit::wheelEvent(QWheelEvent* event) -> void {
-  if(event->orientation() == Qt::Vertical) {
-    s32 offset = event->delta() < 0 ? +1 : -1;
+  auto delta = event->angleDelta().y();
+  if(delta) {
+    s32 offset = delta < 0 ? +1 : -1;
     p._scrollTo(p.qtScrollBar->sliderPosition() + offset);
     event->accept();
   }
@@ -281,8 +282,9 @@ auto QtHexEdit::wheelEvent(QWheelEvent* event) -> void {
 auto QtHexEditScrollBar::event(QEvent* event) -> bool {
   if(event->type() == QEvent::Wheel) {
     auto wheelEvent = (QWheelEvent*)event;
-    if(wheelEvent->orientation() == Qt::Vertical) {
-      s32 offset = wheelEvent->delta() < 0 ? +1 : -1;
+    auto delta = wheelEvent->angleDelta().y();
+    if(delta) {
+      s32 offset = delta < 0 ? +1 : -1;
       p._scrollTo(sliderPosition() + offset);
       return true;
     }

--- a/hiro/qt/widget/label.cpp
+++ b/hiro/qt/widget/label.cpp
@@ -43,7 +43,7 @@ auto pLabel::setText(const string& text) -> void {
 auto QtLabel::mousePressEvent(QMouseEvent* event) -> void {
   switch(event->button()) {
   case Qt::LeftButton: p.self().doMousePress(Mouse::Button::Left); break;
-  case Qt::MidButton: p.self().doMousePress(Mouse::Button::Middle); break;
+  case Qt::MiddleButton: p.self().doMousePress(Mouse::Button::Middle); break;
   case Qt::RightButton: p.self().doMousePress(Mouse::Button::Right); break;
   }
 }
@@ -51,7 +51,7 @@ auto QtLabel::mousePressEvent(QMouseEvent* event) -> void {
 auto QtLabel::mouseReleaseEvent(QMouseEvent* event) -> void {
   switch(event->button()) {
   case Qt::LeftButton: p.self().doMouseRelease(Mouse::Button::Left); break;
-  case Qt::MidButton: p.self().doMouseRelease(Mouse::Button::Middle); break;
+  case Qt::MiddleButton: p.self().doMouseRelease(Mouse::Button::Middle); break;
   case Qt::RightButton: p.self().doMouseRelease(Mouse::Button::Right); break;
   }
 }

--- a/hiro/qt/widget/viewport.cpp
+++ b/hiro/qt/widget/viewport.cpp
@@ -54,7 +54,7 @@ auto QtViewport::mouseMoveEvent(QMouseEvent* event) -> void {
 auto QtViewport::mousePressEvent(QMouseEvent* event) -> void {
   switch(event->button()) {
   case Qt::LeftButton: p.self().doMousePress(Mouse::Button::Left); break;
-  case Qt::MidButton: p.self().doMousePress(Mouse::Button::Middle); break;
+  case Qt::MiddleButton: p.self().doMousePress(Mouse::Button::Middle); break;
   case Qt::RightButton: p.self().doMousePress(Mouse::Button::Right); break;
   }
 }
@@ -62,7 +62,7 @@ auto QtViewport::mousePressEvent(QMouseEvent* event) -> void {
 auto QtViewport::mouseReleaseEvent(QMouseEvent* event) -> void {
   switch(event->button()) {
   case Qt::LeftButton: p.self().doMouseRelease(Mouse::Button::Left); break;
-  case Qt::MidButton: p.self().doMouseRelease(Mouse::Button::Middle); break;
+  case Qt::MiddleButton: p.self().doMouseRelease(Mouse::Button::Middle); break;
   case Qt::RightButton: p.self().doMouseRelease(Mouse::Button::Right); break;
   }
 }

--- a/hiro/qt/window.cpp
+++ b/hiro/qt/window.cpp
@@ -101,10 +101,10 @@ auto pWindow::remove(sStatusBar statusBar) -> void {
 }
 
 auto pWindow::setBackgroundColor(Color color) -> void {
-  static auto defaultColor = qtContainer->palette().color(QPalette::Background);
+  static auto defaultColor = qtContainer->palette().color(QPalette::Window);
 
   auto palette = qtContainer->palette();
-  palette.setColor(QPalette::Background, CreateColor(color, defaultColor));
+  palette.setColor(QPalette::Window, CreateColor(color, defaultColor));
   qtContainer->setPalette(palette);
   qtContainer->setAutoFillBackground((bool)color);
   //translucency results are very unpleasant without a compositor; so disable for now


### PR DESCRIPTION
Replace deprecated elements with suggested replacements.

QApplication::hasPendingEvents() and QWidget::paintEngine() are still in use, their replacement is way out of scope for this PR.