### PR TITLE
desktop-ui: increase height of SettingsWindow to unhide Supersampling option in QT5 builds

### DIFF
--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -222,7 +222,7 @@ SettingsWindow::SettingsWindow() {
 
   setDismissable();
   setTitle("Configuration");
-  setSize({700_sx, 405_sy});
+  setSize({700_sx, 425_sy});
   setAlignment({0.0, 1.0});
   setResizable(false);
 }


### PR DESCRIPTION
The Superampling option in the Video category isn't visible in QT5 builds, the settings window is too small. Therefore increase the height of the window by 20 to unhide the setting. This also gives the setting a little bit more distance to the bottom edge in GTK3 builds.