### PR TITLE
ruby OSS: improve naming and usage of _bufferSize variable

### DIFF
--- a/ruby/audio/oss.cpp
+++ b/ruby/audio/oss.cpp
@@ -65,7 +65,7 @@ struct AudioOSS : AudioDriver {
   auto level() -> double override {
     audio_buf_info info;
     ioctl(_fd, SNDCTL_DSP_GETOSPACE, &info);
-    return (double)(_bufferSize - info.bytes) / _bufferSize;
+    return (double)(_nBlkBytes - info.bytes) / _nBlkBytes;
   }
 
   auto output(const double samples[]) -> void override {
@@ -100,7 +100,7 @@ private:
     updateBlocking();
     audio_buf_info info;
     ioctl(_fd, SNDCTL_DSP_GETOSPACE, &info);
-    _bufferSize = info.bytes;
+    _nBlkBytes = info.bytes;
 
     return true;
   }
@@ -122,7 +122,7 @@ private:
 
   s32 _fd = -1;
   s32 _format = AFMT_S16_LE;
-  s32 _bufferSize = 1;
+  s32 _nBlkBytes = 1;
 
   queue<s16> buffer;
 };

--- a/ruby/audio/oss.cpp
+++ b/ruby/audio/oss.cpp
@@ -23,7 +23,7 @@ struct AudioOSS : AudioDriver {
     super.setChannels(2);
     super.setFrequency(48000);
     super.setLatency(3);
-    buffer.resize(64);
+    buffer.resize(_bufferSize);
     return initialize();
   }
 
@@ -59,7 +59,7 @@ struct AudioOSS : AudioDriver {
   auto setLatency(u32 latency) -> bool override { return initialize(); }
 
   auto clear() -> void override {
-    buffer.resize(64);
+    buffer.resize(_bufferSize);
   }
 
   auto level() -> double override {
@@ -119,6 +119,8 @@ private:
     fcntl(_fd, F_SETFL, flags);
     return true;
   }
+
+  static const u32 _bufferSize = 64;
 
   s32 _fd = -1;
   s32 _format = AFMT_S16_LE;


### PR DESCRIPTION
_bufferSize is used to store the number of bytes that can be written without blocking. It is not the size of the application buffer. Therefore rename this variable to _nBlkBytes. Use the variable _bufferSize as a constant for the size of the application buffer instead.