### PR TITLE
v30mz: fix instruction prefix handling

### DIFF
--- a/ares/component/processor/v30mz/instructions-misc.cpp
+++ b/ares/component/processor/v30mz/instructions-misc.cpp
@@ -1,21 +1,21 @@
 auto V30MZ::instructionSegment(n16 segment) -> void {
-  if(prefixes.full()) prefixes.read(0);
-  prefixes.write(opcode);
+  prefix.segment = opcode;
+  prefix.count++;
   state.prefix = 1;
   state.poll = 0;
 }
 
 auto V30MZ::instructionRepeat() -> void {
-  if(prefixes.full()) prefixes.read(0);
-  prefixes.write(opcode);
+  prefix.repeat = opcode;
+  prefix.count++;
   wait(4);
   state.prefix = 1;
   state.poll = 0;
 }
 
 auto V30MZ::instructionLock() -> void {
-  if(prefixes.full()) prefixes.read(0);
-  prefixes.write(opcode);
+  prefix.lock = opcode;
+  prefix.count++;
   state.prefix = 1;
   state.poll = 0;
 }

--- a/ares/component/processor/v30mz/instructions-string.cpp
+++ b/ares/component/processor/v30mz/instructions-string.cpp
@@ -1,11 +1,11 @@
 template<u32 size> auto V30MZ::instructionInString() -> void {
   wait(3);
-  if(!repeat() || CW) {
+  if(!prefix.repeat || CW) {
     auto data = in<size>(DW);
     write<size>(DS1, IY, data);
     IY += PSW.DIR ? -size : size;
 
-    if(!repeat() || !--CW) return;
+    if(!prefix.repeat || !--CW) return;
 
     state.prefix = 1;
     PC--;
@@ -15,12 +15,12 @@ template<u32 size> auto V30MZ::instructionInString() -> void {
 
 template<u32 size> auto V30MZ::instructionOutString() -> void {
   wait(3);
-  if(!repeat() || CW) {
+  if(!prefix.repeat || CW) {
     auto data = read<size>(segment(DS0), IX);
     out<size>(DW, data);
     IX += PSW.DIR ? -size : size;
 
-    if(!repeat() || !--CW) return;
+    if(!prefix.repeat || !--CW) return;
 
     state.prefix = 1;
     PC--;
@@ -30,13 +30,13 @@ template<u32 size> auto V30MZ::instructionOutString() -> void {
 
 template<u32 size> auto V30MZ::instructionMoveString() -> void {
   wait(3);
-  if(!repeat() || CW) {
+  if(!prefix.repeat || CW) {
     auto data = read<size>(segment(DS0), IX);
     write<size>(DS1, IY, data);
     IX += PSW.DIR ? -size : size;
     IY += PSW.DIR ? -size : size;
 
-    if(!repeat() || !--CW) return;
+    if(!prefix.repeat || !--CW) return;
 
     state.prefix = 1;
     PC--;
@@ -46,16 +46,16 @@ template<u32 size> auto V30MZ::instructionMoveString() -> void {
 
 template<u32 size> auto V30MZ::instructionCompareString() -> void {
   wait(4);
-  if(!repeat() || CW) {
+  if(!prefix.repeat || CW) {
     auto x = read<size>(segment(DS0), IX);
     auto y = read<size>(DS1, IY);
     IX += PSW.DIR ? -size : size;
     IY += PSW.DIR ? -size : size;
     SUB<size>(x, y);
 
-    if(!repeat() || !--CW) return;
-    if(repeat() == RepeatWhileZeroLo && PSW.Z == 1) return;
-    if(repeat() == RepeatWhileZeroHi && PSW.Z == 0) return;
+    if(!prefix.repeat || !--CW) return;
+    if(prefix.repeat == RepeatWhileZeroLo && PSW.Z == 1) return;
+    if(prefix.repeat == RepeatWhileZeroHi && PSW.Z == 0) return;
 
     state.prefix = 1;
     PC--;
@@ -65,11 +65,11 @@ template<u32 size> auto V30MZ::instructionCompareString() -> void {
 
 template<u32 size> auto V30MZ::instructionStoreString() -> void {
   wait(2);
-  if(!repeat() || CW) {
+  if(!prefix.repeat || CW) {
     write<size>(DS1, IY, getAccumulator<size>());
     IY += PSW.DIR ? -size : size;
 
-    if(!repeat() || !--CW) return;
+    if(!prefix.repeat || !--CW) return;
 
     state.prefix = 1;
     PC--;
@@ -79,11 +79,11 @@ template<u32 size> auto V30MZ::instructionStoreString() -> void {
 
 template<u32 size> auto V30MZ::instructionLoadString() -> void {
   wait(2);
-  if(!repeat() || CW) {
+  if(!prefix.repeat || CW) {
     setAccumulator<size>(read<size>(segment(DS0), IX));
     IX += PSW.DIR ? -size : size;
 
-    if(!repeat() || !--CW) return;
+    if(!prefix.repeat || !--CW) return;
 
     state.prefix = 1;
     PC--;
@@ -93,15 +93,15 @@ template<u32 size> auto V30MZ::instructionLoadString() -> void {
 
 template<u32 size> auto V30MZ::instructionScanString() -> void {
   wait(3);
-  if(!repeat() || CW) {
+  if(!prefix.repeat || CW) {
     auto x = getAccumulator<size>();
     auto y = read<size>(DS1, IY);
     IY += PSW.DIR ? -size : size;
     SUB<size>(x, y);
 
-    if(!repeat() || !--CW) return;
-    if(repeat() == RepeatWhileZeroLo && PSW.Z == 1) return;
-    if(repeat() == RepeatWhileZeroHi && PSW.Z == 0) return;
+    if(!prefix.repeat || !--CW) return;
+    if(prefix.repeat == RepeatWhileZeroLo && PSW.Z == 1) return;
+    if(prefix.repeat == RepeatWhileZeroHi && PSW.Z == 0) return;
 
     state.prefix = 1;
     PC--;

--- a/ares/component/processor/v30mz/registers.cpp
+++ b/ares/component/processor/v30mz/registers.cpp
@@ -1,18 +1,8 @@
-auto V30MZ::repeat() -> u8 {
-  for(auto prefix : prefixes) {
-    if(prefix == RepeatWhileZeroLo) return prefix;
-    if(prefix == RepeatWhileZeroHi) return prefix;
-  }
-  return 0;
-}
-
 auto V30MZ::segment(u16 segment) -> u16 {
-  for(auto prefix : prefixes) {
-    if(prefix == SegmentOverrideDS1) return DS1;
-    if(prefix == SegmentOverridePS ) return PS;
-    if(prefix == SegmentOverrideSS ) return SS;
-    if(prefix == SegmentOverrideDS0) return DS0;
-  }
+  if(prefix.segment == SegmentOverrideDS1) return DS1;
+  if(prefix.segment == SegmentOverridePS ) return PS;
+  if(prefix.segment == SegmentOverrideSS ) return SS;
+  if(prefix.segment == SegmentOverrideDS0) return DS0;
   return segment;
 }
 

--- a/ares/component/processor/v30mz/serialization.cpp
+++ b/ares/component/processor/v30mz/serialization.cpp
@@ -4,7 +4,11 @@ auto V30MZ::serialize(serializer& s) -> void {
   s(state.prefix);
 
   s(opcode);
-  s(prefixes);
+
+  s(prefix.count);
+  s(prefix.lock);
+  s(prefix.repeat);
+  s(prefix.segment);
 
   s(modrm.mod);
   s(modrm.reg);

--- a/ares/component/processor/v30mz/v30mz.cpp
+++ b/ares/component/processor/v30mz/v30mz.cpp
@@ -28,7 +28,7 @@ auto V30MZ::power() -> void {
   state.prefix = 0;
 
   opcode = 0;
-  prefixes.flush();
+  prefixFlush();
   modrm.mod = 0;
   modrm.reg = 0;
   modrm.mem = 0;

--- a/ares/component/processor/v30mz/v30mz.hpp
+++ b/ares/component/processor/v30mz/v30mz.hpp
@@ -39,6 +39,7 @@ struct V30MZ {
   auto power() -> void;
 
   //instruction.cpp
+  auto prefixFlush() -> void;
   auto interrupt(u8 vector) -> bool;
   auto nonMaskableInterrupt() -> bool;
   auto instruction() -> void;
@@ -242,7 +243,12 @@ struct V30MZ {
   } state;
 
   u8 opcode;
-  queue<u8[7]> prefixes;
+  struct Prefix {
+    u16 count;
+    u8 lock;
+    u8 repeat;
+    u8 segment;
+  } prefix;
 
   struct ModRM {
     u2 mod;

--- a/ares/ws/system/serialization.cpp
+++ b/ares/ws/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v139";
+static const string SerializerVersion = "v140";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
It appears the datasheet was not entirely conclusive with regard to how the CPU handles chains of more than 7 consecutive instruction prefixes; in addition, Ares was incorrectly using the *first* rather than *last* segment override in the chain.

This doesn't affect well-formed code (duplicate instruction prefixes should never happen, nor should more than one segment override), but brings Ares up from 2/7 to 7/7 in [ws-test-suite](https://github.com/asiekierka/ws-test-suite)'s new `mono/cpu/prefixes` test.