### PR TITLE
ruby: improve OSS audio backend

### DIFF
--- a/ruby/audio/audio.cpp
+++ b/ruby/audio/audio.cpp
@@ -85,12 +85,7 @@ auto Audio::setDynamic(bool dynamic) -> bool {
 }
 
 auto Audio::setChannels(u32 channels) -> bool {
-  if(resamplers.size() != channels) {
-    resamplers.reset();
-    resamplers.resize(channels);
-    for(auto& resampler : resamplers) resampler.reset(instance->frequency);
-    resampleBuffer.resize(channels);
-  }
+  updateResampleChannels(channels);
   if(instance->channels == channels) return true;
   if(!instance->hasChannels(channels)) return false;
   if(!instance->setChannels(instance->channels = channels)) return false;
@@ -110,6 +105,17 @@ auto Audio::setLatency(u32 latency) -> bool {
   if(!instance->hasLatency(latency)) return false;
   if(!instance->setLatency(instance->latency = latency)) return false;
   return true;
+}
+
+//
+
+auto Audio::updateResampleChannels(u32 channels) -> void {
+  if(resamplers.size() != channels) {
+    resamplers.reset();
+    resamplers.resize(channels);
+    for(auto& resampler : resamplers) resampler.reset(instance->frequency);
+    resampleBuffer.resize(channels);
+  }
 }
 
 //

--- a/ruby/audio/audio.cpp
+++ b/ruby/audio/audio.cpp
@@ -73,7 +73,7 @@ auto Audio::setBlocking(bool blocking) -> bool {
   if(instance->blocking == blocking) return true;
   if(!instance->hasBlocking()) return false;
   if(!instance->setBlocking(instance->blocking = blocking)) return false;
-  for(auto& resampler : resamplers) resampler.reset(instance->frequency);
+  updateResampleFrequency(instance->frequency);
   return true;
 }
 
@@ -96,7 +96,7 @@ auto Audio::setFrequency(u32 frequency) -> bool {
   if(instance->frequency == frequency) return true;
   if(!instance->hasFrequency(frequency)) return false;
   if(!instance->setFrequency(instance->frequency = frequency)) return false;
-  for(auto& resampler : resamplers) resampler.reset(instance->frequency);
+  updateResampleFrequency(instance->frequency);
   return true;
 }
 
@@ -113,15 +113,19 @@ auto Audio::updateResampleChannels(u32 channels) -> void {
   if(resamplers.size() != channels) {
     resamplers.reset();
     resamplers.resize(channels);
-    for(auto& resampler : resamplers) resampler.reset(instance->frequency);
+    updateResampleFrequency(instance->frequency);
     resampleBuffer.resize(channels);
   }
+}
+
+auto Audio::updateResampleFrequency(u32 frequency) -> void {
+  for(auto& resampler : resamplers) resampler.reset(frequency);
 }
 
 //
 
 auto Audio::clear() -> void {
-  for(auto& resampler : resamplers) resampler.reset(instance->frequency);
+  updateResampleFrequency(instance->frequency);
   return instance->clear();
 }
 

--- a/ruby/audio/audio.hpp
+++ b/ruby/audio/audio.hpp
@@ -96,6 +96,8 @@ struct Audio {
   auto setFrequency(u32 frequency) -> bool;
   auto setLatency(u32 latency) -> bool;
 
+  auto updateResampleChannels(u32 channels) -> void;
+
   auto clear() -> void;
   auto level() -> double;
   auto output(const f64 samples[]) -> void;

--- a/ruby/audio/audio.hpp
+++ b/ruby/audio/audio.hpp
@@ -97,6 +97,7 @@ struct Audio {
   auto setLatency(u32 latency) -> bool;
 
   auto updateResampleChannels(u32 channels) -> void;
+  auto updateResampleFrequency(u32 frequency) -> void;
 
   auto clear() -> void;
   auto level() -> double;

--- a/ruby/audio/oss.cpp
+++ b/ruby/audio/oss.cpp
@@ -98,9 +98,7 @@ private:
     int frequency = self.frequency;
     if(ioctl(_fd, SNDCTL_DSP_SPEED, &frequency) == -1) return terminate(), false;
     if(!updateBlocking()) return terminate(), false;
-    audio_buf_info info;
-    if(ioctl(_fd, SNDCTL_DSP_GETOSPACE, &info) == -1) return terminate(), false;
-    _nonBlockBytes = info.bytes;
+    if(!updateNonBlockBytes()) return terminate(), false;
 
     return true;
   }
@@ -117,6 +115,14 @@ private:
     if(flags < 0) return false;
     self.blocking ? flags &=~ O_NONBLOCK : flags |= O_NONBLOCK;
     fcntl(_fd, F_SETFL, flags);
+    return true;
+  }
+
+  auto updateNonBlockBytes() -> bool {
+    audio_buf_info info;
+    if(ioctl(_fd, SNDCTL_DSP_GETOSPACE, &info) == -1) return false;
+    if(info.bytes < 1) return false;
+    _nonBlockBytes = info.bytes;
     return true;
   }
 

--- a/ruby/audio/oss.cpp
+++ b/ruby/audio/oss.cpp
@@ -94,8 +94,7 @@ private:
     ioctl(_fd, SNDCTL_DSP_POLICY, &policy);
     if(!updateChannels()) return terminate(), false;
     if(ioctl(_fd, SNDCTL_DSP_SETFMT, &_format) == -1) return terminate(), false;
-    int frequency = self.frequency;
-    if(ioctl(_fd, SNDCTL_DSP_SPEED, &frequency) == -1) return terminate(), false;
+    if(!updateFrequency()) return terminate(), false;
     if(!updateBlocking()) return terminate(), false;
     if(!updateNonBlockBytes()) return terminate(), false;
 
@@ -120,6 +119,15 @@ private:
     if(!super.hasChannels(channels)) return false;
     super.updateResampleChannels(channels);
     self.channels = channels;
+    return true;
+  }
+
+  auto updateFrequency() -> bool {
+    int frequency = self.frequency;
+    if(ioctl(_fd, SNDCTL_DSP_SPEED, &frequency) == -1) return false;
+    if(!super.hasFrequency(frequency)) return false;
+    super.updateResampleFrequency(frequency);
+    self.frequency = frequency;
     return true;
   }
 

--- a/ruby/audio/oss.cpp
+++ b/ruby/audio/oss.cpp
@@ -65,7 +65,7 @@ struct AudioOSS : AudioDriver {
   auto level() -> double override {
     audio_buf_info info;
     ioctl(_fd, SNDCTL_DSP_GETOSPACE, &info);
-    return (double)(_bufferSize - info.bytes) / _bufferSize;
+    return (double)(_nonBlockBytes - info.bytes) / _nonBlockBytes;
   }
 
   auto output(const double samples[]) -> void override {
@@ -100,7 +100,7 @@ private:
     updateBlocking();
     audio_buf_info info;
     ioctl(_fd, SNDCTL_DSP_GETOSPACE, &info);
-    _bufferSize = info.bytes;
+    _nonBlockBytes = info.bytes;
 
     return true;
   }
@@ -122,7 +122,7 @@ private:
 
   s32 _fd = -1;
   s32 _format = AFMT_S16_LE;
-  s32 _bufferSize = 1;
+  s32 _nonBlockBytes = 1;
 
   queue<s16> _buffer;
 };

--- a/ruby/audio/oss.cpp
+++ b/ruby/audio/oss.cpp
@@ -40,7 +40,7 @@ struct AudioOSS : AudioDriver {
   }
 
   auto hasChannels() -> vector<u32> override {
-    return {1, 2};
+    return {1, 2, 3, 4, 5, 6, 7, 8};
   }
 
   auto hasFrequencies() -> vector<u32> override {

--- a/ruby/audio/oss.cpp
+++ b/ruby/audio/oss.cpp
@@ -93,13 +93,13 @@ private:
     int policy = min(10, self.latency);
     ioctl(_fd, SNDCTL_DSP_POLICY, &policy);
     int channels = self.channels;
-    ioctl(_fd, SNDCTL_DSP_CHANNELS, &channels);
-    ioctl(_fd, SNDCTL_DSP_SETFMT, &_format);
+    if(ioctl(_fd, SNDCTL_DSP_CHANNELS, &channels) == -1) return terminate(), false;
+    if(ioctl(_fd, SNDCTL_DSP_SETFMT, &_format) == -1) return terminate(), false;
     int frequency = self.frequency;
-    ioctl(_fd, SNDCTL_DSP_SPEED, &frequency);
-    updateBlocking();
+    if(ioctl(_fd, SNDCTL_DSP_SPEED, &frequency) == -1) return terminate(), false;
+    if(!updateBlocking()) return terminate(), false;
     audio_buf_info info;
-    ioctl(_fd, SNDCTL_DSP_GETOSPACE, &info);
+    if(ioctl(_fd, SNDCTL_DSP_GETOSPACE, &info) == -1) return terminate(), false;
     _nonBlockBytes = info.bytes;
 
     return true;

--- a/ruby/audio/oss.cpp
+++ b/ruby/audio/oss.cpp
@@ -44,7 +44,7 @@ struct AudioOSS : AudioDriver {
   }
 
   auto hasFrequencies() -> vector<u32> override {
-    return {44100, 48000, 96000};
+    return {22050, 44100, 48000, 96000, 192000};
   }
 
   auto hasLatencies() -> vector<u32> override {

--- a/ruby/audio/oss.cpp
+++ b/ruby/audio/oss.cpp
@@ -92,8 +92,7 @@ private:
     //policy: 0 = minimum latency (higher CPU usage); 10 = maximum latency (lower CPU usage)
     int policy = min(10, self.latency);
     ioctl(_fd, SNDCTL_DSP_POLICY, &policy);
-    int channels = self.channels;
-    if(ioctl(_fd, SNDCTL_DSP_CHANNELS, &channels) == -1) return terminate(), false;
+    if(!updateChannels()) return terminate(), false;
     if(ioctl(_fd, SNDCTL_DSP_SETFMT, &_format) == -1) return terminate(), false;
     int frequency = self.frequency;
     if(ioctl(_fd, SNDCTL_DSP_SPEED, &frequency) == -1) return terminate(), false;
@@ -107,6 +106,15 @@ private:
     if(!ready()) return;
     close(_fd);
     _fd = -1;
+  }
+
+  auto updateChannels() -> bool {
+    int channels = self.channels;
+    if(ioctl(_fd, SNDCTL_DSP_CHANNELS, &channels) == -1) return false;
+    if(!super.hasChannels(channels)) return false;
+    super.updateResampleChannels(channels);
+    self.channels = channels;
+    return true;
   }
 
   auto updateBlocking() -> bool {

--- a/ruby/audio/oss.cpp
+++ b/ruby/audio/oss.cpp
@@ -23,7 +23,7 @@ struct AudioOSS : AudioDriver {
     super.setChannels(2);
     super.setFrequency(48000);
     super.setLatency(3);
-    buffer.resize(64);
+    _buffer.resize(64);
     return initialize();
   }
 
@@ -59,7 +59,7 @@ struct AudioOSS : AudioDriver {
   auto setLatency(u32 latency) -> bool override { return initialize(); }
 
   auto clear() -> void override {
-    buffer.resize(64);
+    _buffer.resize(64);
   }
 
   auto level() -> double override {
@@ -70,10 +70,10 @@ struct AudioOSS : AudioDriver {
 
   auto output(const double samples[]) -> void override {
     for(u32 n : range(self.channels)) {
-      buffer.write(sclamp<16>(samples[n] * 32767.0));
-      if(buffer.full()) {
-        write(_fd, buffer.data(), buffer.capacity<u8>());
-        buffer.flush();
+      _buffer.write(sclamp<16>(samples[n] * 32767.0));
+      if(_buffer.full()) {
+        write(_fd, _buffer.data(), _buffer.capacity<u8>());
+        _buffer.flush();
       }
     }
   }
@@ -124,5 +124,5 @@ private:
   s32 _format = AFMT_S16_LE;
   s32 _bufferSize = 1;
 
-  queue<s16> buffer;
+  queue<s16> _buffer;
 };

--- a/ruby/audio/oss.cpp
+++ b/ruby/audio/oss.cpp
@@ -23,7 +23,7 @@ struct AudioOSS : AudioDriver {
     super.setChannels(2);
     super.setFrequency(48000);
     super.setLatency(3);
-    _buffer.resize(64);
+    _buffer.resize(_bufferSize);
     return initialize();
   }
 
@@ -59,7 +59,7 @@ struct AudioOSS : AudioDriver {
   auto setLatency(u32 latency) -> bool override { return initialize(); }
 
   auto clear() -> void override {
-    _buffer.resize(64);
+    _buffer.resize(_bufferSize);
   }
 
   auto level() -> double override {
@@ -125,4 +125,5 @@ private:
   s32 _nonBlockBytes = 1;
 
   queue<s16> _buffer;
+  static constexpr u32 _bufferSize = 64;
 };


### PR DESCRIPTION
The OSS audio backend was very limited in its capabilities and its error handling. Essentially it supported only the initial parameters for channels, format and frequency, e.g. 48000Hz 16bit stereo. If the audio device didn't support these parameters, the backend would keep using the initial values although OSS had probably adjusted the parameters to supported values. Be aware, there are possible configurations for the system and the audio devices which don't support the above mentioned standard values, e.g. on FreeBSD it's possible to configure an audio device to only accept 96000Hz 32bit 7.1 surround sound.

Now the OSS backend takes the changed parameters for channels, format and frequency into account, updates the resampler accordingly and feeds the audio data into the audio device with the right format.