### PR TITLE
Separate gameinput from hotkeys with hotkey prefix binding

### DIFF
--- a/desktop-ui/emulator/emulator.cpp
+++ b/desktop-ui/emulator/emulator.cpp
@@ -200,7 +200,9 @@ auto Emulator::input(ares::Node::Input::Input input) -> void {
 
   auto port = ares::Node::parent(device);
   if(!port) return;
-  
+
+  bool disabledInput = inputManager.hasPrefix && program.prefixed;
+
   for(auto& inputPort : ports) {
     if(inputPort.name != port->name()) continue;
     for(auto& inputDevice : inputPort.devices) {
@@ -208,10 +210,12 @@ auto Emulator::input(ares::Node::Input::Input input) -> void {
       for(auto& inputNode : inputDevice.inputs) {
         if(inputNode.name != input->name()) continue;
         if(auto button = input->cast<ares::Node::Input::Button>()) {
+          if(disabledInput) return;
           auto pressed = inputNode.mapping->pressed();
           return button->setValue(pressed);
         }
         if(auto axis = input->cast<ares::Node::Input::Axis>()) {
+          if(disabledInput) return;
           auto value = inputNode.mapping->value();
           return axis->setValue(value);
         }
@@ -221,6 +225,7 @@ auto Emulator::input(ares::Node::Input::Input input) -> void {
           }
         }
       }
+      if(disabledInput) return;
       for(auto& inputPair : inputDevice.pairs) {
         if(inputPair.name != input->name()) continue;
         if(auto axis = input->cast<ares::Node::Input::Axis>()) {

--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -155,6 +155,9 @@ auto InputManager::pollHotkeys() -> void {
   }
 
   for(auto& hotkey : hotkeys) {
+    if(hasPrefix && !hotkey.isPrefix && !program.prefixed) {
+      continue;
+    }
     auto state = hotkey.value();
     if(hotkey.state == 0 && state == 1 && hotkey.press) hotkey.press();
     if(hotkey.state == 1 && state == 0 && hotkey.release) hotkey.release();

--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -3,7 +3,9 @@ auto InputManager::createHotkeys() -> void {
   static bool fastForwardAudioBlocking;
   static bool fastForwardAudioDynamic;
 
-  hotkeys.append(InputHotkey("Prefix").onPress([&] {
+  InputHotkey prefix("Prefix");
+  prefix.isPrefix = true;
+  hotkeys.append(prefix.onPress([&] {
     program.setPrefix(!program.prefixed);
   }));
 

--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -3,6 +3,10 @@ auto InputManager::createHotkeys() -> void {
   static bool fastForwardAudioBlocking;
   static bool fastForwardAudioDynamic;
 
+  hotkeys.append(InputHotkey("Prefix").onPress([&] {
+    program.setPrefix(!program.prefixed);
+  }));
+
   hotkeys.append(InputHotkey("Toggle Fullscreen").onPress([&] {
     program.videoFullScreenToggle();
   }));
@@ -51,7 +55,7 @@ auto InputManager::createHotkeys() -> void {
       ruby::audio.setBlocking(false);
       ruby::audio.setDynamic(false);
       return;
-    } 
+    }
 
     ruby::video.setBlocking(fastForwardVideoBlocking);
     ruby::audio.setBlocking(fastForwardAudioBlocking);

--- a/desktop-ui/input/input.cpp
+++ b/desktop-ui/input/input.cpp
@@ -193,6 +193,21 @@ auto InputHotkey::bind(u32 binding, shared_pointer<HID::Device> device, u32 grou
   return bindResult;
 }
 
+auto InputHotkey::unbind(u32 binding) -> void {
+  u32 oldCount = 0;
+  if(isPrefix) oldCount = countAssignments();
+
+  InputDigital::unbind(binding);
+
+  if(isPrefix) {
+    inputManager.hasPrefix = countAssignments() > 0;
+    if(!inputManager.hasPrefix) {
+      if(oldCount == 1) inputManager.showPrefixMessage();
+      program.setPrefix(false);
+    }
+  }
+}
+
 
 auto InputHotkey::value() -> s16 {
   s16 result = 0;

--- a/desktop-ui/input/input.cpp
+++ b/desktop-ui/input/input.cpp
@@ -516,7 +516,14 @@ auto InputManager::bind() -> void {
     for(auto& input : port.pad.inputs) input.mapping->bind();
     for(auto& input : port.mouse.inputs) input.mapping->bind();
   }
-  for(auto& mapping : hotkeys) mapping.bind();
+  for(auto& mapping : hotkeys) {
+    mapping.bind();
+
+    if(mapping.isPrefix) {
+      hasPrefix = mapping.countAssignments() > 0;
+      if(!hasPrefix) program.setPrefix(false);
+    }
+  }
 }
 
 auto InputManager::poll(bool force) -> void {

--- a/desktop-ui/input/input.hpp
+++ b/desktop-ui/input/input.hpp
@@ -73,6 +73,8 @@ struct InputHotkey : InputDigital {
 
   const string name;
 
+  bool isPrefix = false;
+
 private:
   function<void ()> press;
   function<void ()> release;

--- a/desktop-ui/input/input.hpp
+++ b/desktop-ui/input/input.hpp
@@ -7,6 +7,7 @@ struct InputMapping {
   auto bind(u32 binding, string assignment) -> void;
   auto unbind() -> void;
   auto unbind(u32 binding) -> void;
+  auto countAssignments() -> u32;
 
   virtual auto bind(u32 binding, shared_pointer<HID::Device>, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> bool = 0;
   virtual auto value() -> s16 = 0;
@@ -66,7 +67,9 @@ struct InputRumble : InputMapping {
 };
 
 struct InputHotkey : InputDigital {
+  using InputDigital::bind;
   InputHotkey(string name) : name(name) {}
+  auto bind(u32 binding, shared_pointer<HID::Device>, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> bool override;
   auto& onPress(function<void ()> press) { return this->press = press, *this; }
   auto& onRelease(function<void ()> release) { return this->release = release, *this; }
   auto value() -> s16 override;
@@ -187,6 +190,7 @@ struct InputManager {
   auto bind() -> void;
   auto poll(bool force = false) -> void;
   auto eventInput(shared_pointer<HID::Device>, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> void;
+  auto showPrefixMessage() -> void;
 
   //hotkeys.cpp
   auto createHotkeys() -> void;
@@ -197,6 +201,8 @@ struct InputManager {
 
   u64 pollFrequency = 5;
   u64 lastPoll = 0;
+
+  bool hasPrefix = false;
 };
 
 extern VirtualPort virtualPorts[5];

--- a/desktop-ui/input/input.hpp
+++ b/desktop-ui/input/input.hpp
@@ -6,10 +6,10 @@ struct InputMapping {
   auto bind() -> void;
   auto bind(u32 binding, string assignment) -> void;
   auto unbind() -> void;
-  auto unbind(u32 binding) -> void;
   auto countAssignments() -> u32;
 
   virtual auto bind(u32 binding, shared_pointer<HID::Device>, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> bool = 0;
+  virtual auto unbind(u32 binding) -> void;
   virtual auto value() -> s16 = 0;
   virtual auto pressed() -> bool { return false; }
 
@@ -68,8 +68,10 @@ struct InputRumble : InputMapping {
 
 struct InputHotkey : InputDigital {
   using InputDigital::bind;
+  using InputDigital::unbind;
   InputHotkey(string name) : name(name) {}
   auto bind(u32 binding, shared_pointer<HID::Device>, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> bool override;
+  auto unbind(u32 binding) -> void override;
   auto& onPress(function<void ()> press) { return this->press = press, *this; }
   auto& onRelease(function<void ()> release) { return this->release = release, *this; }
   auto value() -> s16 override;

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -41,6 +41,7 @@ struct Program : ares::Platform {
   auto captureScreenshot(const u32* data, u32 pitch, u32 width, u32 height) -> void;
   auto openFile(BrowserDialog&) -> string;
   auto selectFolder(BrowserDialog&) -> string;
+  auto setPrefix(bool) -> void;
 
   //drivers.cpp
   auto videoDriverUpdate() -> void;
@@ -65,6 +66,7 @@ struct Program : ares::Platform {
   vector<ares::Node::Video::Screen> screens;
   vector<ares::Node::Audio::Stream> streams;
 
+  bool prefixed = false;
   bool paused = false;
   bool fastForwarding = false;
   bool rewinding = false;

--- a/desktop-ui/program/utility.cpp
+++ b/desktop-ui/program/utility.cpp
@@ -59,3 +59,9 @@ auto Program::selectFolder(BrowserDialog& dialog) -> string {
   window.setParent(dialog.alignmentWindow());
   return window.directory();
 }
+
+auto Program::setPrefix(bool state) -> void {
+  if(prefixed == state) return;
+  prefixed = state;
+  showMessage({"Prefix ", prefixed ? "ON" : "OFF"});
+}


### PR DESCRIPTION
Currently there's no separation between gameinput bindings (e.g. button A) and hotkey bindings (e.g. Pause Emulation). This can be a problem especially for gamepad only users playing on the couch in front of the TV. After assigning all the buttons for the gameinput there are probably not many buttons on the gamepad left to assign freely to frequently used hotkey functions, e.g. Toggle Fullscreen, Save/Load State, Decrement/Increment State Slot, Pause Emulation, Reset System, Quit Emulator.

Introduce a new Prefix hotkey and separate the gameinput from the hotkeys.

This effectively provides two input modes: if the Prefix hotkey has any bindings, the mode is ON, otherwise it's OFF. The user gets informed in which mode the emulator is currently in when adding the first Prefix binding or when removing the last Prefix binding in the Hotkeys settings window. This serves to avoid confusion for the user if he assigns a binding to the Prefix hotkey by accident.

In the OFF state the emulator behaves exactly as before, i.e. gameinputs and hotkeys are executed without restrictions. In the ON state the gameinputs and hotkeys are executed depending on if the Prefix binding was pressed or not in advance. A message "Prefix ON/OFF" is displayed shortly in the statusbar whenever the Prefix hotkey is pressed, indicating if the prefix is active or not.

If the prefix is not active, only the gameinputs are executed, hotkeys aren't processed. If the prefix is active, only the hotkeys are executed, gameinputs aren't processed.

Example: Prefix hotkey is set to the "Home" button, Pause Emulation hotkey is set to the "A" button and Capture Screenshot is set to the "B" button on the gamepad. In order to pause the emulation, take a screenshot, unpause the emulation and then continue the gameplay the user inputs the following sequence:

Home button -> A -> B -> A -> Home button