### PR TITLE
gba: improve DMA timings

### DIFF
--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -55,6 +55,10 @@ auto CPU::dmaRun() -> void {
   if(!context.dmaActive && !context.prefetchActive) {
     context.dmaActive = true;
     while(dma[0].run() | dma[1].run() | dma[2].run() | dma[3].run());
+    if(context.dmaRan) {
+      idle();
+      context.dmaRan = false;
+    }
     context.dmaActive = false;
   }
 }

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -240,6 +240,7 @@ struct CPU : ARM7TDMI, Thread, IO {
     n1  halted;
     n1  stopped;
     n1  booted;  //set to true by the GBA BIOS
+    n1  dmaRan;
     n1  dmaActive;
     n1  prefetchActive;
     n1  timerLatched;

--- a/ares/gba/cpu/dma.cpp
+++ b/ares/gba/cpu/dma.cpp
@@ -12,8 +12,8 @@ auto CPU::DMA::transfer() -> void {
   u32 mode = size ? Word : Half;
   mode |= latch.length() == length() ? Nonsequential : Sequential;
 
-  if(mode & Nonsequential) {
-    cpu.idle();
+  if(!cpu.context.dmaRan) {
+    cpu.context.dmaRan = true;
     cpu.idle();
   }
 

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -107,6 +107,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(context.halted);
   s(context.stopped);
   s(context.booted);
+  s(context.dmaRan);
   s(context.dmaActive);
   s(context.prefetchActive);
   s(context.timerLatched);

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v139";
+static const string SerializerVersion = "v139.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
The 2 DMA idle cycles currently processed before running a DMA channel should instead run for 1 cycle when DMAs start, and 1 cycle when the DMAs have all finished.