### PR TITLE
gba: prefetcher should halt only once DMA accesses ROM

### DIFF
--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -58,6 +58,7 @@ auto CPU::dmaRun() -> void {
     if(context.dmaRan) {
       idle();
       context.dmaRan = false;
+      context.dmaRomAccess = false;
     }
     context.dmaActive = false;
   }

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -241,6 +241,7 @@ struct CPU : ARM7TDMI, Thread, IO {
     n1  stopped;
     n1  booted;  //set to true by the GBA BIOS
     n1  dmaRan;
+    n1  dmaRomAccess;
     n1  dmaActive;
     n1  prefetchActive;
     n1  timerLatched;

--- a/ares/gba/cpu/dma.cpp
+++ b/ares/gba/cpu/dma.cpp
@@ -23,6 +23,7 @@ auto CPU::DMA::transfer() -> void {
     n32 addr = latch.source();
     if(mode & Word) addr &= ~3;
     if(mode & Half) addr &= ~1;
+    if(addr & 0x0800'0000) cpu.context.dmaRomAccess = true;
     cpu.dmabus.data = cpu.get(mode, addr);
     if(mode & Half) cpu.dmabus.data |= cpu.dmabus.data << 16;
   }
@@ -41,6 +42,7 @@ auto CPU::DMA::transfer() -> void {
     n32 addr = latch.target();
     if(mode & Word) addr &= ~3;
     if(mode & Half) addr &= ~1;
+    if(addr & 0x0800'0000) cpu.context.dmaRomAccess = true;
     cpu.set(mode, addr, cpu.dmabus.data);
   }
 

--- a/ares/gba/cpu/prefetch.cpp
+++ b/ares/gba/cpu/prefetch.cpp
@@ -10,7 +10,7 @@ auto CPU::prefetchSync(n32 address) -> void {
 
 auto CPU::prefetchStep(u32 clocks) -> void {
   step(clocks);
-  if(!wait.prefetch || context.dmaActive || (prefetch.addr == 0)) return;
+  if(!wait.prefetch || context.dmaRomAccess || (prefetch.addr == 0)) return;
 
   while(!prefetch.full() && clocks--) {
     if(--prefetch.wait) continue;

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -108,6 +108,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(context.stopped);
   s(context.booted);
   s(context.dmaRan);
+  s(context.dmaRomAccess);
   s(context.dmaActive);
   s(context.prefetchActive);
   s(context.timerLatched);

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v139.1";
+static const string SerializerVersion = "v139.2";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Currently, the prefetcher halts whenever DMAs are running. However, on hardware the prefetcher is able to keep running until DMA accesses cartridge ROM. This PR implements said behaviour, allowing ares to fully pass the mGBA test suite timing tests as shown below:
![2020](https://github.com/user-attachments/assets/bbf8fd3b-c1a1-45f8-b623-8b0bc8d7784d)
