### PR TITLE
n64: remove branch state machine from epilogue

### DIFF
--- a/ares/n64/accuracy.hpp
+++ b/ares/n64/accuracy.hpp
@@ -3,7 +3,7 @@ struct Accuracy {
   static constexpr bool Reference = 0;
 
   struct CPU {
-    static constexpr bool Interpreter = 0 | Reference | !recompiler::generic::supported;
+    static constexpr bool Interpreter = 1 | Reference | !recompiler::generic::supported;
     static constexpr bool Recompiler = !Interpreter;
 
     //exceptions when the CPU accesses unaligned memory addresses
@@ -11,7 +11,7 @@ struct Accuracy {
   };
 
   struct RSP {
-    static constexpr bool Interpreter = 0 | Reference | !recompiler::generic::supported;
+    static constexpr bool Interpreter = 1 | Reference | !recompiler::generic::supported;
     static constexpr bool Recompiler = !Interpreter;
 
     //VU instructions

--- a/ares/n64/accuracy.hpp
+++ b/ares/n64/accuracy.hpp
@@ -3,7 +3,7 @@ struct Accuracy {
   static constexpr bool Reference = 0;
 
   struct CPU {
-    static constexpr bool Interpreter = 1 | Reference | !recompiler::generic::supported;
+    static constexpr bool Interpreter = 0 | Reference | !recompiler::generic::supported;
     static constexpr bool Recompiler = !Interpreter;
 
     //exceptions when the CPU accesses unaligned memory addresses
@@ -11,7 +11,7 @@ struct Accuracy {
   };
 
   struct RSP {
-    static constexpr bool Interpreter = 1 | Reference | !recompiler::generic::supported;
+    static constexpr bool Interpreter = 0 | Reference | !recompiler::generic::supported;
     static constexpr bool Recompiler = !Interpreter;
 
     //VU instructions

--- a/ares/n64/cpu/debugger.cpp
+++ b/ares/n64/cpu/debugger.cpp
@@ -21,10 +21,8 @@ auto CPU::Debugger::unload() -> void {
   tracer.tlb.reset();
 }
 
-auto CPU::Debugger::instruction() -> void {
+auto CPU::Debugger::instruction(u64 address, u32 instruction) -> void {
   if(unlikely(tracer.instruction->enabled())) {
-    u64 address = cpu.pipeline.address;
-    u32 instruction = cpu.pipeline.instruction;
     if(tracer.instruction->address(address)) {
       cpu.disassembler.showColors = 0;
       tracer.instruction->notify(cpu.disassembler.disassemble(address, instruction), {});

--- a/ares/n64/cpu/exceptions.cpp
+++ b/ares/n64/cpu/exceptions.cpp
@@ -22,14 +22,13 @@ auto CPU::Exception::trigger(u32 code, u32 coprocessor, bool tlbMiss) -> void {
     self.scc.status.exceptionLevel = 1;
     self.scc.cause.exceptionCode = code;
     self.scc.cause.coprocessorError = coprocessor;
-    if(self.scc.cause.branchDelay = self.branch.inDelaySlot()) self.scc.epc -= 4;
+    if(self.scc.cause.branchDelay = self.pipeline.wasDelaySlot) self.scc.epc -= 4;
   } else {
     self.scc.cause.exceptionCode = code;
     self.scc.cause.coprocessorError = coprocessor;
   }
 
-  self.ipu.pc = vectorBase + vectorOffset;
-  self.branch.exception();
+  self.pipeline.setPc(vectorBase + vectorOffset);
   self.context.setMode();
 }
 
@@ -62,5 +61,5 @@ auto CPU::Exception::nmi() -> void {
   self.scc.status.softReset = 0;
   self.scc.status.errorLevel = 1;
   self.scc.epcError = self.ipu.pc;
-  self.ipu.pc = 0xffff'ffff'bfc0'0000;
+  self.pipeline.setPc(0xffff'ffff'bfc0'0000);
 }

--- a/ares/n64/cpu/exceptions.cpp
+++ b/ares/n64/cpu/exceptions.cpp
@@ -22,13 +22,14 @@ auto CPU::Exception::trigger(u32 code, u32 coprocessor, bool tlbMiss) -> void {
     self.scc.status.exceptionLevel = 1;
     self.scc.cause.exceptionCode = code;
     self.scc.cause.coprocessorError = coprocessor;
-    if(self.scc.cause.branchDelay = self.pipeline.wasDelaySlot) self.scc.epc -= 4;
+    if(self.scc.cause.branchDelay = self.pipeline.inDelaySlot()) self.scc.epc -= 4;
   } else {
     self.scc.cause.exceptionCode = code;
     self.scc.cause.coprocessorError = coprocessor;
   }
 
   self.pipeline.setPc(vectorBase + vectorOffset);
+  self.pipeline.exception();  //todo: only call this between instruction prologue/epilogue
   self.context.setMode();
 }
 

--- a/ares/n64/cpu/interpreter-fpu.cpp
+++ b/ares/n64/cpu/interpreter-fpu.cpp
@@ -417,9 +417,9 @@ auto CPU::fpuCheckInputConv<s64>(f64& f) -> bool {
 
 auto CPU::BC1(bool value, bool likely, s16 imm) -> void {
   if(!fpuCheckStart()) return;
-  if(CF == value) branch.take(ipu.pc + 4 + (imm << 2));
-  else if(likely) branch.discard();
-  else branch.notTaken();
+  if(CF == value) pipeline.branch(pipeline.pc + (imm << 2));
+  else if(likely) pipeline.skip();
+  else pipeline.noBranch();
 }
 
 auto CPU::CFC1(r64& rt, u8 rd) -> void {

--- a/ares/n64/cpu/interpreter-ipu.cpp
+++ b/ares/n64/cpu/interpreter-ipu.cpp
@@ -1,4 +1,4 @@
-#define PC ipu.pc
+#define PC pipeline.pc
 #define RA ipu.r[31]
 #define LO ipu.lo
 #define HI ipu.hi
@@ -30,88 +30,87 @@ auto CPU::ANDI(r64& rt, cr64& rs, u16 imm) -> void {
 }
 
 auto CPU::BEQ(cr64& rs, cr64& rt, s16 imm) -> void {
-  if(rs.u64 == rt.u64) branch.take(PC + 4 + (imm << 2));
-  else branch.notTaken();
+  if(rs.u64 == rt.u64) pipeline.branch(PC + (imm << 2));
+  else pipeline.noBranch();
 }
 
 auto CPU::BEQL(cr64& rs, cr64& rt, s16 imm) -> void {
-  if(rs.u64 == rt.u64) branch.take(PC + 4 + (imm << 2));
-  else branch.discard();
+  if(rs.u64 == rt.u64) pipeline.branch(PC + (imm << 2));
+  else pipeline.skip();
 }
 
 auto CPU::BGEZ(cr64& rs, s16 imm) -> void {
-  if(rs.s64 >= 0) branch.take(PC + 4 + (imm << 2));
-  else branch.notTaken();
+  if(rs.s64 >= 0) pipeline.branch(PC + (imm << 2));
+  else pipeline.noBranch();
 }
 
 auto CPU::BGEZAL(cr64& rs, s16 imm) -> void {
-  bool inDelaySlot = branch.inDelaySlot();
-  if(rs.s64 >= 0) branch.take(PC + 4 + (imm << 2));
-  else branch.notTaken();
-  RA.u64 = s32(inDelaySlot ? branch.pc+4 : PC+8);
+  if(rs.s64 >= 0) pipeline.branch(PC + (imm << 2));
+  else pipeline.noBranch();
+  RA.u64 = s32(PC + 4);
 }
 
 auto CPU::BGEZALL(cr64& rs, s16 imm) -> void {
-  if(rs.s64 >= 0) branch.take(PC + 4 + (imm << 2));
-  else branch.discard();
-  RA.u64 = s32(PC + 8);
+  RA.u64 = s32(PC + 4);
+  if(rs.s64 >= 0) pipeline.branch(PC + (imm << 2));
+  else pipeline.skip();
 }
 
 auto CPU::BGEZL(cr64& rs, s16 imm) -> void {
-  if(rs.s64 >= 0) branch.take(PC + 4 + (imm << 2));
-  else branch.discard();
+  if(rs.s64 >= 0) pipeline.branch(PC + (imm << 2));
+  else pipeline.skip();
 }
 
 auto CPU::BGTZ(cr64& rs, s16 imm) -> void {
-  if(rs.s64 > 0) branch.take(PC + 4 + (imm << 2));
-  else branch.notTaken();
+  if(rs.s64 > 0) pipeline.branch(PC + (imm << 2));
+  else pipeline.noBranch();
 }
 
 auto CPU::BGTZL(cr64& rs, s16 imm) -> void {
-  if(rs.s64 > 0) branch.take(PC + 4 + (imm << 2));
-  else branch.discard();
+  if(rs.s64 > 0) pipeline.branch(PC + (imm << 2));
+  else pipeline.skip();
 }
 
 auto CPU::BLEZ(cr64& rs, s16 imm) -> void {
-  if(rs.s64 <= 0) branch.take(PC + 4 + (imm << 2));
-  else branch.notTaken();
+  if(rs.s64 <= 0) pipeline.branch(PC + (imm << 2));
+  else pipeline.noBranch();
 }
 
 auto CPU::BLEZL(cr64& rs, s16 imm) -> void {
-  if(rs.s64 <= 0) branch.take(PC + 4 + (imm << 2));
-  else branch.discard();
+  if(rs.s64 <= 0) pipeline.branch(PC + (imm << 2));
+  else pipeline.skip();
 }
 
 auto CPU::BLTZ(cr64& rs, s16 imm) -> void {
-  if(rs.s64 < 0) branch.take(PC + 4 + (imm << 2));
-  else branch.notTaken();
+  if(rs.s64 < 0) pipeline.branch(PC + (imm << 2));
+  else pipeline.noBranch();
 }
 
 auto CPU::BLTZAL(cr64& rs, s16 imm) -> void {
-  RA.u64 = s32(PC + 8);
-  if(rs.s64 < 0) branch.take(PC + 4 + (imm << 2));
-  else branch.notTaken();
+  RA.u64 = s32(PC + 4);
+  if(rs.s64 < 0) pipeline.branch(PC + (imm << 2));
+  else pipeline.noBranch();
 }
 
 auto CPU::BLTZALL(cr64& rs, s16 imm) -> void {
-  RA.u64 = s32(PC + 8);
-  if(rs.s64 < 0) branch.take(PC + 4 + (imm << 2));
-  else branch.discard();
+  RA.u64 = s32(PC + 4);
+  if(rs.s64 < 0) pipeline.branch(PC + (imm << 2));
+  else pipeline.skip();
 }
 
 auto CPU::BLTZL(cr64& rs, s16 imm) -> void {
-  if(rs.s64 < 0) branch.take(PC + 4 + (imm << 2));
-  else branch.discard();
+  if(rs.s64 < 0) pipeline.branch(PC + (imm << 2));
+  else pipeline.skip();
 }
 
 auto CPU::BNE(cr64& rs, cr64& rt, s16 imm) -> void {
-  if(rs.u64 != rt.u64) branch.take(PC + 4 + (imm << 2));
-  else branch.notTaken();
+  if(rs.u64 != rt.u64) pipeline.branch(PC + (imm << 2));
+  else pipeline.noBranch();
 }
 
 auto CPU::BNEL(cr64& rs, cr64& rt, s16 imm) -> void {
-  if(rs.u64 != rt.u64) branch.take(PC + 4 + (imm << 2));
-  else branch.discard();
+  if(rs.u64 != rt.u64) pipeline.branch(PC + (imm << 2));
+  else pipeline.skip();
 }
 
 auto CPU::BREAK() -> void {
@@ -391,26 +390,22 @@ auto CPU::DSUBU(r64& rd, cr64& rs, cr64& rt) -> void {
 }
 
 auto CPU::J(u32 imm) -> void {
-  if (branch.inDelaySlotTaken()) return;
-  branch.take((PC + 4 & 0xffff'ffff'f000'0000) | (imm << 2));
+  pipeline.branch((PC & 0xffff'ffff'f000'0000) | (imm << 2));
 }
 
 auto CPU::JAL(u32 imm) -> void {
-  RA.u64 = branch.inDelaySlotTaken() ? branch.pc+4 : PC+8;
-  if (!branch.inDelaySlotTaken()) branch.take((PC + 4 & 0xffff'ffff'f000'0000) | (imm << 2));
-  else if (!branch.inDelaySlot()) branch.notTaken();
+  RA.u64 = PC+4;
+  pipeline.branch((PC & 0xffff'ffff'f000'0000) | (imm << 2));
 }
 
 auto CPU::JALR(r64& rd, cr64& rs) -> void {
   u64 tgt = rs.u64;
-  rd.u64 = branch.inDelaySlotTaken() ? branch.pc+4 : PC+8;
-  if (!branch.inDelaySlotTaken()) branch.take(tgt);
-  else if (!branch.inDelaySlot()) branch.notTaken();
+  rd.u64 = PC+4;
+  pipeline.branch(tgt);
 }
 
 auto CPU::JR(cr64& rs) -> void {
-  if (!branch.inDelaySlotTaken()) branch.take(rs.u64);
-  else if (!branch.inDelaySlot()) branch.notTaken();
+  pipeline.branch(rs.u64);
 }
 
 auto CPU::LB(r64& rt, cr64& rs, s16 imm) -> void {

--- a/ares/n64/cpu/interpreter-scc.cpp
+++ b/ares/n64/cpu/interpreter-scc.cpp
@@ -288,12 +288,11 @@ auto CPU::ERET() -> void {
   if(!context.kernelMode()) {
     if(!scc.status.enable.coprocessor0) return exception.coprocessor0();
   }
-  branch.exception();
   if(scc.status.errorLevel) {
-    ipu.pc = scc.epcError;
+    pipeline.setPc(scc.epcError);
     scc.status.errorLevel = 0;
   } else {
-    ipu.pc = scc.epc;
+    pipeline.setPc(scc.epc);
     scc.status.exceptionLevel = 0;
   }
   scc.llbit = 0;

--- a/ares/n64/cpu/interpreter-scc.cpp
+++ b/ares/n64/cpu/interpreter-scc.cpp
@@ -295,6 +295,7 @@ auto CPU::ERET() -> void {
     pipeline.setPc(scc.epc);
     scc.status.exceptionLevel = 0;
   }
+  pipeline.exception();
   scc.llbit = 0;
   context.setMode();
 }

--- a/ares/n64/cpu/interpreter.cpp
+++ b/ares/n64/cpu/interpreter.cpp
@@ -1,9 +1,9 @@
-#define OP pipeline.instruction
+#define OP instruction
 #define RD ipu.r[RDn]
 #define RT ipu.r[RTn]
 #define RS ipu.r[RSn]
 
-#define jp(id, name, ...) case id: return decoder##name(__VA_ARGS__)
+#define jp(id, name, ...) case id: return decoder##name(instruction, ##__VA_ARGS__)
 #define op(id, name, ...) case id: return name(__VA_ARGS__)
 #define br(id, name, ...) case id: return name(__VA_ARGS__)
 
@@ -18,7 +18,7 @@
 #define IMMu16 u16(OP)
 #define IMMu26 (OP & 0x03ff'ffff)
 
-auto CPU::decoderEXECUTE() -> void {
+auto CPU::decoderEXECUTE(u32 instruction) -> void {
   switch(OP >> 26) {
   jp(0x00, SPECIAL);
   jp(0x01, REGIMM);
@@ -87,7 +87,7 @@ auto CPU::decoderEXECUTE() -> void {
   }
 }
 
-auto CPU::decoderSPECIAL() -> void {
+auto CPU::decoderSPECIAL(u32 instruction) -> void {
   switch(OP & 0x3f) {
   op(0x00, SLL, RD, RT, SA);
   br(0x01, INVALID);
@@ -156,7 +156,7 @@ auto CPU::decoderSPECIAL() -> void {
   }
 }
 
-auto CPU::decoderREGIMM() -> void {
+auto CPU::decoderREGIMM(u32 instruction) -> void {
   switch(OP >> 16 & 0x1f) {
   br(0x00, BLTZ, RS, IMMi16);
   br(0x01, BGEZ, RS, IMMi16);
@@ -193,7 +193,7 @@ auto CPU::decoderREGIMM() -> void {
   }
 }
 
-auto CPU::decoderSCC() -> void {
+auto CPU::decoderSCC(u32 instruction) -> void {
   switch(OP >> 21 & 0x1f) {
   op(0x00, MFC0, RT, RDn);
   op(0x01, DMFC0, RT, RDn);
@@ -221,10 +221,10 @@ auto CPU::decoderSCC() -> void {
   br(0x18, ERET);
   }
 
-  //undefined instructions do not throw a reserved instruction exception
+  //undefined instructions do not throw a reserv32 instruction exception
 }
 
-auto CPU::decoderFPU() -> void {
+auto CPU::decoderFPU(u32 instruction) -> void {
   switch(OP >> 21 & 0x1f) {
   op(0x00, MFC1, RT, FS);
   op(0x01, DMFC1, RT, FS);
@@ -356,10 +356,10 @@ auto CPU::decoderFPU() -> void {
   op(0x25, FCVT_L_L, FD, FS);
   }
 
-  //undefined instructions do not throw a reserved instruction exception
+  //undefined instructions do not throw a reserv32 instruction exception
 }
 
-auto CPU::decoderCOP2() -> void {
+auto CPU::decoderCOP2(u32 instruction) -> void {
   switch(OP >> 21 & 0x1f) {
   op(0x00, MFC2, RT, RDn);
   op(0x01, DMFC2, RT, RDn);

--- a/ares/n64/cpu/interpreter.cpp
+++ b/ares/n64/cpu/interpreter.cpp
@@ -3,7 +3,7 @@
 #define RT ipu.r[RTn]
 #define RS ipu.r[RSn]
 
-#define jp(id, name, ...) case id: return decoder##name(instruction, ##__VA_ARGS__)
+#define jp(id, name, ...) case id: return decoder##name(instruction, __VA_ARGS__)
 #define op(id, name, ...) case id: return name(__VA_ARGS__)
 #define br(id, name, ...) case id: return name(__VA_ARGS__)
 
@@ -221,7 +221,7 @@ auto CPU::decoderSCC(u32 instruction) -> void {
   br(0x18, ERET);
   }
 
-  //undefined instructions do not throw a reserv32 instruction exception
+  //undefined instructions do not throw a reserved instruction exception
 }
 
 auto CPU::decoderFPU(u32 instruction) -> void {
@@ -356,7 +356,7 @@ auto CPU::decoderFPU(u32 instruction) -> void {
   op(0x25, FCVT_L_L, FD, FS);
   }
 
-  //undefined instructions do not throw a reserv32 instruction exception
+  //undefined instructions do not throw a reserved instruction exception
 }
 
 auto CPU::decoderCOP2(u32 instruction) -> void {

--- a/ares/n64/cpu/serialization.cpp
+++ b/ares/n64/cpu/serialization.cpp
@@ -1,11 +1,9 @@
 auto CPU::serialize(serializer& s) -> void {
   Thread::serialize(s);
 
-  s(pipeline.address);
-  s(pipeline.instruction);
-
-  s(branch.pc);
-  s(branch.state);
+  s(pipeline.pc);
+  s(pipeline.nextpc);
+  s(ipu.pc);
 
   s(context.endian);
   s(context.physMask);
@@ -48,7 +46,6 @@ auto CPU::serialize(serializer& s) -> void {
   for(auto& r : ipu.r) s(r.u64);
   s(ipu.lo.u64);
   s(ipu.hi.u64);
-  s(ipu.pc);
 
   s(scc.index.tlbEntry);
   s(scc.index.probeFailure);

--- a/ares/n64/cpu/serialization.cpp
+++ b/ares/n64/cpu/serialization.cpp
@@ -3,7 +3,8 @@ auto CPU::serialize(serializer& s) -> void {
 
   s(pipeline.pc);
   s(pipeline.nextpc);
-  s(ipu.pc);
+  s(pipeline.state);
+  s(pipeline.nstate);
 
   s(context.endian);
   s(context.physMask);
@@ -46,6 +47,7 @@ auto CPU::serialize(serializer& s) -> void {
   for(auto& r : ipu.r) s(r.u64);
   s(ipu.lo.u64);
   s(ipu.hi.u64);
+  s(ipu.pc);
 
   s(scc.index.tlbEntry);
   s(scc.index.probeFailure);

--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -71,7 +71,7 @@ auto System::load(Node::System& root, string name) -> bool {
 
   if(name.find("NTSC")) {
     information.region = Region::NTSC;
-    information.videoFrequency = 48'681'812;
+    information.videoFrequency = 48'681'818;
   }
   if(name.find("PAL")) {
     information.region = Region::PAL;
@@ -199,7 +199,7 @@ auto System::initDebugHooks() -> void {
       case 36: return true; // COP0 cause (ignore write)
       case 37: { // PC
         if(!GDB::server.getPcOverride()) {
-          cpu.ipu.pc = regValue;
+          cpu.pipeline.setPc(regValue);
         }
         return true;
       }

--- a/ares/n64/system/system.hpp
+++ b/ares/n64/system/system.hpp
@@ -29,7 +29,7 @@ private:
     string name = "Nintendo 64";
     Region region = Region::NTSC;
     u32 frequency = 93'750'000 * 2;
-    u32 videoFrequency = 48'681'812;
+    u32 videoFrequency = 48'681'818;
     bool dd = false;
   } information;
 

--- a/nall/intrinsics.hpp
+++ b/nall/intrinsics.hpp
@@ -39,6 +39,7 @@ namespace nall {
   #pragma clang diagnostic ignored "-Wabsolute-value"
   #pragma clang diagnostic ignored "-Wtrigraphs"
   #pragma clang diagnostic ignored "-Wattributes"
+  #pragma clang diagnostic ignored "-Winvalid-offsetof"
 #elif defined(__GNUC__)
   #define COMPILER_GCC
   struct Compiler {
@@ -56,6 +57,7 @@ namespace nall {
   #pragma GCC diagnostic ignored "-Wtrigraphs"
   #pragma GCC diagnostic ignored "-Wattributes"
   #pragma GCC diagnostic ignored "-Wstringop-overflow"  //GCC 10.2 warning heuristic is buggy
+  #pragma GCC diagnostic ignored "-Winvalid-offsetof"
 #elif defined(_MSC_VER)
   #define COMPILER_MICROSOFT
   struct Compiler {

--- a/nall/recompiler/generic/generic.hpp
+++ b/nall/recompiler/generic/generic.hpp
@@ -46,8 +46,8 @@ namespace nall::recompiler {
       sljit_set_label(sljit_emit_cmp(compiler, SLJIT_NOT_EQUAL | SLJIT_32, SLJIT_RETURN_REG, 0, SLJIT_IMM, 0), epilogue);
     }
 
-    auto jumpEpilog() -> void {
-      sljit_set_label(sljit_emit_jump(compiler, SLJIT_JUMP), epilogue);
+    auto jumpEpilog(sljit_s32 flags = SLJIT_JUMP) -> void {
+      sljit_set_label(sljit_emit_jump(compiler, flags), epilogue);
     }
 
     auto setLabel(sljit_jump* jump) -> void {


### PR DESCRIPTION
This will bloat generated code in the short term, but some of that can be elided with future optimizations.

Passes [n64-systemtest](https://github.com/lemmy-64/n64-systemtest) with both the interpreter and recompiler.