### PR TITLE
nall: accept target-triples below i686 for x86 architecture

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -102,7 +102,7 @@ ifneq ($(filter cl,$(compiler)),)
 else
   machine_opt := $(if $(findstring clang,$(compiler)),-print-target-triple,-dumpmachine)
   machine_str := $(shell $(compiler) $(machine_opt))
-  ifneq ($(filter i686-%,$(machine_str)),)
+  ifneq ($(filter i386-% i486-% i586-% i686-%,$(machine_str)),)
     machine := x86
   else ifneq ($(filter amd64-% x86_64-%,$(machine_str)),)
     machine := amd64


### PR DESCRIPTION
Some systems report target-triples below i686, although they target i686 in reality. One such system is FreeBSD since version 13.0. It reports i386 but targets i686. Without accepting target-triples below i686 such systems can't compile ares on the x86 architecture.