### PR TITLE
hiro/cocoa: Fixes and code cleanup

### DIFF
--- a/hiro/cocoa/action/menu-check-item.cpp
+++ b/hiro/cocoa/action/menu-check-item.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_MenuCheckItem)
 
-@implementation CocoaMenuCheckItem : NSMenuItem
+@implementation CocoaMenuCheckItem
 
 -(id) initWith:(hiro::mMenuCheckItem&)menuCheckItemReference {
   if(self = [super initWithTitle:@"" action:@selector(activate) keyEquivalent:@""]) {

--- a/hiro/cocoa/action/menu-item.cpp
+++ b/hiro/cocoa/action/menu-item.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_MenuItem)
 
-@implementation CocoaMenuItem : NSMenuItem
+@implementation CocoaMenuItem
 
 -(id) initWith:(hiro::mMenuItem&)menuItemReference {
   if(self = [super initWithTitle:@"" action:@selector(activate) keyEquivalent:@""]) {

--- a/hiro/cocoa/action/menu-radio-item.cpp
+++ b/hiro/cocoa/action/menu-radio-item.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_MenuRadioItem)
 
-@implementation CocoaMenuRadioItem : NSMenuItem
+@implementation CocoaMenuRadioItem
 
 -(id) initWith:(hiro::mMenuRadioItem&)menuRadioItemReference {
   if(self = [super initWithTitle:@"" action:@selector(activate) keyEquivalent:@""]) {

--- a/hiro/cocoa/action/menu-separator.cpp
+++ b/hiro/cocoa/action/menu-separator.cpp
@@ -3,7 +3,8 @@
 namespace hiro {
 
 auto pMenuSeparator::construct() -> void {
-  cocoaAction = cocoaSeparator = [NSMenuItem separatorItem];
+  cocoaSeparator = [NSMenuItem separatorItem];
+  cocoaAction = (NSMenuItem<CocoaMenu> *)cocoaSeparator;
   pAction::construct();
 }
 

--- a/hiro/cocoa/action/menu.cpp
+++ b/hiro/cocoa/action/menu.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_Menu)
 
-@implementation CocoaMenu : NSMenuItem
+@implementation CocoaMenu
 
 -(id) initWith:(hiro::mMenu&)menuReference {
   if(self = [super initWithTitle:@"" action:nil keyEquivalent:@""]) {

--- a/hiro/cocoa/desktop.cpp
+++ b/hiro/cocoa/desktop.cpp
@@ -11,7 +11,6 @@ auto pDesktop::size() -> Size {
 }
 
 auto pDesktop::workspace() -> Geometry {
-  auto screen = Desktop::size();
   NSRect area = [[[NSScreen screens] objectAtIndex:0] visibleFrame];
   return {
     (s32)area.origin.x,

--- a/hiro/cocoa/monitor.cpp
+++ b/hiro/cocoa/monitor.cpp
@@ -35,7 +35,6 @@ auto pMonitor::primary() -> u32 {
 }
 
 auto pMonitor::workspace(u32 monitor) -> Geometry {
-  NSRect size = [[[NSScreen screens] objectAtIndex:monitor] frame];
   NSRect area = [[[NSScreen screens] objectAtIndex:monitor] visibleFrame];
   return {
     (s32)area.origin.x,

--- a/hiro/cocoa/popup-menu.cpp
+++ b/hiro/cocoa/popup-menu.cpp
@@ -44,7 +44,7 @@ auto pPopupMenu::remove(sAction action) -> void {
 auto pPopupMenu::setVisible(bool visible) -> void {
   if(!visible) return;
   NSEvent* event = [[NSApplication sharedApplication] currentEvent];
-  [NSMenu popUpContextMenu:[cocoaPopupMenu cocoaPopupMenu] withEvent:event forView:nil];
+  [NSMenu popUpContextMenu:[cocoaPopupMenu cocoaPopupMenu] withEvent:event forView:[cocoaPopupMenu view]];
 }
 
 }

--- a/hiro/cocoa/popup-menu.cpp
+++ b/hiro/cocoa/popup-menu.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_PopupMenu)
 
-@implementation CocoaPopupMenu : NSMenuItem
+@implementation CocoaPopupMenu
 
 -(id) initWith:(hiro::mPopupMenu&)popupMenuReference {
   if(self = [super initWithTitle:@"" action:nil keyEquivalent:@""]) {

--- a/hiro/cocoa/popup-menu.hpp
+++ b/hiro/cocoa/popup-menu.hpp
@@ -16,7 +16,7 @@ struct pPopupMenu : pObject {
 
   auto append(sAction action) -> void;
   auto remove(sAction action) -> void;
-  auto setVisible(bool visible) -> void;
+  auto setVisible(bool visible) -> void override;
 
   CocoaPopupMenu* cocoaPopupMenu = nullptr;
 };

--- a/hiro/cocoa/timer.cpp
+++ b/hiro/cocoa/timer.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_Timer)
 
-@implementation CocoaTimer : NSObject
+@implementation CocoaTimer
 
 -(id) initWith:(hiro::mTimer&)timerReference {
   if(self = [super init]) {

--- a/hiro/cocoa/timer.hpp
+++ b/hiro/cocoa/timer.hpp
@@ -16,7 +16,7 @@ namespace hiro {
 struct pTimer : pObject {
   Declare(Timer, Object)
 
-  auto setEnabled(bool enabled) -> void;
+  auto setEnabled(bool enabled) -> void override;
   auto setInterval(u32 interval) -> void;
 
   CocoaTimer* cocoaTimer = nullptr;

--- a/hiro/cocoa/widget/button.cpp
+++ b/hiro/cocoa/widget/button.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_Button)
 
-@implementation CocoaButton : NSButton
+@implementation CocoaButton
 
 -(id) initWith:(hiro::mButton&)buttonReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {

--- a/hiro/cocoa/widget/canvas.cpp
+++ b/hiro/cocoa/widget/canvas.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_Canvas)
 
-@implementation CocoaCanvas : NSView
+@implementation CocoaCanvas
 
 -(id) initWith:(hiro::mCanvas&)canvasReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {

--- a/hiro/cocoa/widget/canvas.cpp
+++ b/hiro/cocoa/widget/canvas.cpp
@@ -15,6 +15,10 @@
   return self;
 }
 
+-(BOOL) clipsToBounds {
+  return true;
+}
+
 -(void) resetCursorRects {
   if(auto mouseCursor = NSMakeCursor(canvas->mouseCursor())) {
     [self addCursorRect:self.bounds cursor:mouseCursor];

--- a/hiro/cocoa/widget/canvas.hpp
+++ b/hiro/cocoa/widget/canvas.hpp
@@ -4,7 +4,7 @@
 @public
   hiro::mCanvas* canvas;
 }
-@property BOOL clipsToBounds;
+-(BOOL) clipsToBounds;
 -(id) initWith:(hiro::mCanvas&)canvas;
 -(void) resetCursorRects;
 -(NSDragOperation) draggingEntered:(id<NSDraggingInfo>)sender;
@@ -29,7 +29,7 @@ namespace hiro {
 struct pCanvas : pWidget {
   Declare(Canvas, Widget)
 
-  auto minimumSize() const -> Size;
+  auto minimumSize() const -> Size override;
   auto setAlignment(Alignment) -> void;
   auto setColor(Color color) -> void;
   auto setDroppable(bool droppable) -> void override;

--- a/hiro/cocoa/widget/check-button.cpp
+++ b/hiro/cocoa/widget/check-button.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_CheckButton)
 
-@implementation CocoaCheckButton : NSButton
+@implementation CocoaCheckButton
 
 -(id) initWith:(hiro::mCheckButton&)checkButtonReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {

--- a/hiro/cocoa/widget/check-label.cpp
+++ b/hiro/cocoa/widget/check-label.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_CheckLabel)
 
-@implementation CocoaCheckLabel : NSButton
+@implementation CocoaCheckLabel
 
 -(id) initWith:(hiro::mCheckLabel&)checkLabelReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {

--- a/hiro/cocoa/widget/check-label.hpp
+++ b/hiro/cocoa/widget/check-label.hpp
@@ -15,7 +15,7 @@ struct pCheckLabel : pWidget {
 
   auto minimumSize() const -> Size override;
   auto setChecked(bool checked) -> void;
-  auto setGeometry(Geometry geometry) -> void;
+  auto setGeometry(Geometry geometry) -> void override;
   auto setText(const string& text) -> void;
 
   CocoaCheckLabel* cocoaCheckLabel = nullptr;

--- a/hiro/cocoa/widget/combo-button.cpp
+++ b/hiro/cocoa/widget/combo-button.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_ComboButton)
 
-@implementation CocoaComboButton : NSPopUpButton
+@implementation CocoaComboButton
 
 -(id) initWith:(hiro::mComboButton&)comboButtonReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0) pullsDown:NO]) {

--- a/hiro/cocoa/widget/combo-button.hpp
+++ b/hiro/cocoa/widget/combo-button.hpp
@@ -16,7 +16,7 @@ struct pComboButton : pWidget {
   auto append(sComboButtonItem item) -> void;
   auto minimumSize() const -> Size override;
   auto remove(sComboButtonItem item) -> void;
-  auto reset() -> void;
+  auto reset() -> void override;
   auto setGeometry(Geometry geometry) -> void override;
 
   auto _updateSelected(signed selected) -> void;

--- a/hiro/cocoa/widget/console.cpp
+++ b/hiro/cocoa/widget/console.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_Console)
 
-@implementation CocoaConsole : NSScrollView
+@implementation CocoaConsole
 
 -(id) initWith:(phoenix::Console&)consoleReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {

--- a/hiro/cocoa/widget/frame.cpp
+++ b/hiro/cocoa/widget/frame.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_Frame)
 
-@implementation CocoaFrame : NSBox
+@implementation CocoaFrame
 
 -(id) initWith:(hiro::mFrame&)frameReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {

--- a/hiro/cocoa/widget/hex-edit.cpp
+++ b/hiro/cocoa/widget/hex-edit.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_HexEdit)
 
-@implementation CocoaHexEdit : NSScrollView
+@implementation CocoaHexEdit
 
 -(id) initWith:(hiro::mHexEdit&)hexEditReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {

--- a/hiro/cocoa/widget/horizontal-scroll-bar.cpp
+++ b/hiro/cocoa/widget/horizontal-scroll-bar.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_HorizontalScrollBar)
 
-@implementation CocoaHorizontalScrollBar : NSScroller
+@implementation CocoaHorizontalScrollBar
 
 -(id) initWith:(hiro::mHorizontalScrollBar&)horizontalScrollBarReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 1, 0)]) {

--- a/hiro/cocoa/widget/horizontal-slider.cpp
+++ b/hiro/cocoa/widget/horizontal-slider.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_HorizontalSlider)
 
-@implementation CocoaHorizontalSlider : NSSlider
+@implementation CocoaHorizontalSlider
 
 -(id) initWith:(hiro::mHorizontalSlider&)horizontalSliderReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 1, 0)]) {

--- a/hiro/cocoa/widget/horizontal-slider.hpp
+++ b/hiro/cocoa/widget/horizontal-slider.hpp
@@ -14,7 +14,7 @@ struct pHorizontalSlider : pWidget {
   Declare(HorizontalSlider, Widget)
 
   auto minimumSize() const -> Size override;
-  auto setGeometry(Geometry geometry) -> void;
+  auto setGeometry(Geometry geometry) -> void override;
   auto setLength(u32 length) -> void;
   auto setPosition(u32 position) -> void;
 

--- a/hiro/cocoa/widget/label.cpp
+++ b/hiro/cocoa/widget/label.cpp
@@ -166,5 +166,9 @@ auto pLabel::setText(const string& text) -> void {
 
 }
 
+- (BOOL)clipsToBounds {
+  return true;
+}
+
 @end
 #endif

--- a/hiro/cocoa/widget/label.cpp
+++ b/hiro/cocoa/widget/label.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_Label)
 
-@implementation CocoaLabel : NSView
+@implementation CocoaLabel
 {
   NSColor *_foregroundColor;
 }

--- a/hiro/cocoa/widget/label.hpp
+++ b/hiro/cocoa/widget/label.hpp
@@ -4,7 +4,7 @@
 @public
   hiro::mLabel* label;
 }
-@property BOOL clipsToBounds;
+-(BOOL) clipsToBounds;
 -(id) initWith:(hiro::mLabel&)label;
 -(void) resetCursorRects;
 -(void) drawRect:(NSRect)dirtyRect;

--- a/hiro/cocoa/widget/line-edit.cpp
+++ b/hiro/cocoa/widget/line-edit.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_LineEdit)
 
-@implementation CocoaLineEdit : NSTextField
+@implementation CocoaLineEdit
 
 -(id) initWith:(hiro::mLineEdit&)lineEditReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {

--- a/hiro/cocoa/widget/progress-bar.cpp
+++ b/hiro/cocoa/widget/progress-bar.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_ProgressBar)
 
-@implementation CocoaProgressBar : NSProgressIndicator
+@implementation CocoaProgressBar
 
 -(id) initWith:(hiro::mProgressBar&)progressBarReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {

--- a/hiro/cocoa/widget/radio-button.cpp
+++ b/hiro/cocoa/widget/radio-button.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_RadioButton)
 
-@implementation CocoaRadioButton : NSButton
+@implementation CocoaRadioButton
 
 -(id) initWith:(hiro::mRadioButton&)radioButtonReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {

--- a/hiro/cocoa/widget/radio-label.cpp
+++ b/hiro/cocoa/widget/radio-label.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_RadioLabel)
 
-@implementation CocoaRadioLabel : NSButton
+@implementation CocoaRadioLabel
 
 -(id) initWith:(hiro::mRadioLabel&)radioLabelReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {

--- a/hiro/cocoa/widget/tab-frame.cpp
+++ b/hiro/cocoa/widget/tab-frame.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_TabFrame)
 
-@implementation CocoaTabFrame : NSTabView
+@implementation CocoaTabFrame
 
 -(id) initWith:(hiro::mTabFrame&)tabFrameReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {

--- a/hiro/cocoa/widget/table-view-item.hpp
+++ b/hiro/cocoa/widget/table-view-item.hpp
@@ -9,7 +9,7 @@ struct pTableViewItem : pObject {
   auto remove(sTableViewCell cell) -> void;
   auto setAlignment(Alignment alignment) -> void;
   auto setBackgroundColor(Color color) -> void;
-  auto setFocused() -> void;
+  auto setFocused() -> void override;
   auto setForegroundColor(Color color) -> void;
   auto setSelected(bool selected) -> void;
 

--- a/hiro/cocoa/widget/table-view.cpp
+++ b/hiro/cocoa/widget/table-view.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_TableView)
 
-@implementation CocoaTableView : NSScrollView
+@implementation CocoaTableView
 
 -(id) initWith:(hiro::mTableView&)tableViewReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {

--- a/hiro/cocoa/widget/table-view.hpp
+++ b/hiro/cocoa/widget/table-view.hpp
@@ -9,7 +9,6 @@
   NSFont* font;
 }
 -(id) initWith:(hiro::mTableView&)tableViewReference;
--(void) dealloc;
 -(CocoaTableViewContent*) content;
 -(NSFont*) font;
 -(void) setFont:(NSFont*)font;

--- a/hiro/cocoa/widget/text-edit.cpp
+++ b/hiro/cocoa/widget/text-edit.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_TextEdit)
 
-@implementation CocoaTextEdit : NSScrollView
+@implementation CocoaTextEdit
 
 -(id) initWith:(hiro::mTextEdit&)textEditReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {

--- a/hiro/cocoa/widget/vertical-scroll-bar.cpp
+++ b/hiro/cocoa/widget/vertical-scroll-bar.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_VerticalScrollBar)
 
-@implementation CocoaVerticalScrollBar : NSScroller
+@implementation CocoaVerticalScrollBar
 
 -(id) initWith:(hiro::mVerticalScrollBar&)verticalScrollBarReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 1)]) {

--- a/hiro/cocoa/widget/vertical-slider.cpp
+++ b/hiro/cocoa/widget/vertical-slider.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_VerticalSlider)
 
-@implementation CocoaVerticalSlider : NSSlider
+@implementation CocoaVerticalSlider 
 
 -(id) initWith:(hiro::mVerticalSlider&)verticalSliderReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 1)]) {

--- a/hiro/cocoa/widget/viewport.cpp
+++ b/hiro/cocoa/widget/viewport.cpp
@@ -42,6 +42,10 @@
 -(void) keyUp:(NSEvent*)event {
 }
 
+- (BOOL)clipsToBounds {
+  return true;
+}
+
 @end
 
 namespace hiro {

--- a/hiro/cocoa/widget/viewport.hpp
+++ b/hiro/cocoa/widget/viewport.hpp
@@ -4,7 +4,7 @@
 @public
   hiro::mViewport* viewport;
 }
-@property BOOL clipsToBounds;
+-(BOOL) clipsToBounds;
 -(id) initWith:(hiro::mViewport&)viewport;
 -(void) resetCursorRects;
 -(void) drawRect:(NSRect)rect;

--- a/hiro/cocoa/widget/widget.hpp
+++ b/hiro/cocoa/widget/widget.hpp
@@ -5,7 +5,7 @@ namespace hiro {
 struct pWidget : pSizable {
   Declare(Widget, Sizable)
 
-  auto focused() const -> bool;
+  auto focused() const -> bool override;
   virtual auto setDroppable(bool droppable) -> void;
   auto setEnabled(bool enabled) -> void override;
   virtual auto setFocusable(bool focusable) -> void;

--- a/hiro/cocoa/window.cpp
+++ b/hiro/cocoa/window.cpp
@@ -150,6 +150,8 @@
 }
 
 //to hell with gatekeepers
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wwritable-strings"
 -(void) menuDisableGatekeeper {
   NSAlert* alert = [[NSAlert alloc] init];
   [alert setMessageText:@"Disable Gatekeeper"];
@@ -192,6 +194,7 @@
   [alert addButtonWithTitle:@"Ok"];
   [alert runModal];
 }
+#pragma clang diagnostic pop
 
 -(void) menuQuit {
   hiro::Application::Cocoa::doQuit();

--- a/hiro/cocoa/window.cpp
+++ b/hiro/cocoa/window.cpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_Window)
 
-@implementation CocoaWindow : NSWindow
+@implementation CocoaWindow
 
 -(id) initWith:(hiro::mWindow&)windowReference {
   window = &windowReference;

--- a/hiro/cocoa/window.hpp
+++ b/hiro/cocoa/window.hpp
@@ -54,7 +54,7 @@ struct pWindow : pObject {
   auto setResizable(bool resizable) -> void;
   auto setTitle(const string& text) -> void;
   auto setAssociatedFile(const string& filename) -> void;
-  auto setVisible(bool visible) -> void;
+  auto setVisible(bool visible) -> void override;
 
   auto moveEvent() -> void;
   auto sizeEvent() -> void;


### PR DESCRIPTION
Fixes several issues and compiler warnings with hiro's Cocoa implementation. Among them:

* We were technically declaring `clipsToBounds` incorrectly; properties in subclasses aren't correct and can conflict with the system version; rather, implement it as an instance method.
* Fix some non-strict pointer aliasing in menu-separator.cpp;
* Remove a couple blatant unused variables from desktop.cpp and monitor.cpp;
* Fix an instance passing nil to a function that requires a non-null argument in popup-menu.cpp;
* Some ancient C functions in Cocoa don't pass -Wwritable-strings; for now, just surround the function that uses them with a clang diagnostic pragma.

In C++ land:
* Various C++ functions were `override`s but were not declared as such.

Lastly, the second commit:
* In Objective-C, you declare subclasses in the `@interface` header, but not in the implementation. hiro was including the superclasses in the `@implementation` block, which isn't correct. For some reason, clang was only erroring on one instance of this, but we go ahead and fix it everywhere.