### PR TITLE
nall/arithmetic: ignore -Winfinite-recursion warning in square()

### DIFF
--- a/nall/arithmetic/natural.hpp
+++ b/nall/arithmetic/natural.hpp
@@ -167,6 +167,8 @@ alwaysinline auto bits(Pair value) -> u32 {
   }
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winfinite-recursion"
 //Bits * Bits => Bits
 inline auto square(const Pair& lhs) -> Pair {
   static const Type Mask = (Type(0) - 1) >> HalfBits;
@@ -181,6 +183,7 @@ inline auto square(const Pair& lhs) -> Pair {
 
   return {(r3.lo & Mask) << HalfBits | (r2.lo & Mask), (r1.lo & Mask) << HalfBits | (r0.lo & Mask)};
 }
+#pragma clang diagnostic pop
 
 //Bits * Bits => 2 * Bits
 inline auto square(const Pair& lhs, Pair& hi, Pair& lo) -> void {


### PR DESCRIPTION
More code cleanup for the new build system along with https://github.com/ares-emulator/ares/pull/1602, https://github.com/ares-emulator/ares/pull/1603, and https://github.com/ares-emulator/ares/pull/1604.

This one is fairly mysterious. clang thinks that all paths through this particular signature of the `square()` function call itself. This area of nall is a mass of templating and operator overloads, and figuring out exactly what's going on here would be a good one to unravel for a large-brained, C++-enjoying individual.

For now, just ignore this warning locally so that we can compile the rest of ares while still warning about infinite recursion elsewhere.