### PR TITLE
ws: implement cartridge SRAM open bus, clean up I/O port logic

### DIFF
--- a/ares/ws/cartridge/cartridge.hpp
+++ b/ares/ws/cartridge/cartridge.hpp
@@ -50,8 +50,6 @@ struct Cartridge : IO, Thread {
 
   //memory.cpp
   auto readROM(n20 address) -> n8;
-  auto writeROM(n20 address, n8 data) -> void;
-
   auto readRAM(n20 address) -> n8;
   auto writeRAM(n20 address, n8 data) -> void;
 
@@ -150,6 +148,8 @@ struct Cartridge : IO, Thread {
     n8 gpoData;
     n1 flashEnable;
   } io;
+
+  n16 openbus;
 };
 
 #include "slot.hpp"

--- a/ares/ws/cartridge/io.cpp
+++ b/ares/ws/cartridge/io.cpp
@@ -92,10 +92,13 @@ auto Cartridge::readIO(n16 address) -> n8 {
 
   }
 
+  openbus.byte(0) = data;
   return data;
 }
 
 auto Cartridge::writeIO(n16 address, n8 data) -> void {
+  openbus.byte(0) = data;
+  
   switch(address) {
 
   case 0x00c0:  //BANK_ROM2

--- a/ares/ws/cartridge/memory.cpp
+++ b/ares/ws/cartridge/memory.cpp
@@ -1,36 +1,45 @@
 //20000-fffff
 auto Cartridge::readROM(n20 address) -> n8 {
-  if(!rom) return 0x00;
+  int busbyte = ((address & 1) && cpu.width(address) == Word) ? 1 : 0;
+  if(!rom) return openbus.byte(busbyte);
+
+  n8 value;
   n32 offset;
   switch(address.bit(16,19)) {
   case 2:  offset = io.romBank0 << 16 | (n16)address; break;  //20000-2ffff
   case 3:  offset = io.romBank1 << 16 | (n16)address; break;  //30000-3ffff
   default: offset = io.romBank2 << 20 | (n20)address; break;  //40000-fffff
   }
+
   if(has.flash && (flash.idmode || flash.fastmode)) {
     n16 data = flash.read(offset >> 1, true);
-    if(address & 0x1) return data >> 8;
-    return data;
-  }
-  return rom.read(offset);
-}
+    if(address & 0x1) value = data >> 8;
+    else value = data;
+  } else value = rom.read(offset);
 
-auto Cartridge::writeROM(n20 address, n8 data) -> void {
+  openbus.byte(busbyte) = value;
+  return value;
 }
 
 //10000-1ffff
 auto Cartridge::readRAM(n20 address) -> n8 {
   n32 offset = io.sramBank << 16 | (n16)address;
   if(io.flashEnable) {
-    if(!has.flash) return 0x00;
-    return flash.read(offset, false);
+    if(!has.flash) return openbus;
+    n8 value = flash.read(offset, false);
+    openbus.byte(0) = value;
+    return value;
   } else {
-    if(!has.sram) return 0x00;
-    return ram.read(offset);
+    if(!has.sram) return openbus;
+    n8 value = ram.read(offset);
+    openbus.byte(0) = value;
+    return value;
   }
 }
 
 auto Cartridge::writeRAM(n20 address, n8 data) -> void {
+  openbus.byte(0) = data;
+
   n32 offset = io.sramBank << 16 | (n16)address;
   if(io.flashEnable) {
     if(!has.flash) return;

--- a/ares/ws/cartridge/serialization.cpp
+++ b/ares/ws/cartridge/serialization.cpp
@@ -31,6 +31,8 @@ auto Cartridge::serialize(serializer& s) -> void {
   if(has.karnak) {
     karnak.serialize(s);
   }
+
+  s(openbus);
 }
 
 auto Cartridge::RTC::serialize(serializer& s) -> void {

--- a/ares/ws/memory/memory.hpp
+++ b/ares/ws/memory/memory.hpp
@@ -54,7 +54,7 @@ struct Bus {
   auto writeIO(n16 address, n8 data) -> void;
 
 private:
-  IO* port[64 * 1024] = {nullptr};
+  IO* port[256] = {nullptr};
 };
 
 extern InternalRAM iram;

--- a/ares/ws/system/serialization.cpp
+++ b/ares/ws/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v140";
+static const string SerializerVersion = "v140.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Also saves about 500KB of unnecessary memory use. Ouch!

I/O port open bus is not fully implemented.