### PR TITLE
hiro/cocoa: Always draw in view bounds instead of dirtyRect

### DIFF
--- a/hiro/cocoa/widget/canvas.cpp
+++ b/hiro/cocoa/widget/canvas.cpp
@@ -15,10 +15,6 @@
   return self;
 }
 
--(BOOL) clipsToBounds {
-  return true;
-}
-
 -(void) resetCursorRects {
   if(auto mouseCursor = NSMakeCursor(canvas->mouseCursor())) {
     [self addCursorRect:self.bounds cursor:mouseCursor];
@@ -120,7 +116,7 @@
     [NSMakeImage(fill) drawInRect:frame];
   } else {
     [NSMakeColor(canvas->state.color) set];
-    NSRectFill(dirtyRect);
+    NSRectFill(frame);
   }
 }
 

--- a/hiro/cocoa/widget/canvas.hpp
+++ b/hiro/cocoa/widget/canvas.hpp
@@ -4,7 +4,6 @@
 @public
   hiro::mCanvas* canvas;
 }
--(BOOL) clipsToBounds;
 -(id) initWith:(hiro::mCanvas&)canvas;
 -(void) resetCursorRects;
 -(NSDragOperation) draggingEntered:(id<NSDraggingInfo>)sender;

--- a/hiro/cocoa/widget/label.cpp
+++ b/hiro/cocoa/widget/label.cpp
@@ -9,7 +9,6 @@
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {
     label = &labelReference;
   }
-  self.clipsToBounds = true;
   return self;
 }
 
@@ -23,7 +22,8 @@
   if(auto backgroundColor = label->backgroundColor()) {
     NSColor* color = NSMakeColor(backgroundColor);
     [color setFill];
-    NSRectFill(dirtyRect);
+    NSRect frame = self.bounds;
+    NSRectFill(frame);
   }
 
   NSFont* font = hiro::pFont::create(label->font(true));
@@ -164,10 +164,6 @@ auto pLabel::setText(const string& text) -> void {
   [cocoaView setNeedsDisplay:YES];
 }
 
-}
-
-- (BOOL)clipsToBounds {
-  return true;
 }
 
 @end

--- a/hiro/cocoa/widget/label.hpp
+++ b/hiro/cocoa/widget/label.hpp
@@ -4,7 +4,6 @@
 @public
   hiro::mLabel* label;
 }
--(BOOL) clipsToBounds;
 -(id) initWith:(hiro::mLabel&)label;
 -(void) resetCursorRects;
 -(void) drawRect:(NSRect)dirtyRect;

--- a/hiro/cocoa/widget/viewport.cpp
+++ b/hiro/cocoa/widget/viewport.cpp
@@ -6,7 +6,6 @@
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {
     viewport = &viewportReference;
   }
-  self.clipsToBounds = true;
   return self;
 }
 
@@ -18,7 +17,8 @@
 
 -(void) drawRect:(NSRect)rect {
   [[NSColor blackColor] setFill];
-  NSRectFillUsingOperation(rect, NSCompositeSourceOver);
+  NSRect frame = self.bounds;
+  NSRectFillUsingOperation(frame, NSCompositeSourceOver);
 }
 
 -(BOOL) acceptsFirstResponder {
@@ -40,10 +40,6 @@
 }
 
 -(void) keyUp:(NSEvent*)event {
-}
-
-- (BOOL)clipsToBounds {
-  return true;
 }
 
 @end

--- a/hiro/cocoa/widget/viewport.hpp
+++ b/hiro/cocoa/widget/viewport.hpp
@@ -4,7 +4,6 @@
 @public
   hiro::mViewport* viewport;
 }
--(BOOL) clipsToBounds;
 -(id) initWith:(hiro::mViewport&)viewport;
 -(void) resetCursorRects;
 -(void) drawRect:(NSRect)rect;


### PR DESCRIPTION
A better fix for the problem discussed in https://github.com/ares-emulator/ares/pull/1412.

Also unbreaks CI.

Changing `clipsToBounds` was fine, but the property isn't exposed on older SDKs (that are still used by ares to maintain backwards compatibility), and exposing it manually when building with an older SDK was not great practice (and may have just been a noop anyway).

Instead, we should just not draw on the dirtyRect, when we intend to draw on the view's `bounds`. Apple's documentation on this subject is pretty thin on the ground, not to mention contradictory, especially pre-macOS 14. But it seems pretty clear that in any case, a view's `bounds` will always be the area we intend to draw on, while the view's `dirtyRect` may or may not be. So here we make every element in hiro's Cocoa implementation that does manual drawing always draw using `bounds`.