### PR TITLE
gba: reload timer value after tick

### DIFF
--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -79,6 +79,10 @@ auto CPU::step(u32 clocks) -> void {
     timer[1].run();
     timer[2].run();
     timer[3].run();
+    timer[0].reloadLatch();
+    timer[1].reloadLatch();
+    timer[2].reloadLatch();
+    timer[3].reloadLatch();
     if(context.timerLatched) {
       timer[0].stepLatch();
       timer[1].stepLatch();

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -132,6 +132,7 @@ struct CPU : ARM7TDMI, Thread, IO {
   struct Timer {
     //timer.cpp
     auto stepLatch() -> void;
+    auto reloadLatch() -> void;
     auto run() -> void;
     auto step() -> void;
 

--- a/ares/gba/cpu/timer.cpp
+++ b/ares/gba/cpu/timer.cpp
@@ -25,13 +25,14 @@ auto CPU::Timer::stepLatch() -> void {
   }
 }
 
-inline auto CPU::Timer::run() -> void {
+inline auto CPU::Timer::reloadLatch() -> void {
   if(pending) {
+    period = reload;
     pending = false;
-    if(enable) period = reload;
-    return;
   }
+}
 
+inline auto CPU::Timer::run() -> void {
   if(!enable || cascade) return;
 
   static const u32 mask[] = {0, 63, 255, 1023};


### PR DESCRIPTION
If a timer gets enabled while its value is 0xffff, it's possible for the timer to overflow before its reload value is applied. Passes alyosha's [timer-disable.gba](https://github.com/alyosha-tas/gba-tests/blob/master/timer/timer_disable.gba) test ROM.