### PR TITLE
gba: use separate latches per DMA channel

### DIFF
--- a/ares/gba/apu/io.cpp
+++ b/ares/gba/apu/io.cpp
@@ -140,7 +140,6 @@ auto APU::readIO(n32 address) -> n8 {
 
   }
 
-  if(cpu.context.dmaActive) return cpu.dmabus.data.byte(address & 3);
   return cpu.pipeline.fetch.instruction.byte(address & 1);
 }
 

--- a/ares/gba/cpu/bus.cpp
+++ b/ares/gba/cpu/bus.cpp
@@ -6,7 +6,6 @@ template <bool UseDebugger>
 inline auto CPU::getBus(u32 mode, n32 address) -> n32 {
   u32 clocks = _wait(mode, address);
   u32 word = pipeline.fetch.instruction;
-  if(context.dmaActive) word = dmabus.data;
 
   if(address >= 0x1000'0000) {
     if constexpr(!UseDebugger) prefetchStep(clocks);

--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -124,8 +124,6 @@ auto CPU::power() -> void {
   prefetch = {};
   context = {};
 
-  dmabus = {};
-
   dma[0].source.setBits(27); dma[0].latch.source.setBits(27);
   dma[0].target.setBits(27); dma[0].latch.target.setBits(27);
   dma[0].length.setBits(14); dma[0].latch.length.setBits(14);

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -94,11 +94,6 @@ struct CPU : ARM7TDMI, Thread, IO {
     n32 mask;
   };
 
-  //DMA data bus shared between all DMA channels
-  struct DMABus {
-    n32 data;
-  } dmabus;
-
   struct DMA {
     //dma.cpp
     auto run() -> bool;
@@ -126,6 +121,7 @@ struct CPU : ARM7TDMI, Thread, IO {
       uintVN source;
       uintVN target;
       uintVN length;
+      u32 data;
     } latch;
   } dma[4];
 

--- a/ares/gba/cpu/dma.cpp
+++ b/ares/gba/cpu/dma.cpp
@@ -24,8 +24,8 @@ auto CPU::DMA::transfer() -> void {
     if(mode & Word) addr &= ~3;
     if(mode & Half) addr &= ~1;
     if(addr & 0x0800'0000) cpu.context.dmaRomAccess = true;
-    cpu.dmabus.data = cpu.get(mode, addr);
-    if(mode & Half) cpu.dmabus.data |= cpu.dmabus.data << 16;
+    latch.data = cpu.get(mode, addr);
+    if(mode & Half) latch.data |= latch.data << 16;
   }
 
   if(mode & Nonsequential) {
@@ -43,7 +43,7 @@ auto CPU::DMA::transfer() -> void {
     if(mode & Word) addr &= ~3;
     if(mode & Half) addr &= ~1;
     if(addr & 0x0800'0000) cpu.context.dmaRomAccess = true;
-    cpu.set(mode, addr, cpu.dmabus.data);
+    cpu.set(mode, addr, latch.data >> (addr & 2) * 8);
   }
 
   switch(sourceMode) {

--- a/ares/gba/cpu/io.cpp
+++ b/ares/gba/cpu/io.cpp
@@ -243,7 +243,6 @@ auto CPU::readIO(n32 address) -> n8 {
 
   }
 
-  if(cpu.context.dmaActive) return cpu.dmabus.data.byte(address & 3);
   return cpu.pipeline.fetch.instruction.byte(address & 1);
 }
 

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -5,8 +5,6 @@ auto CPU::serialize(serializer& s) -> void {
   s(iwram);
   s(ewram);
 
-  s(dmabus.data);
-
   for(auto& dma : this->dma) {
     s(dma.id);
     s(dma.active);
@@ -31,6 +29,7 @@ auto CPU::serialize(serializer& s) -> void {
     s(dma.latch.target.mask);
     s(dma.latch.length.data);
     s(dma.latch.length.mask);
+    s(dma.latch.data);
   }
 
   for(auto& timer : this->timer) {

--- a/ares/gba/ppu/io.cpp
+++ b/ares/gba/ppu/io.cpp
@@ -99,7 +99,6 @@ auto PPU::readIO(n32 address) -> n8 {
 
   }
 
-  if(cpu.context.dmaActive) return cpu.dmabus.data.byte(address & 3);
   return cpu.pipeline.fetch.instruction.byte(address & 1);
 }
 

--- a/ares/gba/system/bios.cpp
+++ b/ares/gba/system/bios.cpp
@@ -17,7 +17,6 @@ auto BIOS::readROM(n25 address) -> n32 {
 auto BIOS::read(u32 mode, n25 address) -> n32 {
   //unmapped memory
   if(address >= 0x0000'4000) {
-    if(cpu.context.dmaActive) return cpu.dmabus.data;
     return cpu.pipeline.fetch.instruction;  //0000'4000-01ff'ffff
   }
 

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v139.2";
+static const string SerializerVersion = "v139.3";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Each DMA channel should have its own latch rather than sharing a latched value. It's also possible to read open bus values into the latches.