### PR TITLE
build, n64: fix build

### DIFF
--- a/ares/n64/cpu/interpreter.cpp
+++ b/ares/n64/cpu/interpreter.cpp
@@ -3,7 +3,7 @@
 #define RT ipu.r[RTn]
 #define RS ipu.r[RSn]
 
-#define jp(id, name, ...) case id: return decoder##name(instruction)
+#define jp(id, name)      case id: return decoder##name(instruction)
 #define op(id, name, ...) case id: return name(__VA_ARGS__)
 #define br(id, name, ...) case id: return name(__VA_ARGS__)
 

--- a/ares/n64/cpu/interpreter.cpp
+++ b/ares/n64/cpu/interpreter.cpp
@@ -3,7 +3,7 @@
 #define RT ipu.r[RTn]
 #define RS ipu.r[RSn]
 
-#define jp(id, name, ...) case id: return decoder##name(instruction, __VA_ARGS__)
+#define jp(id, name, ...) case id: return decoder##name(instruction)
 #define op(id, name, ...) case id: return name(__VA_ARGS__)
 #define br(id, name, ...) case id: return name(__VA_ARGS__)
 


### PR DESCRIPTION
Removed `__VA_ARGS__` from line 6 of interpreter.cpp, since it appears to be unused and was causing compiler issues. Tested on Ubuntu with g++ and clang++ with both interpreter and recompiler running a default build of n64-systemtest.

Needs testing to make sure msvc still compiles correctly, and preferably also testing from someone more familiar with the N64 core in case I've overlooked something.