### PR TITLE
n64: add support for multi-byte writes to gdb

### DIFF
--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -169,6 +169,7 @@ struct CPU : Thread {
     auto power(bool reset) -> void;
 
     auto readDebug(u32 vaddr, u32 address) -> u8;
+    auto writeDebug(u32 vaddr, u32 address, u8 value) -> void;
 
     //8KB
     struct Line {

--- a/ares/n64/cpu/dcache.cpp
+++ b/ares/n64/cpu/dcache.cpp
@@ -79,6 +79,15 @@ auto CPU::DataCache::write(u32 vaddr, u32 address, u64 data) -> void {
   line.write<Size>(address, data);
 }
 
+auto CPU::DataCache::writeDebug(u32 vaddr, u32 address, u8 data) -> void {
+  auto& line = this->line(vaddr);
+  if(!line.hit(address)) {
+    Thread dummyThread{};
+    return bus.write<Byte>(address, data, dummyThread, "Ares Debugger");
+  }
+  line.write<Byte>(address, data);
+}
+
 auto CPU::DataCache::power(bool reset) -> void {
   u32 index = 0;
   for(auto& line : lines) {

--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -137,7 +137,7 @@ auto System::initDebugHooks() -> void {
   };
 
   GDB::server.hooks.read = [](u64 address, u32 byteCount) -> string {
-    address |= 0xFFFFFFFF'00000000ull;
+    address = (s32)address;
 
     string res{};
     res.resize(byteCount * 2);
@@ -152,15 +152,47 @@ auto System::initDebugHooks() -> void {
     return res;
   };
 
-  GDB::server.hooks.write = [](u64 address, u32 unitSize, u64 value) {
-    address |= 0xFFFFFFFF'00000000ull;
-    switch(unitSize) {
-      case Byte: cpu.write<Byte>(address, value, false); break;
-      case Half: cpu.write<Half>(address, value, false); break;
-      case Word: cpu.write<Word>(address, value, false); break;
-      case Dual: cpu.write<Dual>(address, value, false); break;
+  GDB::server.hooks.write = [](u64 address, vector<u8> data) {
+    u64 value;
+    address = (s32)address;
+    switch(data.size()) {
+      case Byte: 
+        value = (u64)data[0];
+        cpu.write<Byte>(address, value, false);
+        break;
+      case Half: 
+        value = ((u64)data[0]<<8) | ((u64)data[1]<<0);
+        cpu.write<Half>(address, value, false);
+        break;
+      case Word: 
+        value = ((u64)data[0]<<24) | ((u64)data[1]<<16) | ((u64)data[2]<<8) | ((u64)data[3]<<0);
+        cpu.write<Word>(address, value, false);
+        break;
+      case Dual:
+        value  = ((u64)data[0]<<56) | ((u64)data[1]<<48) | ((u64)data[2]<<40) | ((u64)data[3]<<32);
+        value |= ((u64)data[4]<<24) | ((u64)data[5]<<16) | ((u64)data[6]<< 8) | ((u64)data[7]<< 0);
+        cpu.write<Dual>(address, value, false);
+        break;
+      default:
+        // Handle writes of different sizes only within the RDRAM area, where
+        // we are sure that the write size does not really matter
+        if(address >= 0xffff'ffff'8000'0000ull && address <= 0xffff'ffff'83ef'ffffull) {
+          for(auto b : data) {
+            cpu.dcache.writeDebug(address, address & 0x1fff'ffff, b);
+            address++;
+          }
+        }
+        if(address >= 0xffff'ffff'a000'0000ull && address <= 0xffff'ffff'a3ef'ffffull) {
+          Thread dummyThread{};
+          for(auto b : data) {
+            bus.write<Byte>(address & 0x1fff'ffff, b, dummyThread, "Ares Debugger");
+            address++;
+          }
+        }
+        break;
     }
   };
+
 
   GDB::server.hooks.regRead = [](u32 regIdx) {
     if(regIdx < 32) {

--- a/nall/gdb/server.cpp
+++ b/nall/gdb/server.cpp
@@ -192,10 +192,15 @@ namespace nall::GDB {
           u32 sepIdx = sepIdxMaybe ? sepIdxMaybe.get() : 1;
 
           u64 address = cmdName.slice(1, sepIdx-1).hex();
-          u64 unitSize = cmdName.slice(sepIdx+1, 1).hex();
-          u64 value = cmdParts.size() > 1 ? cmdParts[1].hex() : 0;
-
-          hooks.write(address, unitSize, value);
+          u64 byteSize = cmdName.slice(sepIdx+1, 1).hex();
+          string hexvalue = cmdParts.size() > 1 ? cmdParts[1] : "";
+          vector<u8> value;
+          string hexbyte;
+          for (int i=0; i<hexvalue.size(); i+=2) {
+            hexbyte = hexvalue.slice(i, 2);
+            value.append((u8)toHex(hexbyte.data()));
+          }
+          hooks.write(address, value);
           return "OK";
         }
 

--- a/nall/gdb/server.hpp
+++ b/nall/gdb/server.hpp
@@ -48,7 +48,7 @@ class Server : public nall::TCPText::Server {
     struct {
       // Memory
       function<string(u64 address, u32 byteCount)> read{};
-      function<void(u64 address, u32 unitSize, u64 value)> write{};
+      function<void(u64 address, vector<u8> value)> write{};
       function<u64(u64 address)> normalizeAddress{};
 
       // Registers


### PR DESCRIPTION
Currently, gdb hooks in n64 doesn't allow for large sizes of writes because it wouldn't be obvious which data size use on the bus. While this is true, it doesn't really matter for RDRAM where all data sizes work in the obvious, correct way. So relax the constraint to allow writing large portions of RDRAM with a single gdb command.