### PR TITLE
build: Check for clang in diagnostic pragmas

### DIFF
--- a/ares/n64/n64.hpp
+++ b/ares/n64/n64.hpp
@@ -20,10 +20,14 @@ using v128 = __m128i;
 #endif
 
 #if defined(VULKAN)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnewline-eof"
+  #if defined(__clang__)
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wnewline-eof"
+  #endif
   #include <n64/vulkan/vulkan.hpp>
-#pragma clang diagnostic pop
+  #if defined(__clang__)
+    #pragma clang diagnostic pop
+  #endif
 #endif
 
 // Include the GB core, we can use its cartridge emulation for Transfer Pak

--- a/nall/arithmetic/natural.hpp
+++ b/nall/arithmetic/natural.hpp
@@ -167,8 +167,10 @@ alwaysinline auto bits(Pair value) -> u32 {
   }
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Winfinite-recursion"
+#if defined(__clang__)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Winfinite-recursion"
+#endif
 //Bits * Bits => Bits
 inline auto square(const Pair& lhs) -> Pair {
   static const Type Mask = (Type(0) - 1) >> HalfBits;
@@ -183,7 +185,9 @@ inline auto square(const Pair& lhs) -> Pair {
 
   return {(r3.lo & Mask) << HalfBits | (r2.lo & Mask), (r1.lo & Mask) << HalfBits | (r0.lo & Mask)};
 }
-#pragma clang diagnostic pop
+#if defined(__clang__)
+  #pragma clang diagnostic pop
+#endif
 
 //Bits * Bits => 2 * Bits
 inline auto square(const Pair& lhs, Pair& hi, Pair& lo) -> void {


### PR DESCRIPTION
MSVC build logs are complaining [very loudly](https://github.com/ares-emulator/ares/actions/runs/10524248801/job/29160592080#step:10:835) about unknown pragmas.

Only clang complains about these code areas currently, so for now, just put these diagnostic pragmas behind a check for clang. If MSVC pragmas end up being a good idea, could look into compiler-agnostic pragma macros, but that doesn't seem necessary at present.