### PR TITLE
Correct misspelling of interpreter

### DIFF
--- a/desktop-ui/settings/options.cpp
+++ b/desktop-ui/settings/options.cpp
@@ -30,7 +30,7 @@ auto OptionSettings::construct() -> void {
   homebrewModeLayout.setAlignment(1).setPadding(12_sx, 0);
       homebrewModeHint.setText("Activate core-specific features to help homebrew developers").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
-  forceInterpreter.setText("Force Intepreter").setChecked(settings.general.forceInterpreter).onToggle([&] {
+  forceInterpreter.setText("Force Interpreter").setChecked(settings.general.forceInterpreter).onToggle([&] {
     settings.general.forceInterpreter = forceInterpreter.checked();
   });
   forceInterpreterLayout.setAlignment(1).setPadding(12_sx, 0);

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -103,7 +103,7 @@ auto Settings::process(bool load) -> void {
   bind(boolean, "General/RunAhead", general.runAhead);
   bind(boolean, "General/AutoSaveMemory", general.autoSaveMemory);
   bind(boolean, "General/HomebrewMode", general.homebrewMode);
-  bind(boolean, "General/ForceIntepreter", general.forceInterpreter);
+  bind(boolean, "General/ForceInterpreter", general.forceInterpreter);
 
   bind(natural, "Rewind/Length", rewind.length);
   bind(natural, "Rewind/Frequency", rewind.frequency);


### PR DESCRIPTION
Interpreter was spelled incorrectly in the option name, and the setting name stored in the settings.bml file.