### PR TITLE
gba: add graphics viewer support

### DIFF
--- a/ares/gba/ppu/debugger.cpp
+++ b/ares/gba/ppu/debugger.cpp
@@ -28,8 +28,8 @@ auto PPU::Debugger::load(Node::Object parent) -> void {
         for(u32 y : range(8)) {
           for(u32 x : range(4)) {
             n8 colors = ppu.vram[address + y * 4 + x];
-            n4 pixel1 = ppu.pram[colors & 0xf];
-            n4 pixel2 = ppu.pram[colors >> 4];
+            n4 pixel1 = colors & 0xf;
+            n4 pixel2 = colors >> 4;
             output[(tileY * 8 + y) * 512 + (tileX * 8 + (x << 1))]     = pixel1 * 0x111111;
             output[(tileY * 8 + y) * 512 + (tileX * 8 + (x << 1)) + 1] = pixel2 * 0x111111;
           }
@@ -49,7 +49,8 @@ auto PPU::Debugger::load(Node::Object parent) -> void {
         n32 address = tileY * 32 + tileX << 6;
         for(u32 y : range(8)) {
           for(u32 x : range(8)) {
-            n8 color = ppu.vram[address + y * 8 + x];
+            n9 color = ppu.vram[address + y * 8 + x];
+            if(tileY >= 32) color += 0x100;  //bottom 1/3 of tile viewer uses OBJ palettes
             n15 pixel = ppu.pram[color];
             n8 r = pixel >>  0 & 31; r = r << 3 | r >> 2;
             n8 g = pixel >>  5 & 31; g = g << 3 | g >> 2;

--- a/ares/gba/ppu/debugger.cpp
+++ b/ares/gba/ppu/debugger.cpp
@@ -28,10 +28,10 @@ auto PPU::Debugger::load(Node::Object parent) -> void {
         for(u32 y : range(8)) {
           for(u32 x : range(4)) {
             n8 colors = ppu.vram[address + y * 4 + x];
-            n4 pixel1 = colors & 0xf;
-            n4 pixel2 = colors >> 4;
-            output[(tileY * 8 + y) * 512 + (tileX * 8 + (x << 1))]     = pixel1 * 0x111111;
-            output[(tileY * 8 + y) * 512 + (tileX * 8 + (x << 1)) + 1] = pixel2 * 0x111111;
+            n4 leftPixel = colors & 0xf;
+            n4 rightPixel = colors >> 4;
+            output[(tileY * 8 + y) * 512 + (tileX * 8 + (x << 1))]     =  leftPixel * 0x111111;
+            output[(tileY * 8 + y) * 512 + (tileX * 8 + (x << 1)) + 1] = rightPixel * 0x111111;
           }
         }
       }

--- a/ares/gba/ppu/debugger.cpp
+++ b/ares/gba/ppu/debugger.cpp
@@ -40,13 +40,13 @@ auto PPU::Debugger::load(Node::Object parent) -> void {
   });
 
   graphics.tiles8bpp = parent->append<Node::Debugger::Graphics>("8 BPP Tiles");
-  graphics.tiles8bpp->setSize(384, 256);
+  graphics.tiles8bpp->setSize(256, 384);
   graphics.tiles8bpp->setCapture([&]() -> vector<u32> {
     vector<u32> output;
-    output.resize(384 * 256);
-    for(u32 tileY : range(32)) {
-      for(u32 tileX : range(48)) {
-        n32 address = tileY * 48 + tileX << 6;
+    output.resize(256 * 384);
+    for(u32 tileY : range(48)) {
+      for(u32 tileX : range(32)) {
+        n32 address = tileY * 32 + tileX << 6;
         for(u32 y : range(8)) {
           for(u32 x : range(8)) {
             n8 color = ppu.vram[address + y * 8 + x];
@@ -55,7 +55,7 @@ auto PPU::Debugger::load(Node::Object parent) -> void {
             n8 g = pixel >>  5 & 31; g = g << 3 | g >> 2;
             n8 b = pixel >> 10 & 31; b = b << 3 | b >> 2;
             n8 a = 255;
-            output[(tileY * 8 + y) * 384 + (tileX * 8 + x)] = a << 24 | r << 16 | g << 8 | b << 0;
+            output[(tileY * 8 + y) * 256 + (tileX * 8 + x)] = a << 24 | r << 16 | g << 8 | b << 0;
           }
         }
       }

--- a/ares/gba/ppu/debugger.cpp
+++ b/ares/gba/ppu/debugger.cpp
@@ -24,12 +24,42 @@ auto PPU::Debugger::load(Node::Object parent) -> void {
     output.resize(240 * 160);
     for(u32 y : range(160)) {
       for(u32 x : range(240)) {
-        n15 pixel = ppu.readVRAM_BG(Half, y * 480 + x * 2);
+        n15 pixel = ppu.vram[y * 480 + x * 2 + 1] << 8 | ppu.vram[y * 480 + x * 2] << 0;
         n8 r = pixel >>  0 & 31; r = r << 3 | r >> 2;
         n8 g = pixel >>  5 & 31; g = g << 3 | g >> 2;
         n8 b = pixel >> 10 & 31; b = b << 3 | b >> 2;
         n8 a = 255;
         output[y * 240 + x] = a << 24 | r << 16 | g << 8 | b << 0;
+      }
+    }
+    return output;
+  });
+
+  graphics.mode4 = parent->append<Node::Debugger::Graphics>("Mode 4");
+  graphics.mode4->setSize(240, 320);
+  graphics.mode4->setCapture([&]() -> vector<u32> {
+    vector<u32> output;
+    output.resize(240 * 320);
+    for(u32 y : range(160)) {
+      for(u32 x : range(240)) {
+        n8 color = ppu.vram[y * 240 + x];
+        n15 pixel = ppu.pram[color];
+        n8 r = pixel >>  0 & 31; r = r << 3 | r >> 2;
+        n8 g = pixel >>  5 & 31; g = g << 3 | g >> 2;
+        n8 b = pixel >> 10 & 31; b = b << 3 | b >> 2;
+        n8 a = 255;
+        output[y * 240 + x] = a << 24 | r << 16 | g << 8 | b << 0;
+      }
+    }
+    for(u32 y : range(160)) {
+      for(u32 x : range(240)) {
+        n8 color = ppu.vram[0xa000 + y * 240 + x];
+        n15 pixel = ppu.pram[color];
+        n8 r = pixel >>  0 & 31; r = r << 3 | r >> 2;
+        n8 g = pixel >>  5 & 31; g = g << 3 | g >> 2;
+        n8 b = pixel >> 10 & 31; b = b << 3 | b >> 2;
+        n8 a = 255;
+        output[(y + 160) * 240 + x] = a << 24 | r << 16 | g << 8 | b << 0;
       }
     }
     return output;
@@ -42,7 +72,7 @@ auto PPU::Debugger::load(Node::Object parent) -> void {
     output.resize(160 * 256);
     for(u32 y : range(256)) {
       for(u32 x : range(160)) {
-        n15 pixel = ppu.readVRAM_BG(Half, y * 320 + x * 2);
+        n15 pixel = ppu.vram[y * 320 + x * 2 + 1] << 8 | ppu.vram[y * 320 + x * 2] << 0;
         n8 r = pixel >>  0 & 31; r = r << 3 | r >> 2;
         n8 g = pixel >>  5 & 31; g = g << 3 | g >> 2;
         n8 b = pixel >> 10 & 31; b = b << 3 | b >> 2;
@@ -58,9 +88,11 @@ auto PPU::Debugger::unload(Node::Object parent) -> void {
   parent->remove(memory.vram);
   parent->remove(memory.pram);
   parent->remove(graphics.mode3);
+  parent->remove(graphics.mode4);
   parent->remove(graphics.mode5);
   memory.vram.reset();
   memory.pram.reset();
   graphics.mode3.reset();
+  graphics.mode4.reset();
   graphics.mode5.reset();
 }

--- a/ares/gba/ppu/debugger.cpp
+++ b/ares/gba/ppu/debugger.cpp
@@ -34,13 +34,33 @@ auto PPU::Debugger::load(Node::Object parent) -> void {
     }
     return output;
   });
+
+  graphics.mode5 = parent->append<Node::Debugger::Graphics>("Mode 5");
+  graphics.mode5->setSize(160, 256);
+  graphics.mode5->setCapture([&]() -> vector<u32> {
+    vector<u32> output;
+    output.resize(160 * 256);
+    for(u32 y : range(256)) {
+      for(u32 x : range(160)) {
+        n15 pixel = ppu.readVRAM_BG(Half, y * 320 + x * 2);
+        n8 r = pixel >>  0 & 31; r = r << 3 | r >> 2;
+        n8 g = pixel >>  5 & 31; g = g << 3 | g >> 2;
+        n8 b = pixel >> 10 & 31; b = b << 3 | b >> 2;
+        n8 a = 255;
+        output[y * 160 + x] = a << 24 | r << 16 | g << 8 | b << 0;
+      }
+    }
+    return output;
+  });
 }
 
 auto PPU::Debugger::unload(Node::Object parent) -> void {
   parent->remove(memory.vram);
   parent->remove(memory.pram);
   parent->remove(graphics.mode3);
+  parent->remove(graphics.mode5);
   memory.vram.reset();
   memory.pram.reset();
   graphics.mode3.reset();
+  graphics.mode5.reset();
 }

--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -60,7 +60,7 @@ auto PPU::load(Node::Object parent) -> void {
 }
 
 auto PPU::unload() -> void {
-  debugger = {};
+  debugger.unload(node);
   colorEmulation.reset();
   interframeBlending.reset();
   rotation.reset();

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -18,6 +18,7 @@ struct PPU : Thread, IO {
     } memory;
 
     struct Graphics {
+      Node::Debugger::Graphics tiles4bpp;
       Node::Debugger::Graphics tiles8bpp;
       Node::Debugger::Graphics mode3;
       Node::Debugger::Graphics mode4;

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -18,6 +18,7 @@ struct PPU : Thread, IO {
     } memory;
 
     struct Graphics {
+      Node::Debugger::Graphics tiles8bpp;
       Node::Debugger::Graphics mode3;
       Node::Debugger::Graphics mode4;
       Node::Debugger::Graphics mode5;

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -10,11 +10,16 @@ struct PPU : Thread, IO {
   struct Debugger {
     //debugger.cpp
     auto load(Node::Object) -> void;
+    auto unload(Node::Object) -> void;
 
     struct Memory {
       Node::Debugger::Memory vram;
       Node::Debugger::Memory pram;
     } memory;
+
+    struct Graphics {
+      Node::Debugger::Graphics mode3;
+    } graphics;
   } debugger;
 
   //ppu.cpp

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -19,6 +19,7 @@ struct PPU : Thread, IO {
 
     struct Graphics {
       Node::Debugger::Graphics mode3;
+      Node::Debugger::Graphics mode5;
     } graphics;
   } debugger;
 

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -19,6 +19,7 @@ struct PPU : Thread, IO {
 
     struct Graphics {
       Node::Debugger::Graphics mode3;
+      Node::Debugger::Graphics mode4;
       Node::Debugger::Graphics mode5;
     } graphics;
   } debugger;


### PR DESCRIPTION
Adds GBA support to the ares graphics viewer. Supports viewing VRAM contents as Mode 3/4/5 bitmaps, or as 4bpp/8bpp tiles.