### PR TITLE
Stage resources into the output directory on Linux.

### DIFF
--- a/desktop-ui/GNUmakefile
+++ b/desktop-ui/GNUmakefile
@@ -138,13 +138,15 @@ endif
 	$(call rcopy,$(mia.path)/Database/*,$(output.path)/$(name).app/Contents/Resources/Database/)
 	sips -s format icns resource/$(name).png --out $(output.path)/$(name).app/Contents/Resources/$(name).icns
 	codesign --force --deep --options runtime --entitlements resource/$(name).selfsigned.entitlements --sign - $(output.path)/$(name).app
-else ifeq ($(platform),windows)
+else ifneq ($(filter $(platform),windows linux bsd),)
 	$(call mkdir,$(output.path)/Shaders/)
 	$(call mkdir,$(output.path)/Database/)
 	$(call rcopy,$(thirdparty.path)/slang-shaders/*,$(output.path)/Shaders/)
 	$(call rcopy,$(mia.path)/Database/*,$(output.path)/Database/)
 ifeq ($(librashader), true)
+ifdef librashader.path
 	$(call copy,$(librashader.path),$(output.path)/)
+endif
 endif
 endif
 


### PR DESCRIPTION
Originally, to run ares on Linux after building it, you'd `make install` which copied everything into the right places in your home directory. Windows and macOS don't have the same traditions about installing apps, so on those platforms the makefile staged a "portable" installation in the output directory.

Since then, `make install` was modified to install ares system-wide. It's possible to use it to install ares into your home directory, but a bit overkill. For consistency, let's also stage a "portable" installation in the output directory on Linux and the BSDs, so it's easier to test on those platforms.