### PR TITLE
Fix detection of the Sufami Turbo base cartridge.

### DIFF
--- a/mia/medium/super-famicom.cpp
+++ b/mia/medium/super-famicom.cpp
@@ -529,6 +529,13 @@ auto SuperFamicom::board() const -> string {
     if(headerAddress == 0x40ffb0) mode = "EXHIROM-";
   }
 
+  //the Sufami Turbo has the non-descriptive label "ADD-ON BASE CASSETE"
+  //(yes, missing a T), and its serial "A9PJ" is shared with
+  //Bishoujo Senshi Sailor Moon SuperS - Fuwafuwa Panic (Japan)
+  //so we identify it with this embedded string
+  string sufamiSignature = "BANDAI SFC-ADX";
+  if(string(data.view(0, sufamiSignature.length())) == sufamiSignature) board.append("ST-", mode);
+
   //this game's title overwrite the map mode with '!' (0x21), but is a LOROM game
   if(label() == "YUYU NO QUIZ DE GO!GO") mode = "LOROM-";
 
@@ -538,10 +545,7 @@ auto SuperFamicom::board() const -> string {
   bool epsonRTC = false;
   bool sharpRTC = false;
 
-         if(serial() == "A9PJ") {
-  //Sufami Turbo (JPN)
-    board.append("ST-", mode);
-  } else if(serial() == "ZBSJ") {
+  if(serial() == "ZBSJ") {
   //BS-X: Sore wa Namae o Nusumareta Machi no Monogatari (JPN)
     board.append("BS-MCC-");
   } else if(serial() == "042J") {


### PR DESCRIPTION
The Sufami Turbo base cartridge is listed in the Super Famicom verified dump database, so it did not use the heuristics. It turns out the heuristic detection wouldn't have worked anyway - although the game's header does contain the serial A9PJ, the heuristic revision() method does not report that serial at all.

Meanwhile, the serial A9PJ is *also* used by the game Bishoujo Senshi Sailor Moon SuperS - Fuwafuwa Panic, so loading this game would prompt for Sufami Turbo mini-cartridges even though the game could not make use of them.

I have used mia to generated heuristic manifests for every SNES/SFC game in the No-Intro set, and the only difference introduced by this change is that the Sufami Turbo base cartridge is now detected as having Sufami Turbo slots, and Fuwafuwa Panic is not.

It took me a little messing around to find a syntax for comparing an `array_view<u8>` that the compiler would accept; if there's some more concise or idiomatic way to do it, please let me know.

Of the other emulators I surveyed, bsnes works just like ares did, MesenS doesn't seem to support the Sufami Turbo, and snes9x uses a slightly stricter check than I implemented:

https://github.com/snes9xgit/snes9x/blob/85591435763dede7ef111aab8070cdf2d5a7da49/memmap.cpp#L1016-L1023