### PR TITLE
n64: use devirtualize for code block lookup

### DIFF
--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -109,17 +109,6 @@ auto CPU::instruction() -> void {
   }
 
   if(Accuracy::CPU::Recompiler && recompiler.enabled) {
-    // Fast path: attempt to lookup previously compiled blocks with devirtualizeFast
-    // and fastFetchBlock, this skips exception handling, error checking, and
-    // code emitting pathways for maximum lookup performance.
-    // As memory writes cause recompiler block invalidation, this shouldn't be detectable.
-    if (auto address = devirtualizeFast(ipu.pc)) {
-      if(auto block = recompiler.fastFetchBlock(address)) {
-        block->execute(*this);
-        return;
-      }
-    }
-
     if (auto address = devirtualize(ipu.pc)) {
       auto block = recompiler.block(ipu.pc, *address, GDB::server.hasBreakpoints());
       block->execute(*this);

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -891,7 +891,6 @@ struct CPU : Thread {
 
     auto pool(u32 address) -> Pool*;
     auto block(u32 vaddr, u32 address, bool singleInstruction = false) -> Block*;
-    auto fastFetchBlock(u32 address) -> Block*;
 
     auto emit(u32 vaddr, u32 address, bool singleInstruction = false) -> Block*;
     auto emitZeroClear(u32 n) -> void;

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -17,12 +17,6 @@ auto CPU::Recompiler::block(u32 vaddr, u32 address, bool singleInstruction) -> B
   return block;
 }
 
-auto CPU::Recompiler::fastFetchBlock(u32 address) -> Block* {
-  auto& pool = pools[address >> 8 & 0x1fffff];
-  if(pool) return pool->blocks[address >> 2 & 0x3f];
-  return nullptr;
-}
-
 #define IpuBase        offsetof(IPU, r[16])
 #define IpuReg(r)      sreg(1), offsetof(IPU, r) - IpuBase
 #define PipelineReg(x) mem(sreg(0), offsetof(CPU, pipeline) + offsetof(Pipeline, x))


### PR DESCRIPTION
Essentially a revert of fbaf7d811883b94b2742a8d9992f5deb39812924

This optimization was found to compromise correctness due to the lack of alignment checks. If something like this proves truly beneficial for performance, we can bring it back.