### PR TITLE
gba: latch IE and IF values for 1 cycle, and improve stop mode emulation

### DIFF
--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -66,7 +66,7 @@ auto CPU::dmaRun() -> void {
   }
 }
 
-auto CPU::raiseIRQ(u32 source) -> void {
+auto CPU::setInterruptFlag(u32 source) -> void {
   irq.flag[1] |= source;
 }
 

--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -33,7 +33,7 @@ auto CPU::main() -> void {
   ARM7TDMI::irq = irq.ime && (irq.enable[0] & irq.flag[0]);
 
   if(stopped()) {
-    if(!(irq.enable[0] & irq.flag[0] & Interrupt::Keypad)) {
+    if(!keypad.conditionMet) {
       stepIRQ();
       Thread::step(16);
       Thread::synchronize();

--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -30,18 +30,20 @@ auto CPU::unload() -> void {
 }
 
 auto CPU::main() -> void {
-  ARM7TDMI::irq = irq.ime && (irq.enable & irq.flag);
+  ARM7TDMI::irq = irq.ime && (irq.enable[0] & irq.flag[0]);
 
   if(stopped()) {
-    if(!(irq.enable & irq.flag & Interrupt::Keypad)) {
+    if(!(irq.enable[0] & irq.flag[0] & Interrupt::Keypad)) {
+      stepIRQ();
       Thread::step(16);
       Thread::synchronize();
+      return;
     }
     context.stopped = false;
   }
 
   if(halted()) {
-    if(!(irq.enable & irq.flag)) {
+    if(!(irq.enable[0] & irq.flag[0])) {
       return step(16);
     }
     context.halted = false;
@@ -64,6 +66,15 @@ auto CPU::dmaRun() -> void {
   }
 }
 
+auto CPU::raiseIRQ(u32 source) -> void {
+  irq.flag[1] |= source;
+}
+
+inline auto CPU::stepIRQ() -> void {
+  irq.enable[0] = irq.enable[1];
+  irq.flag[0] = irq.flag[1];
+}
+
 auto CPU::step(u32 clocks) -> void {
   if(!clocks) return;
 
@@ -75,6 +86,7 @@ auto CPU::step(u32 clocks) -> void {
   dma[3].waiting = max(0, dma[3].waiting - (s32)clocks);
 
   for(auto _ : range(clocks)) {
+    stepIRQ();
     timer[0].run();
     timer[1].run();
     timer[2].run();

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -174,6 +174,8 @@ struct CPU : ARM7TDMI, Thread, IO {
     n1 enable;
     n1 condition;
     n1 flag[10];
+
+    n1 conditionMet;
   } keypad;
 
   struct Joybus {

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -47,7 +47,7 @@ struct CPU : ARM7TDMI, Thread, IO {
 
   auto main() -> void;
   auto dmaRun() -> void;
-  auto raiseIRQ(u32 source) -> void;
+  auto setInterruptFlag(u32 source) -> void;
   auto stepIRQ() -> void;
   auto step(u32 clocks) -> void override;
   auto power() -> void;

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -47,6 +47,8 @@ struct CPU : ARM7TDMI, Thread, IO {
 
   auto main() -> void;
   auto dmaRun() -> void;
+  auto raiseIRQ(u32 source) -> void;
+  auto stepIRQ() -> void;
   auto step(u32 clocks) -> void override;
   auto power() -> void;
 
@@ -201,8 +203,8 @@ struct CPU : ARM7TDMI, Thread, IO {
 
   struct IRQ {
     n1  ime;
-    n16 enable;
-    n16 flag;
+    n16 enable[2];
+    n16 flag[2];
   } irq;
 
   struct Wait {

--- a/ares/gba/cpu/dma.cpp
+++ b/ares/gba/cpu/dma.cpp
@@ -2,8 +2,8 @@ inline auto CPU::DMA::run() -> bool {
   if(!active || waiting) return false;
 
   transfer();
-  if(irq) cpu.irq.flag |= CPU::Interrupt::DMA0 << id;
-  if(drq && id == 3) cpu.irq.flag |= CPU::Interrupt::Cartridge;
+  if(irq) cpu.raiseIRQ(CPU::Interrupt::DMA0 << id);
+  if(drq && id == 3) cpu.raiseIRQ(CPU::Interrupt::Cartridge);
   return true;
 }
 

--- a/ares/gba/cpu/dma.cpp
+++ b/ares/gba/cpu/dma.cpp
@@ -2,8 +2,8 @@ inline auto CPU::DMA::run() -> bool {
   if(!active || waiting) return false;
 
   transfer();
-  if(irq) cpu.raiseIRQ(CPU::Interrupt::DMA0 << id);
-  if(drq && id == 3) cpu.raiseIRQ(CPU::Interrupt::Cartridge);
+  if(irq) cpu.setInterruptFlag(CPU::Interrupt::DMA0 << id);
+  if(drq && id == 3) cpu.setInterruptFlag(CPU::Interrupt::Cartridge);
   return true;
 }
 

--- a/ares/gba/cpu/io.cpp
+++ b/ares/gba/cpu/io.cpp
@@ -183,12 +183,12 @@ auto CPU::readIO(n32 address) -> n8 {
   case 0x0400'015b: return 0;
 
   //IE
-  case 0x0400'0200: return irq.enable.byte(0);
-  case 0x0400'0201: return irq.enable.byte(1);
+  case 0x0400'0200: return irq.enable[0].byte(0);
+  case 0x0400'0201: return irq.enable[0].byte(1);
 
   //IF
-  case 0x0400'0202: return irq.flag.byte(0);
-  case 0x0400'0203: return irq.flag.byte(1);
+  case 0x0400'0202: return irq.flag[0].byte(0);
+  case 0x0400'0203: return irq.flag[0].byte(1);
 
   //WAITCNT
   case 0x0400'0204: return (
@@ -415,12 +415,12 @@ auto CPU::writeIO(n32 address, n8 data) -> void {
   case 0x0400'0159: return;
 
   //IE
-  case 0x0400'0200: irq.enable.byte(0) = data; return;
-  case 0x0400'0201: irq.enable.byte(1) = data; return;
+  case 0x0400'0200: irq.enable[1].byte(0) = data; return;
+  case 0x0400'0201: irq.enable[1].byte(1) = data; return;
 
   //IF
-  case 0x0400'0202: irq.flag.byte(0) = irq.flag.byte(0) & ~data; return;
-  case 0x0400'0203: irq.flag.byte(1) = irq.flag.byte(1) & ~data; return;
+  case 0x0400'0202: irq.flag[1].byte(0) = irq.flag[1].byte(0) & ~data; return;
+  case 0x0400'0203: irq.flag[1].byte(1) = irq.flag[1].byte(1) & ~data; return;
 
   //WAITCNT
   case 0x0400'0204:

--- a/ares/gba/cpu/keypad.cpp
+++ b/ares/gba/cpu/keypad.cpp
@@ -22,5 +22,5 @@ auto CPU::Keypad::run() -> void {
     if(condition == 0) test |= input;
     if(condition == 1) test &= input;
   }
-  if(test) cpu.raiseIRQ(CPU::Interrupt::Keypad);
+  if(test) cpu.setInterruptFlag(CPU::Interrupt::Keypad);
 }

--- a/ares/gba/cpu/keypad.cpp
+++ b/ares/gba/cpu/keypad.cpp
@@ -22,5 +22,5 @@ auto CPU::Keypad::run() -> void {
     if(condition == 0) test |= input;
     if(condition == 1) test &= input;
   }
-  if(test) cpu.irq.flag |= CPU::Interrupt::Keypad;
+  if(test) cpu.raiseIRQ(CPU::Interrupt::Keypad);
 }

--- a/ares/gba/cpu/keypad.cpp
+++ b/ares/gba/cpu/keypad.cpp
@@ -1,5 +1,4 @@
 auto CPU::Keypad::run() -> void {
-  if(!enable) return;
   system.controls.poll();
 
   const bool lookup[] = {
@@ -15,12 +14,13 @@ auto CPU::Keypad::run() -> void {
     system.controls.l->value(),
   };
 
-  bool test = condition;  //0 = OR, 1 = AND
+  conditionMet = condition;  //0 = OR, 1 = AND
   for(u32 index : range(10)) {
     if(!flag[index]) continue;
-    bool input = lookup[index];
-    if(condition == 0) test |= input;
-    if(condition == 1) test &= input;
+    n1 input = lookup[index];
+    if(condition == 0) conditionMet |= input;
+    if(condition == 1) conditionMet &= input;
   }
-  if(test) cpu.setInterruptFlag(CPU::Interrupt::Keypad);
+  
+  if(conditionMet && enable) cpu.setInterruptFlag(CPU::Interrupt::Keypad);
 }

--- a/ares/gba/cpu/keypad.cpp
+++ b/ares/gba/cpu/keypad.cpp
@@ -1,6 +1,4 @@
 auto CPU::Keypad::run() -> void {
-  system.controls.poll();
-
   const bool lookup[] = {
     system.controls.a->value(),
     system.controls.b->value(),

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -82,8 +82,8 @@ auto CPU::serialize(serializer& s) -> void {
   s(joybus.generalFlag);
 
   s(irq.ime);
-  s(irq.enable);
-  s(irq.flag);
+  for(auto& flag : irq.enable) s(flag);
+  for(auto& flag : irq.flag) s(flag);
 
   for(auto& flag : wait.nwait) s(flag);
   for(auto& flag : wait.swait) s(flag);

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -60,6 +60,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(keypad.enable);
   s(keypad.condition);
   for(auto& flag : keypad.flag) s(flag);
+  s(keypad.conditionMet);
 
   s(joybus.sc);
   s(joybus.sd);

--- a/ares/gba/cpu/timer.cpp
+++ b/ares/gba/cpu/timer.cpp
@@ -43,7 +43,7 @@ auto CPU::Timer::step() -> void {
   if(++period == 0) {
     period = reload;
 
-    if(irq) cpu.irq.flag |= CPU::Interrupt::Timer0 << id;
+    if(irq) cpu.raiseIRQ(CPU::Interrupt::Timer0 << id);
 
     if(apu.fifo[0].timer == id) cpu.runFIFO(0);
     if(apu.fifo[1].timer == id) cpu.runFIFO(1);

--- a/ares/gba/cpu/timer.cpp
+++ b/ares/gba/cpu/timer.cpp
@@ -43,7 +43,7 @@ auto CPU::Timer::step() -> void {
   if(++period == 0) {
     period = reload;
 
-    if(irq) cpu.raiseIRQ(CPU::Interrupt::Timer0 << id);
+    if(irq) cpu.setInterruptFlag(CPU::Interrupt::Timer0 << id);
 
     if(apu.fifo[0].timer == id) cpu.runFIFO(0);
     if(apu.fifo[1].timer == id) cpu.runFIFO(1);

--- a/ares/gba/player/player.cpp
+++ b/ares/gba/player/player.cpp
@@ -86,7 +86,7 @@ auto Player::frame() -> void {
     case 15: status.send = 0x30000003; break;
     case 16: status.send = 0x30000003; break;
     }
-    cpu.irq.flag |= CPU::Interrupt::Serial;
+    cpu.raiseIRQ(CPU::Interrupt::Serial);
   }
 }
 

--- a/ares/gba/player/player.cpp
+++ b/ares/gba/player/player.cpp
@@ -86,7 +86,7 @@ auto Player::frame() -> void {
     case 15: status.send = 0x30000003; break;
     case 16: status.send = 0x30000003; break;
     }
-    cpu.raiseIRQ(CPU::Interrupt::Serial);
+    cpu.setInterruptFlag(CPU::Interrupt::Serial);
   }
 }
 

--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -149,6 +149,7 @@ auto PPU::main() -> void {
 }
 
 auto PPU::frame() -> void {
+  system.controls.poll();
   screen->frame();
   scheduler.exit(Event::Frame);
 }

--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -98,12 +98,12 @@ auto PPU::main() -> void {
   }
 
   if(io.vcounter == 160) {
-    if(io.irqvblank) cpu.irq.flag |= CPU::Interrupt::VBlank;
+    if(io.irqvblank) cpu.raiseIRQ(CPU::Interrupt::VBlank);
     cpu.dmaVblank();
   }
 
   if(io.irqvcoincidence) {
-    if(io.vcoincidence) cpu.irq.flag |= CPU::Interrupt::VCoincidence;
+    if(io.vcoincidence) cpu.raiseIRQ(CPU::Interrupt::VCoincidence);
   }
 
   step(46);
@@ -135,7 +135,7 @@ auto PPU::main() -> void {
   }
 
   io.hblank = 1;
-  if(io.irqhblank) cpu.irq.flag |= CPU::Interrupt::HBlank;
+  if(io.irqhblank) cpu.raiseIRQ(CPU::Interrupt::HBlank);
   if(io.vcounter < 160) cpu.dmaHblank();
 
   step(226);

--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -98,12 +98,12 @@ auto PPU::main() -> void {
   }
 
   if(io.vcounter == 160) {
-    if(io.irqvblank) cpu.raiseIRQ(CPU::Interrupt::VBlank);
+    if(io.irqvblank) cpu.setInterruptFlag(CPU::Interrupt::VBlank);
     cpu.dmaVblank();
   }
 
   if(io.irqvcoincidence) {
-    if(io.vcoincidence) cpu.raiseIRQ(CPU::Interrupt::VCoincidence);
+    if(io.vcoincidence) cpu.setInterruptFlag(CPU::Interrupt::VCoincidence);
   }
 
   step(46);
@@ -135,7 +135,7 @@ auto PPU::main() -> void {
   }
 
   io.hblank = 1;
-  if(io.irqhblank) cpu.raiseIRQ(CPU::Interrupt::HBlank);
+  if(io.irqhblank) cpu.setInterruptFlag(CPU::Interrupt::HBlank);
   if(io.vcounter < 160) cpu.dmaHblank();
 
   step(226);

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v139.3";
+static const string SerializerVersion = "v140";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Improved interrupt timings, and made sure stop mode exits only once the requested keypad input is registered.