### PR TITLE
Add option to enable TMSS boot rom for Mega Drive

### DIFF
--- a/ares/md/cpu/cpu.cpp
+++ b/ares/md/cpu/cpu.cpp
@@ -93,7 +93,7 @@ auto CPU::power(bool reset) -> void {
   M68000::power();
   Thread::create(system.frequency() / 7.0, {&CPU::main, this});
 
-  tmssEnable = system.tmss->value();
+  tmssEnable = system.tmss;
   if(!reset) ram.fill();
 
   io = {};

--- a/ares/md/system/system.cpp
+++ b/ares/md/system/system.cpp
@@ -35,6 +35,9 @@ auto option(string name, string value) -> bool {
       m32x.shs.recompiler.enabled = value.boolean();
     }
   }
+  if(name == "TMSS") {
+    system.tmss = value.boolean();
+  }
   return true;
 }
 
@@ -114,8 +117,6 @@ auto System::load(Node::System& root, string name) -> bool {
   node->setUnserialize({&System::unserialize, this});
   root = node;
   if(!node->setPak(pak = platform->pak(node))) return false;
-
-  tmss = node->append<Node::Setting::Boolean>("TMSS", false);
 
   scheduler.reset();
   controls.load(node);

--- a/ares/md/system/system.hpp
+++ b/ares/md/system/system.hpp
@@ -2,7 +2,7 @@ extern Random random;
 
 struct System {
   Node::System node;
-  Node::Setting::Boolean tmss;
+  bool tmss;
   VFS::Pak pak;
 
   struct Controls {

--- a/desktop-ui/emulator/mega-drive.cpp
+++ b/desktop-ui/emulator/mega-drive.cpp
@@ -84,6 +84,8 @@ auto MegaDrive::load() -> bool {
     if(!system->load()) return false;
   }
 
+  ares::MegaDrive::option("TMSS", settings.megadrive.tmss);
+
   if(!ares::MegaDrive::load(root, {"[Sega] ", name, " (", region, ")"})) return false;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {

--- a/desktop-ui/settings/options.cpp
+++ b/desktop-ui/settings/options.cpp
@@ -43,5 +43,13 @@ auto OptionSettings::construct() -> void {
   });
   nintendo64ExpansionPakLayout.setAlignment(1).setPadding(12_sx, 0);
       nintendo64ExpansionPakHint.setText("Enable/Disable the 4MB Expansion Pak").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
-  
+
+  megaDriveSettingsLabel.setText("Mega Drive Settings").setFont(Font().setBold());
+
+  megaDriveTmssOption.setText("TMSS Boot Rom").setChecked(settings.megadrive.tmss).onToggle([&] {
+    settings.megadrive.tmss = megaDriveTmssOption.checked();
+  });
+  megaDriveTmssLayout.setAlignment(1).setPadding(12_sx, 0);
+    megaDriveTmssHint.setText("Enable/Disable the TMSS Boot Rom at system initialization").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
 }

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -124,6 +124,8 @@ auto Settings::process(bool load) -> void {
 
   bind(boolean, "Nintendo64/ExpansionPak", nintendo64.expansionPak);
 
+  bind(boolean, "MegaDrive/TMSS", megadrive.tmss);
+
   for(u32 index : range(9)) {
     string name = {"Recent/Game-", 1 + index};
     bind(string, name, recent.game[index]);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -104,6 +104,10 @@ struct Settings : Markup::Node {
   struct Nintendo64 {
     bool expansionPak = true;
   } nintendo64;
+
+  struct MegaDrive {
+    bool tmss = false;
+  } megadrive;
 };
 
 struct VideoSettings : VerticalLayout {
@@ -258,6 +262,10 @@ struct OptionSettings : VerticalLayout {
     HorizontalLayout nintendo64ExpansionPakLayout{this, Size{~0, 0}, 5};
       CheckLabel nintendo64ExpansionPakOption{&nintendo64ExpansionPakLayout, Size{0, 0}, 5};
       Label nintendo64ExpansionPakHint{&nintendo64ExpansionPakLayout, Size{0, 0}};
+  Label megaDriveSettingsLabel{this, Size{~0, 0}, 5};
+    HorizontalLayout megaDriveTmssLayout{this, Size{~0, 0}, 5};
+      CheckLabel megaDriveTmssOption{&megaDriveTmssLayout, Size{0, 0}, 5};
+      Label megaDriveTmssHint{&megaDriveTmssLayout, Size{0, 0}};
 };
 
 struct FirmwareSettings : VerticalLayout {


### PR DESCRIPTION
If you like to slow down booting into your game and want to read the same old text each time on the Mega Drive, the option is yours now! This is available as a choice in Settings > Options now. By default, this will not be enabled (same behavior as existed prior to this PR). You don't need to specify anything in the firmware section, ares had the plumbing in place all along, it was just hardcoded to not load the tmss boot rom. 