### PR TITLE
n64: refactor devirtualize and memory ops, force JIT only with instruction cache

### DIFF
--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -111,7 +111,7 @@ auto CPU::instruction() -> void {
   auto access = devirtualize<Read, Word>(ipu.pc);
   if(!access) return;
 
-  if(Accuracy::CPU::Recompiler && recompiler.enabled) {
+  if(Accuracy::CPU::Recompiler && recompiler.enabled && access.cache) {
     if(vaddrAlignedError<Word>(access.vaddr, false)) return;
     auto block = recompiler.block(ipu.pc, access.paddr, GDB::server.hasBreakpoints());
     block->execute(*this);

--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -108,11 +108,12 @@ auto CPU::instruction() -> void {
     return;
   }
 
+  auto access = devirtualize(ipu.pc);
+  if(!access) return;
+
   if(Accuracy::CPU::Recompiler && recompiler.enabled) {
-    if (auto address = devirtualize(ipu.pc)) {
-      auto block = recompiler.block(ipu.pc, *address, GDB::server.hasBreakpoints());
-      block->execute(*this);
-    }
+    auto block = recompiler.block(ipu.pc, access.paddr, GDB::server.hasBreakpoints());
+    block->execute(*this);
   } else {
     auto data = fetch(ipu.pc);
     if (!data) return;

--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -108,14 +108,15 @@ auto CPU::instruction() -> void {
     return;
   }
 
-  auto access = devirtualize(ipu.pc);
+  auto access = devirtualize<Read, Word>(ipu.pc);
   if(!access) return;
 
   if(Accuracy::CPU::Recompiler && recompiler.enabled) {
+    if(vaddrAlignedError<Word>(access.vaddr, false)) return;
     auto block = recompiler.block(ipu.pc, access.paddr, GDB::server.hasBreakpoints());
     block->execute(*this);
   } else {
-    auto data = fetch(ipu.pc);
+    auto data = fetch(access);
     if (!data) return;
     pipeline.begin();
     instructionPrologue(ipu.pc, *data);

--- a/ares/n64/cpu/interpreter-ipu.cpp
+++ b/ares/n64/cpu/interpreter-ipu.cpp
@@ -118,7 +118,7 @@ auto CPU::BREAK() -> void {
 }
 
 auto CPU::CACHE(u8 operation, cr64& rs, s16 imm) -> void {
-  auto access = devirtualize(rs.u64 + imm);
+  auto access = devirtualize<Read, Word>(rs.u64 + imm);
   if (!access) return;
 
   switch(operation) {
@@ -609,7 +609,7 @@ auto CPU::LHU(r64& rt, cr64& rs, s16 imm) -> void {
 }
 
 auto CPU::LL(r64& rt, cr64& rs, s16 imm) -> void {
-  if(auto access = devirtualize(rs.u64 + imm)) {
+  if(auto access = devirtualize<Read, Word>(rs.u64 + imm)) {
     if (auto data = read<Word>(access.vaddr)) {
       rt.u64 = s32(*data);
       scc.ll = access.paddr >> 4;
@@ -620,7 +620,7 @@ auto CPU::LL(r64& rt, cr64& rs, s16 imm) -> void {
 
 auto CPU::LLD(r64& rt, cr64& rs, s16 imm) -> void {
   if(!context.kernelMode() && context.bits == 32) return exception.reservedInstruction();
-  if(auto access = devirtualize(rs.u64 + imm)) {
+  if(auto access = devirtualize<Read, Word>(rs.u64 + imm)) {
     if (auto data = read<Dual>(access.vaddr)) {
       rt.u64 = *data;
       scc.ll = access.paddr >> 4;

--- a/ares/n64/cpu/interpreter-ipu.cpp
+++ b/ares/n64/cpu/interpreter-ipu.cpp
@@ -118,27 +118,26 @@ auto CPU::BREAK() -> void {
 }
 
 auto CPU::CACHE(u8 operation, cr64& rs, s16 imm) -> void {
-  u32 address;
-  if (auto phys = devirtualize(rs.u64 + imm)) address = *phys;
-  else return;
+  auto access = devirtualize(rs.u64 + imm);
+  if (!access) return;
 
   switch(operation) {
 
   case 0x00: {  //icache index invalidate
-    auto& line = icache.line(address);
+    auto& line = icache.line(access.vaddr);
     line.valid = 0;
     break;
   }
 
   case 0x04: {  //icache load tag
-    auto& line = icache.line(address);
+    auto& line = icache.line(access.vaddr);
     scc.tagLo.primaryCacheState = line.valid << 1;
     scc.tagLo.physicalAddress   = line.tag;
     break;
   }
 
   case 0x08: {  //icache store tag
-    auto& line = icache.line(address);
+    auto& line = icache.line(access.vaddr);
     line.valid = scc.tagLo.primaryCacheState.bit(1);
     line.tag   = scc.tagLo.physicalAddress;
     if(scc.tagLo.primaryCacheState == 0b01) debug(unusual, "[CPU] CACHE CPCS=1");
@@ -147,39 +146,39 @@ auto CPU::CACHE(u8 operation, cr64& rs, s16 imm) -> void {
   }
 
   case 0x10: {  //icache hit invalidate
-    auto& line = icache.line(address);
-    if(line.hit(address)) line.valid = 0;
+    auto& line = icache.line(access.vaddr);
+    if(line.hit(access.paddr)) line.valid = 0;
     break;
   }
 
   case 0x14: {  //icache fill
-    auto& line = icache.line(address);
-    line.fill(address, cpu);
+    auto& line = icache.line(access.vaddr);
+    line.fill(access.paddr, cpu);
     break;
   }
 
   case 0x18: {  //icache hit write back
-    auto& line = icache.line(address);
-    if(line.hit(address)) line.writeBack(cpu);
+    auto& line = icache.line(access.vaddr);
+    if(line.hit(access.paddr)) line.writeBack(cpu);
     break;
   }
 
   case 0x01: {  //dcache index write back invalidate
-    auto& line = dcache.line(address);
+    auto& line = dcache.line(access.vaddr);
     if(line.valid && line.dirty) line.writeBack();
     line.valid = 0;
     break;
   }
 
   case 0x05: {  //dcache index load tag
-    auto& line = dcache.line(address);
+    auto& line = dcache.line(access.vaddr);
     scc.tagLo.primaryCacheState = line.valid << 1 | line.dirty << 0;
     scc.tagLo.physicalAddress   = line.tag;
     break;
   }
 
   case 0x09: {  //dcache index store tag
-    auto& line = dcache.line(address);
+    auto& line = dcache.line(access.vaddr);
     line.valid = scc.tagLo.primaryCacheState.bit(1);
     line.dirty = scc.tagLo.primaryCacheState.bit(0);
     line.tag   = scc.tagLo.physicalAddress;
@@ -189,17 +188,17 @@ auto CPU::CACHE(u8 operation, cr64& rs, s16 imm) -> void {
   }
 
   case 0x0d: {  //dcache create dirty exclusive
-    auto& line = dcache.line(address);
-    if(!line.hit(address) && line.dirty) line.writeBack();
-    line.tag   = address & ~0xfff;
+    auto& line = dcache.line(access.vaddr);
+    if(!line.hit(access.paddr) && line.dirty) line.writeBack();
+    line.tag   = access.paddr & ~0xfff;
     line.valid = 1;
     line.dirty = 1;
     break;
   }
 
   case 0x11: {  //dcache hit invalidate
-    auto& line = dcache.line(address);
-    if(line.hit(address)) {
+    auto& line = dcache.line(access.vaddr);
+    if(line.hit(access.paddr)) {
       line.valid = 0;
       line.dirty = 0;
     }
@@ -207,8 +206,8 @@ auto CPU::CACHE(u8 operation, cr64& rs, s16 imm) -> void {
   }
 
   case 0x15: {  //dcache hit write back invalidate
-    auto& line = dcache.line(address);
-    if(line.hit(address)) {
+    auto& line = dcache.line(access.vaddr);
+    if(line.hit(access.paddr)) {
       if(line.dirty) line.writeBack();
       line.valid = 0;
     }
@@ -216,8 +215,8 @@ auto CPU::CACHE(u8 operation, cr64& rs, s16 imm) -> void {
   }
 
   case 0x19: {  //dcache hit write back
-    auto& line = dcache.line(address);
-    if(line.hit(address)) {
+    auto& line = dcache.line(access.vaddr);
+    if(line.hit(access.paddr)) {
       if(line.dirty) line.writeBack();
     }
     break;
@@ -610,10 +609,10 @@ auto CPU::LHU(r64& rt, cr64& rs, s16 imm) -> void {
 }
 
 auto CPU::LL(r64& rt, cr64& rs, s16 imm) -> void {
-  if(auto address = devirtualize(rs.u64 + imm)) {
-    if (auto data = read<Word>(rs.u64 + imm)) {
+  if(auto access = devirtualize(rs.u64 + imm)) {
+    if (auto data = read<Word>(access.vaddr)) {
       rt.u64 = s32(*data);
-      scc.ll = *address >> 4;
+      scc.ll = access.paddr >> 4;
       scc.llbit = 1;
     }
   }
@@ -621,10 +620,10 @@ auto CPU::LL(r64& rt, cr64& rs, s16 imm) -> void {
 
 auto CPU::LLD(r64& rt, cr64& rs, s16 imm) -> void {
   if(!context.kernelMode() && context.bits == 32) return exception.reservedInstruction();
-  if(auto address = devirtualize(rs.u64 + imm)) {
-    if (auto data = read<Dual>(rs.u64 + imm)) {
+  if(auto access = devirtualize(rs.u64 + imm)) {
+    if (auto data = read<Dual>(access.vaddr)) {
       rt.u64 = *data;
-      scc.ll = *address >> 4;
+      scc.ll = access.paddr >> 4;
       scc.llbit = 1;
     }
   }

--- a/ares/n64/cpu/tlb.cpp
+++ b/ares/n64/cpu/tlb.cpp
@@ -1,23 +1,23 @@
 
-auto CPU::TLB::load(u64 vaddr, const Entry& entry, bool noExceptions) -> maybe<Match> {
+auto CPU::TLB::load(u64 vaddr, const Entry& entry, bool noExceptions) -> maybe<PhysAccess> {
   if(!entry.globals && entry.addressSpaceID != self.scc.tlb.addressSpaceID) return nothing;
   if((vaddr & entry.addressMaskHi) != entry.virtualAddress) return nothing;
   if(vaddr >> 62 != entry.region) return nothing;
   bool lo = vaddr & entry.addressSelect;
   if(!entry.valid[lo]) {
-    if(noExceptions)return Match{false};
+    if(noExceptions)return PhysAccess{false};
     
     self.addressException(vaddr);
     self.debugger.tlbLoadInvalid(vaddr);
     self.exception.tlbLoadInvalid();
-    return Match{false};
+    return PhysAccess{false};
   }
   physicalAddress = entry.physicalAddress[lo] + (vaddr & entry.addressMaskLo);
   self.debugger.tlbLoad(vaddr, physicalAddress);
-  return Match{true, entry.cacheAlgorithm[lo] != 2, physicalAddress};
+  return PhysAccess{true, entry.cacheAlgorithm[lo] != 2, physicalAddress, vaddr};
 }
 
-auto CPU::TLB::load(u64 vaddr, bool noExceptions) -> Match {
+auto CPU::TLB::load(u64 vaddr, bool noExceptions) -> PhysAccess {
   for(auto& entry : this->tlbCache.entry) {
     if(!entry.entry) continue;
     if(auto match = load(vaddr, *entry.entry, noExceptions)) {
@@ -43,7 +43,7 @@ auto CPU::TLB::load(u64 vaddr, bool noExceptions) -> Match {
 
 // Fast(er) version of load for recompiler icache lookups
 // avoids exceptions/debug checks
-auto CPU::TLB::loadFast(u64 vaddr) -> Match {
+auto CPU::TLB::loadFast(u64 vaddr) -> PhysAccess {
   for(auto& entry : this->entry) {
     if(!entry.globals && entry.addressSpaceID != self.scc.tlb.addressSpaceID) continue;
     if((vaddr & entry.addressMaskHi) != entry.virtualAddress) continue;
@@ -51,13 +51,13 @@ auto CPU::TLB::loadFast(u64 vaddr) -> Match {
     bool lo = vaddr & entry.addressSelect;
     if(!entry.valid[lo]) return { false, 0, 0 };
     physicalAddress = entry.physicalAddress[lo] + (vaddr & entry.addressMaskLo);
-    return {true, entry.cacheAlgorithm[lo] != 2, physicalAddress};
+    return {true, entry.cacheAlgorithm[lo] != 2, physicalAddress, vaddr};
   }
 
   return {false, 0, 0};
 }
 
-auto CPU::TLB::store(u64 vaddr, const Entry& entry) -> maybe<Match> {
+auto CPU::TLB::store(u64 vaddr, const Entry& entry) -> maybe<PhysAccess> {
   if(!entry.globals && entry.addressSpaceID != self.scc.tlb.addressSpaceID) return nothing;
   if((vaddr & entry.addressMaskHi) != entry.virtualAddress) return nothing;
   if(vaddr >> 62 != entry.region) return nothing;
@@ -66,20 +66,20 @@ auto CPU::TLB::store(u64 vaddr, const Entry& entry) -> maybe<Match> {
     self.addressException(vaddr);
     self.debugger.tlbStoreInvalid(vaddr);
     self.exception.tlbStoreInvalid();
-    return Match{false};
+    return PhysAccess{false};
   }
   if(!entry.dirty[lo]) {
     self.addressException(vaddr);
     self.debugger.tlbModification(vaddr);
     self.exception.tlbModification();
-    return Match{false};
+    return PhysAccess{false};
   }
   physicalAddress = entry.physicalAddress[lo] + (vaddr & entry.addressMaskLo);
   self.debugger.tlbStore(vaddr, physicalAddress);
-  return Match{true, entry.cacheAlgorithm[lo] != 2, physicalAddress};
+  return PhysAccess{true, entry.cacheAlgorithm[lo] != 2, physicalAddress, vaddr};
 }
 
-auto CPU::TLB::store(u64 vaddr) -> Match {
+auto CPU::TLB::store(u64 vaddr) -> PhysAccess {
   for(auto& entry : this->tlbCache.entry) {
     if(!entry.entry) continue;
     if(auto match = store(vaddr, *entry.entry)) {

--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -158,20 +158,20 @@ auto System::initDebugHooks() -> void {
     switch(data.size()) {
       case Byte: 
         value = (u64)data[0];
-        cpu.write<Byte>(address, value, false);
+        cpu.writeDebug<Byte>(address, value);
         break;
       case Half: 
         value = ((u64)data[0]<<8) | ((u64)data[1]<<0);
-        cpu.write<Half>(address, value, false);
+        cpu.writeDebug<Half>(address, value);
         break;
       case Word: 
         value = ((u64)data[0]<<24) | ((u64)data[1]<<16) | ((u64)data[2]<<8) | ((u64)data[3]<<0);
-        cpu.write<Word>(address, value, false);
+        cpu.writeDebug<Word>(address, value);
         break;
       case Dual:
         value  = ((u64)data[0]<<56) | ((u64)data[1]<<48) | ((u64)data[2]<<40) | ((u64)data[3]<<32);
         value |= ((u64)data[4]<<24) | ((u64)data[5]<<16) | ((u64)data[6]<< 8) | ((u64)data[7]<< 0);
-        cpu.write<Dual>(address, value, false);
+        cpu.writeDebug<Dual>(address, value);
         break;
       default:
         // Handle writes of different sizes only within the RDRAM area, where

--- a/nall/gdb/server.cpp
+++ b/nall/gdb/server.cpp
@@ -193,7 +193,7 @@ namespace nall::GDB {
 
           u64 address = cmdName.slice(1, sepIdx-1).hex();
           u64 byteSize = cmdName.slice(sepIdx+1, 1).hex();
-          string hexvalue = cmdParts.size() > 1 ? cmdParts[1] : "";
+          string hexvalue = cmdParts.size() > 1 ? cmdParts[1] : string{};
           vector<u8> value;
           string hexbyte;
           for (int i=0; i<hexvalue.size(); i+=2) {


### PR DESCRIPTION
This change contains a large refactoring with no functional changes, plus a small functional change that will help speeding up the JIT.

The refactoring allows CPU::devirtualize to return all the information regarding the memory access. This in turn allows to simplify all memory ops (which contained lots of duplicated code) to use devirtualize, reducing code duplication.

The functional change is that we now use JIT only when running code from icache (which is 99.9999% of the times). Running code without icache is extremely slow on real hardware and only happens in specific situations (eg: during boot when RDRAM is not initialized). By limiting the JIT to run from icache, we open the door to implement proper icache support in the JIT and finish remove the instruction epilogue with its slow "instruction cache stepper" (which in addition to being slow, is also inaccurate and make us fail cache test ROMs).