### PR TITLE
Address possible use of uninitialized variables

### DIFF
--- a/ares/sfc/coprocessor/sdd1/decompressor.cpp
+++ b/ares/sfc/coprocessor/sdd1/decompressor.cpp
@@ -152,7 +152,7 @@ auto SDD1::Decompressor::PEM::getBit(n8 context) -> n8 {
   const State& s = SDD1::Decompressor::PEM::evolutionTable[currentStatus];
 
   n8 bit;
-  bool endOfRun;
+  bool endOfRun = false;
   switch(s.codeNumber) {
   case 0: bit = self.bg0.getBit(endOfRun); break;
   case 1: bit = self.bg1.getBit(endOfRun); break;

--- a/ares/sfc/coprocessor/superfx/core.cpp
+++ b/ares/sfc/coprocessor/superfx/core.cpp
@@ -49,7 +49,7 @@ auto SuperFX::rpix(n8 x, n8 y) -> n8 {
   flushPixelCache(pixelcache[1]);
   flushPixelCache(pixelcache[0]);
 
-  u32 cn;  //character number
+  u32 cn = 0; //character number
   switch(regs.por.obj ? 3 : regs.scmr.ht) {
   case 0: cn = ((x & 0xf8) << 1) + ((y & 0xf8) >> 3); break;
   case 1: cn = ((x & 0xf8) << 1) + ((x & 0xf8) >> 1) + ((y & 0xf8) >> 3); break;
@@ -76,7 +76,7 @@ auto SuperFX::flushPixelCache(PixelCache& cache) -> void {
   n8 x = cache.offset << 3;
   n8 y = cache.offset >> 5;
 
-  u32 cn;  //character number
+  u32 cn = 0; //character number
   switch(regs.por.obj ? 3 : regs.scmr.ht) {
   case 0: cn = ((x & 0xf8) << 1) + ((y & 0xf8) >> 3); break;
   case 1: cn = ((x & 0xf8) << 1) + ((x & 0xf8) >> 1) + ((y & 0xf8) >> 3); break;

--- a/ares/sfc/ppu-performance/window.cpp
+++ b/ares/sfc/ppu-performance/window.cpp
@@ -38,7 +38,8 @@ auto PPU::Window::render(Layer& layer, bool enable, bool output[448]) -> void {
 }
 
 auto PPU::Window::render(Color& color, u32 mask, bool output[448]) -> void {
-  bool set, clear;
+  bool set = 0;
+  bool clear = 0;
   switch(mask) {
   case 0: memory::fill<bool>(output, 256, 1); return;  //always
   case 1: set = 1, clear = 0; break;  //inside

--- a/nall/decode/chd.hpp
+++ b/nall/decode/chd.hpp
@@ -84,8 +84,8 @@ inline auto CHD::load(const string& location) -> bool {
 
     int track_no;
     int frames;
-    int pregap_frames;
-    int postgap_frames;
+    int pregap_frames = 0;
+    int postgap_frames = 0;
 
     // First, attempt to fetch CDROMv2 metadata
     err = chd_get_metadata(chd, CDROM_TRACK_METADATA2_TAG, tracks.size(), metadata, sizeof(metadata), &metadata_size, nullptr, nullptr);


### PR DESCRIPTION
Minor code cleanup. clang reports that it's possible under some circumstances these variables are uninitialized when used.

Overall motivation is to utilize some stricter compiler settings in the future and error on `-Wuninitialized`.