### PR TITLE
Fixing PowerFest '94 and Campus Challenge '92 for SNES

### DIFF
--- a/mia/Database/Super Famicom Boards.bml
+++ b/mia/Database/Super Famicom Boards.bml
@@ -664,7 +664,7 @@ board: BS-SA1-RAM
 
 board: EVENT-CC92
   memory type=RAM content=Save
-    map address=70-7d,f0-ff:0000-7fff mask=0x8000
+    map address=70-7d,f0-ff:0000-7fff mask=0x3fff
   processor manufacturer=NEC architecture=uPD78214
     identifier: Campus Challenge '92
     map address=c0,e0:0000

--- a/mia/Database/Super Famicom Boards.bml
+++ b/mia/Database/Super Famicom Boards.bml
@@ -676,7 +676,7 @@ board: EVENT-CC92
       memory type=ROM content=Level-3
     dip
   processor manufacturer=NEC architecture=uPD7725
-    map address=20-3f,a0-bf:8000-ffff mask=0x7fff
+    map address=20-3f,a0-bf:8000-ffff mask=0x8000
     memory type=ROM content=Program architecture=uPD7725
     memory type=ROM content=Data architecture=uPD7725
     memory type=RAM content=Data architecture=uPD7725

--- a/mia/Database/Super Famicom Boards.bml
+++ b/mia/Database/Super Famicom Boards.bml
@@ -664,7 +664,7 @@ board: BS-SA1-RAM
 
 board: EVENT-CC92
   memory type=RAM content=Save
-    map address=70-7d,f0-ff:0000-7fff mask=0x3fff
+    map address=70-7d,f0-ff:0000-7fff mask=0x8000
   processor manufacturer=NEC architecture=uPD78214
     identifier: Campus Challenge '92
     map address=c0,e0:0000
@@ -676,7 +676,7 @@ board: EVENT-CC92
       memory type=ROM content=Level-3
     dip
   processor manufacturer=NEC architecture=uPD7725
-    map address=20-3f,a0-bf:8000-ffff mask=0x8000
+    map address=20-3f,a0-bf:8000-ffff mask=0x3fff
     memory type=ROM content=Program architecture=uPD7725
     memory type=ROM content=Data architecture=uPD7725
     memory type=RAM content=Data architecture=uPD7725

--- a/mia/Database/Super Famicom.bml
+++ b/mia/Database/Super Famicom.bml
@@ -288,6 +288,32 @@ game
       content: Download
 
 game
+   sha256:   67c1a4917f4cd0fd704b83330a7e91763736c2d2a10a7e12318fdac54cd9c6c6
+   title:    Campus Challenge '92
+   name:     Super Nintendo Campus Challenge 1992
+   region:   Japan
+   revision:    1.0
+   board: EVENT-CC92
+     memory type=RAM content=Save
+       map address=70-7d,f0-ff:0000-7fff mask=0x8000
+     processor manufacturer=NEC architecture=uPD78214
+       identifier: Campus Challenge '92
+       map address=c0,e0:0000
+       mcu
+         map address=00-1f,80-9f:8000-ffff
+         memory type=ROM content=Program
+         memory type=ROM content=Level-1
+         memory type=ROM content=Level-2
+         memory type=ROM content=Level-3
+       dip
+     processor manufacturer=NEC architecture=uPD7725
+       map address=20-3f,a0-bf:8000-ffff mask=0x7fff
+       memory type=ROM content=Program architecture=uPD7725
+       memory type=ROM content=Data architecture=uPD7725
+       memory type=RAM content=Data architecture=uPD7725
+       oscillator
+
+game
   sha256:   6e7dcbb4df32903d6ff5da1e308342c0a72f5af3f11479cf49391dc3a17d5d7b
   title:    キャプテンコマンドー
   name:     Captain Commando

--- a/mia/Database/Super Famicom.bml
+++ b/mia/Database/Super Famicom.bml
@@ -12200,7 +12200,7 @@ game
       content: Level-2
     memory
       type: ROM
-      size: 0x80000
+      size: 0x100000
       content: Level-3
     memory
       type: RAM

--- a/mia/Database/Super Famicom.bml
+++ b/mia/Database/Super Famicom.bml
@@ -293,25 +293,52 @@ game
    name:     Super Nintendo Campus Challenge 1992
    region:   Japan
    revision:    1.0
-   board: EVENT-CC92
-     memory type=RAM content=Save
-       map address=70-7d,f0-ff:0000-7fff mask=0x8000
-     processor manufacturer=NEC architecture=uPD78214
-       identifier: Campus Challenge '92
-       map address=c0,e0:0000
-       mcu
-         map address=00-1f,80-9f:8000-ffff
-         memory type=ROM content=Program
-         memory type=ROM content=Level-1
-         memory type=ROM content=Level-2
-         memory type=ROM content=Level-3
-       dip
-     processor manufacturer=NEC architecture=uPD7725
-       map address=20-3f,a0-bf:8000-ffff mask=0x7fff
-       memory type=ROM content=Program architecture=uPD7725
-       memory type=ROM content=Data architecture=uPD7725
-       memory type=RAM content=Data architecture=uPD7725
-       oscillator
+   board:    EVENT-CC92
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x80000
+      content: Level-1
+    memory
+      type: ROM
+      size: 0x80000
+      content: Level-2
+    memory
+      type: ROM
+      size: 0x80000
+      content: Level-3
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+      volatile
+    memory
+      type: ROM
+      size: 0x1800
+      content: Program
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+    memory
+      type: ROM
+      size: 0x800
+      content: Data
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+    memory
+      type: RAM
+      size: 0x200
+      content: Data
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+      volatile
+    oscillator
+      frequency: 7600000
 
 game
   sha256:   6e7dcbb4df32903d6ff5da1e308342c0a72f5af3f11479cf49391dc3a17d5d7b
@@ -12178,6 +12205,7 @@ game
     memory type=ROM content=Data architecture=uPD7725
     memory type=RAM content=Data architecture=uPD7725
     oscillator
+	  frequency: 7600000
 	
 game
   sha256:   06c8fc466805f97c9147711b2d8370d4f4d05d9fa3a916f17aa1682f73c9a63b

--- a/mia/Database/Super Famicom.bml
+++ b/mia/Database/Super Famicom.bml
@@ -12186,27 +12186,52 @@ game
   region:   USA
   revision: 1.0
   board: EVENT-PF94
-  memory type=RAM content=Save
-    map address=30-3f,b0-bf:6000-7fff mask=0xe000
-  processor manufacturer=NEC architecture=uPD78214
-    identifier: PowerFest '94
-    map address=10,20:6000
-    mcu
-      map address=00-3f,80-bf:8000-ffff
-      map address=c0-ff:0000-ffff
-      memory type=ROM content=Program
-      memory type=ROM content=Level-1
-      memory type=ROM content=Level-2
-      memory type=ROM content=Level-3
-    dip
-  processor manufacturer=NEC architecture=uPD7725
-    map address=00-0f,80-8f:6000-7fff mask=0xfff
-    memory type=ROM content=Program architecture=uPD7725
-    memory type=ROM content=Data architecture=uPD7725
-    memory type=RAM content=Data architecture=uPD7725
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x80000
+      content: Level-1
+    memory
+      type: ROM
+      size: 0x80000
+      content: Level-2
+    memory
+      type: ROM
+      size: 0x80000
+      content: Level-3
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+      volatile
+    memory
+      type: ROM
+      size: 0x1800
+      content: Program
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+    memory
+      type: ROM
+      size: 0x800
+      content: Data
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+    memory
+      type: RAM
+      size: 0x200
+      content: Data
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+      volatile
     oscillator
-	  frequency: 7600000
-	
+      frequency: 7600000
+
 game
   sha256:   06c8fc466805f97c9147711b2d8370d4f4d05d9fa3a916f17aa1682f73c9a63b
   title:    Power Instinct

--- a/mia/Database/Super Famicom.bml
+++ b/mia/Database/Super Famicom.bml
@@ -12127,6 +12127,33 @@ game
       content: Program
 
 game
+  sha256:   5443a97e9c40e25821a8fb8c91b63c7bd8c3060d9ff888ee6c573b87b53935f4
+  title:    PowerFest '94
+  name:     PowerFest '94
+  region:   USA
+  revision: 1.0
+  board: EVENT-PF94
+  memory type=RAM content=Save
+    map address=30-3f,b0-bf:6000-7fff mask=0xe000
+  processor manufacturer=NEC architecture=uPD78214
+    identifier: PowerFest '94
+    map address=10,20:6000
+    mcu
+      map address=00-3f,80-bf:8000-ffff
+      map address=c0-ff:0000-ffff
+      memory type=ROM content=Program
+      memory type=ROM content=Level-1
+      memory type=ROM content=Level-2
+      memory type=ROM content=Level-3
+    dip
+  processor manufacturer=NEC architecture=uPD7725
+    map address=00-0f,80-8f:6000-7fff mask=0xfff
+    memory type=ROM content=Program architecture=uPD7725
+    memory type=ROM content=Data architecture=uPD7725
+    memory type=RAM content=Data architecture=uPD7725
+    oscillator
+	
+game
   sha256:   06c8fc466805f97c9147711b2d8370d4f4d05d9fa3a916f17aa1682f73c9a63b
   title:    Power Instinct
   name:     Power Instinct

--- a/mia/Database/Super Famicom.bml
+++ b/mia/Database/Super Famicom.bml
@@ -338,7 +338,7 @@ game
       identifier: DSP1
       volatile
     oscillator
-      frequency: 7600000
+      frequency: 8000000
 
 game
   sha256:   6e7dcbb4df32903d6ff5da1e308342c0a72f5af3f11479cf49391dc3a17d5d7b
@@ -12230,7 +12230,7 @@ game
       identifier: DSP1
       volatile
     oscillator
-      frequency: 7600000
+      frequency: 8000000
 
 game
   sha256:   06c8fc466805f97c9147711b2d8370d4f4d05d9fa3a916f17aa1682f73c9a63b


### PR DESCRIPTION
Hoping to get the last games fixed for SNES! Basically this is a draft PR, RFC.

Currently these modify how the DSP works and change the frequency of the oscillator to match newer information and the rest of the titles in the database, but those are subject to change.

Campus Challenge '92 seems to be fully functional, but PowerFest '94 seems to have issues regarding the DSP for Super Mario Kart. Super Mario Kart freezes using the latest nightly of ares.

On vanilla ares, neither of these boot.

bsnes and higan can boot these if they are in the appropriate format, and they seem to work fine there.

I tried to boot both into bsnes+ for more research, but I couldn't get that working, so it might be a core issue.

SNES9x can boot PowerFest '94, but not Campus Challenge '92, not sure why.

I would like to thank the ares Discord for help with this!