### PR TITLE
hiro/cocoa: Add bounds checking for table view context menus

### DIFF
--- a/hiro/cocoa/widget/table-view.cpp
+++ b/hiro/cocoa/widget/table-view.cpp
@@ -162,7 +162,10 @@
   NSPoint localPoint = [self convertPoint:event.locationInWindow fromView:nil];
   NSInteger row = [self rowAtPoint:localPoint];
   NSInteger column = [self columnAtPoint:localPoint];
-
+  
+  if (row < 0 || row >= tableView->state.items.size()) {
+    return nil;
+  }
 
   if (row >= 0 && ![self isRowSelected:row]) {
     [self selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];


### PR DESCRIPTION
Right-clicking in a table view beyond the bounds of the defined rows in the table would crash previously.