### PR TITLE
gba: add 2-cycle IRQ synchronizer and improve halted CPU timings

### DIFF
--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -44,21 +44,13 @@ auto CPU::main() -> void {
     context.stopped = false;
   }
 
-  #if defined(PROFILE_PERFORMANCE)
-    #define HALT_STEP 16
-  #else
-    #define HALT_STEP 1
-  #endif
-
   if(halted()) {
     if(!(irq.enable[0] & irq.flag[0])) {
-      return step(HALT_STEP);
+      return step(4);
     }
     step(2);
     context.halted = false;
   }
-
-  #undef HALT_STEP
 
   debugger.instruction();
   instruction();

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -205,6 +205,7 @@ struct CPU : ARM7TDMI, Thread, IO {
 
   struct IRQ {
     n1  ime;
+    n1  synchronizer[2];
     n16 enable[2];
     n16 flag[2];
   } irq;

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -83,6 +83,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(joybus.generalFlag);
 
   s(irq.ime);
+  for(auto& flag : irq.synchronizer) s(flag);
   for(auto& flag : irq.enable) s(flag);
   for(auto& flag : irq.flag) s(flag);
 

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v140.1";
+static const string SerializerVersion = "v140.2";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Adds a 2-cycle synchronizer delay to IRQs. Unhalting the CPU also appears to be delayed by 2 cycles.

The GBA CPU core currently steps in increments of 16 cycles when halted or stopped to reduce emulation overhead. Since this optimization can cause unhalt timings to be off by a few cycles, this PR reduces the step size for halt mode and removes the optimization for stop mode. Performance impact should be minimal in cases where performance is a concern.