### PR TITLE
sfc: fix PowerFest '94 and Campus Challenge '92

### DIFF
--- a/ares/sfc/coprocessor/dip/dip.hpp
+++ b/ares/sfc/coprocessor/dip/dip.hpp
@@ -8,7 +8,7 @@ struct DIP {
   //serialization.cpp
   auto serialize(serializer&) -> void;
 
-  n8 value = 0x00;
+  n8 value = 0x03; // default game time used for the competition is 6 minutes
 };
 
 extern DIP dip;

--- a/mia/Database/Super Famicom Boards.bml
+++ b/mia/Database/Super Famicom Boards.bml
@@ -676,7 +676,7 @@ board: EVENT-CC92
       memory type=ROM content=Level-3
     dip
   processor manufacturer=NEC architecture=uPD7725
-    map address=20-3f,a0-bf:8000-ffff mask=0x7fff
+    map address=20-3f,a0-bf:8000-ffff mask=0x3fff
     memory type=ROM content=Program architecture=uPD7725
     memory type=ROM content=Data architecture=uPD7725
     memory type=RAM content=Data architecture=uPD7725

--- a/mia/Database/Super Famicom.bml
+++ b/mia/Database/Super Famicom.bml
@@ -287,6 +287,60 @@ game
       size: 0x80000
       content: Download
 
+//sha256 is without firmware
+game
+   sha256:   67c1a4917f4cd0fd704b83330a7e91763736c2d2a10a7e12318fdac54cd9c6c6
+   title:    Campus Challenge '92
+   name:     Super Nintendo Campus Challenge 1992
+   region:   Japan
+   revision:    1.0
+   board:    EVENT-CC92
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x80000
+      content: Level-1
+    memory
+      type: ROM
+      size: 0x80000
+      content: Level-2
+    memory
+      type: ROM
+      size: 0x80000
+      content: Level-3
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+      volatile
+    memory
+      type: ROM
+      size: 0x1800
+      content: Program
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+    memory
+      type: ROM
+      size: 0x800
+      content: Data
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+    memory
+      type: RAM
+      size: 0x200
+      content: Data
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+      volatile
+    oscillator
+      frequency: 8000000
+
 game
   sha256:   6e7dcbb4df32903d6ff5da1e308342c0a72f5af3f11479cf49391dc3a17d5d7b
   title:    キャプテンコマンドー
@@ -12125,6 +12179,60 @@ game
       type: ROM
       size: 0x200000
       content: Program
+
+//sha256 is without firmware
+game
+  sha256:   5443a97e9c40e25821a8fb8c91b63c7bd8c3060d9ff888ee6c573b87b53935f4
+  title:    PowerFest '94
+  name:     PowerFest '94
+  region:   USA
+  revision: 1.0
+  board: EVENT-PF94
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x80000
+      content: Level-1
+    memory
+      type: ROM
+      size: 0x80000
+      content: Level-2
+    memory
+      type: ROM
+      size: 0x100000
+      content: Level-3
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+      volatile
+    memory
+      type: ROM
+      size: 0x1800
+      content: Program
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+    memory
+      type: ROM
+      size: 0x800
+      content: Data
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+    memory
+      type: RAM
+      size: 0x200
+      content: Data
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+      volatile
+    oscillator
+      frequency: 8000000
 
 game
   sha256:   06c8fc466805f97c9147711b2d8370d4f4d05d9fa3a916f17aa1682f73c9a63b


### PR DESCRIPTION
Based on database fixes and research from #1648 (thx @DerekTurtleRoe, remutro & SuperMikeMan100!)

Fixes #1361 

Only supports the merged one-file ROMs for these games (without appended firmware).
Also sets the default dip value for the known competition boards to 0x03 for 6 minutes (default mode used in these competitions)

See for dip settings:
https://www.snesmaps.com/maps/NintendoPowerFest94/NintendoPowerFest94.html
https://www.snesmaps.com/maps/1992Challenge/1992Challenge.html

Nitpick: The mia database for existing sfc games only contains sha256 hashes including all appended firmware - these two competition games use the hash WITHOUT firmware (=matches the no-intro hashes).