### PR TITLE
mia: try to load external sfc manifest if not found in internal db

### DIFF
--- a/mia/medium/super-famicom.cpp
+++ b/mia/medium/super-famicom.cpp
@@ -73,6 +73,14 @@ auto SuperFamicom::load(string location) -> bool {
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
   this->manifest = Medium::manifestDatabase(sha256);
+  
+  if(!manifest) {
+    auto local_manifest = location.replace({".", location.split(".").last()}, ".bml");
+    if(file::exists(local_manifest)) {
+      manifest = file::read(local_manifest);
+    }
+  }
+  
   if(!manifest) manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
   if(!document) return false;


### PR DESCRIPTION
This allows fan translations like Heartthrob Memorial to use their own supplied manifest.bml file (e.g. for higan), without having to be included in the internal ares db or heuristics to be hardcoded for special cases.