### PR TITLE
desktop-ui: enable loading rom folders from the cmd line

### DIFF
--- a/ares/sfc/coprocessor/dip/dip.hpp
+++ b/ares/sfc/coprocessor/dip/dip.hpp
@@ -8,7 +8,7 @@ struct DIP {
   //serialization.cpp
   auto serialize(serializer&) -> void;
 
-  n8 value = 0x00;
+  n8 value = 0x03; // default game time used for the competition is 6 minutes
 };
 
 extern DIP dip;

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -138,7 +138,7 @@ auto nall::main(Arguments arguments) -> void {
 
   program.startGameLoad.reset();
   for(auto argument : arguments) {
-    if(file::exists(argument)) program.startGameLoad.append(argument);
+    if(file::exists(argument) || directory::exists(argument)) program.startGameLoad.append(argument);
   }
 
   Instances::presentation.construct();

--- a/mia/Database/Super Famicom Boards.bml
+++ b/mia/Database/Super Famicom Boards.bml
@@ -676,7 +676,7 @@ board: EVENT-CC92
       memory type=ROM content=Level-3
     dip
   processor manufacturer=NEC architecture=uPD7725
-    map address=20-3f,a0-bf:8000-ffff mask=0x7fff
+    map address=20-3f,a0-bf:8000-ffff mask=0x3fff
     memory type=ROM content=Program architecture=uPD7725
     memory type=ROM content=Data architecture=uPD7725
     memory type=RAM content=Data architecture=uPD7725

--- a/mia/Database/Super Famicom.bml
+++ b/mia/Database/Super Famicom.bml
@@ -287,6 +287,60 @@ game
       size: 0x80000
       content: Download
 
+//sha256 is without firmware
+game
+   sha256:   67c1a4917f4cd0fd704b83330a7e91763736c2d2a10a7e12318fdac54cd9c6c6
+   title:    Campus Challenge '92
+   name:     Super Nintendo Campus Challenge 1992
+   region:   Japan
+   revision:    1.0
+   board:    EVENT-CC92
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x80000
+      content: Level-1
+    memory
+      type: ROM
+      size: 0x80000
+      content: Level-2
+    memory
+      type: ROM
+      size: 0x80000
+      content: Level-3
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+      volatile
+    memory
+      type: ROM
+      size: 0x1800
+      content: Program
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+    memory
+      type: ROM
+      size: 0x800
+      content: Data
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+    memory
+      type: RAM
+      size: 0x200
+      content: Data
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+      volatile
+    oscillator
+      frequency: 8000000
+
 game
   sha256:   6e7dcbb4df32903d6ff5da1e308342c0a72f5af3f11479cf49391dc3a17d5d7b
   title:    キャプテンコマンドー
@@ -12125,6 +12179,60 @@ game
       type: ROM
       size: 0x200000
       content: Program
+
+//sha256 is without firmware
+game
+  sha256:   5443a97e9c40e25821a8fb8c91b63c7bd8c3060d9ff888ee6c573b87b53935f4
+  title:    PowerFest '94
+  name:     PowerFest '94
+  region:   USA
+  revision: 1.0
+  board: EVENT-PF94
+    memory
+      type: ROM
+      size: 0x40000
+      content: Program
+    memory
+      type: ROM
+      size: 0x80000
+      content: Level-1
+    memory
+      type: ROM
+      size: 0x80000
+      content: Level-2
+    memory
+      type: ROM
+      size: 0x100000
+      content: Level-3
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+      volatile
+    memory
+      type: ROM
+      size: 0x1800
+      content: Program
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+    memory
+      type: ROM
+      size: 0x800
+      content: Data
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+    memory
+      type: RAM
+      size: 0x200
+      content: Data
+      manufacturer: NEC
+      architecture: uPD7725
+      identifier: DSP1
+      volatile
+    oscillator
+      frequency: 8000000
 
 game
   sha256:   06c8fc466805f97c9147711b2d8370d4f4d05d9fa3a916f17aa1682f73c9a63b

--- a/mia/medium/super-famicom.cpp
+++ b/mia/medium/super-famicom.cpp
@@ -65,7 +65,7 @@ auto SuperFamicom::load(string location) -> bool {
     append(rom, {location, "program.rom"  });
     append(rom, {location, "data.rom"     });
     append(rom, {location, "expansion.rom"});
-	for(auto& file : files.match("slot-*.rom"   )) { append(rom, {location, file});                        }
+    for(auto& file : files.match("slot-*.rom"   )) { append(rom, {location, file});                        }
     for(auto& file : files.match("*.program.rom")) { append(rom, {location, file}); local_firmware = true; }
     for(auto& file : files.match("*.data.rom"   )) { append(rom, {location, file}); local_firmware = true; }
     for(auto& file : files.match("*.boot.rom"   )) { append(rom, {location, file});                        }

--- a/mia/medium/super-famicom.cpp
+++ b/mia/medium/super-famicom.cpp
@@ -73,16 +73,16 @@ auto SuperFamicom::load(string location) -> bool {
     directory = Location::dir(location);
   }
   
+  if(!rom) return false;
+  
   //append firmware to the ROM if it is missing
   auto tmp_manifest = analyze(rom);
   auto document = BML::unserialize(tmp_manifest);
   append_missing_firmware(document);
   
-  if(!rom) return false;
-
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
-  this->manifest = Medium::manifestDatabase(sha256); 
+  this->manifest = Medium::manifestDatabase(sha256);
   document = BML::unserialize(manifest);
   append_missing_firmware(document); // if auto-detect failed, use chips from the manifest
   


### PR DESCRIPTION
Needs to merge #1654 first.

Enables loading folders instead files from cmd line.
Removes loading firmware files from rom folders in sfc mia (firmware data would be loaded twice, db hashes would not match anymore).