### PR TITLE
gba: improve SIO register handling

### DIFF
--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -160,7 +160,7 @@ struct CPU : ARM7TDMI, Thread, IO {
     n1  transferEnableReceive;
     n1  transferEnableSend;
     n1  startBit;
-    n4  unused;
+    n4  uartFlags;
     n2  mode;
     n1  irqEnable;
 

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -160,7 +160,8 @@ struct CPU : ARM7TDMI, Thread, IO {
     n1  transferEnableReceive;
     n1  transferEnableSend;
     n1  startBit;
-    n1  transferLength;
+    n4  unused;
+    n2  mode;
     n1  irqEnable;
 
     n16 data[4];

--- a/ares/gba/cpu/io.cpp
+++ b/ares/gba/cpu/io.cpp
@@ -55,8 +55,9 @@ auto CPU::readIO(n32 address) -> n8 {
   | serial.startBit              << 7
   );
   case 0x0400'0129: return (
-    serial.transferLength << 4
-  | serial.irqEnable      << 6
+    serial.unused    << 0
+  | serial.mode      << 4
+  | serial.irqEnable << 6
   );
 
   //SIOMLT_SEND (SIODATA8)
@@ -339,8 +340,9 @@ auto CPU::writeIO(n32 address, n8 data) -> void {
     serial.startBit              = data.bit(7);
     return;
   case 0x0400'0129:
-    serial.transferLength = data.bit(4);
-    serial.irqEnable      = data.bit(6);
+    serial.unused    = data.bit(0,3);
+    serial.mode      = data.bit(4,5);
+    serial.irqEnable = data.bit(6);
     return;
 
   //SIOMLT_SEND (SIODATA8)
@@ -383,10 +385,10 @@ auto CPU::writeIO(n32 address, n8 data) -> void {
 
   //JOYCNT
   case 0x0400'0140:
-    joybus.resetSignal     = data.bit(0);
-    joybus.receiveComplete = data.bit(1);
-    joybus.sendComplete    = data.bit(2);
-    joybus.resetIRQEnable  = data.bit(6);
+    joybus.resetSignal     &= ~data.bit(0);
+    joybus.receiveComplete &= ~data.bit(1);
+    joybus.sendComplete    &= ~data.bit(2);
+    joybus.resetIRQEnable   =  data.bit(6);
     return;
   case 0x0400'0141: return;
   case 0x0400'0142: return;

--- a/ares/gba/cpu/io.cpp
+++ b/ares/gba/cpu/io.cpp
@@ -55,7 +55,7 @@ auto CPU::readIO(n32 address) -> n8 {
   | serial.startBit              << 7
   );
   case 0x0400'0129: return (
-    serial.unused    << 0
+    serial.uartFlags << 0
   | serial.mode      << 4
   | serial.irqEnable << 6
   );
@@ -340,7 +340,7 @@ auto CPU::writeIO(n32 address, n8 data) -> void {
     serial.startBit              = data.bit(7);
     return;
   case 0x0400'0129:
-    serial.unused    = data.bit(0,3);
+    serial.uartFlags = data.bit(0,3);
     serial.mode      = data.bit(4,5);
     serial.irqEnable = data.bit(6);
     return;

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -52,7 +52,8 @@ auto CPU::serialize(serializer& s) -> void {
   s(serial.transferEnableReceive);
   s(serial.transferEnableSend);
   s(serial.startBit);
-  s(serial.transferLength);
+  s(serial.unused);
+  s(serial.mode);
   s(serial.irqEnable);
   for(auto& value : serial.data) s(value);
   s(serial.data8);

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -52,7 +52,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(serial.transferEnableReceive);
   s(serial.transferEnableSend);
   s(serial.startBit);
-  s(serial.unused);
+  s(serial.uartFlags);
   s(serial.mode);
   s(serial.irqEnable);
   for(auto& value : serial.data) s(value);

--- a/ares/gba/player/player.cpp
+++ b/ares/gba/player/player.cpp
@@ -63,7 +63,7 @@ auto Player::frame() -> void {
   && !cpu.serial.transferEnableReceive
   &&  cpu.serial.transferEnableSend
   &&  cpu.serial.startBit
-  &&  cpu.serial.transferLength
+  &&  cpu.serial.mode == 0x1
   &&  cpu.serial.irqEnable
   ) {
     status.packet = (status.packet + 1) % 17;

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v140.2";
+static const string SerializerVersion = "v140.3";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Implements the following changes:

- Bits 8-11 of SIOCNT should be read/write
- Mode specified by SIOCNT uses 2 bits rather than 1
- Lower 3 bits of JOYCNT are cleared when 1's are written