### PR TITLE
gba: horizontal mosaic fixes

### DIFF
--- a/ares/gba/ppu/background.cpp
+++ b/ares/gba/ppu/background.cpp
@@ -43,11 +43,11 @@ auto PPU::Background::run(u32 x, u32 y) -> void {
   }
 
   //horizontal mosaic
-  if(!io.mosaic || mosaicOffset >= 1 + io.mosaicWidth) {
-    mosaicOffset = 0;
+  if(!io.mosaic || !mosaicOffset) {
+    mosaicOffset = 1 + io.mosaicWidth;
     mosaic = output;
   }
-  mosaicOffset++;
+  mosaicOffset--;
 }
 
 auto PPU::Background::linear(u32 x, u32 y) -> void {

--- a/ares/gba/ppu/background.cpp
+++ b/ares/gba/ppu/background.cpp
@@ -43,10 +43,11 @@ auto PPU::Background::run(u32 x, u32 y) -> void {
   }
 
   //horizontal mosaic
-  if(!io.mosaic || ++mosaicOffset >= 1 + io.mosaicWidth) {
+  if(!io.mosaic || mosaicOffset >= 1 + io.mosaicWidth) {
     mosaicOffset = 0;
     mosaic = output;
   }
+  mosaicOffset++;
 }
 
 auto PPU::Background::linear(u32 x, u32 y) -> void {

--- a/ares/gba/ppu/object.cpp
+++ b/ares/gba/ppu/object.cpp
@@ -90,13 +90,13 @@ auto PPU::Objects::run(u32 x, u32 y) -> void {
   output = buffer[x];
   
   //horizontal mosaic
-  if(mosaicOffset >= 1 + io.mosaicWidth) {
-    mosaicOffset = 0;
+  if(!mosaicOffset) {
+    mosaicOffset = io.mosaicWidth;
     mosaic = output;
   } else if(!mosaic.mosaic || !output.mosaic) {
     mosaic = output;
   }
-  mosaicOffset++;
+  mosaicOffset--;
 }
 
 auto PPU::Objects::power() -> void {

--- a/ares/gba/ppu/object.cpp
+++ b/ares/gba/ppu/object.cpp
@@ -91,7 +91,7 @@ auto PPU::Objects::run(u32 x, u32 y) -> void {
   
   //horizontal mosaic
   if(!mosaicOffset) {
-    mosaicOffset = io.mosaicWidth;
+    mosaicOffset = 1 + io.mosaicWidth;
     mosaic = output;
   } else if(!mosaic.mosaic || !output.mosaic) {
     mosaic = output;


### PR DESCRIPTION
Addresses an off-by-one error with BG mosaic, and fixes an oversight in how OBJ mosaic was handled at x=0.