### PR TITLE
GNUmakefile: minor compiler and flags improvement

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -128,13 +128,13 @@ endif
 
 # global compiler flags
 ifeq ($(cl),true)
-  flags.c      = -TC -std:c11
-  flags.cpp    = -TP -std:c++17 -EHsc
+  flags.c      = -TC -std:c11 $(CFLAGS)
+  flags.cpp    = -TP -std:c++17 -EHsc $(CXXFLAGS)
   flags       += -nologo -permissive- -utf-8 -W2 -Fd$(object.path)/
   options     += -nologo $(if $(findstring clang,$(compiler)),-fuse-ld=lld) -link
 else
-  flags.c      = -x c -std=c11
-  flags.cpp    = -x c++ -std=c++17
+  flags.c      = -x c -std=c11 $(CFLAGS)
+  flags.cpp    = -x c++ -std=c++17 $(CXXFLAGS)
   flags.objc   = -x objective-c -std=c11
   flags.objcpp = -x objective-c++ -std=c++17
   flags.deps   = -MMD -MP -MF $(@:.o=.d)

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -261,7 +261,7 @@ endif
 ifeq ($(findstring clang++,$(compiler)),clang++)
   flags += -fno-strict-aliasing -fwrapv
   ifneq ($(platform),macos)
-    options += -fuse-ld=lld
+    options += -fuse-ld=lld$(subst clang++,,$(compiler))
   endif
 # gcc settings
 else ifeq ($(findstring g++,$(compiler)),g++)


### PR DESCRIPTION
With this applied, it's now possible to choose a different clang version, and pass the canonical GNU makefile variables CFLAGS and CXXFLAGS.