### PR TITLE
[N64] allow for pak swapping on controller port 1

### DIFF
--- a/desktop-ui/emulator/emulator.hpp
+++ b/desktop-ui/emulator/emulator.hpp
@@ -46,6 +46,8 @@ struct Emulator {
   vector<Firmware> firmware;
   shared_pointer<mia::Pak> system;
   shared_pointer<mia::Pak> game;
+  shared_pointer<mia::Pak> gamepad;
+  shared_pointer<mia::Pak> gb;
   vector<InputPort> ports;
   vector<string> inputBlacklist;
   vector<string> portBlacklist;

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -6,9 +6,7 @@ struct Nintendo64 : Emulator {
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
 
-  shared_pointer<mia::Pak> gamepad;
   shared_pointer<mia::Pak> disk;
-  shared_pointer<mia::Pak> gb;
   u32 regionID = 0;
   sTimer diskInsertTimer;
 };


### PR DESCRIPTION
This pull request allows for all pak swapping on controller port 1 only. It also enables support for the transfer pak for the 64DD which was previously missing. 

It is being added for port 1 only now because there is additional work to manage all the different saves, and gameboy games/saves with the transfer pak which is a larger effort, and Luke is currently looking into modifying settings in a more complete manner. So other ports can be added later. For most people, being able to swap for the first controller is likely good enough. 

This pull request doesn't change any of the current initialization logic regarding default pak selection that already existed. 