### PR TITLE
nall: Namespace noinline macro

### DIFF
--- a/ares/component/processor/gsu/gsu.hpp
+++ b/ares/component/processor/gsu/gsu.hpp
@@ -75,8 +75,8 @@ struct GSU {
   auto serialize(serializer&) -> void;
 
   //disassembler.cpp
-  noinline auto disassembleInstruction() -> string;
-  noinline auto disassembleContext() -> string;
+  NALL_NOINLINE auto disassembleInstruction() -> string;
+  NALL_NOINLINE auto disassembleContext() -> string;
 
   auto disassembleOpcode(char* output) -> void;
   auto disassembleALT0(char* output) -> void;

--- a/ares/component/processor/hg51b/hg51b.hpp
+++ b/ares/component/processor/hg51b/hg51b.hpp
@@ -111,8 +111,8 @@ struct HG51B {
   auto writeRegister(n7 address, n24 data) -> void;
 
   //disassembler.cpp
-  noinline auto disassembleInstruction(maybe<n15> pb = {}, maybe<n8> pc = {}) -> string;
-  noinline auto disassembleContext() -> string;
+  NALL_NOINLINE auto disassembleInstruction(maybe<n15> pb = {}, maybe<n8> pc = {}) -> string;
+  NALL_NOINLINE auto disassembleContext() -> string;
 
 protected:
   struct Registers {

--- a/ares/component/processor/i8080/i8080.hpp
+++ b/ares/component/processor/i8080/i8080.hpp
@@ -124,8 +124,8 @@ struct I8080 {
   auto serialize(serializer&) -> void;
 
   //disassembler.cpp
-  noinline auto disassembleInstruction(maybe<n16> pc = {}) -> string;
-  noinline auto disassembleContext() -> string;
+  NALL_NOINLINE auto disassembleInstruction(maybe<n16> pc = {}) -> string;
+  NALL_NOINLINE auto disassembleContext() -> string;
 
   auto disassemble(n16 pc, n8 prefix, n8 code) -> string;
 

--- a/ares/component/processor/mos6502/mos6502.hpp
+++ b/ares/component/processor/mos6502/mos6502.hpp
@@ -156,8 +156,8 @@ struct MOS6502 {
   auto serialize(serializer&) -> void;
 
   //disassembler.cpp
-  noinline auto disassembleInstruction(maybe<n16> pc = {}) -> string;
-  noinline auto disassembleContext() -> string;
+  NALL_NOINLINE auto disassembleInstruction(maybe<n16> pc = {}) -> string;
+  NALL_NOINLINE auto disassembleContext() -> string;
 
   struct PR {
     bool c;  //carry

--- a/ares/component/processor/sh2/instructions.cpp
+++ b/ares/component/processor/sh2/instructions.cpp
@@ -513,19 +513,19 @@ auto SH2::MOVI(u32 i, u32 n) -> void {
 }
 
 //MOV.W @(disp,PC),Rn
-noinline auto SH2::MOVWI(u32 d, u32 n) -> void {
+NALL_NOINLINE auto SH2::MOVWI(u32 d, u32 n) -> void {
   u32 pc = inDelaySlot() ? PPC - 2 : PC;
   R[n] = (s16)readWord(pc + d * 2);
 }
 
 //MOV.L @(disp,PC),Rn
-noinline auto SH2::MOVLI(u32 d, u32 n) -> void {
+NALL_NOINLINE auto SH2::MOVLI(u32 d, u32 n) -> void {
   u32 pc = inDelaySlot() ? PPC - 2 : PC;
   R[n] = readLong((pc & ~3) + d * 4);
 }
 
 //MOVA @(disp,PC),R0
-noinline auto SH2::MOVA(u32 d) -> void {
+NALL_NOINLINE auto SH2::MOVA(u32 d) -> void {
   u32 pc = inDelaySlot() ? PPC - 2 : PC;
   R[0] = (pc & ~3) + d * 4;
 }

--- a/ares/component/processor/sm83/sm83.hpp
+++ b/ares/component/processor/sm83/sm83.hpp
@@ -29,8 +29,8 @@ struct SM83 {
 
   //disassembler.cpp
   virtual auto readDebugger(n16 address) -> n8 { return 0; }
-  noinline auto disassembleInstruction(maybe<n16> pc = {}) -> string;
-  noinline auto disassembleContext() -> string;
+  NALL_NOINLINE auto disassembleInstruction(maybe<n16> pc = {}) -> string;
+  NALL_NOINLINE auto disassembleContext() -> string;
 
   //memory.cpp
   auto operand() -> n8;

--- a/ares/component/processor/spc700/spc700.hpp
+++ b/ares/component/processor/spc700/spc700.hpp
@@ -117,9 +117,9 @@ struct SPC700 {
   auto serialize(serializer&) -> void;
 
   //disassembler.cpp
-  noinline auto disassembleInstruction(n16 address, n1 p) -> string;
-  noinline auto disassembleInstruction() -> string;
-  noinline auto disassembleContext() -> string;
+  NALL_NOINLINE auto disassembleInstruction(n16 address, n1 p) -> string;
+  NALL_NOINLINE auto disassembleInstruction() -> string;
+  NALL_NOINLINE auto disassembleContext() -> string;
 
   struct Flags {
     bool c;  //carry

--- a/ares/component/processor/tlcs900h/disassembler.cpp
+++ b/ares/component/processor/tlcs900h/disassembler.cpp
@@ -1,4 +1,4 @@
-noinline auto TLCS900H::disassembleInstruction() -> string {
+NALL_NOINLINE auto TLCS900H::disassembleInstruction() -> string {
   string output;
 
   auto pc = load(PC);
@@ -636,7 +636,7 @@ noinline auto TLCS900H::disassembleInstruction() -> string {
   return pad(output, -48);
 }
 
-noinline auto TLCS900H::disassembleContext() -> string {
+NALL_NOINLINE auto TLCS900H::disassembleContext() -> string {
   string output;
   output.append("XWA:", hex(r.xwa[RFP].l.l0, 8L), " ");
   output.append("XBC:", hex(r.xbc[RFP].l.l0, 8L), " ");

--- a/ares/component/processor/upd96050/upd96050.hpp
+++ b/ares/component/processor/upd96050/upd96050.hpp
@@ -25,8 +25,8 @@ struct uPD96050 {
   auto writeDP(n12 address, n8 data) -> void;
 
   //disassembler.cpp
-  noinline auto disassembleInstruction(maybe<n14> ip = {}) -> string;
-  noinline auto disassembleContext() -> string;
+  NALL_NOINLINE auto disassembleInstruction(maybe<n14> ip = {}) -> string;
+  NALL_NOINLINE auto disassembleContext() -> string;
 
   enum class Revision : u32 { uPD7725, uPD96050 } revision;
   n24 programROM[16384];

--- a/ares/component/processor/wdc65816/wdc65816.hpp
+++ b/ares/component/processor/wdc65816/wdc65816.hpp
@@ -235,9 +235,9 @@ struct WDC65816 {
   auto serialize(serializer&) -> void;
 
   //disassembler.cpp
-  noinline auto disassembleInstruction(n24 address, bool e, bool m, bool x) -> string;
-  noinline auto disassembleInstruction() -> string;
-  noinline auto disassembleContext(maybe<bool> e = {}) -> string;
+  NALL_NOINLINE auto disassembleInstruction(n24 address, bool e, bool m, bool x) -> string;
+  NALL_NOINLINE auto disassembleInstruction() -> string;
+  NALL_NOINLINE auto disassembleContext(maybe<bool> e = {}) -> string;
 
   struct f8 {
     bool c = 0;  //carry

--- a/ares/component/processor/z80/z80.hpp
+++ b/ares/component/processor/z80/z80.hpp
@@ -211,8 +211,8 @@ struct Z80 {
   auto serialize(serializer&) -> void;
 
   //disassembler.cpp
-  noinline auto disassembleInstruction(maybe<n16> pc = {}) -> string;
-  noinline auto disassembleContext() -> string;
+  NALL_NOINLINE auto disassembleInstruction(maybe<n16> pc = {}) -> string;
+  NALL_NOINLINE auto disassembleContext() -> string;
 
   auto disassemble(n16 pc, n8 prefix, n8 code) -> string;
   auto disassembleCB(n16 pc, n8 prefix, n8 code) -> string;

--- a/ares/n64/cpu/interpreter-fpu.cpp
+++ b/ares/n64/cpu/interpreter-fpu.cpp
@@ -250,7 +250,7 @@ auto CPU::checkFPUExceptions() -> bool {
 
 #define CHECK_FPE_IMPL(type, res, operation, convert) \
   fenv.clearExcept(); \
-  volatile type v##res = [&]() noinline -> type { return operation; }(); \
+  volatile type v##res = [&]() NALL_NOINLINE -> type { return operation; }(); \
   if (checkFPUExceptions<convert>()) return; \
   type res = v##res;
 

--- a/ares/sfc/ppu/ppu.hpp
+++ b/ares/sfc/ppu/ppu.hpp
@@ -90,12 +90,12 @@ struct PPU : PPUBase::Implementation, PPUcounter {
 
   //main.cpp
   auto main() -> void;
-  noinline auto cycleObjectEvaluate() -> void;
-  template<u32 Cycle> noinline auto cycleBackgroundFetch() -> void;
-  noinline auto cycleBackgroundBegin() -> void;
-  noinline auto cycleBackgroundBelow() -> void;
-  noinline auto cycleBackgroundAbove() -> void;
-  noinline auto cycleRenderPixel() -> void;
+  NALL_NOINLINE auto cycleObjectEvaluate() -> void;
+  template<u32 Cycle> NALL_NOINLINE auto cycleBackgroundFetch() -> void;
+  NALL_NOINLINE auto cycleBackgroundBegin() -> void;
+  NALL_NOINLINE auto cycleBackgroundBelow() -> void;
+  NALL_NOINLINE auto cycleBackgroundAbove() -> void;
+  NALL_NOINLINE auto cycleRenderPixel() -> void;
   template<u32> auto cycle() -> void;
 
   //io.cpp

--- a/nall/platform.hpp
+++ b/nall/platform.hpp
@@ -161,15 +161,15 @@ namespace nall {
 
 #if defined(COMPILER_CLANG) || defined(COMPILER_GCC)
   #define no_optimize __attribute__((optnone))
-  #define noinline __attribute__((noinline))
+  #define NALL_NOINLINE __attribute__((noinline))
   #define alwaysinline inline __attribute__((always_inline))
 #elif defined(COMPILER_MICROSOFT)
   #define no_optimize
-  #define noinline __declspec(noinline)
+  #define NALL_NOINLINE __declspec(noinline)
   #define alwaysinline inline __forceinline
 #else
   #define no_optimize
-  #define noinline
+  #define NALL_NOINLINE
   #define alwaysinline inline
 #endif
 


### PR DESCRIPTION
This is a change spun off from continuing build system work.

There, we've found that precompiling the `ares/ares.hpp` header can speed up compile times for the emulator cores by 30-35%. Doing so, however, leads to a few collisions:

* Several files in parallel-rdp use the `Hash` type, which variously resolves to a `Hash` in its own namespace as well as nall's namespace.
* Also in the N64 core, nall's `noinline` macro conflicts with similar definitions present in `xxhash`.

For parallel-rdp, we can simply skip precompiled headers for the conflicting files; parallel-rdp does not use anything in the `ares/ares.hpp` header, so including it there is unnecessary anyway.

This change resolves the second set of collisions by putting nall's noinline preprocessor macro into its own namespace.

There are many macros remaining that are not namespaced. I did not proceed in namespacing them for this PR, because there are a lot of them, and it would be a fairly significant code style change that probably merits further discussion (not to mention, it will be a decent amount of work). However, in this instance, there is (or will be) a material benefit that probably trumps the minor style issue.