### PR TITLE
gba: OBJ timing improvements

### DIFF
--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -114,7 +114,7 @@ auto PPU::main() -> void {
   bg1.scanline(y);
   bg2.scanline(y);
   bg3.scanline(y);
-  objects.scanline(y);
+  objects.scanline((y + 1) % 228);
   if(y < 160) {
     auto line = screen->pixels().data() + y * 240;
     for(u32 x : range(240)) {

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -180,7 +180,7 @@ private:
       n5 mosaicHeight;
     } io;
 
-    Pixel buffer[240];
+    Pixel lineBuffers[2][240];
     Pixel output;
     Pixel mosaic;
     u32 mosaicOffset;


### PR DESCRIPTION
Implements a couple improvements to OBJ-related timings:

- OBJs are now rendered one scanline in advance, as on hardware
- OBJ palette RAM accesses are now performed in `PPU::Objects::run` rather than `PPU::Objects::scanline`, bringing OBJ PRAM access timings closer to matching hardware