### PR TITLE
n64: add unusual warning when using CACHE on uncached addresses

### DIFF
--- a/ares/n64/cpu/interpreter-ipu.cpp
+++ b/ares/n64/cpu/interpreter-ipu.cpp
@@ -120,6 +120,9 @@ auto CPU::BREAK() -> void {
 auto CPU::CACHE(u8 operation, cr64& rs, s16 imm) -> void {
   auto access = devirtualize<Read, Word>(rs.u64 + imm);
   if (!access) return;
+  if(!access.cache) {
+    debug(unusual, "[CPU] CACHE access to non-cacheable address ", hex(access.vaddr, 8L), " at PC ", hex(PC, 16L));
+  }
 
   switch(operation) {
 


### PR DESCRIPTION
The CACHE opcode does not work correctly when the specified virtual address is in an uncached segment. The exact hardware behavior has not been reversed yet (we know for instance that when doing cache invalidation, some other cacheline is invalidated instead, but we do not know the relation yet).

Nonetheless, the behavior is really obscure and all usages should be considered bugs. Add a debug unusual warning for now (mainly to help developers, as this is a known instance where Ares doesn't yet follow hardware behavior).