### PR TITLE
gba: selectively synchronize CPU and APU, and add option to disable pixel accuracy

### DIFF
--- a/ares/gba/apu/io.cpp
+++ b/ares/gba/apu/io.cpp
@@ -1,4 +1,6 @@
 auto APU::readIO(n32 address) -> n8 {
+  cpu.synchronize(apu);
+
   switch(address) {
 
   //NR10
@@ -144,6 +146,8 @@ auto APU::readIO(n32 address) -> n8 {
 }
 
 auto APU::writeIO(n32 address, n8 data) -> void {
+  cpu.synchronize(apu);
+
   switch(address) {
 
   //NR10

--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -110,17 +110,16 @@ auto CPU::step(u32 clocks) -> void {
     context.clock++;
   }
 
-  #if defined(PROFILE_PERFORMANCE)
-  //10-20% speedup by only synchronizing other components every 16 clock cycles
+  Thread::step(clocks);
+  Thread::synchronize(ppu, player);
+
+  //occasionally synchronize with APU in case it has not recently interacted with CPU
   static u32 counter = 0;
   counter += clocks;
-  if(counter < 16) return;
-  clocks = counter;
-  counter = 0;
-  #endif
-
-  Thread::step(clocks);
-  Thread::synchronize();
+  if(counter >= 1024) {
+    Thread::synchronize(apu);
+    counter = 0;
+  }
 }
 
 auto CPU::power() -> void {

--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -113,7 +113,7 @@ auto CPU::step(u32 clocks) -> void {
   Thread::step(clocks);
   Thread::synchronize(ppu, player);
 
-  //occasionally synchronize with APU in case it has not recently interacted with CPU
+  //occasionally synchronize with APU in case CPU has not recently interacted with it
   static u32 counter = 0;
   counter += clocks;
   if(counter >= 1024) {

--- a/ares/gba/gba.hpp
+++ b/ares/gba/gba.hpp
@@ -9,6 +9,7 @@ namespace ares::GameBoyAdvance {
   #include <ares/inline.hpp>
   auto enumerate() -> vector<string>;
   auto load(Node::System& node, string name) -> bool;
+  auto option(string name, string value) -> bool;
 
   enum : u32 {           //mode flags for bus read, write:
     Nonsequential =   1,  //N cycle

--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -23,6 +23,10 @@ PPU ppu;
 #include "debugger.cpp"
 #include "serialization.cpp"
 
+auto PPU::setAccurate(bool value) -> void {
+  accurate = value;
+}
+
 auto PPU::load(Node::Object parent) -> void {
   vram.allocate(96_KiB);
   pram.allocate(512);
@@ -129,8 +133,9 @@ auto PPU::main() -> void {
       window3.output = true;
       n15 color = dac.run(x, y);
       line[x] = color;
-      step(4);
+      if(accurate) step(4);
     }
+    if(!accurate) step(960);
   } else {
     step(960);
   }

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -7,6 +7,8 @@ struct PPU : Thread, IO {
   Memory::Writable<n8 > vram;  //96KB
   Memory::Writable<n16> pram;
 
+  bool accurate;
+
   struct Debugger {
     //debugger.cpp
     auto load(Node::Object) -> void;
@@ -27,6 +29,8 @@ struct PPU : Thread, IO {
   } debugger;
 
   //ppu.cpp
+  auto setAccurate(bool value) -> void;
+
   auto load(Node::Object) -> void;
   auto unload() -> void;
 

--- a/ares/gba/system/system.cpp
+++ b/ares/gba/system/system.cpp
@@ -14,6 +14,13 @@ auto load(Node::System& node, string name) -> bool {
   return system.load(node, name);
 }
 
+auto option(string name, string value) -> bool {
+  if(name == "Pixel Accuracy") {
+    ppu.setAccurate(value.boolean());
+  }
+  return true;
+}
+
 Scheduler scheduler;
 BIOS bios;
 System system;

--- a/desktop-ui/emulator/emulators.cpp
+++ b/desktop-ui/emulator/emulators.cpp
@@ -39,6 +39,7 @@ namespace ares::Atari2600 {
 #ifdef CORE_GBA
   namespace ares::GameBoyAdvance {
     auto load(Node::System& node, string name) -> bool;
+    auto option(string name, string value) -> bool;
   }
   #include "game-boy-advance.cpp"
 #endif

--- a/desktop-ui/emulator/game-boy-advance.cpp
+++ b/desktop-ui/emulator/game-boy-advance.cpp
@@ -57,6 +57,8 @@ auto GameBoyAdvance::load() -> bool {
   system = mia::System::create("Game Boy Advance");
   if(!system->load(firmware[0].location)) return errorFirmware(firmware[0]), false;
 
+  ares::GameBoyAdvance::option("Pixel Accuracy", settings.video.pixelAccuracy);
+
   if(!ares::GameBoyAdvance::load(root, "[Nintendo] Game Boy Advance")) return false;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {


### PR DESCRIPTION
Similarly to how the S-CPU and S-SMP are handled in the SFC core, it's possible to run the GBA CPU and APU more asychronously as long as synchronization is performed on FIFO or APU I/O accesses. From my testing on Linux, this performs comparably to the performance profile but without the accuracy downsides, so the performance/accuracy profiles have been removed (the more accurate behaviour is now always used).

This PR also adds an option to disable pixel accuracy in the GBA core in exchange for ~10-15% performance benefits, and makes some small PPU timing improvements that were not feasible to implement in the performance profile.