### PR TITLE
Slower PS1 DMA. Fixes #1680

### DIFF
--- a/ares/ps1/dma/dma.cpp
+++ b/ares/ps1/dma/dma.cpp
@@ -21,9 +21,9 @@ auto DMA::unload() -> void {
 
 auto DMA::main() -> void {
   for(u32 id : channelsByPriority) {
-    if(channels[id].step(16)) break;
+    if(channels[id].step(32)) break;
   }
-  step(16);
+  step(32);
 }
 
 auto DMA::step(u32 clocks) -> void {


### PR DESCRIPTION
I'm not sure about the correctness of this patch.
It does fix Fear Effect, it might break other games.
I'll try to run other games to check for regressions.