### PR TITLE
build: macOS back-compatibility fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,9 +122,11 @@ jobs:
       run: |
         if [ $ImageOS == "macos14" ]; then
             sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
+            export MACOSX_DEPLOYMENT_TARGET=10.13
             echo "Set Xcode version to 15.2 for macos-latest build."
         elif [ $ImageOS == "macos12" ]; then
             sudo xcode-select -s /Applications/Xcode_13.4.app/Contents/Developer
+            export MACOSX_DEPLOYMENT_TARGET=10.9
             echo "Set Xcode version to 13.4 for macos-compat build."
         fi
         brew install make ninja cmake
@@ -140,6 +142,7 @@ jobs:
         pushd thirdparty/MoltenVK
         ./build-moltenvk.sh
         popd
+        export MACOSX_DEPLOYMENT_TARGET=10.15
         pushd thirdparty/librashader
         ./build-librashader.sh
         popd

--- a/ruby/video/metal/metal.cpp
+++ b/ruby/video/metal/metal.cpp
@@ -122,10 +122,14 @@ struct VideoMetal : VideoDriver, Metal {
   }
   
   auto isVRRSupported() -> bool {
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000
     if (@available(macOS 12.0, *)) {
       NSTimeInterval minInterval = view.window.screen.minimumRefreshInterval;
       NSTimeInterval maxInterval = view.window.screen.maximumRefreshInterval;
       _vrrIsSupported = minInterval != maxInterval;
+#else
+      _vrrIsSupported = false;
+#endif
       return _vrrIsSupported;
     } else {
       return false;
@@ -139,6 +143,7 @@ struct VideoMetal : VideoDriver, Metal {
       CFTimeInterval refreshRate = CGDisplayModeGetRefreshRate(displayMode);
       _presentInterval = (1.0 / refreshRate);
     } else {
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000
       if (@available(macOS 12.0, *)) {
         CFTimeInterval minimumInterval = view.window.screen.minimumRefreshInterval;
         if (_refreshRateHint != 0) {
@@ -149,6 +154,7 @@ struct VideoMetal : VideoDriver, Metal {
           _presentInterval = minimumInterval;
         }
       }
+#endif
     }
   }
 


### PR DESCRIPTION
While checking out minimum requirements for the new build system, found a couple small issues worth fixing:

* librashader was not operable on systems pre-macOS 12 with a linker issue; it can be resolved by setting a minimum deployment target; here we do that by setting an environment variable on CI.
    * While investigating this, I found that librashader's minimum required macOS seems to be 10.15; this is because `glslang` seems to require macOS 10.15.
* It wasn't possible to build the Metal driver because of the older SDK lacking some definitions; however, we can fall back to the `__MAC_OS_X_VERSION_MAX_ALLOWED` compile definition which we do here.
    * Not sure if building on these older systems should really be considered "supported", but since the fix here was simple enough it seems fine to throw it in.

paraLLEl-RDP and MoltenVK seem to have [a lot of issues](https://github.com/user-attachments/assets/088879a9-9153-4b05-a207-212cfac7f831) on my older system's GeForce 650M. I was able to compile debug MoltenVK locally, but Xcode GPU capture just hung, so I was unable to figure out what was going on. Either a driver issue or a MoltenVK issue seems like the probable culprit. In any case, performance wasn't really good enough to make me want to investigate further. Other cores seem to work well.

Tested [on my fork's CI](https://github.com/jcm93/ares/actions/runs/11554703214) to make sure everything still works.