### PR TITLE
nall: Use relative path for prefix

### DIFF
--- a/nall/path.cpp
+++ b/nall/path.cpp
@@ -1,5 +1,4 @@
 #include <nall/path.hpp>
-#include <nall/stringize.hpp>
 
 #if defined(PLATFORM_WINDOWS)
   #include <shlobj.h>
@@ -153,13 +152,7 @@ NALL_HEADER_INLINE auto sharedData() -> string {
 
 #if defined(PLATFORM_LINUX) || defined(PLATFORM_BSD)
 NALL_HEADER_INLINE auto prefixSharedData() -> string {
-  #if defined(ARES_PREFIX)
-  string result = stringize(ARES_PREFIX/share/);
-  #else
-  string result;
-  #endif
-  if(!result) result = ".";
-  if(!result.endsWith("/")) result.append("/");
+  string result = program().append("../share/");
   return result;
 }
 

--- a/nall/stringize.hpp
+++ b/nall/stringize.hpp
@@ -1,8 +1,0 @@
-#pragma once
-
-// The # preprocessing operator converts the argument into a quoted string literal.
-// In order to use this for macro parameters which need to be expanded, this must
-// be a two-level-macro call.
-
-#define stringize_(arg) #arg
-#define stringize(arg) stringize_(arg)


### PR DESCRIPTION
Following up on #1688 and #1575; removes the ARES_PREFIX preprocessor variable and its use in `prefixSharedData()` in favor of a relative path.

Passing a preprocessor argument to the program to define an install prefix, which is then used to locate application data, is awkward and overall not an ideal approach. Wherever possible, ares should have the same behavior on the same classes of OS. Further, if we are to cleanly separate ares's build and install steps, we shouldn't be defining anything related to install locations at build-time. After building ares, it should be able to be installed wherever the user wishes without any unexpected changes in behavior.

Following the standard paradigm here means that on *nix systems, the prefix's data directory would be, relative to the executable, in `../share/ares/`. Hence, define `prefixSharedData()` from #1688 to return this relative path appended to the executable path (given by nall's `Path::program()`), instead of doing the preprocessor prefix hooplah.

Tested on aarch64 Fedora; made sure ares can still locate the database and shaders.