### PR TITLE
ares: move generated sources out of ares.hpp

### DIFF
--- a/ares/ares/ares.hpp
+++ b/ares/ares/ares.hpp
@@ -78,4 +78,3 @@ namespace ares {
 #include <ares/memory/fixed-allocator.hpp>
 #include <ares/memory/readable.hpp>
 #include <ares/memory/writable.hpp>
-#include <ares/resource/resource.hpp>

--- a/ares/fc/controller/controller.cpp
+++ b/ares/fc/controller/controller.cpp
@@ -1,4 +1,5 @@
 #include <fc/fc.hpp>
+#include <ares/resource/resource.hpp>
 
 namespace ares::Famicom {
 

--- a/ares/ms/controller/controller.cpp
+++ b/ares/ms/controller/controller.cpp
@@ -1,4 +1,5 @@
 #include <ms/ms.hpp>
+#include <ares/resource/resource.hpp>
 
 namespace ares::MasterSystem {
 

--- a/ares/sfc/controller/controller.cpp
+++ b/ares/sfc/controller/controller.cpp
@@ -1,4 +1,5 @@
 #include <sfc/sfc.hpp>
+#include <ares/resource/resource.hpp>
 
 namespace ares::SuperFamicom {
 

--- a/ares/ws/ppu/ppu.cpp
+++ b/ares/ws/ppu/ppu.cpp
@@ -1,4 +1,5 @@
 #include <ws/ws.hpp>
+#include <ares/resource/resource.hpp>
 
 namespace ares::WonderSwan {
 

--- a/desktop-ui/desktop-ui.hpp
+++ b/desktop-ui/desktop-ui.hpp
@@ -5,6 +5,7 @@
 using namespace hiro;
 
 #include <ares/ares.hpp>
+#include <ares/resource/resource.hpp>
 #include <nall/gdb/server.hpp>
 #include <mia/mia.hpp>
 

--- a/mia/mia.hpp
+++ b/mia/mia.hpp
@@ -14,6 +14,7 @@ using namespace hiro;
 #endif
 
 #include <ares/ares.hpp>
+#include <ares/resource/resource.hpp>
 #include <mia/resource/resource.hpp>
 
 namespace mia {


### PR DESCRIPTION
Random fix from CMake work.

Precompiled headers under CMake are currently buggy and unreliable on Windows, largely because the precompiled `<ares/ares.hpp>` header includes `<ares/resource/resource.hpp>`, which is generated by `sourcery` as part of the build process. 

While sourcery will almost never meaningfully change the contents of this `resource.hpp` file, Windows may insert its own line endings depending on the user's environment, and despite enforcing uniform line endings as part of our `.gitattributes` file, some compilers will throw a fit about the precompiled header being modified from underneath it.

Since the `resource.hpp` file is simple, short, and not included in that many places, we can just refactor it out of `<ares/ares.hpp>` without issue, and precompiled headers will work again regardless of system line ending convention or environment.

Tested to build locally on macOS; CI run definitely recommended.