### PR TITLE
gba: open bus improvements

### DIFF
--- a/ares/gba/apu/io.cpp
+++ b/ares/gba/apu/io.cpp
@@ -142,7 +142,7 @@ auto APU::readIO(n32 address) -> n8 {
 
   }
 
-  return cpu.pipeline.fetch.instruction.byte(address & 1);
+  return cpu.getOpenBus().byte(address & 1);
 }
 
 auto APU::writeIO(n32 address, n8 data) -> void {

--- a/ares/gba/apu/io.cpp
+++ b/ares/gba/apu/io.cpp
@@ -142,7 +142,7 @@ auto APU::readIO(n32 address) -> n8 {
 
   }
 
-  return cpu.getOpenBus().byte(address & 1);
+  return cpu.openBus.get().byte(address & 1);
 }
 
 auto APU::writeIO(n32 address, n8 data) -> void {

--- a/ares/gba/apu/io.cpp
+++ b/ares/gba/apu/io.cpp
@@ -142,7 +142,7 @@ auto APU::readIO(n32 address) -> n8 {
 
   }
 
-  return cpu.openBus.get().byte(address & 1);
+  return cpu.openBus.get(Byte, address);
 }
 
 auto APU::writeIO(n32 address, n8 data) -> void {

--- a/ares/gba/cpu/bus.cpp
+++ b/ares/gba/cpu/bus.cpp
@@ -112,25 +112,17 @@ auto CPU::OpenBus::get(u32 mode, n32 address) -> n32 {
 
 auto CPU::OpenBus::set(u32 mode, n32 address, n32 word) -> void {
   if(address >> 24 == 0x3) {
-    //open bus from IWRAM has unique behaviour
+    //open bus from IWRAM only overwrites part of the last IWRAM value accessed
     if(mode & Word) {
       iwramData = word;
     } else if(mode & Half) {
-      word &= 0xffff;
-      n32 mask = 0x0000ffff;
-      n32 shift = 8 * (address & 2);
-      mask = ~(mask << shift);
-      word <<= shift;
-      iwramData &= mask;
-      iwramData |= word;
+      if(address & 2) {
+        iwramData.bit(16,31) = (n16)word;
+      } else {
+        iwramData.bit( 0,15) = (n16)word;
+      }
     } else if(mode & Byte) {
-      word &= 0xff;
-      n32 mask = 0x000000ff;
-      n32 shift = 8 * (address & 3);
-      mask = ~(mask << shift);
-      word <<= shift;
-      iwramData &= mask;
-      iwramData |= word;
+      iwramData.byte(address & 3) = (n8)word;
     }
     data = iwramData;
   } else {

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -228,7 +228,7 @@ struct CPU : ARM7TDMI, Thread, IO {
   } memory;
 
   struct OpenBus {
-    auto get() -> n32;
+    auto get(u32 mode, n32 address) -> n32;
     auto set(u32 mode, n32 address, n32 word) -> void;
     n32 data;
     n32 iwramData;

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -60,11 +60,9 @@ struct CPU : ARM7TDMI, Thread, IO {
 
   //bus.cpp
   auto sleep() -> void override;
-  auto getOpenBus() -> n32;
   template<bool UseDebugger> auto getBus(u32 mode, n32 address) -> n32;
   auto get(u32 mode, n32 address) -> n32 override;
   auto getDebugger(u32 mode, n32 address) -> n32 override;
-  auto setOpenBus(u32 mode, n32 address, n32 word) -> void;
   auto set(u32 mode, n32 address, n32 word) -> void override;
   auto _wait(u32 mode, n32 address) -> u32;
 
@@ -230,6 +228,8 @@ struct CPU : ARM7TDMI, Thread, IO {
   } memory;
 
   struct OpenBus {
+    auto get() -> n32;
+    auto set(u32 mode, n32 address, n32 word) -> void;
     n32 data;
     n32 iwramData;
   } openBus;

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -60,9 +60,11 @@ struct CPU : ARM7TDMI, Thread, IO {
 
   //bus.cpp
   auto sleep() -> void override;
+  auto getOpenBus() -> n32;
   template<bool UseDebugger> auto getBus(u32 mode, n32 address) -> n32;
   auto get(u32 mode, n32 address) -> n32 override;
   auto getDebugger(u32 mode, n32 address) -> n32 override;
+  auto setOpenBus(u32 mode, n32 address, n32 word) -> void;
   auto set(u32 mode, n32 address, n32 word) -> void override;
   auto _wait(u32 mode, n32 address) -> u32;
 
@@ -226,6 +228,11 @@ struct CPU : ARM7TDMI, Thread, IO {
     n4 ewramWait = 13;
     n4 unknown2;
   } memory;
+
+  struct OpenBus {
+    n32 data;
+    n32 iwramData;
+  } openBus;
 
   struct {
     auto empty() const { return addr == load; }

--- a/ares/gba/cpu/io.cpp
+++ b/ares/gba/cpu/io.cpp
@@ -244,7 +244,7 @@ auto CPU::readIO(n32 address) -> n8 {
 
   }
 
-  return cpu.openBus.get().byte(address & 1);
+  return cpu.openBus.get(Byte, address);
 }
 
 auto CPU::writeIO(n32 address, n8 data) -> void {

--- a/ares/gba/cpu/io.cpp
+++ b/ares/gba/cpu/io.cpp
@@ -244,7 +244,7 @@ auto CPU::readIO(n32 address) -> n8 {
 
   }
 
-  return cpu.pipeline.fetch.instruction.byte(address & 1);
+  return cpu.getOpenBus().byte(address & 1);
 }
 
 auto CPU::writeIO(n32 address, n8 data) -> void {

--- a/ares/gba/cpu/io.cpp
+++ b/ares/gba/cpu/io.cpp
@@ -244,7 +244,7 @@ auto CPU::readIO(n32 address) -> n8 {
 
   }
 
-  return cpu.getOpenBus().byte(address & 1);
+  return cpu.openBus.get().byte(address & 1);
 }
 
 auto CPU::writeIO(n32 address, n8 data) -> void {

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -100,6 +100,9 @@ auto CPU::serialize(serializer& s) -> void {
   s(memory.ewramWait);
   s(memory.unknown2);
 
+  s(openBus.data);
+  s(openBus.iwramData);
+
   s(prefetch.slot);
   s(prefetch.addr);
   s(prefetch.load);

--- a/ares/gba/memory/memory.cpp
+++ b/ares/gba/memory/memory.cpp
@@ -42,7 +42,7 @@ auto IO::writeIO(u32 mode, n32 address, n32 word) -> void {
 
 struct UnmappedIO : IO {
   auto readIO(n32 address) -> n8 override {
-    return cpu.getOpenBus().byte(address & 1);
+    return cpu.openBus.get().byte(address & 1);
   }
 
   auto writeIO(n32 address, n8 byte) -> void override {

--- a/ares/gba/memory/memory.cpp
+++ b/ares/gba/memory/memory.cpp
@@ -42,7 +42,7 @@ auto IO::writeIO(u32 mode, n32 address, n32 word) -> void {
 
 struct UnmappedIO : IO {
   auto readIO(n32 address) -> n8 override {
-    return cpu.pipeline.fetch.instruction.byte(address & 1);
+    return cpu.getOpenBus().byte(address & 1);
   }
 
   auto writeIO(n32 address, n8 byte) -> void override {

--- a/ares/gba/memory/memory.cpp
+++ b/ares/gba/memory/memory.cpp
@@ -42,7 +42,7 @@ auto IO::writeIO(u32 mode, n32 address, n32 word) -> void {
 
 struct UnmappedIO : IO {
   auto readIO(n32 address) -> n8 override {
-    return cpu.openBus.get().byte(address & 1);
+    return cpu.openBus.get(Byte, address);
   }
 
   auto writeIO(n32 address, n8 byte) -> void override {

--- a/ares/gba/ppu/io.cpp
+++ b/ares/gba/ppu/io.cpp
@@ -99,7 +99,7 @@ auto PPU::readIO(n32 address) -> n8 {
 
   }
 
-  return cpu.getOpenBus().byte(address & 1);
+  return cpu.openBus.get().byte(address & 1);
 }
 
 auto PPU::writeIO(n32 address, n8 data) -> void {

--- a/ares/gba/ppu/io.cpp
+++ b/ares/gba/ppu/io.cpp
@@ -99,7 +99,7 @@ auto PPU::readIO(n32 address) -> n8 {
 
   }
 
-  return cpu.pipeline.fetch.instruction.byte(address & 1);
+  return cpu.getOpenBus().byte(address & 1);
 }
 
 auto PPU::writeIO(n32 address, n8 data) -> void {

--- a/ares/gba/ppu/io.cpp
+++ b/ares/gba/ppu/io.cpp
@@ -99,7 +99,7 @@ auto PPU::readIO(n32 address) -> n8 {
 
   }
 
-  return cpu.openBus.get().byte(address & 1);
+  return cpu.openBus.get(Byte, address);
 }
 
 auto PPU::writeIO(n32 address, n8 data) -> void {

--- a/ares/gba/system/bios.cpp
+++ b/ares/gba/system/bios.cpp
@@ -17,7 +17,7 @@ auto BIOS::readROM(n25 address) -> n32 {
 auto BIOS::read(u32 mode, n25 address) -> n32 {
   //unmapped memory
   if(address >= 0x0000'4000) {
-    return cpu.pipeline.fetch.instruction;  //0000'4000-01ff'ffff
+    return cpu.getOpenBus();  //0000'4000-01ff'ffff
   }
 
   //GBA BIOS is read-protected; only the BIOS itself can read its own memory

--- a/ares/gba/system/bios.cpp
+++ b/ares/gba/system/bios.cpp
@@ -17,7 +17,7 @@ auto BIOS::readROM(n25 address) -> n32 {
 auto BIOS::read(u32 mode, n25 address) -> n32 {
   //unmapped memory
   if(address >= 0x0000'4000) {
-    return cpu.openBus.get();  //0000'4000-01ff'ffff
+    return cpu.openBus.get(mode, address);  //0000'4000-01ff'ffff
   }
 
   //GBA BIOS is read-protected; only the BIOS itself can read its own memory

--- a/ares/gba/system/bios.cpp
+++ b/ares/gba/system/bios.cpp
@@ -17,7 +17,7 @@ auto BIOS::readROM(n25 address) -> n32 {
 auto BIOS::read(u32 mode, n25 address) -> n32 {
   //unmapped memory
   if(address >= 0x0000'4000) {
-    return cpu.getOpenBus();  //0000'4000-01ff'ffff
+    return cpu.openBus.get();  //0000'4000-01ff'ffff
   }
 
   //GBA BIOS is read-protected; only the BIOS itself can read its own memory

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v141.1";
+static const string SerializerVersion = "v141.2";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Fixes a few issues relating to open bus emulation:

- Accounts for cases where the last memory access was not an instruction fetch
- For most memory regions, 8-bit and 16-bit accesses should be mirrored along bus (except in IWRAM, where only part of the open bus value gets overwritten, and the rest is carried over from the last IWRAM access)
- Open bus read alignment was not being respected in all regions