### PR TITLE
md: dma timing fixes

### DIFF
--- a/ares/md/vdp/dma.cpp
+++ b/ares/md/vdp/dma.cpp
@@ -25,6 +25,7 @@ auto VDP::DMA::run() -> bool {
 auto VDP::DMA::load() -> void {
   if(delay > 0) { delay--; return; }
   auto address = mode.bit(0) << 23 | source << 1;
+  if(vdp.refreshing()) return; // bus not available
   auto data = bus.read(1, 1, address);
   vdp.writeDataPort(data);
   vdp.debugger.dmaLoad(address, vdp.command.target, vdp.command.address, data);

--- a/ares/md/vdp/main.cpp
+++ b/ares/md/vdp/main.cpp
@@ -21,7 +21,6 @@ template<bool _h40> auto VDP::tick() -> void {
   }
 
   irq.poll();
-  vram.refreshing = 0;
 }
 
 auto VDP::vblankcheck() -> void {
@@ -91,8 +90,8 @@ auto VDP::slot() -> void {
   dma.run();
 }
 
-auto VDP::refresh() -> void {
-  vram.refreshing = 1;
+auto VDP::refresh(bool active) -> void {
+  vram.refreshing = active;
 }
 
 auto VDP::main() -> void {
@@ -150,8 +149,8 @@ auto VDP::mainH32() -> void {
   window.attributesFetch(-1);
 
   tick<false>(); layerA.mappingFetch(-1);
-  tick<false>(); !displayEnable() ? refresh() : sprite.patternFetch(30);
-  tick<false>(); layerA.patternFetch( 0);
+  tick<false>(); !displayEnable() ? refresh(true) : sprite.patternFetch(30);
+  tick<false>(); layerA.patternFetch( 0); refresh(false);
   tick<false>(); layerA.patternFetch( 1);
   tick<false>(); layerB.mappingFetch(-1);
   tick<false>(); sprite.patternFetch(31);
@@ -199,8 +198,8 @@ auto VDP::mainH40() -> void {
   window.attributesFetch(-1);
 
   tick<true>(); layerA.mappingFetch(-1);
-  tick<true>(); !displayEnable() ? refresh() : sprite.patternFetch(38);
-  tick<true>(); layerA.patternFetch( 0);
+  tick<true>(); !displayEnable() ? refresh(true) : sprite.patternFetch(38);
+  tick<true>(); layerA.patternFetch( 0); refresh(false);
   tick<true>(); layerA.patternFetch( 1);
   tick<true>(); layerB.mappingFetch(-1);
   tick<true>(); sprite.patternFetch(39);
@@ -217,8 +216,8 @@ template<bool _h40, bool _pixels> auto VDP::blocks() -> void {
     layerB.attributesFetch();
     window.attributesFetch(block);
     tick<_h40>(); layerA.mappingFetch(block);
-    tick<_h40>(); (block & 3) != 3 ? slot() : refresh();
-    tick<_h40>(); layerA.patternFetch(block * 2 + 2);
+    tick<_h40>(); (block & 3) != 3 ? slot() : refresh(true);
+    tick<_h40>(); layerA.patternFetch(block * 2 + 2); refresh(false);
     tick<_h40>(); layerA.patternFetch(block * 2 + 3);
     tick<_h40>(); layerB.mappingFetch(block);
     tick<_h40>(); sprite.mappingFetch(block);

--- a/ares/md/vdp/vdp.hpp
+++ b/ares/md/vdp/vdp.hpp
@@ -70,7 +70,7 @@ struct VDP : Thread {
   auto vblankcheck() -> void;
   auto vedge() -> void;
   auto slot() -> void;
-  auto refresh() -> void;
+  auto refresh(bool active) -> void;
   auto main() -> void;
   auto render() -> void;
   auto mainH32() -> void;


### PR DESCRIPTION
Fixes test cases in the dma_speed_test rom.
1. "*VRAM TO ROM" is a dma load to a VRAM read target, which doesn't have any effect. Though, for timing purposes, it's similar to a VRAM write (1 byte access per slot) so fifo throughput is the limiting factor.
2. A VDP refresh blocks bus access for 2 consecutive slots, slightly affecting dma load transfer rates.