### PR TITLE
Bring back bsnes Pseudo Fullscreen Option

### DIFF
--- a/ares/ares/node/video/screen.hpp
+++ b/ares/ares/node/video/screen.hpp
@@ -83,7 +83,7 @@ protected:
   f64  _luminance = 1.0;
   u32  _fillColor = 0;
   bool _colorBleed = false;
-  bool _colorBleedWidth = 1;
+  u32  _colorBleedWidth = 1;
   bool _interframeBlending = false;
   bool _overscan = true;
   u32  _rotation = 0;  //counter-clockwise (90 = left, 270 = right)

--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -7,6 +7,10 @@ auto InputManager::createHotkeys() -> void {
     program.videoFullScreenToggle();
   }));
 
+  hotkeys.append(InputHotkey("Toggle Pseudo-Fullscreen").onPress([&] {
+    program.videoPseudoFullScreenToggle();
+  }));
+
   hotkeys.append(InputHotkey("Toggle Mouse Capture").onPress([&] {
     if(!emulator) return;
     if(!ruby::input.acquired()) {

--- a/desktop-ui/program/drivers.cpp
+++ b/desktop-ui/program/drivers.cpp
@@ -54,7 +54,19 @@ auto Program::videoFullScreenToggle() -> void {
   }
 }
 
-//
+auto Program::videoPseudoFullScreenToggle() -> void {
+  if(ruby::video.fullScreen()) return;
+
+  if(!presentation.fullScreen()) {
+    presentation.setFullScreen(true);
+    presentation.menuBar.setVisible(false);
+    if(!ruby::input.acquired() && ruby::video.hasMonitors().size() == 1) ruby::input.acquire();
+  } else {
+    if(ruby::input.acquired()) ruby::input.release();
+    presentation.menuBar.setVisible(true);
+    presentation.setFullScreen(false);
+  }
+}
 
 auto Program::audioDriverUpdate() -> void {
   ruby::audio.create(settings.audio.driver);

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -47,6 +47,7 @@ struct Program : ares::Platform {
   auto videoMonitorUpdate() -> void;
   auto videoFormatUpdate() -> void;
   auto videoFullScreenToggle() -> void;
+  auto videoPseudoFullScreenToggle() -> void;
 
   auto audioDriverUpdate() -> void;
   auto audioDeviceUpdate() -> void;


### PR DESCRIPTION
Brings back the Pseudo Full Screen option present in bsnes as a configurable hotkey.

I'm also including the type mistake pointed out for the colorWidthBleed value someone pointed out so we don't lose track of it. 