### PR TITLE
gba: cycle-based bitmap and affine backgrounds

### DIFF
--- a/ares/gba/GNUmakefile
+++ b/ares/gba/GNUmakefile
@@ -7,6 +7,7 @@ ares.objects += ares-gba-player
 ares.objects += ares-gba-cpu
 ares.objects += ares-gba-ppu
 ares.objects += ares-gba-apu
+ares.objects += ares-gba-display
 
 $(object.path)/ares-gba-memory.o:    $(ares.path)/gba/memory/memory.cpp
 $(object.path)/ares-gba-system.o:    $(ares.path)/gba/system/system.cpp
@@ -15,3 +16,4 @@ $(object.path)/ares-gba-player.o:    $(ares.path)/gba/player/player.cpp
 $(object.path)/ares-gba-cpu.o:       $(ares.path)/gba/cpu/cpu.cpp
 $(object.path)/ares-gba-ppu.o:       $(ares.path)/gba/ppu/ppu.cpp
 $(object.path)/ares-gba-apu.o:       $(ares.path)/gba/apu/apu.cpp
+$(object.path)/ares-gba-display.o:   $(ares.path)/gba/display/display.cpp

--- a/ares/gba/cpu/bus.cpp
+++ b/ares/gba/cpu/bus.cpp
@@ -70,9 +70,9 @@ auto CPU::set(u32 mode, n32 address, n32 word) -> void {
          if(address  < 0x0200'0000) bios.write(mode, address, word);
     else if(address  < 0x0300'0000) writeEWRAM(mode, address, word);
     else if(address  < 0x0400'0000) writeIWRAM(mode, address, word);
-    else if(address >= 0x0700'0000) ppu.writeOAM(mode, address, word);
-    else if(address >= 0x0600'0000) ppu.writeVRAM(mode, address, word);
-    else if(address >= 0x0500'0000) ppu.writePRAM(mode, address, word);
+    else if(address >= 0x0700'0000) { synchronize(ppu); ppu.writeOAM(mode, address, word); }
+    else if(address >= 0x0600'0000) { synchronize(ppu); ppu.writeVRAM(mode, address, word); }
+    else if(address >= 0x0500'0000) { synchronize(ppu); ppu.writePRAM(mode, address, word); }
     else if((address & 0xffff'fc00) == 0x0400'0000) bus.io[address & 0x3ff]->writeIO(mode, address, word);
     else if((address & 0xff00'ffff) == 0x0400'0800) ((IO*)this)->writeIO(mode, 0x0400'0800 | (address & 3), word);
   }

--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -108,13 +108,13 @@ auto CPU::step(u32 clocks) -> void {
   }
 
   Thread::step(clocks);
-  Thread::synchronize(ppu, player);
+  Thread::synchronize(display, player);
 
-  //occasionally synchronize with APU in case CPU has not recently interacted with it
+  //occasionally synchronize with PPU and APU in case CPU has not recently interacted with them
   static u32 counter = 0;
   counter += clocks;
   if(counter >= 1024) {
-    Thread::synchronize(apu);
+    Thread::synchronize(ppu, apu);
     counter = 0;
   }
 }

--- a/ares/gba/display/display.cpp
+++ b/ares/gba/display/display.cpp
@@ -1,0 +1,89 @@
+#include <gba/gba.hpp>
+
+//The only PPU state the CPU needs on every cycle is raised IRQs and DMAs,
+//which occur independently of the render process.
+//Display exists to put these events on a separate thread,
+//so the CPU and PPU can run out-of-order.
+
+//hdraw:    1006 cycles
+//hblank:    226 cycles
+//scanline: 1232 cycles
+
+//vdraw:     160 scanlines (197120 cycles)
+//vblank:     68 scanlines ( 83776 cycles)
+//frame:     228 scanlines (280896 cycles)
+
+namespace ares::GameBoyAdvance {
+
+Display display;
+#include "io.cpp"
+#include "serialization.cpp"
+
+auto Display::load(Node::Object parent) -> void {
+  node = parent->append<Node::Object>("Display");
+}
+
+auto Display::unload() -> void {
+  node.reset();
+}
+
+auto Display::step(u32 clocks) -> void {
+  Thread::step(clocks);
+  Thread::synchronize(cpu);
+}
+
+auto Display::main() -> void {
+  cpu.keypad.run();
+
+  io.vblank = io.vcounter >= 160 && io.vcounter <= 226;
+
+  step(1);
+
+  io.vcoincidence = io.vcounter == io.vcompare;
+
+  if(io.vcounter == 160) {
+    if(io.irqvblank) cpu.setInterruptFlag(CPU::Interrupt::VBlank);
+  }
+
+  step(1);
+
+  if(io.irqvcoincidence) {
+    if(io.vcoincidence) cpu.setInterruptFlag(CPU::Interrupt::VCoincidence);
+  }
+
+  if(io.vcounter == 160) {
+    cpu.dmaVblank();
+  }
+
+  step(3);
+
+  if(io.vcounter == 162) {
+    if(videoCapture) cpu.dma[3].enable = 0;
+    videoCapture = !videoCapture && cpu.dma[3].timingMode == 3 && cpu.dma[3].enable;
+  }
+  if(io.vcounter >= 2 && io.vcounter < 162 && videoCapture) cpu.dmaHDMA();
+
+  step(1002);
+
+  io.hblank = 1;
+
+  step(1);
+  if(io.irqhblank) cpu.setInterruptFlag(CPU::Interrupt::HBlank);
+
+  step(1);
+  if(io.vcounter < 160) cpu.dmaHblank();
+
+  step(223);
+  io.hblank = 0;
+  if(++io.vcounter == 228) io.vcounter = 0;
+}
+
+auto Display::power() -> void {
+  Thread::create(system.frequency(), {&Display::main, this});
+
+  for(u32 n = 0x004; n <= 0x007; n++) bus.io[n] = this;
+
+  io = {};
+}
+
+}

--- a/ares/gba/display/display.hpp
+++ b/ares/gba/display/display.hpp
@@ -1,0 +1,34 @@
+struct Display : Thread, IO {
+  Node::Object node;
+
+  auto load(Node::Object) -> void;
+  auto unload() -> void;
+
+  auto step(u32 clocks) -> void;
+  auto main() -> void;
+
+  auto power() -> void;
+
+  //io.cpp
+  auto readIO(n32 address) -> n8;
+  auto writeIO(n32 address, n8 byte) -> void;
+
+  //serialization.cpp
+  auto serialize(serializer&) -> void;
+
+  struct IO {
+    n1  vblank;
+    n1  hblank;
+    n1  vcoincidence;
+    n1  irqvblank;
+    n1  irqhblank;
+    n1  irqvcoincidence;
+    n8  vcompare;
+
+    n16 vcounter;
+  } io;
+  
+  n1 videoCapture = 0;
+};
+
+extern Display display;

--- a/ares/gba/display/io.cpp
+++ b/ares/gba/display/io.cpp
@@ -1,0 +1,40 @@
+auto Display::readIO(n32 address) -> n8 {
+  switch(address) {
+
+  //DISPSTAT
+  case 0x0400'0004: return (
+    io.vblank          << 0
+  | io.hblank          << 1
+  | io.vcoincidence    << 2
+  | io.irqvblank       << 3
+  | io.irqhblank       << 4
+  | io.irqvcoincidence << 5
+  );
+  case 0x0400'0005: return (
+    io.vcompare
+  );
+
+  //VCOUNT
+  case 0x0400'0006: return io.vcounter.byte(0);
+  case 0x0400'0007: return io.vcounter.byte(1);
+
+  }
+
+  return cpu.openBus.get(Byte, address);
+}
+
+auto Display::writeIO(n32 address, n8 data) -> void {
+  switch(address) {
+
+  //DISPSTAT
+  case 0x0400'0004:
+    io.irqvblank       = data.bit(3);
+    io.irqhblank       = data.bit(4);
+    io.irqvcoincidence = data.bit(5);
+    return;
+  case 0x0400'0005:
+    io.vcompare = data;
+    return;
+
+  }
+}

--- a/ares/gba/display/serialization.cpp
+++ b/ares/gba/display/serialization.cpp
@@ -1,0 +1,12 @@
+auto Display::serialize(serializer& s) -> void {
+  s(io.vblank);
+  s(io.hblank);
+  s(io.vcoincidence);
+  s(io.irqvblank);
+  s(io.irqhblank);
+  s(io.irqvcoincidence);
+  s(io.vcompare);
+  s(io.vcounter);
+
+  s(videoCapture);
+}

--- a/ares/gba/gba.hpp
+++ b/ares/gba/gba.hpp
@@ -35,4 +35,5 @@ namespace ares::GameBoyAdvance {
   #include <gba/cpu/cpu.hpp>
   #include <gba/ppu/ppu.hpp>
   #include <gba/apu/apu.hpp>
+  #include <gba/display/display.hpp>
 }

--- a/ares/gba/ppu/dac.cpp
+++ b/ares/gba/ppu/dac.cpp
@@ -18,13 +18,6 @@ auto PPU::DAC::upperLayer(u32 x, u32 y) -> void {
     if(ppu.window0.io.enable && ppu.window0.output) memory::copy(&active, &ppu.window0.io.active, sizeof(active));
   }
 
-  //get background and object pixels
-  ppu.objects.outputPixel(x, y);
-  ppu.bg0.outputPixel(x, y);
-  ppu.bg1.outputPixel(x, y);
-  ppu.bg2.outputPixel(x, y);
-  ppu.bg3.outputPixel(x, y);
-
   //priority sorting: find topmost two pixels
   layers[OBJ] = ppu.objects.mosaic;
   layers[BG0] = ppu.bg0.mosaic;

--- a/ares/gba/ppu/io.cpp
+++ b/ares/gba/ppu/io.cpp
@@ -1,4 +1,6 @@
 auto PPU::readIO(n32 address) -> n8 {
+  cpu.synchronize(ppu);
+
   switch(address) {
 
   //DISPCNT
@@ -24,23 +26,6 @@ auto PPU::readIO(n32 address) -> n8 {
   //GRSWP
   case 0x0400'0002: return io.greenSwap;
   case 0x0400'0003: return 0;
-
-  //DISPSTAT
-  case 0x0400'0004: return (
-    io.vblank          << 0
-  | io.hblank          << 1
-  | io.vcoincidence    << 2
-  | io.irqvblank       << 3
-  | io.irqhblank       << 4
-  | io.irqvcoincidence << 5
-  );
-  case 0x0400'0005: return (
-    io.vcompare
-  );
-
-  //VCOUNT
-  case 0x0400'0006: return io.vcounter.byte(0);
-  case 0x0400'0007: return io.vcounter.byte(1);
 
   //BG0CNT
   case 0x0400'0008: return bg0.io.priority << 0 | bg0.io.characterBase << 2 | bg0.io.unused << 4 | bg0.io.mosaic << 6 | bg0.io.colorMode << 7;
@@ -103,6 +88,8 @@ auto PPU::readIO(n32 address) -> n8 {
 }
 
 auto PPU::writeIO(n32 address, n8 data) -> void {
+  cpu.synchronize(ppu);
+
   switch(address) {
 
   //DISPCNT
@@ -133,16 +120,6 @@ auto PPU::writeIO(n32 address, n8 data) -> void {
     io.greenSwap = data.bit(0);
     return;
   case 0x0400'0003:
-    return;
-
-  //DISPSTAT
-  case 0x0400'0004:
-    io.irqvblank       = data.bit(3);
-    io.irqhblank       = data.bit(4);
-    io.irqvcoincidence = data.bit(5);
-    return;
-  case 0x0400'0005:
-    io.vcompare = data;
     return;
 
   //BG0CNT

--- a/ares/gba/ppu/object.cpp
+++ b/ares/gba/ppu/object.cpp
@@ -4,7 +4,6 @@ auto PPU::Objects::setEnable(n1 status) -> void {
 }
 
 auto PPU::Objects::scanline(u32 y) -> void {
-  memory::move(io.enable, io.enable + 1, sizeof(io.enable) - 1);
   if(y >= 160) return;
 
   mosaicOffset = 0;
@@ -81,7 +80,7 @@ auto PPU::Objects::scanline(u32 y) -> void {
   }
 }
 
-auto PPU::Objects::run(u32 x, u32 y) -> void {
+auto PPU::Objects::outputPixel(u32 x, u32 y) -> void {
   output = {};
   if(ppu.blank() || !io.enable[0]) {
     mosaic = {};

--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -93,6 +93,11 @@ auto PPU::cycleRenderBG(u32 x, u32 y) -> void {
 }
 
 auto PPU::cycleUpperLayer(u32 x, u32 y) -> void {
+  ppu.bg0.outputPixel(x, y);
+  ppu.bg1.outputPixel(x, y);
+  ppu.bg2.outputPixel(x, y);
+  ppu.bg3.outputPixel(x, y);
+  ppu.objects.outputPixel(x, y);
   window0.run(x, y);
   window1.run(x, y);
   window2.output = objects.output.window;

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -292,8 +292,6 @@ private:
     i16 pc;
     i16 pd;
   } objectParam[32];
-  
-  n1 videoCapture = 0;
 };
 
 extern PPU ppu;

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -79,16 +79,6 @@ private:
     n1  gameBoyColorMode;
     n1  forceBlank[4];
     n1  greenSwap;
-
-    n1  vblank;
-    n1  hblank;
-    n1  vcoincidence;
-    n1  irqvblank;
-    n1  irqhblank;
-    n1  irqvcoincidence;
-    n8  vcompare;
-
-    n16 vcounter;
   } io;
 
   struct Pixel {

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -37,7 +37,7 @@ struct PPU : Thread, IO {
   auto blank() -> bool;
 
   auto step(u32 clocks) -> void;
-  template<u32> auto cycleLinear(u32 x, u32 y) -> void;;
+  template<u32> auto cycleLinear(u32 x, u32 y) -> void;
   template<u32> auto cycleAffine(u32 x, u32 y) -> void;
   auto cycleBitmap(u32 x, u32 y) -> void;
   auto cycleUpperLayer(u32 x, u32 y) -> void;

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -37,6 +37,9 @@ struct PPU : Thread, IO {
   auto blank() -> bool;
 
   auto step(u32 clocks) -> void;
+  auto cycleRenderBG(u32 x, u32 y) -> void;
+  auto cycleUpperLayer(u32 x, u32 y) -> void;
+  template<u32> auto cycle(u32 y) -> void;
   auto main() -> void;
 
   auto frame() -> void;
@@ -106,6 +109,7 @@ private:
     //background.cpp
     auto setEnable(n1 status) -> void;
     auto scanline(u32 y) -> void;
+    auto outputPixel(u32 x, u32 y) -> void;
     auto run(u32 x, u32 y) -> void;
     auto linear(u32 x, u32 y) -> void;
     auto affine(u32 x, u32 y) -> void;
@@ -157,7 +161,7 @@ private:
       n4 palette;
     } latch;
 
-    Pixel output;
+    Pixel output[240];
     Pixel mosaic;
     u32 mosaicOffset;
 
@@ -172,7 +176,7 @@ private:
     //object.cpp
     auto setEnable(n1 status) -> void;
     auto scanline(u32 y) -> void;
-    auto run(u32 x, u32 y) -> void;
+    auto outputPixel(u32 x, u32 y) -> void;
     auto power() -> void;
 
     //object.cpp
@@ -219,8 +223,9 @@ private:
 
   struct DAC {
     //dac.cpp
-    auto upperLayer() -> bool;
-    auto lowerLayer() -> void;
+    auto scanline(u32 y) -> void;
+    auto upperLayer(u32 x, u32 y) -> void;
+    auto lowerLayer(u32 x, u32 y) -> void;
     auto pramLookup(Pixel& layer) -> n15;
     auto blend(n15 above, u32 eva, n15 below, u32 evb) -> n15;
     auto power() -> void;
@@ -241,8 +246,11 @@ private:
     u32 aboveLayer;
     u32 belowLayer;
     n15 color;
+    n1  blending;
 
     Pixel layers[6];
+
+    u32* line = nullptr;
   } dac;
 
   struct Object {

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -37,7 +37,9 @@ struct PPU : Thread, IO {
   auto blank() -> bool;
 
   auto step(u32 clocks) -> void;
-  auto cycleRenderBG(u32 x, u32 y) -> void;
+  template<u32> auto cycleLinear(u32 x, u32 y) -> void;;
+  template<u32> auto cycleAffine(u32 x, u32 y) -> void;
+  auto cycleBitmap(u32 x, u32 y) -> void;
   auto cycleUpperLayer(u32 x, u32 y) -> void;
   template<u32> auto cycle(u32 y) -> void;
   auto main() -> void;
@@ -102,7 +104,8 @@ private:
     auto outputPixel(u32 x, u32 y) -> void;
     auto run(u32 x, u32 y) -> void;
     auto linear(u32 x, u32 y) -> void;
-    auto affine(u32 x, u32 y) -> void;
+    auto affineFetchTileMap(u32 x, u32 y) -> void;
+    auto affineFetchTileData(u32 x, u32 y) -> void;
     auto bitmap(u32 x, u32 y) -> void;
     auto power(u32 id) -> void;
 
@@ -150,6 +153,16 @@ private:
       n1 vflip;
       n4 palette;
     } latch;
+
+    struct Affine {
+      u32 screenSize;
+      u32 screenWrap;
+      u32 cx;
+      u32 cy;
+      u32 tx;
+      u32 ty;
+      n8  character;
+    } affine;
 
     Pixel output[240];
     Pixel mosaic;

--- a/ares/gba/ppu/serialization.cpp
+++ b/ares/gba/ppu/serialization.cpp
@@ -7,16 +7,6 @@ auto PPU::serialize(serializer& s) -> void {
   s(io.gameBoyColorMode);
   for(auto& flag : io.forceBlank) s(flag);
   s(io.greenSwap);
-  s(io.vblank);
-  s(io.hblank);
-  s(io.vcoincidence);
-  s(io.irqvblank);
-  s(io.irqhblank);
-  s(io.irqvcoincidence);
-  s(io.vcompare);
-  s(io.vcounter);
-
-  s(videoCapture);
 
   s(Background::IO::mode);
   s(Background::IO::frame);

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v141.3";
+static const string SerializerVersion = "v141.4";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);
@@ -44,5 +44,6 @@ auto System::serialize(serializer& s, bool synchronize) -> void {
   s(cpu);
   s(ppu);
   s(apu);
+  s(display);
   s(player);
 }

--- a/ares/gba/system/system.cpp
+++ b/ares/gba/system/system.cpp
@@ -71,6 +71,7 @@ auto System::load(Node::System& root, string name) -> bool {
   cpu.load(node);
   ppu.load(node);
   apu.load(node);
+  display.load(node);
   cartridgeSlot.load(node);
   return true;
 }
@@ -87,6 +88,7 @@ auto System::unload() -> void {
   cpu.unload();
   ppu.unload();
   apu.unload();
+  display.unload();
   cartridgeSlot.unload();
   pak.reset();
   node.reset();
@@ -100,6 +102,7 @@ auto System::power(bool reset) -> void {
   cpu.power();
   ppu.power();
   apu.power();
+  display.power();
   cartridge.power();
   scheduler.power(cpu);
 }


### PR DESCRIPTION
The pixel accuracy setting will now emulate the sub-pixel timing behaviours for bitmap and affine backgrounds described in [fleroviux's PPU docs](https://github.com/nba-emu/hw-docs/blob/main/src/ppu/background.md).

This PR also splits the PPU into two separate libco threads: one for rendering and one for raising IRQs and starting DMAs. This allows the CPU and PPU to be run more asynchronously, which helps mitigate the performance cost of finer-grained PPU emulation.