### PR TITLE
n64: improve VI timings and interrupts

### DIFF
--- a/ares/n64/vi/io.cpp
+++ b/ares/n64/vi/io.cpp
@@ -32,7 +32,7 @@ auto VI::readWord(u32 address, Thread& thread) -> u32 {
 
   if(address == 4) {
     //VI_V_CURRENT_LINE
-    data.bit(0)   = io.field & io.serrate;
+    data.bit(0)   = io.field;
     data.bit(1,9) = io.vcounter;
   }
 
@@ -52,7 +52,7 @@ auto VI::readWord(u32 address, Thread& thread) -> u32 {
   if(address == 7) {
     //VI_H_SYNC
     data.bit( 0,11) = io.quarterLineDuration;
-    data.bit(16,20) = io.palLeapPattern;
+    data.bit(16,20) = io.leapPattern;
   }
 
   if(address == 8) {
@@ -145,14 +145,14 @@ auto VI::writeWord(u32 address, u32 data_, Thread& thread) -> void {
   }
 
   if(address == 6) {
-    //VI_V_SYNC
+    //VI_V_TOTAL
     io.halfLinesPerField = data.bit(0,9);
   }
 
   if(address == 7) {
-    //VI_H_SYNC
+    //VI_H_TOTAL
     io.quarterLineDuration = data.bit( 0,11);
-    io.palLeapPattern      = data.bit(16,20);
+    io.leapPattern         = data.bit(16,20);
   }
 
   if(address == 8) {

--- a/ares/n64/vi/serialization.cpp
+++ b/ares/n64/vi/serialization.cpp
@@ -17,7 +17,7 @@ auto VI::serialize(serializer& s) -> void {
   s(io.colorBurstHsync);
   s(io.halfLinesPerField);
   s(io.quarterLineDuration);
-  s(io.palLeapPattern);
+  s(io.leapPattern);
   s(io.hsyncLeap);
   s(io.hend);
   s(io.hstart);
@@ -31,4 +31,7 @@ auto VI::serialize(serializer& s) -> void {
   s(io.ysubpixel);
   s(io.vcounter);
   s(io.field);
+  s(io.leapCounter);
+
+  s(clockFraction);
 }

--- a/ares/n64/vi/vi.hpp
+++ b/ares/n64/vi/vi.hpp
@@ -17,10 +17,12 @@ struct VI : Thread, Memory::RCP<VI> {
   //vi.cpp
   auto load(Node::Object) -> void;
   auto unload() -> void;
+  auto step(u32 clocks) -> void;
 
   auto main() -> void;
   auto refresh() -> void;
   auto power(bool reset) -> void;
+  auto active() -> bool { return io.colorDepth != 0; }
 
   //io.cpp
   auto readWord(u32 address, Thread& thread) -> u32;
@@ -46,7 +48,7 @@ struct VI : Thread, Memory::RCP<VI> {
     n10 colorBurstHsync;
     n10 halfLinesPerField;
     n12 quarterLineDuration;
-    n5  palLeapPattern;
+    n5  leapPattern;
     n12 hsyncLeap[2];
     n10 hend;
     n10 hstart;
@@ -62,7 +64,10 @@ struct VI : Thread, Memory::RCP<VI> {
   //internal:
     n9  vcounter;
     n1  field;
+    n3  leapCounter;
   } io;
+
+  u32 clockFraction;
 
 //unserialized:
   bool refreshed;


### PR DESCRIPTION
This commit implements correct VI timings using VI registers rather than hardcoding the behavior for the default presets made by commercial games. This makes Ares behaves correctly, timing-wise, also with non standard timing like eg: the so-called PAL60 mode.

Moreover, it fixes VI interrupts in interlaced mode to happen on the exact scanline they happen on the hardware, including known hardware bugs.