### PR TITLE
build: Remove macos-compat, establish appropriate minimum macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,12 +51,8 @@ jobs:
           windres: rc
           shell: bash
           msvc-arch: x64_arm64
-        - name: macos-compat
-          os: macos-12
-          compiler: clang++
-          shell: sh
-        - name: macos-latest
-          os: macos-latest
+        - name: macos-universal
+          os: macos-15
           compiler: clang++
           shell: sh
         - name: ubuntu
@@ -120,22 +116,14 @@ jobs:
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'
       run: |
-        if [ $ImageOS == "macos14" ]; then
-            sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
-            export MACOSX_DEPLOYMENT_TARGET=10.13
-            echo "Set Xcode version to 15.2 for macos-latest build."
-        elif [ $ImageOS == "macos12" ]; then
-            sudo xcode-select -s /Applications/Xcode_13.4.app/Contents/Developer
-            export MACOSX_DEPLOYMENT_TARGET=10.9
-            echo "Set Xcode version to 13.4 for macos-compat build."
-        fi
-        brew install make ninja cmake
+        sudo xcode-select -s /Applications/Xcode_16.1.0.app/Contents/Developer
+        export MACOSX_DEPLOYMENT_TARGET=10.13
+        brew install ninja cmake
         pip install --no-input setuptools
         rustup toolchain install nightly
         rustup default nightly
         rustup target add x86_64-apple-darwin
         rustup target add aarch64-apple-darwin
-        echo "MAKE=gmake" >> $GITHUB_ENV
         pushd thirdparty/SDL
         ./build-SDL.sh
         popd
@@ -216,10 +204,9 @@ jobs:
         bindir="${GITHUB_WORKSPACE}/bin"
 
         # Hack: Workaround for GitHub artifacts losing attributes.
-        chmod +x ${bindir}/ares-macos-latest/ares.app/Contents/MacOS/ares
-        chmod +x ${bindir}/ares-macos-compat/ares.app/Contents/MacOS/ares
+        chmod +x ${bindir}/ares-macos-universal/ares.app/Contents/MacOS/ares
 
-        for package in windows windows-msvc-arm64 macos-latest macos-compat
+        for package in windows windows-msvc-arm64 macos-universal
         do
           mkdir "${package}"
           cd "${package}"
@@ -319,14 +306,10 @@ jobs:
       uses: actions/upload-release-asset@v1
       env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' }
       with: { upload_url: '${{ env.UPLOAD_URL }}', asset_path: 'ares-windows-msvc-arm64.zip', asset_name: 'ares-windows-msvc-arm64.zip', asset_content_type: 'application/zip' }      
-    - name: Upload ares-macos-latest
+    - name: Upload ares-macos-universal
       uses: actions/upload-release-asset@v1
       env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' }
-      with: { upload_url: '${{ env.UPLOAD_URL }}', asset_path: 'ares-macos-latest.zip', asset_name: 'ares-macos-latest.zip', asset_content_type: 'application/zip' }
-    - name: Upload ares-macos-compat
-      uses: actions/upload-release-asset@v1
-      env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' }
-      with: { upload_url: '${{ env.UPLOAD_URL }}', asset_path: 'ares-macos-compat.zip', asset_name: 'ares-macos-compat.zip', asset_content_type: 'application/zip' }
+      with: { upload_url: '${{ env.UPLOAD_URL }}', asset_path: 'ares-macos-universal.zip', asset_name: 'ares-macos-universal.zip', asset_content_type: 'application/zip' }
 #  - name: Upload ares-ubuntu
 #      uses: actions/upload-release-asset@v1
 #      env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' }

--- a/desktop-ui/resource/ares.plist
+++ b/desktop-ui/resource/ares.plist
@@ -2,38 +2,38 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>LSApplicationCategoryType</key>
-  <string>public.app-category.games</string>
-  <key>CFBundleIdentifier</key>
-  <string>dev.ares.ares</string>
-  <key>CFBundleDisplayName</key>
-  <string>ares</string>
-  <key>CFBundleExecutable</key>
-  <string>ares</string>
-  <key>CFBundleIconFile</key>
-  <string>ares.icns</string>
-  <key>CFBundlePackageType</key>
-  <string>APPL</string>
-  <key>NSHighResolutionCapable</key>
-  <true/>
-  <key>NSSupportsAutomaticGraphicsSwitching</key>
-  <true/>
-  <key>LSMinimumSystemVersion</key>
-  <string>10.9</string>
-  <key>NSHumanReadableCopyright</key>
-  <string>Copyright © ares Team and Contributors.</string>
-  <key>CFBundleDocumentTypes</key>
-  <array>
-    <dict>
-      <key>CFBundleTypeExtensions</key>
-      <array>
-        <string>*</string>
-      </array>
-      <key>CFBundleTypeName</key>
-      <string>DocumentType</string>
-      <key>CFBundleTypeRole</key>
-      <string>Viewer</string>
-     </dict>
-  </array>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
+	<key>CFBundleIdentifier</key>
+	<string>dev.ares.ares</string>
+	<key>CFBundleDisplayName</key>
+	<string>ares</string>
+	<key>CFBundleExecutable</key>
+	<string>ares</string>
+	<key>CFBundleIconFile</key>
+	<string>ares.icns</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.13</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © ares Team and Contributors.</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>*</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>DocumentType</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -310,8 +310,8 @@ endif
 
 # macos settings
 ifeq ($(platform),macos)
-  flags   += -mmacosx-version-min=10.9 -Wno-auto-var-id -Wno-deprecated-declarations -fobjc-arc
-  options += -lc++ -lobjc -mmacosx-version-min=10.9
+  flags   += -mmacosx-version-min=10.13 -Wno-auto-var-id -Wno-deprecated-declarations -fobjc-arc
+  options += -lc++ -lobjc -mmacosx-version-min=10.13
   # allow mprotect() on dynamic recompiler code blocks
   options += -Wl,-segprot,__DATA,rwx,rw
 endif

--- a/scripts/macos-make-universal.sh
+++ b/scripts/macos-make-universal.sh
@@ -15,10 +15,10 @@ fi
 cd "$(dirname "$0")"/.. || exit 1
 
 echo "Building for amd64..."
-gmake arch=amd64 object.path=obj-amd64 output.path=out-amd64 "$@"
+make arch=amd64 object.path=obj-amd64 output.path=out-amd64 "$@"
 
 echo "Building for arm64..."
-gmake arch=arm64 object.path=obj-arm64 output.path=out-arm64 "$@"
+make arch=arm64 object.path=obj-arm64 output.path=out-arm64 "$@"
 
 echo "Assembling universal binary"
 rm -rf desktop-ui/out

--- a/thirdparty/SDL/build-sdl.sh
+++ b/thirdparty/SDL/build-sdl.sh
@@ -12,15 +12,7 @@ pushd SDL/build
 
 SDLARGS=()
 SDLARGS+=("-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64")
-if [ -n "${GITHUB_ACTIONS+1}" ]; then
-    if [ $ImageOS == "macos12" ]; then
-        SDLARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=10.11)
-        echo "Added 10.11 deployment target to SDL build arguments"
-    elif [ $ImageOS == "macos14" ]; then
-        SDLARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13)
-        echo "Added 10.13 deployment target to SDL build arguments"
-    fi
-fi
+SDLARGS+=("-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13")
 
 cmake .. "${SDLARGS[@]}"
 cmake --build .


### PR DESCRIPTION
* Remove `macos-compat`, since the macOS 12 runner is no longer in GitHub Actions, so we can no longer target macOS 10.9
* Rename the macOS build to "macos-universal", reflecting the OS and arch
* Don't install `make` via brew any more, since it isn't necessary
* Establish the macOS version minimum as 10.13
    * 10.9 was not a proper target, because of `fstatat` usage, which isn't available on macOS 10.9. On a code level, we may technically be compatible with macOS 10.10, but because no available build environment can target this macOS version, it makes no sense to support it without being able to test it. Since we can deploy for macOS 10.13, just establish this version as the minimum. If someone wants to compile themselves for lower macOS versions, they should still be able to.
* Increment the macOS runner for the primary macOS build to macOS 15, and the Xcode version to Xcode 16.1.
    * Better to explicitly pick the macOS and Xcode version rather than using `macos-latest` as the runner, even though they refer to the same thing, just so that we have explicit versioning wherever possible.

Not tested; CI run needed.