### PR TITLE
Don't default to 'Text' column visibility being false in firmware window

### DIFF
--- a/desktop-ui/settings/firmware.cpp
+++ b/desktop-ui/settings/firmware.cpp
@@ -17,7 +17,7 @@ auto FirmwareSettings::construct() -> void {
 auto FirmwareSettings::refresh() -> void {
   firmwareList.reset();
   firmwareList.append(TableViewColumn().setText("Emulator"));
-  firmwareList.append(TableViewColumn().setText("Type").setVisible(false));
+  firmwareList.append(TableViewColumn().setText("Type"));
   firmwareList.append(TableViewColumn().setText("Region"));
   firmwareList.append(TableViewColumn().setText("Location").setExpandable());
 


### PR DESCRIPTION
The "Type" column in the Settings > Firmware table view was being set to false by default. As there is no visibility handling for columns in hiro for Windows or Cocoa, this column would always be visible. But in the hiro GTK table view definition (there is also a visibility implementation for Qt) it did contain a function to disable/enable a specific column so this column would be absent on Linux distros making it look like there were duplicate entries in the table. This PR removes removes the call setting visibility by default so that the column is always visible. 