### PR TITLE
n64: step rsp dma during rsp execution

### DIFF
--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -67,7 +67,6 @@ auto CPU::synchronize() -> void {
 
   queue.step(clocks, [](u32 event) {
     switch(event) {
-    case Queue::RSP_DMA:       return rsp.dmaTransferStep();
     case Queue::PI_DMA_Read:   return pi.dmaFinished();
     case Queue::PI_DMA_Write:  return pi.dmaFinished();
     case Queue::PI_BUS_Write:  return pi.writeFinished();

--- a/ares/n64/n64.hpp
+++ b/ares/n64/n64.hpp
@@ -68,7 +68,6 @@ namespace ares::Nintendo64 {
 
   struct Queue : priority_queue<u32[512]> {
     enum : u32 {
-      RSP_DMA,
       PI_DMA_Read,
       PI_DMA_Write,
       PI_BUS_Write,

--- a/ares/n64/rsp/io.cpp
+++ b/ares/n64/rsp/io.cpp
@@ -100,7 +100,7 @@ auto RSP::ioWrite(u32 address, u32 data_, Thread& thread) -> void {
     dma.full.read  = 1;
     dma.full.write = 0;
     // printf("RSP DMA Read: %08x => %08x %08x\n", dma.pending.dramAddress, dma.pending.pbusAddress, dma.pending.length);
-    dmaTransferStart();
+    dmaTransferStart(thread);
   }
 
   if(address == 3) {
@@ -112,7 +112,7 @@ auto RSP::ioWrite(u32 address, u32 data_, Thread& thread) -> void {
     dma.pending.originPc = dma.pending.originCpu ? cpu.ipu.pc : (u64)rsp.ipu.r[31].u32;
     dma.full.write = 1;
     dma.full.read  = 0;
-    dmaTransferStart();
+    dmaTransferStart(thread);
   }
 
   if(address == 4) {

--- a/ares/n64/rsp/rsp.cpp
+++ b/ares/n64/rsp/rsp.cpp
@@ -31,8 +31,15 @@ auto RSP::unload() -> void {
 
 auto RSP::main() -> void {
   while(Thread::clock < 0) {
-    if(status.halted) return step(128);
-    instruction();
+    auto clock = Thread::clock;
+
+    if(status.halted) {
+      step(128);
+    } else {
+      instruction();
+    }
+
+    dmaStep(Thread::clock - clock);
   }
 }
 

--- a/ares/n64/rsp/rsp.hpp
+++ b/ares/n64/rsp/rsp.hpp
@@ -208,7 +208,9 @@ struct RSP : Thread, Memory::RCP<RSP> {
   } pipeline;
 
   //dma.cpp
-  auto dmaTransferStart() -> void;
+  auto dmaQueue(u32 clocks, Thread& thread) -> void;
+  auto dmaStep(u32 clocks) -> void;
+  auto dmaTransferStart(Thread& thread) -> void;
   auto dmaTransferStep() -> void;
 
   //io.cpp
@@ -240,6 +242,8 @@ struct RSP : Thread, Memory::RCP<RSP> {
 
       auto any() -> n1 { return read | write; }
     } busy, full;
+
+    s64 clock;
   } dma;
 
   struct Status : Memory::RCP<Status> {

--- a/ares/n64/rsp/serialization.cpp
+++ b/ares/n64/rsp/serialization.cpp
@@ -18,6 +18,7 @@ auto RSP::serialize(serializer& s) -> void {
   s(dma.busy.write);
   s(dma.full.read);
   s(dma.full.write);
+  s(dma.clock);
 
   s(status.semaphore);
   s(status.halted);

--- a/ares/n64/system/serialization.cpp
+++ b/ares/n64/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v135";
+static const string SerializerVersion = "v141.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   serializer s;


### PR DESCRIPTION
Instead of advancing RSP DMA only after each CPU basic block, allow it to run between each RSP block. This prevents the RSP from racing with the DMAs it initiates in the event of a long running CPU block (which can trigger multiple consecutive blocks of RSP execution).

This fixes hangs in Tarzan and possibly other games that use MusyX.

Another observable side effect of this change is that when the RSP is halted, it no longer risks falling increasingly behind the CPU, because ares will now step multiple times if needed instead of just once.