### PR TITLE
Implement the hex editor widget for Cocoa and enable memory editor on macOS

### DIFF
--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -179,12 +179,9 @@ Presentation::Presentation() {
   cheatEditorAction.setText("Cheats").setIcon(Icon::Emblem::File).onActivate([&] {
     toolsWindow.show("Cheats");
   });
-  #if !defined(PLATFORM_MACOS)
-  // Cocoa hiro is missing the hex editor widget
   memoryEditorAction.setText("Memory").setIcon(Icon::Device::Storage).onActivate([&] {
     toolsWindow.show("Memory");
   });
-  #endif
   graphicsViewerAction.setText("Graphics").setIcon(Icon::Emblem::Image).onActivate([&] {
     toolsWindow.show("Graphics");
   });

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -66,10 +66,7 @@ struct Presentation : Window {
       MenuSeparator toolsMenuSeparatorB{&toolsMenu};
       MenuItem manifestViewerAction{&toolsMenu};
       MenuItem cheatEditorAction{&toolsMenu};
-      #if !defined(PLATFORM_MACOS)
-      // Cocoa hiro is missing the hex editor widget
       MenuItem memoryEditorAction{&toolsMenu};
-      #endif
       MenuItem graphicsViewerAction{&toolsMenu};
       MenuItem streamManagerAction{&toolsMenu};
       MenuItem propertiesViewerAction{&toolsMenu};

--- a/desktop-ui/tools/tools.cpp
+++ b/desktop-ui/tools/tools.cpp
@@ -21,10 +21,10 @@ ToolsWindow::ToolsWindow() {
 
   panelList.append(ListViewItem().setText("Manifest").setIcon(Icon::Emblem::Binary));
   panelList.append(ListViewItem().setText("Cheats").setIcon(Icon::Emblem::Text));
-#if !defined(PLATFORM_MACOS)
+
   // Cocoa hiro is missing the hex editor widget
   panelList.append(ListViewItem().setText("Memory").setIcon(Icon::Device::Storage));
-#endif
+
   panelList.append(ListViewItem().setText("Graphics").setIcon(Icon::Emblem::Image));
   panelList.append(ListViewItem().setText("Streams").setIcon(Icon::Emblem::Audio));
   panelList.append(ListViewItem().setText("Properties").setIcon(Icon::Emblem::Text));

--- a/hiro/cocoa/widget/hex-edit.cpp
+++ b/hiro/cocoa/widget/hex-edit.cpp
@@ -5,43 +5,157 @@
 -(id) initWith:(hiro::mHexEdit&)hexEditReference {
   if(self = [super initWithFrame:NSMakeRect(0, 0, 0, 0)]) {
     hexEdit = &hexEditReference;
+    if (tableView = [[NSTableView alloc] initWithFrame:[self bounds]]) {
+      [tableView setDataSource:self];
+      [tableView setHeaderView:nil];
+      
+      // remove padding and stuff to fit all 16 columns
+      [tableView setIntercellSpacing:NSMakeSize(0, 0)];
+      [tableView setStyle:NSTableViewStylePlain];
+      NSTableColumn* addressCol = [[NSTableColumn alloc] initWithIdentifier:@"Address"];
+      addressCol.editable = NO;
+      [tableView addTableColumn:addressCol];
+      
+      for (int i = 0; i < hexEdit->columns(); i++) {
+        NSTableColumn* col = [[NSTableColumn alloc] initWithIdentifier:[NSString stringWithFormat:@"%d",
+                                                                        i]];
+        col.width = 20;
+        col.title = @"";
+        [tableView addTableColumn:col];
+      }
+      /*
+       NSTableColumn* hexCol = [[NSTableColumn alloc] initWithIdentifier:@"Hex"];
+       [hexCol setTitle:@"Hex"];
+       [tableView addTableColumn:hexCol];
+       */
+      
+      NSTableColumn* ansiCol = [[NSTableColumn alloc] initWithIdentifier:@"ANSI"];
+      ansiCol.editable = NO;
+      [tableView addTableColumn:ansiCol];
+      
+      // must programmatically do this so the table shows up.
+      [self setDocumentView:tableView];
+      [self setHasVerticalScroller:YES];
+    }
   }
   return self;
+}
+
+- (NSTableView *) tableView {
+  return tableView;
+}
+
+- (NSInteger) numberOfRowsInTableView:(NSTableView *)tableView {
+  return hexEdit->rows();
+}
+
+-(id) tableView:(NSTableView *) tableView
+objectValueForTableColumn:(NSTableColumn *) tableColumn
+            row:(NSInteger) row {
+  // return a string with the content of (row, column)
+  u32 address = hexEdit->address() + row * hexEdit->columns();
+  // address only
+  if ([[tableColumn identifier] isEqualToString:@"Address"]) {
+    return [NSString stringWithUTF8String:hex(address, 8L).data()];
+  } else if ([[tableColumn identifier] isEqualToString:@"ANSI"]){
+    // create the ansi string by concatenating
+    NSMutableString *output = [NSMutableString stringWithCapacity:hexEdit->columns()];
+    for (auto column : range(hexEdit->columns())) {
+      if (address < hexEdit->length()) {
+        u8 data = hexEdit->doRead(address++);
+        [output appendString:[NSString stringWithFormat:@"%c",
+                              (data >= 0x20 && data <= 0x7e ? (char)data : '.')]];
+      }
+    }
+    return output;
+  } else {
+    // return only the single byte at the correct position
+    NSInteger columnNumber = [tableColumn.identifier integerValue];
+    address += columnNumber;
+    if (address < hexEdit->length()) {
+      u8 data = hexEdit->doRead(address);
+      return [NSString stringWithUTF8String:hex(data, 2L).data()];
+    } else {
+      return @"  ";
+    }
+  }
+}
+
+-(void) tableView:(NSTableView *) tableView
+   setObjectValue:(id) object
+   forTableColumn:(NSTableColumn *) tableColumn
+              row:(NSInteger) row {
+  // when table is edited, modify underlying data source
+  NSInteger colNumber = [tableColumn.identifier integerValue];
+  u32 address = hexEdit->address() + row * hexEdit->columns() + colNumber;
+  
+  // unclear if this is needed, but just to make sure the cast is safe
+  if ([object isKindOfClass:[NSString class]]) {
+    if (address < hexEdit->length()) {
+      // only get the first 2 characters
+      NSString* newVal = [(NSString *)object substringToIndex:2];
+      NSScanner* hexScanner = [NSScanner scannerWithString:newVal];
+      unsigned int data = 0;
+      if ([hexScanner scanHexInt:&data]) {
+        // this.......is probably ok....???
+        hexEdit->doWrite(address, (u8)data);
+      }
+    }
+    
+  }
+  [tableView reloadData];
 }
 
 @end
 
 namespace hiro {
-
-auto pHexEdit::construct() -> void {
-  cocoaView = cocoaHexEdit = [[CocoaHexEdit alloc] initWith:self()];
-}
-
-auto pHexEdit::destruct() -> void {
-  [cocoaView removeFromSuperview];
-}
-
-auto pHexEdit::setAddress(u32 offset) -> void {
-}
-
-auto pHexEdit::setBackgroundColor(Color color) -> void {
-}
-
-auto pHexEdit::setColumns(u32 columns) -> void {
-}
-
-auto pHexEdit::setForegroundColor(Color color) -> void {
-}
-
-auto pHexEdit::setLength(u32 length) -> void {
-}
-
-auto pHexEdit::setRows(u32 rows) -> void {
-}
-
-auto pHexEdit::update() -> void {
-}
-
+  
+  auto pHexEdit::construct() -> void {
+    cocoaView = cocoaHexEdit = [[CocoaHexEdit alloc] initWith:self()];
+    pWidget::construct();
+    for (NSTableColumn *column in cocoaHexEdit.tableView.tableColumns) {
+      NSTextFieldCell *cell = column.dataCell;
+      
+      // Set the font for the data cell.
+      cell.font = [NSFont monospacedSystemFontOfSize:10 weight:NSFontWeightRegular];
+    }
+    update();
+  }
+  
+  auto pHexEdit::destruct() -> void {
+    [cocoaView removeFromSuperview];
+  }
+  
+  // these helper functions are unneeded, we can just reload the table data and
+  // it will automatically reflect the contents of hexEdit!
+  auto pHexEdit::setAddress(u32 offset) -> void {
+    update();
+  }
+  
+  auto pHexEdit::setBackgroundColor(Color color) -> void {
+    update();
+  }
+  
+  auto pHexEdit::setColumns(u32 columns) -> void {
+    update();
+  }
+  
+  auto pHexEdit::setForegroundColor(Color color) -> void {
+    update();
+  }
+  
+  auto pHexEdit::setLength(u32 length) -> void {
+    update();
+  }
+  
+  auto pHexEdit::setRows(u32 rows) -> void {
+    update();
+  }
+  
+  auto pHexEdit::update() -> void {
+    [[cocoaHexEdit tableView] reloadData];
+  }
+  
 }
 
 #endif

--- a/hiro/cocoa/widget/hex-edit.cpp
+++ b/hiro/cocoa/widget/hex-edit.cpp
@@ -9,6 +9,8 @@
       [tableView setDataSource:self];
       // [tableView setHeaderView:nil];
       [tableView setUsesAlternatingRowBackgroundColors:true];
+      [tableView setGridStyleMask:(NSTableViewDashedHorizontalGridLineMask | NSTableViewSolidVerticalGridLineMask)];
+      [tableView setRowHeight:14.0];
       
       // remove padding and stuff to fit all 16 columns
       [tableView setIntercellSpacing:NSMakeSize(0, 0)];
@@ -95,19 +97,15 @@ objectValueForTableColumn:(NSTableColumn *) tableColumn
   NSInteger colNumber = [tableColumn.identifier integerValue];
   u32 address = row * hexEdit->columns() + colNumber;
   
-  // unclear if this is needed, but just to make sure the cast is safe
-  if ([object isKindOfClass:[NSString class]]) {
-    if (address < hexEdit->length()) {
-      // only get the first 2 characters
-      NSString* newVal = [(NSString *)object substringToIndex:2];
-      NSScanner* hexScanner = [NSScanner scannerWithString:newVal];
-      unsigned int data = 0;
-      if ([hexScanner scanHexInt:&data]) {
-        // this.......is probably ok....???
-        hexEdit->doWrite(address, (u8)data);
-      }
+  if (address < hexEdit->length()) {
+    // only get the first 2 characters
+    NSString* newVal = [(NSString *)object substringToIndex:2];
+    NSScanner* hexScanner = [NSScanner scannerWithString:newVal];
+    unsigned int data = 0;
+    if ([hexScanner scanHexInt:&data]) {
+      // this.......is probably ok....???
+      hexEdit->doWrite(address, (u8)data);
     }
-    
   }
   [tableView reloadData];
 }
@@ -121,10 +119,10 @@ namespace hiro {
     pWidget::construct();
 
     for (NSTableColumn *column in cocoaHexEdit.tableView.tableColumns) {
-        if (@available(macOS 10.15, *)) {
+      if (@available(macOS 10.15, *)) {
         NSTextFieldCell *cell = column.dataCell;
-          NSTableHeaderCell *headerCell = column.headerCell;
-        
+        NSTableHeaderCell *headerCell = column.headerCell;
+      
         // Set the font for the data cell.
         cell.font = [NSFont monospacedSystemFontOfSize:10 weight:NSFontWeightRegular];
       }

--- a/hiro/cocoa/widget/hex-edit.cpp
+++ b/hiro/cocoa/widget/hex-edit.cpp
@@ -45,15 +45,21 @@
   return tableView;
 }
 
+- (hiro::mHexEdit *) hexEdit {
+  return hexEdit;
+}
+
+
 - (NSInteger) numberOfRowsInTableView:(NSTableView *)tableView {
-  return hexEdit->rows();
+  return (max(1, hexEdit->length()) + hexEdit->columns() - 1) / hexEdit->columns();
 }
 
 -(id) tableView:(NSTableView *) tableView
 objectValueForTableColumn:(NSTableColumn *) tableColumn
             row:(NSInteger) row {
   // return a string with the content of (row, column)
-  u32 address = hexEdit->address() + row * hexEdit->columns();
+  // u32 address = hexEdit->address() + row * hexEdit->columns();
+  u32 address = row * hexEdit->columns();
   // address only
   if ([[tableColumn identifier] isEqualToString:@"Address"]) {
     return [NSString stringWithUTF8String:hex(address, 8L).data()];
@@ -126,10 +132,10 @@ namespace hiro {
     [cocoaView removeFromSuperview];
   }
   
-  // these helper functions are unneeded, we can just reload the table data and
-  // it will automatically reflect the contents of hexEdit!
   auto pHexEdit::setAddress(u32 offset) -> void {
-    update();
+    mHexEdit* hexEdit = [cocoaHexEdit hexEdit];
+    int row = offset / hexEdit->columns();
+    [[cocoaHexEdit tableView] scrollRowToVisible:row];
   }
   
   auto pHexEdit::setBackgroundColor(Color color) -> void {

--- a/hiro/cocoa/widget/hex-edit.hpp
+++ b/hiro/cocoa/widget/hex-edit.hpp
@@ -1,10 +1,13 @@
 #if defined(Hiro_HexEdit)
 
-@interface CocoaHexEdit : NSScrollView {
+@interface CocoaHexEdit : NSScrollView <NSTableViewDataSource>  {
+  // Not an NSTableViewDelegate because the table is cell-based, not view-based
 @public
-  hiro::mHexEdit* hexEdit;
+  hiro::mHexEdit* hexEdit; // this will be the data source for tableView.
+  NSTableView* tableView;
 }
 -(id) initWith:(hiro::mHexEdit&)hexEdit;
+-(NSTableView*) tableView; // helper function used in update()
 @end
 
 namespace hiro {

--- a/hiro/cocoa/widget/hex-edit.hpp
+++ b/hiro/cocoa/widget/hex-edit.hpp
@@ -8,6 +8,7 @@
 }
 -(id) initWith:(hiro::mHexEdit&)hexEdit;
 -(NSTableView*) tableView; // helper function used in update()
+-(hiro::mHexEdit*) hexEdit;
 @end
 
 namespace hiro {


### PR DESCRIPTION
This PR adds the hex editor widget to Cocoa hiro and enables the memory editor in Tools. The widget is a cell-based NSTableView with data source the core hex editor widget and supports editing of memory (but not of the encoded ANSI).