### PR TITLE
fc: Save FDS disk when saving Famicom system

### DIFF
--- a/ares/fc/fds/fds.cpp
+++ b/ares/fc/fds/fds.cpp
@@ -81,6 +81,12 @@ auto FDS::connect() -> void {
 auto FDS::disconnect() -> void {
   if(!node) return;
 
+  save();
+  pak.reset();
+  node.reset();
+}
+
+auto FDS::save() -> void {
   if(disk1.sideA)
   if(auto fp = pak->write("disk1.sideA")) {
     disk1.sideA.save(fp);
@@ -100,9 +106,6 @@ auto FDS::disconnect() -> void {
   if(auto fp = pak->write("disk2.sideB")) {
     disk2.sideB.save(fp);
   }
-
-  pak.reset();
-  node.reset();
 }
 
 auto FDS::change(string value) -> void {

--- a/ares/fc/fds/fds.hpp
+++ b/ares/fc/fds/fds.hpp
@@ -34,6 +34,7 @@ struct FDS {
   auto change(string value) -> void;
   auto change() -> void;
 
+  auto save() -> void;
   auto poll() -> void;
   auto main() -> void;
   auto power() -> void;

--- a/ares/fc/system/system.cpp
+++ b/ares/fc/system/system.cpp
@@ -85,6 +85,7 @@ auto System::load(Node::System& root, string name) -> bool {
 auto System::save() -> void {
   if(!node) return;
   cartridge.save();
+  if(fds.present) fds.save();
 }
 
 auto System::unload() -> void {


### PR DESCRIPTION
This commit ensures that changes to the FDS disk get saved when the Famicom system saves (similar to how the 64DD works already). Without this, changes to the FDS disk were only written back to the pak in FDS::disconnect, _after_ the save on unloading/exit or any periodic autosaves.