### PR TITLE
build: Finalize CMake merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,7 @@ jobs:
 
      
   release:
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+    if: false
     runs-on: ubuntu-latest
     needs:
     - build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ add_subdirectory(hiro)
 set(
   ARES_CORES
   a26 fc sfc sg ms md ps1 pce ng msx cv myvision gb gba ws ngp spec n64
-  CACHE INTERNAL LIST
+  CACHE STRING LIST
 )
 # gersemi: on
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -86,7 +86,6 @@
         "ARES_CODESIGN_IDENTITY": {"type": "STRING", "value": "$penv{MACOS_CERTIFICATE_NAME}"},
         "ARES_CODESIGN_TEAM": {"type": "STRING", "value": "$penv{MACOS_NOTARIZATION_TEAMID}"},
         "ENABLE_CCACHE": true,
-        "ARES_VERSION_OVERRIDE": {"type": "STRING", "value": "v199"},
         "ARES_BUILD_LOCAL": false,
         "ARES_BUILD_OPTIONAL_TARGETS": true
       }
@@ -101,7 +100,6 @@
         "ENABLE_CCACHE": true,
         "ARES_BUILD_LOCAL": false,
         "ARES_BUILD_OPTIONAL_TARGETS": true,
-        "ARES_VERSION_OVERRIDE": {"type": "STRING", "value": "v199"},
         "ARES_PRECOMPILE_HEADERS": true
       }
     },


### PR DESCRIPTION
* Remove version overrides from CMakePresets.json
    * These were necessary for CI to run when CMake existed on the forked branch, but *should* no longer be necessary
* Disable release flows for the legacy build
    * Keep legacy builds running for the time being, but disable the release flow so it does not conflict with the new CI