### PR TITLE
desktop-ui/presentation: Add an alternative path for loading shaders on Linux and BSD

### DIFF
--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -690,6 +690,10 @@ auto Presentation::loadShaders() -> void {
   shaders.append(none);
 
   string location = locate("Shaders/");
+  #if defined(PLATFORM_LINUX) || defined(PLATFORM_BSD)
+  // In some Linux or BSD distro shaders may not be bundled with ares, so try to locate them at a different path
+  if(not inode::exists(location)) location = locate("../libretro/shaders/shaders_slang/");
+  #endif
 
   if(shaderDirectories.size() == 0) {
     function<void(string)> findShaderDirectories = [&](string path) {


### PR DESCRIPTION
On some Linux and BSD distribution, Ares from the repositories may not come with shaders preinstalled. Instead, these one may come from another package, for example on Archlinux the package `libretro-shaders-slang` installs the shaders in the following path: `/usr/share/libretro/shaders/shaders_slang/` . 

This will make Ares fail to load any shaders on these distro. So to fix it, this PR adds the aforementioned location as another path to search for, as a fallback.

I know, the two dots are a bit ugly, given that locate() normally doesn't search for files or directories outside of those of Ares...Ideally, locate() should be expanded to search the entire file system, but I'm afraid the required changes may be a bit more far reaching than expected.