### PR TITLE
md: vdp improvements, dots and stuff

### DIFF
--- a/ares/md/m32x/pwm.cpp
+++ b/ares/md/m32x/pwm.cpp
@@ -35,7 +35,7 @@ auto M32X::PWM::main() -> void {
   while(counter >= 522) {
     counter -= 522;
     auto left = cycle > 0 ? lsample / (f32)cycle : 0;
-    auto right = cycle > 0 ? lsample / (f32)cycle : 0;
+    auto right = cycle > 0 ? rsample / (f32)cycle : 0;
     stream->frame(left, right);
   }
 

--- a/ares/md/system/serialization.cpp
+++ b/ares/md/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v135";
+static const string SerializerVersion = "v141";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);

--- a/ares/md/vdp/main.cpp
+++ b/ares/md/vdp/main.cpp
@@ -3,24 +3,68 @@ auto VDP::step(u32 clocks) -> void {
   Thread::synchronize(cpu);
 }
 
-template<bool _h40> auto VDP::tick() -> void {
-  step(cycles[0] + cycles[1]);
-  cycles += 2;
-  state.hcounter++;
+template<bool _h40> auto VDP::fullslotStep() -> void {
+  // EDCLK hybrid rate : 15cyc @ MClk/5 + 2cyc @ MClk/4
+  static u8 EDCLK[17] = {5,5,5,5,5, 5,5,5,5,5, 5,5,5,5,5, 4,4};
+  if(( _h40 && latch.clockSelect && hcounter() >= 0xe6 && hcounter() <= 0xf6) ||
+     (!_h40 && latch.clockSelect && hcounter() >= 0xec && hcounter() <= 0xfc)) {
+    u32 q1 = EDCLK[state.edclkPos];
+    state.edclkPos = (state.edclkPos+1) % 17;
+    u32 q2 = EDCLK[state.edclkPos];
+    state.edclkPos = (state.edclkPos+1) % 17;
+    u32 q3 = EDCLK[state.edclkPos];
+    state.edclkPos = (state.edclkPos+1) % 17;
+    u32 q4 = EDCLK[state.edclkPos];
+    state.edclkPos = (state.edclkPos+1) % 17;
+    step(q1+q2+q3+q4);
+    return;
+  }
+  if(_h40)
+    step(4+4+4+4); // MClk/4
+  else
+    step(5+5+5+5); // MClk/5
+}
 
-  if(_h40) {
-    if(hcounter() == 0x00) hblank(0), vedge();
-    else if(hcounter() == 0xa3) vtick();
-    else if(hcounter() == 0xb3) hblank(1);
-    else if(hcounter() == 0xb6) state.hcounter = 0xe4;
-  } else {
-    if(hcounter() == 0x00) hblank(0), vedge();
-    else if(hcounter() == 0x83) vtick();
-    else if(hcounter() == 0x93) hblank(1);
-    else if(hcounter() == 0x94) state.hcounter = 0xe9;
+template<bool _h40, bool _refresh> auto VDP::tick() -> void {
+  // Run DMA here -- fifo & prefetch have ram priority, so somes ops may be blocked
+  dma.run();
+
+  fullslotStep<_h40>();
+  htick<_h40>(); // +2 pixels
+
+  if(cram.bus.active) {
+    vdp.dac.dot(hcounter()*2+1, cram.bus.data);
+    vdp.dac.dot(hcounter()*2+2, cram.bus.data);
+    // DAC dot artifacts may be drawn continuously in the case of consectutive writes.
+    // We can detect for this by checking for an impending CRAM write thru the fifo.
+    // If refresh or fifo delay occurs, the data will not be updated, resulting in an extended dot.
+    if(displayEnable() || fifo.slots[0].empty() || fifo.slots[0].target != 3) cram.bus.active = 0;
   }
 
-  irq.poll();
+  // There is reportedly a latch effect when enabling the display, but it might be a fixed delay
+  // rather than a wait until the fifo clears. So, this is precautionary and not necessily correct.
+  if(latch.displayEnable > io.displayEnable || fifo.empty())
+    latch.displayEnable = io.displayEnable;
+
+  if(_refresh) {
+    vram.refreshing = 1;
+
+    // The start of a DMA load will be aligned if it coincides with a refresh slot.
+    // The duration may differ between H32 & H40 due to pixel clock, or this may just
+    // be the result of some other emulation inaccuracy. Either way, this works for now.
+    if(dma.active && dma.preload > 0) dma.preload = h40()?6:4;
+  } else {
+    fifo.tick();
+
+    // When display is blanked, DMA load fetch may be performed in every slot
+    // except for refresh slots and any slot immediately following refresh.
+    if(dma.active && !vram.refreshing) dma.fetch();
+    vram.refreshing = 0;
+
+    if(dma.active && dma.preload > 0) dma.preload--;
+  }
+
+  state.rambusy = 1;
 }
 
 auto VDP::vblankcheck() -> void {
@@ -34,6 +78,26 @@ auto VDP::vblankcheck() -> void {
   }
 }
 
+template<bool _h40> auto VDP::htick() -> void {
+  state.hcounter++;
+
+  if(_h40) {
+    if(hcounter() == 0x00) vedge();
+    else if(hcounter() == 0x05) hblank(0);
+    else if(hcounter() == 0xa5) vtick();
+    else if(hcounter() == 0xb3) hblank(1);
+    else if(hcounter() == 0xb6) state.hcounter = 0xe4;
+  } else {
+    if(hcounter() == 0x00) vedge();
+    else if(hcounter() == 0x05) hblank(0);
+    else if(hcounter() == 0x85) vtick();
+    else if(hcounter() == 0x93) hblank(1);
+    else if(hcounter() == 0x94) state.hcounter = 0xe9;
+  }
+
+  irq.poll();
+}
+
 auto VDP::vtick() -> void {
   if(vblank()) {
     irq.hblank.counter = irq.hblank.frequency;
@@ -43,15 +107,10 @@ auto VDP::vtick() -> void {
     debugger.interrupt(CPU::Interrupt::HorizontalBlank);
   }
 
-  state.vcounter++;
-  if(v28()) {
-    if(vcounter() == 0x0eb && Region::NTSC()) state.vcounter = 0x1e5;
-    if(vcounter() == 0x103 && Region::PAL ()) state.vcounter = 0x1ca;
-  }
-  if(v30()) {
-    if(vcounter() == 0x200 && Region::NTSC()) state.vcounter = 0x000;
-    if(vcounter() == 0x10b && Region::PAL ()) state.vcounter = 0x1d2;
-  }
+  if(vcounter() == state.bottomline)
+    state.vcounter = state.topline;
+  else
+    state.vcounter++;
 
   vblankcheck();
 }
@@ -67,6 +126,7 @@ auto VDP::hblank(bool line) -> void {
 
 auto VDP::vblank(bool line) -> void {
   irq.vblank.transitioned |= state.vblank ^ line;
+  if(state.vblank > line) state.topline = vcounter();
   state.vblank = line;
 }
 
@@ -86,31 +146,32 @@ auto VDP::vedge() -> void {
 }
 
 auto VDP::slot() -> void {
-  if(!fifo.run()) prefetch.run();
-  dma.run();
-}
-
-auto VDP::refresh(bool active) -> void {
-  vram.refreshing = active;
+  state.rambusy = 0;
+  if(!(state.rambusy = fifo.run()))
+    state.rambusy = prefetch.run();
 }
 
 auto VDP::main() -> void {
   latch.displayWidth = io.displayWidth;
   latch.clockSelect  = io.clockSelect;
+  state.edclkPos = 0;
   if(h32()) mainH32();
+  else
   if(h40()) mainH40();
-  if(vcounter() == 0) {
+  if(vcounter() == state.bottomline) {
     screen->setColorBleedWidth(latch.displayWidth ? 4 : 5);
     latch.interlace = io.interlaceMode == 3;
     latch.overscan  = io.overscan;
     frame();
     state.field ^= 1;
+    updateScreenParams();
   }
 }
 
 auto VDP::mainH32() -> void {
-  auto pixels = dac.pixels = vdp.pixels();
-  cycles = &cyclesH32[edclk()][0];
+  dac.pixels = vdp.pixels();
+  auto pixels = dac.active = dac.pixels+13*5;
+  state.hcounter = 0;
 
   sprite.begin();
   if(dac.pixels) blocks<false, true>();
@@ -124,24 +185,30 @@ auto VDP::mainH32() -> void {
   layers.vscrollFetch();
   sprite.end();
 
-  for(auto cycle : range(13)) {
+  for(auto cycle : range(4)) {
     tick<false>(); sprite.patternFetch(cycle + 0);
   }
-  tick<false>(); slot();
   for(auto cycle : range(13)) {
-    tick<false>(); sprite.patternFetch(cycle + 13);
+    tick<false>(); sprite.patternFetch(cycle + 4); sprite.scan();
+  }
+  // Placement of this free slot conflicts with documentation by Nemesis which has it 4 slots earlier,
+  // but this works more reliably with the Direct Color DMA demos.
+  tick<false>(); slot();
+  // window begin call (reg latch) is placed here due to garbage line edge case in International Superstar Soccer Deluxe (E)
+  window.begin();
+  for(auto cycle : range(9)) {
+    tick<false>(); sprite.patternFetch(cycle + 17); sprite.scan();
   }
   tick<false>(); slot();
 
   layerA.begin();
   layerB.begin();
-  window.begin();
 
   tick<false>(); layers.hscrollFetch();
-  tick<false>(); sprite.patternFetch(26);
-  tick<false>(); sprite.patternFetch(27);
-  tick<false>(); sprite.patternFetch(28);
-  tick<false>(); sprite.patternFetch(29);
+  tick<false>(); sprite.patternFetch(26); sprite.scan();
+  tick<false>(); sprite.patternFetch(27); sprite.scan();
+  tick<false>(); sprite.patternFetch(28); sprite.scan();
+  tick<false>(); sprite.patternFetch(29); sprite.scan();
 
   layers.vscrollFetch(-1);
   layerA.attributesFetch();
@@ -149,18 +216,23 @@ auto VDP::mainH32() -> void {
   window.attributesFetch(-1);
 
   tick<false>(); layerA.mappingFetch(-1);
-  tick<false>(); !displayEnable() ? refresh(true) : sprite.patternFetch(30);
-  tick<false>(); layerA.patternFetch( 0); refresh(false);
-  tick<false>(); layerA.patternFetch( 1);
+  if(!displayEnable()) {
+    tick<false,true>(); //refresh
+  } else {
+    tick<false>(); sprite.patternFetch(30); sprite.scan();
+  }
+  tick<false>(); layerA.patternFetch( 0); sprite.scan();
+  tick<false>(); layerA.patternFetch( 1); sprite.scan();
   tick<false>(); layerB.mappingFetch(-1);
-  tick<false>(); sprite.patternFetch(31);
-  tick<false>(); layerB.patternFetch( 0);
-  tick<false>(); layerB.patternFetch( 1);
+  tick<false>(); sprite.patternFetch(31); sprite.scan();
+  tick<false>(); layerB.patternFetch( 0); sprite.scan();
+  tick<false>(); layerB.patternFetch( 1); sprite.scan();
 }
 
 auto VDP::mainH40() -> void {
-  auto pixels = dac.pixels = vdp.pixels();
-  cycles = &cyclesH40[edclk()][0];
+  dac.pixels = vdp.pixels();
+  auto pixels = dac.active = dac.pixels+13*4;
+  state.hcounter = 0;
 
   sprite.begin();
   if(dac.pixels) blocks<true, true>();
@@ -174,12 +246,15 @@ auto VDP::mainH40() -> void {
   layers.vscrollFetch();
   sprite.end();
 
-  for(auto cycle : range(23)) {
+  for(auto cycle : range(4)) {
     tick<true>(); sprite.patternFetch(cycle + 0);
+  }
+  for(auto cycle : range(19)) {
+    tick<true>(); sprite.patternFetch(cycle + 4); sprite.scan();
   }
   tick<true>(); slot();
   for(auto cycle : range(11)) {
-    tick<true>(); sprite.patternFetch(cycle + 23);
+    tick<true>(); sprite.patternFetch(cycle + 23); sprite.scan();
   }
 
   layerA.begin();
@@ -187,10 +262,10 @@ auto VDP::mainH40() -> void {
   window.begin();
 
   tick<true>(); layers.hscrollFetch();
-  tick<true>(); sprite.patternFetch(34);
-  tick<true>(); sprite.patternFetch(35);
-  tick<true>(); sprite.patternFetch(36);
-  tick<true>(); sprite.patternFetch(37);
+  tick<true>(); sprite.patternFetch(34); sprite.scan();
+  tick<true>(); sprite.patternFetch(35); sprite.scan();
+  tick<true>(); sprite.patternFetch(36); sprite.scan();
+  tick<true>(); sprite.patternFetch(37); sprite.scan();
 
   layers.vscrollFetch(-1);
   layerA.attributesFetch();
@@ -198,26 +273,35 @@ auto VDP::mainH40() -> void {
   window.attributesFetch(-1);
 
   tick<true>(); layerA.mappingFetch(-1);
-  tick<true>(); !displayEnable() ? refresh(true) : sprite.patternFetch(38);
-  tick<true>(); layerA.patternFetch( 0); refresh(false);
-  tick<true>(); layerA.patternFetch( 1);
+  if(!displayEnable()) {
+    tick<true,true>(); //refresh
+  } else {
+    tick<true>(); sprite.patternFetch(38); sprite.scan();
+  }
+  tick<true>(); layerA.patternFetch( 0); sprite.scan();
+  tick<true>(); layerA.patternFetch( 1); sprite.scan();
   tick<true>(); layerB.mappingFetch(-1);
-  tick<true>(); sprite.patternFetch(39);
-  tick<true>(); layerB.patternFetch( 0);
-  tick<true>(); layerB.patternFetch( 1);
+  tick<true>(); sprite.patternFetch(39); sprite.scan();
+  tick<true>(); layerB.patternFetch( 0); sprite.scan();
+  tick<true>(); layerB.patternFetch( 1); sprite.scan();
 }
 
 template<bool _h40, bool _pixels> auto VDP::blocks() -> void {
-  bool den = displayEnable();
-  bool vc = vcounter() == 0x1ff;
+  bool top = vcounter() == state.topline;
+  dac.fillLeftBorder();
   for(auto block : range(_h40 ? 20 : 16)) {
     layers.vscrollFetch(block);
     layerA.attributesFetch();
     layerB.attributesFetch();
     window.attributesFetch(block);
     tick<_h40>(); layerA.mappingFetch(block);
-    tick<_h40>(); (block & 3) != 3 ? slot() : refresh(true);
-    tick<_h40>(); layerA.patternFetch(block * 2 + 2); refresh(false);
+    if((block & 3) == 3) {
+      tick<_h40,true>(); //refresh
+    } else {
+      tick<_h40>(); slot();
+    }
+    bool den = displayEnable();
+    tick<_h40>(); layerA.patternFetch(block * 2 + 2);
     tick<_h40>(); layerA.patternFetch(block * 2 + 3);
     tick<_h40>(); layerB.mappingFetch(block);
     tick<_h40>(); sprite.mappingFetch(block);
@@ -225,73 +309,13 @@ template<bool _h40, bool _pixels> auto VDP::blocks() -> void {
     tick<_h40>(); layerB.patternFetch(block * 2 + 3);
 
     if(_pixels) {
-      if(!den || vc) {
+      if(!den || top) {
         for(auto pixel: range(16)) dac.pixel<_h40, false>(block * 16 + pixel);
       } else {
         for(auto pixel: range(16)) dac.pixel<_h40, true>(block * 16 + pixel);
       }
     }
   }
+  dac.fillRightBorder();
 }
 
-//timings are approximations; exact positions of slow/normal/fast cycles are not known
-auto VDP::generateCycleTimings() -> void {
-  //full lines
-  //==========
-
-  //H32/DCLK: 342 slow + 0 normal +   0 fast = 3420 cycles
-  for(auto cycle : range(342)) cyclesH32[0][cycle *  1] = 10;
-
-  //H32/EDCLK: 21 slow + 3 normal + 318 fast = 2781 cycles
-  for(auto cycle : range(342)) cyclesH32[1][cycle *  1] =  8;
-  for(auto cycle : range( 24)) cyclesH32[1][cycle * 14] = 10;
-  for(auto cycle : range(  3)) cyclesH32[1][cycle * 14] =  9;
-
-  //H40/DCLK:   0 slow + 0 normal + 420 fast = 3360 cycles
-  for(auto cycle : range(420)) cyclesH40[0][cycle *  1] =  8;
-
-  //H40/EDCLK: 28 slow + 4 normal + 388 fast = 3420 cycles
-  for(auto cycle : range(420)) cyclesH40[1][cycle *  1] =  8;
-  for(auto cycle : range( 32)) cyclesH40[1][cycle * 13] = 10;
-  for(auto cycle : range(  4)) cyclesH40[1][cycle * 13] =  9;
-
-  //half lines
-  //==========
-
-  //H32/DCLK: 171 slow + 0 normal +   0 fast = 1710 cycles
-  for(auto cycle : range(171)) halvesH32[0][cycle *  1] = 10;
-
-  //H32/EDCLK: 10 slow + 2 normal + 159 fast = 1390 cycles
-  for(auto cycle : range(171)) halvesH32[1][cycle *  1] =  8;
-  for(auto cycle : range( 12)) halvesH32[1][cycle * 14] = 10;
-  for(auto cycle : range(  2)) halvesH32[1][cycle * 14] =  9;
-
-  //H40/DCLK:   0 slow + 0 normal + 210 fast = 1680 cycles
-  for(auto cycle : range(210)) halvesH40[0][cycle *  1] =  8;
-
-  //H40/EDCLK: 14 slow + 2 normal + 194 fast = 1710 cycles
-  for(auto cycle : range(210)) halvesH40[1][cycle *  1] =  8;
-  for(auto cycle : range( 16)) halvesH40[1][cycle * 13] = 10;
-  for(auto cycle : range(  2)) halvesH40[1][cycle * 13] =  9;
-
-  //active even half lines
-  //======================
-
-  //H32/DCLK: 171 slow + 0 normal +   0 fast = 1710 cycles
-  for(auto cycle : range(171)) extrasH32[0][cycle *  1] = 10;
-
-  //H32/EDCLK: 21 slow + 3 normal + 147 fast = 1413 cycles
-  for(auto cycle : range(171)) extrasH32[1][cycle *  1] =  8;
-  for(auto cycle : range( 24)) extrasH32[1][cycle *  7] = 10;
-  for(auto cycle : range(  3)) extrasH32[1][cycle *  7] =  9;
-
-  //H40/DCLK:   0 slow + 0 normal + 210 fast = 1680 cycles
-  for(auto cycle : range(171)) extrasH40[0][cycle *  1] =  8;
-
-  //H40/EDCLK: 28 slow + 4 normal + 178 fast = 1740 cycles
-  for(auto cycle : range(171)) extrasH40[1][cycle *  1] =  8;
-  for(auto cycle : range( 32)) extrasH40[1][cycle *  5] = 10;
-  for(auto cycle : range(  4)) extrasH40[1][cycle *  5] =  9;
-
-  cycles = nullptr;
-}

--- a/ares/md/vdp/memory.cpp
+++ b/ares/md/vdp/memory.cpp
@@ -50,4 +50,6 @@ auto VDP::CRAM::read(n6 address) const -> n16 {
 auto VDP::CRAM::write(n6 address, n16 data) -> void {
   data = data.bit(1,3) << 0 | data.bit(5,7) << 3 | data.bit(9,11) << 6;
   memory[address] = data;
+  bus.data = data;
+  bus.active = 1;
 }

--- a/ares/md/vdp/prefetch.cpp
+++ b/ares/md/vdp/prefetch.cpp
@@ -2,12 +2,17 @@ auto VDP::Prefetch::run() -> bool {
   if(full()) return false;
 
   if(vdp.command.target == 0 && vdp.vram.mode == 0) {
-    slot.lower = 1;
-    slot.upper = 1;
-    slot.data.byte(0) = vdp.vram.readByte(vdp.command.address & ~1 | 1);
-    slot.data.byte(1) = vdp.vram.readByte(vdp.command.address & ~1 | 0);
-    vdp.command.ready = 1;
-    return true;
+    if(!slot.lower) {
+      slot.lower = 1;
+      slot.data.byte(0) = vdp.vram.readByte(vdp.command.address & ~1 | 1);
+      return true;
+    }
+    if(!slot.upper) {
+      slot.data.byte(1) = vdp.vram.readByte(vdp.command.address & ~1 | 0);
+      slot.upper = 1;
+      vdp.command.ready = 1;
+      return true;
+    }
   }
 
   if(vdp.command.target == 0 && vdp.vram.mode == 1) {

--- a/ares/md/vdp/serialization.cpp
+++ b/ares/md/vdp/serialization.cpp
@@ -46,6 +46,7 @@ auto VDP::serialize(serializer& s) -> void {
   s(latch.overscan);
   s(latch.displayWidth);
   s(latch.clockSelect);
+  s(latch.displayEnable);
 
   s(state.counterLatchValue);
   s(state.hcounter);
@@ -54,6 +55,10 @@ auto VDP::serialize(serializer& s) -> void {
   s(state.hblank);
   s(state.vblank);
   s(state.refreshing);
+  s(state.rambusy);
+  s(state.edclkPos);
+  s(state.topline);
+  s(state.bottomline);
 }
 
 auto VDP::PSG::serialize(serializer& s) -> void {
@@ -83,6 +88,7 @@ auto VDP::Slot::serialize(serializer& s) -> void {
   s(data);
   s(upper);
   s(lower);
+  s(latency);
 }
 
 auto VDP::Prefetch::serialize(serializer& s) -> void {
@@ -102,7 +108,7 @@ auto VDP::DMA::serialize(serializer& s) -> void {
   s(wait);
   s(read);
   s(enable);
-  s(delay);
+  s(preload);
 }
 
 auto VDP::Pixel::serialize(serializer& s) -> void {
@@ -217,5 +223,7 @@ auto VDP::VSRAM::serialize(serializer& s) -> void {
 }
 
 auto VDP::CRAM::serialize(serializer& s) -> void {
+  s(bus.active);
+  s(bus.data);
   s(memory);
 }

--- a/ares/md/vdp/sprite.cpp
+++ b/ares/md/vdp/sprite.cpp
@@ -85,8 +85,6 @@ auto VDP::Sprite::patternFetch(u32) -> void {
   if(test.disablePhase3) mappings[patternIndex].valid = 0;
 
   auto interlace = vdp.io.interlaceMode == 3;
-  auto y = 129 + (i9)vdp.vcounter();
-  if(interlace) y = y << 1 | vdp.field();
 
   if(mappings[patternIndex].valid) {
     auto& object = mappings[patternIndex];
@@ -134,6 +132,14 @@ auto VDP::Sprite::patternFetch(u32) -> void {
   } else {
     maskCheck = 0;
   }
+}
+
+auto VDP::Sprite::scan() -> void {
+  if(!vdp.displayEnable()) return;
+
+  auto interlace = vdp.io.interlaceMode == 3;
+  auto y = 129 + (i9)vdp.vcounter();
+  if(interlace) y = y << 1 | vdp.field();
 
   if(test.disablePhase1) visibleStop = 1;
 


### PR DESCRIPTION
- Completes #1498 -- dots should be clearly visible in overscan areas normally. If you notice odd dots appearing on top of games irregularly (inbounds, non-overscan), please mention it. The Direct Color DMA demos (https://gendev.spritesmind.net/forum/viewtopic.php?f=8&t=1203) should be stable for the most part (note, they are very timing sensitive).
- VDPFIFOTesting rom should run without any failures. Previously, 16-FIFO Wait States was the only failed test.
- Both Titan Overdrive demos should run cleanly. There were a few minor wrinkles that needed to be ironed out.
- Fixes #1075 -- there was a minor adjustment for a window edge case in H32 mode. Unlikely to affect other games.
- Fixes #1061 -- looks pretty clean now.
- Fixes #626 -- I don't notice anything weird currently, just some minor fringe in the left border, not visible when overscan is disabled.
- Review #1675 wrt md -- there are no parts of the active display area that are currently cropped out. There was an unreported issue with Exo Squad (E) that had clipped the topmost lines in PAL V30 mode (observed on the copyright screen) but that has been fixed.
- Fixes an unreported bug in 32X PWM sound (right channel was missing), typo from previous commit d7dfae7a7a24e20e45495472dc9fa447fe556618.