### PR TITLE
CI: Fetch tags on checkout (again)

### DIFF
--- a/.github/workflows/build_new.yml
+++ b/.github/workflows/build_new.yml
@@ -70,6 +70,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-tags: true
+        fetch-depth: 0
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'
       run: |


### PR DESCRIPTION
`fetch-tags: true` only works within the specified fetch depth.

`fetch-depth: 0` fetches more than necessary, but seems to be the simplest way to guarantee we actually fetch the latest release tag needed by CI.

See also: https://github.com/actions/checkout/issues/338