### PR TITLE
build: Disable OpenAL on Windows

### DIFF
--- a/ruby/cmake/os-windows.cmake
+++ b/ruby/cmake/os-windows.cmake
@@ -29,7 +29,6 @@ target_sources(
 
 find_package(SDL)
 find_package(librashader)
-find_package(OpenAL)
 
 target_enable_feature(ruby "Direct3D 9 video driver" VIDEO_DIRECT3D9)
 target_enable_feature(ruby "OpenGL video driver" VIDEO_WGL)
@@ -44,10 +43,6 @@ if(SDL_FOUND)
   target_enable_feature(ruby "SDL audio driver" AUDIO_SDL)
 endif()
 
-if(OpenAL_FOUND)
-  target_enable_feature(ruby "OpenAL audio driver" AUDIO_OPENAL)
-endif()
-
 if(librashader_FOUND AND ARES_ENABLE_LIBRASHADER)
   target_enable_feature(ruby "librashader OpenGL runtime" LIBRA_RUNTIME_OPENGL)
 else()
@@ -57,7 +52,6 @@ endif()
 target_link_libraries(
   ruby
   PRIVATE
-    $<$<BOOL:${OpenAL_FOUND}>:OpenAL::OpenAL>
     $<$<BOOL:TRUE>:librashader::librashader>
     $<$<BOOL:${SDL_FOUND}>:SDL::SDL>
     d3d9


### PR DESCRIPTION
For various reasons, OpenAL on Windows is not supported. If we do manage to find it and link against it, the build we produce is unlikely to work outside of an MSYS2 command line environment, so we should just disable it.

If we ever want OpenAL support on Windows, we would need to either locate a version that depends only on Windows system libraries (i.e. does not dynamically load libc++ or other MSYS2 libraries), or else build and provide OpenAL ourselves as part of `ares-deps`.