### PR TITLE
hiro: Fix various warnings and deprecations in Cocoa

### DIFF
--- a/hiro/cocoa/action/action.hpp
+++ b/hiro/cocoa/action/action.hpp
@@ -8,7 +8,7 @@ struct pAction :  pObject {
   auto setEnabled(bool enabled) -> void override;
   auto setVisible(bool visible) -> void override;
 
-  NSMenuItem<CocoaMenu>* cocoaAction = nullptr;
+  NSMenuItem<CocoaMenuProtocol>* cocoaAction = nullptr;
 };
 
 }

--- a/hiro/cocoa/action/menu-check-item.hpp
+++ b/hiro/cocoa/action/menu-check-item.hpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_MenuCheckItem)
 
-@interface CocoaMenuCheckItem : NSMenuItem<CocoaMenu> {
+@interface CocoaMenuCheckItem : CocoaMenu {
 @public
   hiro::mMenuCheckItem* menuCheckItem;
 }

--- a/hiro/cocoa/action/menu-item.hpp
+++ b/hiro/cocoa/action/menu-item.hpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_MenuItem)
 
-@interface CocoaMenuItem : NSMenuItem<CocoaMenu> {
+@interface CocoaMenuItem : CocoaMenu {
 @public
   hiro::mMenuItem* menuItem;
 }

--- a/hiro/cocoa/action/menu-protocol.hpp
+++ b/hiro/cocoa/action/menu-protocol.hpp
@@ -1,3 +1,3 @@
-@protocol CocoaMenu<NSObject>
+@protocol CocoaMenuProtocol <NSObject>
 -(NSMenu*) cocoaMenu;
 @end

--- a/hiro/cocoa/action/menu-radio-item.hpp
+++ b/hiro/cocoa/action/menu-radio-item.hpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_MenuRadioItem)
 
-@interface CocoaMenuRadioItem : NSMenuItem<CocoaMenu> {
+@interface CocoaMenuRadioItem : CocoaMenu {
 @public
   hiro::mMenuRadioItem* menuRadioItem;
 }

--- a/hiro/cocoa/action/menu-separator.cpp
+++ b/hiro/cocoa/action/menu-separator.cpp
@@ -4,7 +4,7 @@ namespace hiro {
 
 auto pMenuSeparator::construct() -> void {
   cocoaSeparator = [NSMenuItem separatorItem];
-  cocoaAction = (NSMenuItem<CocoaMenu> *)cocoaSeparator;
+  cocoaAction = (NSMenuItem<CocoaMenuProtocol> *)cocoaSeparator;
   pAction::construct();
 }
 

--- a/hiro/cocoa/action/menu.hpp
+++ b/hiro/cocoa/action/menu.hpp
@@ -1,6 +1,6 @@
 #if defined(Hiro_Menu)
 
-@interface CocoaMenu : NSMenuItem<CocoaMenu> {
+@interface CocoaMenu : NSMenuItem<CocoaMenuProtocol> {
 @public
   hiro::mMenu* menu;
   NSMenu* cocoaMenu;

--- a/hiro/cocoa/application.cpp
+++ b/hiro/cocoa/application.cpp
@@ -64,7 +64,7 @@ auto pApplication::run() -> void {
 auto pApplication::pendingEvents() -> bool {
   bool result = false;
   @autoreleasepool {
-    NSEvent* event = [NSApp nextEventMatchingMask:NSAnyEventMask untilDate:[NSDate distantPast] inMode:NSDefaultRunLoopMode dequeue:NO];
+    NSEvent* event = [NSApp nextEventMatchingMask:NSEventMaskAny untilDate:[NSDate distantPast] inMode:NSDefaultRunLoopMode dequeue:NO];
     if(event != nil) result = true;
   }
   return result;
@@ -73,7 +73,7 @@ auto pApplication::pendingEvents() -> bool {
 auto pApplication::processEvents() -> void {
   @autoreleasepool {
     while(!Application::state().quit) {
-      NSEvent* event = [NSApp nextEventMatchingMask:NSAnyEventMask untilDate:[NSDate distantPast] inMode:NSDefaultRunLoopMode dequeue:YES];
+      NSEvent* event = [NSApp nextEventMatchingMask:NSEventMaskAny untilDate:[NSDate distantPast] inMode:NSDefaultRunLoopMode dequeue:YES];
       if(event == nil) break;
       [NSApp sendEvent:event];
     }
@@ -84,7 +84,7 @@ auto pApplication::quit() -> void {
   @autoreleasepool {
     [applicationTimer invalidate];
     [NSApp stop:nil];
-    NSEvent* event = [NSEvent otherEventWithType:NSApplicationDefined location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0.0 windowNumber:0 context:nil subtype:0 data1:0 data2:0];
+    NSEvent* event = [NSEvent otherEventWithType:NSEventTypeApplicationDefined location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0.0 windowNumber:0 context:nil subtype:0 data1:0 data2:0];
     [NSApp postEvent:event atStart:true];
   }
 }

--- a/hiro/cocoa/browser-window.cpp
+++ b/hiro/cocoa/browser-window.cpp
@@ -10,11 +10,11 @@ auto pBrowserWindow::directory(BrowserWindow::State& state) -> string {
     if(state.title) [panel setTitle:[NSString stringWithUTF8String:state.title]];
     panel.canChooseDirectories = YES;
     panel.canChooseFiles = NO;
-    panel.directory = [NSString stringWithUTF8String:state.path];
-    if([panel runModal] == NSOKButton) {
-      NSArray* names = [panel filenames];
-      const char* name = [[names objectAtIndex:0] UTF8String];
-      if(name) result = name;
+    panel.directoryURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:state.path]];
+    if([panel runModal] == NSModalResponseOK) {
+      NSArray* files = [panel URLs];
+      const char* path = [[[files objectAtIndex:0] path] UTF8String];
+      if(path) result = path;
     }
   }
 
@@ -40,13 +40,13 @@ auto pBrowserWindow::open(BrowserWindow::State& state) -> string {
     panel.canChooseFiles = YES;
     if([filters count] > 0) panel.allowedFileTypes = filters;
     panel.allowsOtherFileTypes = NO;
-    panel.directory = [NSString stringWithUTF8String:state.path];
-    if([panel runModal] == NSOKButton) {
-      NSString* name = panel.filenames.firstObject;
+    panel.directoryURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:state.path]];
+    if([panel runModal] == NSModalResponseOK) {
+      NSString* path = panel.URLs.firstObject.path;
       BOOL isDirectory = NO;
-      [[NSFileManager defaultManager] fileExistsAtPath:name isDirectory:&isDirectory];
-      if(isDirectory) name = [name stringByAppendingString:@"/"];
-      if(name) result = name.UTF8String;
+      [[NSFileManager defaultManager] fileExistsAtPath:path isDirectory:&isDirectory];
+      if(isDirectory) path = [path stringByAppendingString:@"/"];
+      if(path) result = path.UTF8String;
     }
   }
 
@@ -69,10 +69,10 @@ auto pBrowserWindow::save(BrowserWindow::State& state) -> string {
     NSSavePanel* panel = [NSSavePanel savePanel];
     if(state.title) [panel setTitle:[NSString stringWithUTF8String:state.title]];
     if([filters count] > 0) panel.allowedFileTypes = filters;
-    panel.directory = [NSString stringWithUTF8String:state.path];
-    if([panel runModal] == NSOKButton) {
-      const char* name = panel.URL.path.UTF8String;
-      if(name) result = name;
+    panel.directoryURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:state.path]];
+    if([panel runModal] == NSModalResponseOK) {
+      const char* path = panel.URL.path.UTF8String;
+      if(path) result = path;
     }
   }
 

--- a/hiro/cocoa/message-window.cpp
+++ b/hiro/cocoa/message-window.cpp
@@ -30,10 +30,10 @@ auto MessageWindow_dialog(MessageWindow::State& state, MessageWindowType type) -
     }
 
     switch(type) {
-    case MessageWindowType::Error: [alert setAlertStyle:NSCriticalAlertStyle]; break;
-    case MessageWindowType::Information: [alert setAlertStyle:NSInformationalAlertStyle]; break;
-    case MessageWindowType::Question: [alert setAlertStyle:NSInformationalAlertStyle]; break;
-    case MessageWindowType::Warning: [alert setAlertStyle:NSWarningAlertStyle]; break;
+      case MessageWindowType::Error: [alert setAlertStyle:NSAlertStyleCritical]; break;
+      case MessageWindowType::Information: [alert setAlertStyle:NSAlertStyleInformational]; break;
+      case MessageWindowType::Question: [alert setAlertStyle:NSAlertStyleInformational]; break;
+      case MessageWindowType::Warning: [alert setAlertStyle:NSAlertStyleWarning]; break;
     }
 
     NSInteger response = [alert runModal];

--- a/hiro/cocoa/widget/horizontal-scroll-bar.cpp
+++ b/hiro/cocoa/widget/horizontal-scroll-bar.cpp
@@ -9,7 +9,7 @@
     [self setTarget:self];
     [self setAction:@selector(scroll:)];
 
-    [self setControlSize:NSRegularControlSize];
+    [self setControlSize:NSControlSizeRegular];
     [self setScrollerStyle:NSScrollerStyleLegacy];
     [self setEnabled:YES];
 
@@ -67,7 +67,7 @@ auto pHorizontalScrollBar::destruct() -> void {
 }
 
 auto pHorizontalScrollBar::minimumSize() const -> Size {
-  return {32, (s32)[NSScroller scrollerWidthForControlSize:NSRegularControlSize scrollerStyle:NSScrollerStyleLegacy]};
+  return {32, (s32)[NSScroller scrollerWidthForControlSize:NSControlSizeRegular scrollerStyle:NSScrollerStyleLegacy]};
 }
 
 auto pHorizontalScrollBar::setLength(u32 length) -> void {

--- a/hiro/cocoa/widget/tab-frame.cpp
+++ b/hiro/cocoa/widget/tab-frame.cpp
@@ -52,7 +52,7 @@
 
         [[NSGraphicsContext currentContext] saveGraphicsState];
         NSRect targetRect = NSMakeRect(tabRect.origin.x, tabRect.origin.y + 2, iconSize, iconSize);
-        [image drawInRect:targetRect fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0 respectFlipped:YES hints:nil];
+        [image drawInRect:targetRect fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:1.0 respectFlipped:YES hints:nil];
         [[NSGraphicsContext currentContext] restoreGraphicsState];
 
         tabRect.origin.x += iconSize + 2;

--- a/hiro/cocoa/widget/table-view.cpp
+++ b/hiro/cocoa/widget/table-view.cpp
@@ -203,7 +203,7 @@
     tableView = &tableViewReference;
     buttonCell = [[NSButtonCell alloc] initTextCell:@""];
     [buttonCell setButtonType:NSSwitchButton];
-    [buttonCell setControlSize:NSSmallControlSize];
+    [buttonCell setControlSize:NSControlSizeSmall];
     [buttonCell setRefusesFirstResponder:YES];
     [buttonCell setTarget:self];
     textCell = [[NSTextFieldCell alloc] init];
@@ -236,7 +236,7 @@
         NSRect targetRect = NSMakeRect(frame.origin.x + 2, frame.origin.y + (frame.size.height - image.size.height) / 2,
                                        image.size.width, image.size.height);
         NSRect sourceRect = NSMakeRect(0, 0, image.size.width, image.size.height);
-        [image drawInRect:targetRect fromRect:sourceRect operation:NSCompositeSourceOver fraction:1.0 respectFlipped:YES hints:nil];
+        [image drawInRect:targetRect fromRect:sourceRect operation:NSCompositingOperationSourceOver fraction:1.0 respectFlipped:YES hints:nil];
         [[NSGraphicsContext currentContext] restoreGraphicsState];
         frame.origin.x += image.size.width + 4;
         frame.size.width -= image.size.width + 4;
@@ -276,11 +276,11 @@
 //so instead, I have to run a modal loop on events until the mouse button is released
 -(BOOL) trackMouse:(NSEvent*)event inRect:(NSRect)frame ofView:(NSView*)_view untilMouseUp:(BOOL)flag {
   NSTableView* view = (NSTableView*)_view;
-  if([event type] == NSLeftMouseDown) {
+  if([event type] == NSEventTypeLeftMouseDown) {
     NSWindow* window = [view window];
     NSEvent* nextEvent;
-    while((nextEvent = [window nextEventMatchingMask:(NSLeftMouseDragged | NSLeftMouseUp)])) {
-      if([nextEvent type] == NSLeftMouseUp) {
+    while((nextEvent = [window nextEventMatchingMask:(NSEventTypeLeftMouseDragged | NSEventTypeLeftMouseUp)])) {
+      if([nextEvent type] == NSEventTypeLeftMouseUp) {
         NSPoint point = [view convertPoint:[nextEvent locationInWindow] fromView:nil];
         NSRect rect = NSMakeRect(frame.origin.x, frame.origin.y, frame.size.height, frame.size.height);
         if(NSMouseInRect(point, rect, [view isFlipped])) {

--- a/hiro/cocoa/widget/vertical-scroll-bar.cpp
+++ b/hiro/cocoa/widget/vertical-scroll-bar.cpp
@@ -9,7 +9,7 @@
     [self setTarget:self];
     [self setAction:@selector(scroll:)];
 
-    [self setControlSize:NSRegularControlSize];
+    [self setControlSize:NSControlSizeRegular];
     [self setScrollerStyle:NSScrollerStyleLegacy];
     [self setEnabled:YES];
 
@@ -67,7 +67,7 @@ auto pVerticalScrollBar::destruct() -> void {
 }
 
 auto pVerticalScrollBar::minimumSize() const -> Size {
-  return {(s32)[NSScroller scrollerWidthForControlSize:NSRegularControlSize scrollerStyle:NSScrollerStyleLegacy], 32};
+  return {(s32)[NSScroller scrollerWidthForControlSize:NSControlSizeRegular scrollerStyle:NSScrollerStyleLegacy], 32};
 }
 
 auto pVerticalScrollBar::setLength(u32 length) -> void {

--- a/hiro/cocoa/widget/viewport.cpp
+++ b/hiro/cocoa/widget/viewport.cpp
@@ -18,7 +18,7 @@
 -(void) drawRect:(NSRect)rect {
   [[NSColor blackColor] setFill];
   NSRect frame = self.bounds;
-  NSRectFillUsingOperation(frame, NSCompositeSourceOver);
+  NSRectFillUsingOperation(frame, NSCompositingOperationSourceOver);
 }
 
 -(BOOL) acceptsFirstResponder {

--- a/hiro/cocoa/window.hpp
+++ b/hiro/cocoa/window.hpp
@@ -20,7 +20,6 @@
 -(NSMenu*) menuBar;
 -(void) menuAbout;
 -(void) menuPreferences;
--(void) menuDisableGatekeeper;
 -(void) menuQuit;
 -(NSTextField*) statusBar;
 @end

--- a/ruby/video/opengl/main.hpp
+++ b/ruby/video/opengl/main.hpp
@@ -131,6 +131,8 @@ auto OpenGL::initialize(const string& shader) -> bool {
   return initialized = true;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 auto OpenGL::resolveSymbol(const char* name) -> const void * {
 #if defined(PLATFORM_MACOS)
   NSSymbol symbol;
@@ -153,6 +155,7 @@ auto OpenGL::resolveSymbol(const char* name) -> const void * {
     }
   #endif
 #endif
+#pragma clang diagnostic pop
 
   return symbol;
 }


### PR DESCRIPTION
* Fix a bunch of miscellaneous name deprecations
* Fix deprecated modal file handling patterns; use the `URL` properties rather than the ones for paths
* Remove the Gatekeeper bypass menu item
    * While the idea here was quaint, it's very dated, the approach doesn't work at all on modern macOS (and would be a significant exploit surface if it did), and the functionality is somewhat outside the scope of the ares application in the first place. It won't remove Gatekeeper restrictions on ares itself, since if we're using the menu item, we've already made it past Gatekeeper. Functionality to disable Gatekeeper in general for other applications is, again, maybe nice in an abstract way, but well outside our scope.
* Suppress OpenGL symbol resolver deprecation warnings
* Fix protocol warnings in `CocoaMenu` that revealed a mistaken design pattern:
    * We had both a protocol and an interface called `CocoaMenu`, and our Cocoa hiro menu subclasses were declaring that they adopted the `CocoaMenu` protocol, rather than what was almost certainly intended, to be subclasses of `CocoaMenu` which would itself conform to the protocol by virtue of being an `NSMenuItem`.
    * In effect, this meant that each CocoaMenu subclass interface was telling the compiler it wanted to reimplement the `NSObject` protocol rather than be an `NSObject` subclass. This may have resulted in various typical properties of `NSObject`s not being present, and various methods (such as Accessibility) entirely not working.