### PR TITLE
build: gcc improvements

### DIFF
--- a/.github/scripts/build_ubuntu.sh
+++ b/.github/scripts/build_ubuntu.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# configure
+cmake --preset $TARGET_PRESET
+
+# change into the build directory
+pushd build
+
+ninja
+
+popd

--- a/.github/workflows/build_new.yml
+++ b/.github/workflows/build_new.yml
@@ -20,6 +20,13 @@ jobs:
           msystem: clang64
           install: mingw-w64-clang-x86_64-clang
           target-cmake-preset: windows-ci-mingw-native
+        - name: windows-x64-gcc
+          os: windows-latest
+          compiler: g++
+          shell: 'msys2 {0}'
+          msystem: mingw64
+          install: mingw-w64-x86_64-toolchain
+          target-cmake-preset: windows-ci-mingw-native
         - name: windows-clang-cl-x64
           os: windows-latest
           windres: rc
@@ -48,6 +55,12 @@ jobs:
           shell: sh
           install: cmake ccache xcbeautify
           target-cmake-preset: macos-ci-universal
+        - name: ubuntu
+          os: ubuntu-latest
+          compiler: g++
+          shell: bash
+          install: cmake ccache ninja-build libsdl2-dev libgtk-3-dev libao-dev libopenal-dev
+          target-cmake-preset: ubuntu-ci
     name: ${{ matrix.program }}-${{ matrix.platform.name }}
     runs-on: ${{ matrix.platform.os }}
     defaults:
@@ -71,12 +84,22 @@ jobs:
       with:
         fetch-tags: true
         fetch-depth: 0
+    - name: Install Linux Dependencies
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update -y -qq
+        sudo apt-get install ${{ matrix.platform.install }}
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'
       run: |
         brew install ${{ matrix.platform.install }}
+    - name: "Build: Linux"
+      if: runner.os == 'Linux'
+      run: .github/scripts/build_ubuntu.sh
+      env:
+        TARGET_PRESET: ${{ matrix.platform.target-cmake-preset }}
     - name: "Build: Windows"
-      if: runner.os != 'macOS'
+      if: runner.os != 'macOS' && runner.os != 'Linux'
       run: .github/scripts/build_windows.sh
       env:
         CROSS_COMPILE: ${{ matrix.platform.native-cmake-preset != '' }}
@@ -112,7 +135,7 @@ jobs:
         MACOS_NOTARIZATION_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}
         MACOS_NOTARIZATION_TEAMID: ${{ secrets.MACOS_NOTARIZATION_TEAMID }}
     - name: Upload Build (Windows)
-      if: runner.os != 'macOS'
+      if: runner.os != 'macOS' && runner.os != 'Linux'
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.program }}-${{ matrix.platform.name }}
@@ -124,7 +147,7 @@ jobs:
         name: ${{ matrix.program }}-${{ matrix.platform.name }}
         path: build/desktop-ui/RelWithDebInfo/
     - name: Upload Debug Symbols (Windows)
-      if: runner.os != 'macOS'
+      if: runner.os != 'macOS' && runner.os != 'Linux'
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.program }}-${{ matrix.platform.name }}-PDBs

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -147,6 +147,20 @@
       "cacheVariables": {
         "ARES_CROSSCOMPILING": true
       }
+    },
+    {
+      "name": "ubuntu-ci",
+      "displayName": "Ubuntu CI (x64 gcc)",
+      "description": "Single-arch binary for building on Github Actions",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "RelWithDebInfo"},
+        "ENABLE_CCACHE": true,
+        "ARES_BUILD_LOCAL": false,
+        "ARES_BUILD_OPTIONAL_TARGETS": true,
+        "ARES_PRECOMPILE_HEADERS": false
+      }
     }
   ],
   "buildPresets": [

--- a/ares/n64/CMakeLists.txt
+++ b/ares/n64/CMakeLists.txt
@@ -36,6 +36,13 @@ elseif(OS_LINUX OR OS_FREEBSD OR OS_OPENBSD)
   include(cmake/os-linux.cmake)
 endif()
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  message(WARNING "
+Building N64 with optimizations under GCC currently results in broken graphical output, see \
+https://github.com/ares-emulator/ares/issues/1737 . Building with clang instead will work around this issue. \
+")
+endif()
+
 ares_add_sources(
   CORE #
     n64

--- a/desktop-ui/cmake/os-windows.cmake
+++ b/desktop-ui/cmake/os-windows.cmake
@@ -2,6 +2,13 @@ target_sources(desktop-ui PRIVATE resource/ares.rc resource/ares.Manifest)
 
 set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT desktop-ui)
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_link_libraries(
+    desktop-ui
+    PRIVATE mingw32
+  )
+endif()
+
 if(ARES_ENABLE_LIBRASHADER)
   if(TARGET libretro::slang_shaders)
     add_custom_command(

--- a/mia/CMakeLists.txt
+++ b/mia/CMakeLists.txt
@@ -127,6 +127,15 @@ if(ARES_BUILD_OPTIONAL_TARGETS)
     target_sources(mia-ui PRIVATE resource/mia.rc resource/mia.Manifest)
   endif()
 
+  if(OS_WINDOWS)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      target_link_libraries(
+        mia-ui
+        PRIVATE nall
+      )
+    endif()
+  endif()
+
   set_target_properties(
     mia-ui
     PROPERTIES

--- a/tests/i8080/CMakeLists.txt
+++ b/tests/i8080/CMakeLists.txt
@@ -3,6 +3,16 @@ add_executable(i8080 i8080.cpp ../../ares/component/processor/i8080/i8080.cpp)
 target_include_directories(i8080 PRIVATE ${CMAKE_SOURCE_DIR})
 
 target_link_libraries(i8080 PRIVATE ares::ares)
+
+if(OS_WINDOWS)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_link_libraries(
+      i8080
+      PRIVATE nall
+    )
+  endif()
+endif()
+
 set_target_properties(i8080 PROPERTIES FOLDER tests PREFIX "")
 target_enable_subproject(i8080 "i8080 processor test harness")
 ares_configure_executable(i8080)


### PR DESCRIPTION
Linking was failing under MinGW gcc because of a link order issue between `libares` and  `mingw32`. Establishing a direct link relationship between `desktop-ui` and `mingw32` means that our `WinMain` definition will not be discarded by `ld` before it's needed.

We also here add a Linux gcc runner and a Windows gcc runner; these do not upload artifacts, but will allow us to detect build failures on CI.

At the moment, gcc support in general under CMake will still rougher edges than clang or MSVC support, but it is intended that building with `gcc` and `ld` should always at least work, even if `clang` remains recommended and achieves superior performance.

This PR also adds a warning in the N64 core to acknowledge https://github.com/ares-emulator/ares/issues/1737 until that issue can be fixed.