### PR TITLE
Fix misc build warnings and vertical scroll on controller combo box (Windows)

### DIFF
--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -41,14 +41,15 @@ auto locate(const string& name) -> string {
 #endif
 
   // If the file was not found in any of the above locations, we may be intending to create it
-  // We must return a path to a user writable directory; on Windows, this is the executable directory
 #if defined(PLATFORM_WINDOWS)
+  // We must return a path to a user writable directory; on Windows, this is the executable directory
   return {Path::program(), name};
-#endif
-
+#else
   // On other platforms, this is the "user data" directory
   directory::create({Path::userData(), "ares/"});
   return {Path::userData(), "ares/", name};
+#endif
+
 }
 
 #include <nall/main.hpp>

--- a/hiro/core/widget/table-view-cell.cpp
+++ b/hiro/core/widget/table-view-cell.cpp
@@ -123,7 +123,7 @@ auto mTableViewCell::setForegroundColor(Color color) -> type& {
 }
 
 auto mTableViewCell::setForegroundColor(SystemColor color) -> type& {
-    state.foregroundColor = color;
+    state.foregroundColor = Color(color);
     state.foregroundSystemColor = color;
     signal(setForegroundColor, color);
     return *this;

--- a/hiro/windows/widget/combo-button.cpp
+++ b/hiro/windows/widget/combo-button.cpp
@@ -5,7 +5,7 @@ namespace hiro {
 auto pComboButton::construct() -> void {
   hwnd = CreateWindow(
     L"COMBOBOX", L"",
-    WS_CHILD | WS_TABSTOP | CBS_DROPDOWNLIST | CBS_HASSTRINGS,
+    WS_CHILD | WS_TABSTOP | WS_VSCROLL | CBS_DROPDOWNLIST | CBS_HASSTRINGS,
     0, 0, 0, 0,
     _parentHandle(), nullptr, GetModuleHandle(0), 0
   );

--- a/mia/mia.cpp
+++ b/mia/mia.cpp
@@ -43,14 +43,15 @@ auto locate(const string &name) -> string {
 #endif
 
   // If the file was not found in any of the above locations, we may be intending to create it
-  // We must return a path to a user writable directory; on Windows, this is the executable directory
 #if defined(PLATFORM_WINDOWS)
+  // We must return a path to a user writable directory; on Windows, this is the executable directory
   return {Path::program(), name};
-#endif
-
+#else
   // On other platforms, this is the "user data" directory
   directory::create({Path::userData(), "ares/"});
   return {Path::userData(), "ares/", name};
+#endif
+
 }
 
 auto operator+=(string& lhs, const string& rhs) -> string& {


### PR DESCRIPTION
Cmake based builds don't disable as many checks as the old make files, so there were a few new warnings clang was showing during the Windows build about unreachable code in mia.cpp & desktop-ui.cpp that are now fixed (it would fall through properly on other OSes). Note that there are still two remaining warnings about unreachable code during the build but this is within zstd included in libchdr so this needs to be addressed upstream. 

A user trying to compile ares made a single post in the ares Discord channel about a warning they were receiving during the link phase about an overflow. I've never seen the warning or remember anyone bringing it up so I asked about OS/compiler (I know it was Linux flavored cause they mentioned working on an AppImage) but they never responded. I think they were using openSUSE, but it is interesting this wasn't flagged anywhere else. We were assigning an enum value to a Color struct in table-view-cell.cpp which wasn't correct, so this has been fixed.

Finally, SuperMikeMan100 pointed out that when the controller combobox in Settings > Input didn't fit entirely on the screen, you couldn't scroll to the bottom of the list (Windows issue). They also pointed out the fix needed in combo-button.cpp which I've tested and have included the fix for it here.