### PR TITLE
CI: fixups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,7 @@ jobs:
         folder: 'desktop-ui/out'
         timestampUrl: 'http://timestamp.digicert.com' 
     - name: "macOS: notarize"
-      if: runner.os == 'macOS' && github.event_name != 'pull_request'
+      if: false
       continue-on-error: ${{ github.repository != 'ares-emulator/ares' }}
       run: |
         ditto -c -k --keepParent desktop-ui/out/ares.app /tmp/ares.zip

--- a/.github/workflows/build_new.yml
+++ b/.github/workflows/build_new.yml
@@ -63,6 +63,7 @@ jobs:
     - name: "macOS: Import Certificate"
       if: runner.os == 'macOS'
       uses: apple-actions/import-codesign-certs@v3
+      continue-on-error: ${{ github.repository != 'ares-emulator/ares' }}
       with:
         p12-file-base64: ${{ secrets.MACOS_CERTIFICATE_DATA }}
         p12-password: ${{ secrets.MACOS_CERTIFICATE_PASSPHRASE }}
@@ -103,6 +104,7 @@ jobs:
         timestampUrl: 'http://timestamp.digicert.com'
     - name: "macOS: notarize"
       if: runner.os == 'macOS' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
+      continue-on-error: ${{ github.repository != 'ares-emulator/ares' }}
       run: |
         ditto -c -k --keepParent ${{ github.workspace }}/build/desktop-ui/RelWithDebInfo/ares.app /tmp/ares.zip
         xcrun notarytool submit /tmp/ares.zip --apple-id "$MACOS_NOTARIZATION_USERNAME" --password "$MACOS_NOTARIZATION_PASSWORD" --team-id "$MACOS_NOTARIZATION_TEAMID" --wait


### PR DESCRIPTION
First commit stops notarizing the legacy build; for some reason notarization currently [fails](https://github.com/ares-emulator/ares/actions/runs/12626365618/job/35179407527) only with the legacy build, despite us not having modified the legacy workflow. In any case it seems fine to no longer notarize this artifact.

Second commit allows the new build CI to continue if the repository it is being run on does not have macOS codesigning set up. This means CI won't automatically fail on your fork if you do not have macOS codesigning set up on your repository.