### PR TITLE
recompiler: code cache compaction

### DIFF
--- a/ares/ares/memory/fixed-allocator.cpp
+++ b/ares/ares/memory/fixed-allocator.cpp
@@ -6,7 +6,7 @@
 
 namespace ares::Memory {
 
-constexpr u32 fixedBufferSize = 128_MiB;
+constexpr u32 fixedBufferSize = 64_MiB;
 
 #if defined(STATIC_ALLOCATION)
 u8 fixedBuffer[fixedBufferSize + 64_KiB];

--- a/ares/component/processor/sh2/sh2.hpp
+++ b/ares/component/processor/sh2/sh2.hpp
@@ -283,7 +283,8 @@ struct SH2 {
     auto reset() -> void {
       generation = 0;
       blocks.reset();
-      for(u32 index : range(1 << 24)) pools[index] = nullptr;
+      pools.reallocate(1 << 24);
+      pools.fill();
     }
 
     auto invalidateCached() -> void {
@@ -311,7 +312,7 @@ struct SH2 {
     bump_allocator allocator;
     hashset<BlockHashPair> blocks;
     u16 instructions[1 << 7];
-    Pool* pools[1 << 24];
+    vector<Pool*> pools;
   } recompiler{*this};
 
   #include "sh7604/sh7604.hpp"

--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -163,8 +163,8 @@ auto CPU::power(bool reset) -> void {
   context.setMode();
 
   if constexpr(Accuracy::CPU::Recompiler) {
-    auto buffer = ares::Memory::FixedAllocator::get().tryAcquire(64_MiB);
-    recompiler.allocator.resize(64_MiB, bump_allocator::executable, buffer);
+    auto buffer = ares::Memory::FixedAllocator::get().tryAcquire(63_MiB);
+    recompiler.allocator.resize(63_MiB, bump_allocator::executable, buffer);
     recompiler.reset();
   }
 }

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -888,7 +888,8 @@ struct CPU : Thread {
     };
 
     auto reset() -> void {
-      for(u32 index : range(1 << 21)) pools[index] = nullptr;
+      pools.reallocate(1 << 21);  //2_MiB * sizeof(void*) == 16_MiB
+      pools.fill();
     }
 
     auto invalidate(u32 address) -> void {
@@ -934,7 +935,7 @@ struct CPU : Thread {
     bool enabled = false;
     bool callInstructionPrologue = false;
     bump_allocator allocator;
-    Pool* pools[1 << 21];  //2_MiB * sizeof(void*) == 16_MiB
+    vector<Pool*> pools;
   } recompiler{*this};
 
   struct Disassembler {

--- a/ares/n64/rsp/recompiler.cpp
+++ b/ares/n64/rsp/recompiler.cpp
@@ -63,7 +63,7 @@ auto RSP::Recompiler::block(u12 address) -> Block* {
 #define R0        IpuReg(r[0])
 
 auto RSP::Recompiler::emit(u12 address) -> Block* {
-  if(unlikely(allocator.available() < 1_MiB)) {
+  if(unlikely(allocator.available() < 128_KiB)) {
     print("RSP allocator flush\n");
     allocator.release();
     reset();

--- a/ares/n64/rsp/rsp.cpp
+++ b/ares/n64/rsp/rsp.cpp
@@ -152,8 +152,8 @@ auto RSP::power(bool reset) -> void {
   }
 
   if constexpr(Accuracy::RSP::Recompiler) {
-    auto buffer = ares::Memory::FixedAllocator::get().tryAcquire(64_MiB);
-    recompiler.allocator.resize(64_MiB, bump_allocator::executable, buffer);
+    auto buffer = ares::Memory::FixedAllocator::get().tryAcquire(1_MiB);
+    recompiler.allocator.resize(1_MiB, bump_allocator::executable, buffer);
     recompiler.reset();
   }
 

--- a/ares/ps1/cpu/cpu.hpp
+++ b/ares/ps1/cpu/cpu.hpp
@@ -525,7 +525,8 @@ struct CPU : Thread {
     };
 
     auto reset() -> void {
-      for(u32 index : range(1 << 21)) pools[index] = nullptr;
+      pools.reallocate(1 << 21);  //2_MiB * sizeof(void*) = 16_MiB
+      pools.fill();
     }
 
     auto invalidate(u32 address) -> void {
@@ -549,7 +550,7 @@ struct CPU : Thread {
     bool enabled = false;
     bool callInstructionPrologue = false;
     bump_allocator allocator;
-    Pool* pools[1 << 21];  //2_MiB * sizeof(void*) = 16_MiB
+    vector<Pool*> pools;
   } recompiler{*this};
 
   struct Disassembler {


### PR DESCRIPTION
- Reduce the code cache allocation from 128 MiB to 64 MiB. The CPU/RSP split is now 63/1 instead of 64/64 (which was egregiously generous to the RSP) so this should have little practical impact on cache flushes.
- Convert some larger static allocations to heap allocations to shrink the ares executable's data section.

These changes increase the likelihood of the entire code cache being within 128 MiB of the ares executable's text section, allowing for more efficient branch encodings on ARM64 and better performance from the host CPU's branch predictor.