### PR TITLE
build: Add local build option on Linux; compiler fixups

### DIFF
--- a/ares/n64/CMakeLists.txt
+++ b/ares/n64/CMakeLists.txt
@@ -36,13 +36,6 @@ elseif(OS_LINUX OR OS_FREEBSD OR OS_OPENBSD)
   include(cmake/os-linux.cmake)
 endif()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  message(WARNING "
-Building N64 with optimizations under GCC currently results in broken graphical output, see \
-https://github.com/ares-emulator/ares/issues/1737 . Building with clang instead will work around this issue. \
-")
-endif()
-
 ares_add_sources(
   CORE #
     n64

--- a/cmake/common/compiler_common.cmake
+++ b/cmake/common/compiler_common.cmake
@@ -100,11 +100,7 @@ set(
   -Wno-delete-non-abstract-non-virtual-dtor
 )
 
-set(
-  _ares_gcc_common_options
-  -fwrapv
-  -fno-strict-aliasing
-)
+set(_ares_gcc_common_options -fwrapv -fno-strict-aliasing -Wno-unused-result)
 
 if(NOT DEFINED CMAKE_COMPILE_WARNING_AS_ERROR)
   set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)

--- a/cmake/linux/compilerconfig.cmake
+++ b/cmake/linux/compilerconfig.cmake
@@ -3,6 +3,17 @@ include_guard(GLOBAL)
 option(ENABLE_COMPILER_TRACE "Enable clang time-trace" OFF)
 mark_as_advanced(ENABLE_COMPILER_TRACE)
 
+option(
+  ARES_BUILD_LOCAL
+  "Allows the compiler to generate code optimized for the target machine; increases performance."
+  ON
+)
+option(
+  ARES_ENABLE_MINIMUM_CPU
+  "Defines a project minimum instruction set version in order to expose advanced SSE functionality to the compiler. Currently x86-64-v2 on x86_64; not defined on arm64."
+  ON
+)
+
 include(ccache)
 include(compiler_common)
 
@@ -14,7 +25,16 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     -fwrapv
   )
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  add_compile_options(
-    ${_ares_gcc_common_options}
-  )
+  add_compile_options(${_ares_gcc_common_options})
+endif()
+
+if(ARES_BUILD_LOCAL)
+  add_compile_options($<$<NOT:$<CONFIG:Debug>>:-march=native>)
+else()
+  if(ARES_ENABLE_MINIMUM_CPU)
+    string(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} LOWERCASE_CMAKE_SYSTEM_PROCESSOR)
+    if(LOWERCASE_CMAKE_SYSTEM_PROCESSOR MATCHES "(i[3-6]86|x86|x64|x86_64|amd64|e2k)")
+      add_compile_options($<$<NOT:$<CONFIG:Debug>>:-march=x86-64-v2>)
+    endif()
+  endif()
 endif()

--- a/cmake/macos/compilerconfig.cmake
+++ b/cmake/macos/compilerconfig.cmake
@@ -5,12 +5,18 @@ include_guard(GLOBAL)
 option(ENABLE_COMPILER_TRACE "Enable clang time-trace" OFF)
 mark_as_advanced(ENABLE_COMPILER_TRACE)
 
+option(
+  ARES_BUILD_LOCAL
+  "Allows the compiler to generate code optimized for the target machine; increases performance. Also disables certain entitlements and runtime options that interfere with debugging but are required for notarization and distribution."
+  ON
+)
+
 include(ccache)
 include(compiler_common)
 
 # Enable selection between arm64 and x86_64 targets
 if(NOT CMAKE_OSX_ARCHITECTURES)
-  set(CMAKE_OSX_ARCHITECTURES arm64 CACHE STRING "Build architectures for macOS" FORCE)
+  set(CMAKE_OSX_ARCHITECTURES ${CMAKE_SYSTEM_PROCESSOR} CACHE STRING "Build architectures for macOS" FORCE)
 endif()
 set_property(CACHE CMAKE_OSX_ARCHITECTURES PROPERTY STRINGS arm64 x86_64)
 
@@ -37,6 +43,16 @@ string(APPEND CMAKE_C_FLAGS_RELEASE " -g")
 string(APPEND CMAKE_CXX_FLAGS_RELEASE " -g")
 string(APPEND CMAKE_OBJC_FLAGS_RELEASE " -g")
 string(APPEND CMAKE_OBJCXX_FLAGS_RELEASE " -g")
+
+if(ARES_BUILD_LOCAL)
+  add_compile_options($<$<NOT:$<CONFIG:Debug>>:-march=native>)
+else()
+  if(CMAKE_OSX_ARCHITECTURES MATCHES arm64)
+    #
+  else()
+    add_compile_options($<$<NOT:$<CONFIG:Debug>>:-march=x86-64-v2>)
+  endif()
+endif()
 
 if(ENABLE_COMPILER_TRACE)
   add_compile_options(-ftime-trace)

--- a/cmake/macos/defaults.cmake
+++ b/cmake/macos/defaults.cmake
@@ -2,6 +2,7 @@
 
 include_guard(GLOBAL)
 
+# Required to avoid us finding a system SDL2.framework before our provided SDL2.dylib
 set(CMAKE_FIND_FRAMEWORK LAST)
 
 # Set empty codesigning team if not specified as cache variable

--- a/desktop-ui/cmake/os-windows.cmake
+++ b/desktop-ui/cmake/os-windows.cmake
@@ -3,10 +3,7 @@ target_sources(desktop-ui PRIVATE resource/ares.rc resource/ares.Manifest)
 set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT desktop-ui)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  target_link_libraries(
-    desktop-ui
-    PRIVATE mingw32
-  )
+  target_link_libraries(desktop-ui PRIVATE mingw32)
 endif()
 
 if(ARES_ENABLE_LIBRASHADER)

--- a/mia/CMakeLists.txt
+++ b/mia/CMakeLists.txt
@@ -129,10 +129,7 @@ if(ARES_BUILD_OPTIONAL_TARGETS)
 
   if(OS_WINDOWS)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      target_link_libraries(
-        mia-ui
-        PRIVATE nall
-      )
+      target_link_libraries(mia-ui PRIVATE nall)
     endif()
   endif()
 


### PR DESCRIPTION
> [!IMPORTANT]
> This alters default behavior for configuration on Linux that maintainers should be aware of.

Introduces `ARES_BUILD_LOCAL` on Linux, enabled by default, that will pass `-march=native` if enabled. Maintainers will probably want to disable this. Also adds `ARES_ENABLE_MINIMUM_CPU`, `ON` by default, that compiles with the previously enforced `x86-64-v2` minimum on x86_64. Maintainers should do whatever they want with this option.

(@bsdcode @Mastergatto)

These changes are intended to give Linux users building from source a better experience. Enabling x86-64-v2 compared to compiling without any SSE functionality is a 10%+ performance loss locally in the N64 core, and may be higher on actual x86_64 machines.

> [!NOTE]
> It is worth noting that even though we do not explicitly define a minimum SSE functionality on arm64, in practice nall will still [define `__SSE4_1__`](https://github.com/ares-emulator/ares/blob/e808d2c5ab5be91d3e1035063892e8c5115d25e2/nall/intrinsics.hpp#L232) and take advantage of SIMD on that platform via sse2neon.

### Other changes

* Adds `-march=native` on macOS builds under the control of `ARES_BUILD_LOCAL`, and fixes `ARES_BUILD_LOCAL` on Windows so that `-march=native` is added under gcc and not just clang.

* Removes warning in the N64 core related to the issue caused by strict aliasing under GCC.

* Fixed an issue where macOS would always generate for arm64 rather than the host architecture.

* Ran a formatter pass that was previously missed on the CMake code, so there are a couple miscellaneous formatting changes.