### PR TITLE
sh2: fix recompiler regressions

### DIFF
--- a/ares/component/processor/sh2/sh2.cpp
+++ b/ares/component/processor/sh2/sh2.cpp
@@ -65,8 +65,8 @@ auto SH2::power(bool reset) -> void {
 
   if constexpr(Accuracy::Recompiler) {
     if(!reset) {
-      auto buffer = ares::Memory::FixedAllocator::get().tryAcquire(64_MiB);
-      recompiler.allocator.resize(64_MiB, bump_allocator::executable, buffer);
+      auto buffer = ares::Memory::FixedAllocator::get().tryAcquire(32_MiB);
+      recompiler.allocator.resize(32_MiB, bump_allocator::executable, buffer);
     }
     recompiler.reset();
   }

--- a/ares/component/processor/sh2/sh7604/cache.cpp
+++ b/ares/component/processor/sh2/sh7604/cache.cpp
@@ -105,8 +105,6 @@ auto SH2::Cache::purge() -> void {
 }
 
 auto SH2::Cache::power() -> void {
-  purge(4 * 256);
-
   for(n6 n : range(64)) {
     if(n.bit(5) == 1 && n.bit(4) == 1 && n.bit(3) == 1) { lruSelect[n] = 0; continue; }
     if(n.bit(5) == 0 && n.bit(2) == 1 && n.bit(1) == 1) { lruSelect[n] = 1; continue; }


### PR DESCRIPTION
This change corrects two regressions introduced by my last change.

1.  The purge() call in SH2::Cache::power() was, through a call to Recompiler::invalidate(), accessing the pool array before it was allocated.

    This purge call was erronous for two reasons:
    -   It was purging a single line, though it *appears* the intent was
        to purge the entire cache.
    -   According to the SH7604 manual, the cache is not initialized on
        reset.

    Therefore, I simply removed the call.

2.  The size of the recompiler code cache for both of the two SH2s is now halved to fit within the recently halved fixed code cache buffer. The SH2 recompiler is good at reusing previously compiled blocks, so flushes should not be especially common even with this reduced capacity.