### PR TITLE
ruby: Driver defaults fixups

### DIFF
--- a/ruby/audio/sdl.cpp
+++ b/ruby/audio/sdl.cpp
@@ -12,7 +12,7 @@ struct AudioSDL : AudioDriver {
   auto create() -> bool override {
     super.setChannels(2);
     super.setFrequency(48000);
-    super.setLatency(0);
+    super.setLatency(20);
     return initialize();
   }
 

--- a/ruby/video/video.cpp
+++ b/ruby/video/video.cpp
@@ -227,14 +227,14 @@ auto Video::hasDrivers() -> vector<string> {
 auto Video::optimalDriver() -> string {
   #if defined(VIDEO_WGL)
   return "OpenGL 3.2";
+  #elif defined(VIDEO_METAL)
+  return "Metal";
+  #elif defined(VIDEO_GLX)
+  return "OpenGL 3.2";
   #elif defined(VIDEO_DIRECT3D9)
   return "Direct3D 9.0";
   #elif defined(VIDEO_CGL)
   return "OpenGL 3.2";
-  #elif defined(VIDEO_GLX)
-  return "OpenGL 3.2";
-  #elif defined(VIDEO_Metal)
-  return "Metal";
   #else
   return "None";
   #endif
@@ -249,7 +249,7 @@ auto Video::safestDriver() -> string {
   return "OpenGL 3.2";
   #elif defined(VIDEO_GLX)
   return "OpenGL 3.2";
-  #elif defined(VIDEO_Metal)
+  #elif defined(VIDEO_METAL)
   return "Metal";
   #else
   return "None";


### PR DESCRIPTION
By default the SDL audio driver would initialize with a latency value of 0; this doesn't crash, but it ends up causing an unpleasant stuttering and hitching, which is a bad default.

Also makes Metal the default driver on macOS.