### PR TITLE
gba: stall CPU when accessing memory in use by PPU

### DIFF
--- a/ares/gba/cpu/bus.cpp
+++ b/ares/gba/cpu/bus.cpp
@@ -12,7 +12,7 @@ inline auto CPU::getBus(u32 mode, n32 address) -> n32 {
 
   switch(address >> 24) {
 
-  case 0x00 ... 0x01:
+  case 0x00: case 0x01:
     if constexpr(!UseDebugger) prefetchStep(1);
     word = bios.read(mode, address);
     break;
@@ -43,7 +43,7 @@ inline auto CPU::getBus(u32 mode, n32 address) -> n32 {
     word = ppu.readOAM(mode, address);
     break;
 
-  case 0x08 ... 0x0f:
+  case 0x08: case 0x09: case 0x0a: case 0x0b: case 0x0c: case 0x0d: case 0x0e: case 0x0f:
     if(mode & Prefetch && wait.prefetch) {
       prefetchSync(address);
       prefetchStep(1);
@@ -86,7 +86,7 @@ auto CPU::set(u32 mode, n32 address, n32 word) -> void {
 
   switch(address >> 24) {
 
-  case 0x00 ... 0x01:
+  case 0x00: case 0x01:
     prefetchStep(1);
     bios.write(mode, address, word);
     break;
@@ -117,7 +117,7 @@ auto CPU::set(u32 mode, n32 address, n32 word) -> void {
     ppu.writeOAM(mode, address, word);
     break;
 
-  case 0x08 ... 0x0f:
+  case 0x08: case 0x09: case 0x0a: case 0x0b: case 0x0c: case 0x0d: case 0x0e: case 0x0f:
     prefetchReset();
     step(waitCartridge(mode, address));
     cartridge.write(mode, address, word);

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -66,7 +66,8 @@ struct CPU : ARM7TDMI, Thread, IO {
   auto set(u32 mode, n32 address, n32 word) -> void override;
   auto lock() -> void override;
   auto unlock() -> void override;
-  auto _wait(u32 mode, n32 address) -> u32;
+  auto waitEWRAM(u32 mode) -> u32;
+  auto waitCart(u32 mode, n32 address) -> u32;
 
   //io.cpp
   auto readIO(n32 address) -> n8 override;
@@ -77,6 +78,12 @@ struct CPU : ARM7TDMI, Thread, IO {
 
   auto readEWRAM(u32 mode, n32 address) -> n32;
   auto writeEWRAM(u32 mode, n32 address, n32 word) -> void;
+
+  template<bool UseDebugger> auto readPRAM(u32 mode, n32 address) -> n32;
+  auto writePRAM(u32 mode, n32 address, n32 word) -> void;
+
+  template<bool UseDebugger> auto readVRAM(u32 mode, n32 address) -> n32;
+  auto writeVRAM(u32 mode, n32 address, n32 word) -> void;
 
   //dma.cpp
   auto dmaVblank() -> void;

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -67,7 +67,7 @@ struct CPU : ARM7TDMI, Thread, IO {
   auto lock() -> void override;
   auto unlock() -> void override;
   auto waitEWRAM(u32 mode) -> u32;
-  auto waitCart(u32 mode, n32 address) -> u32;
+  auto waitCartridge(u32 mode, n32 address) -> u32;
 
   //io.cpp
   auto readIO(n32 address) -> n8 override;

--- a/ares/gba/cpu/prefetch.cpp
+++ b/ares/gba/cpu/prefetch.cpp
@@ -6,7 +6,7 @@ auto CPU::prefetchSync(n32 address) -> void {
   prefetch.stopped = false;
   prefetch.addr = address;
   prefetch.load = address;
-  prefetch.wait = waitCart(Half | Nonsequential, prefetch.load);
+  prefetch.wait = waitCartridge(Half | Nonsequential, prefetch.load);
 }
 
 auto CPU::prefetchStep(u32 clocks) -> void {
@@ -17,7 +17,7 @@ auto CPU::prefetchStep(u32 clocks) -> void {
     if(--prefetch.wait) continue;
     prefetch.slot[prefetch.load >> 1 & 7] = cartridge.read(Half, prefetch.load);
     prefetch.load += 2;
-    prefetch.wait = waitCart(Half | Sequential, prefetch.load);
+    prefetch.wait = waitCartridge(Half | Sequential, prefetch.load);
   }
 
   if(prefetch.full()) prefetch.stopped = true;
@@ -40,7 +40,7 @@ auto CPU::prefetchRead() -> n16 {
 
   if(prefetch.stopped && prefetch.empty()) {
     prefetch.stopped = false;
-    prefetch.wait = waitCart(Half | Nonsequential, prefetch.load);
+    prefetch.wait = waitCartridge(Half | Nonsequential, prefetch.load);
   }
 
   return word;

--- a/ares/gba/cpu/prefetch.cpp
+++ b/ares/gba/cpu/prefetch.cpp
@@ -6,7 +6,7 @@ auto CPU::prefetchSync(n32 address) -> void {
   prefetch.stopped = false;
   prefetch.addr = address;
   prefetch.load = address;
-  prefetch.wait = _wait(Half | Nonsequential, prefetch.load);
+  prefetch.wait = waitCart(Half | Nonsequential, prefetch.load);
 }
 
 auto CPU::prefetchStep(u32 clocks) -> void {
@@ -17,7 +17,7 @@ auto CPU::prefetchStep(u32 clocks) -> void {
     if(--prefetch.wait) continue;
     prefetch.slot[prefetch.load >> 1 & 7] = cartridge.read(Half, prefetch.load);
     prefetch.load += 2;
-    prefetch.wait = _wait(Half | Sequential, prefetch.load);
+    prefetch.wait = waitCart(Half | Sequential, prefetch.load);
   }
 
   if(prefetch.full()) prefetch.stopped = true;
@@ -40,7 +40,7 @@ auto CPU::prefetchRead() -> n16 {
 
   if(prefetch.stopped && prefetch.empty()) {
     prefetch.stopped = false;
-    prefetch.wait = _wait(Half | Nonsequential, prefetch.load);
+    prefetch.wait = waitCart(Half | Nonsequential, prefetch.load);
   }
 
   return word;

--- a/ares/gba/ppu/background.cpp
+++ b/ares/gba/ppu/background.cpp
@@ -46,6 +46,35 @@ auto PPU::Background::run(u32 x, u32 y) -> void {
   }
 }
 
+auto PPU::Background::linearFetchTileMap() -> void {
+  n6 tx = fx >> 3;
+  n6 ty = fy >> 3;
+
+  u32 offset = (ty & 31) << 5 | (tx & 31);
+  if(io.screenSize.bit(0) && (tx & 32)) offset += 32 << 5;
+  if(io.screenSize.bit(1) && (ty & 32)) offset += 32 << 5 + io.screenSize.bit(0);
+  offset = (io.screenBase << 11) + (offset << 1);
+
+  n16 tilemap  = ppu.readVRAM_BG(Half, offset);
+  latch.character = tilemap.bit(0,9);
+  latch.hflip     = tilemap.bit(10);
+  latch.vflip     = tilemap.bit(11);
+  latch.palette   = tilemap.bit(12,15);
+}
+
+auto PPU::Background::linearFetchTileData() -> void {
+  n3 px = fx;
+  n3 py = fy;
+  if(latch.hflip) px = ~px;
+  if(latch.vflip) py = ~py;
+
+  u32 tileOffset = ((latch.character << 5) + (py << 2)) << io.colorMode;
+  u32 pixelOffset = px >> (1 - io.colorMode);
+  u32 offset = (io.characterBase << 14) + tileOffset + pixelOffset;
+
+  latch.data = ppu.readVRAM_BG(Half, offset);
+}
+
 auto PPU::Background::linear(u32 x, u32 y) -> void {
   if(x > 239) return;
   if(ppu.blank() || !io.enable[0]) return;
@@ -61,39 +90,31 @@ auto PPU::Background::linear(u32 x, u32 y) -> void {
   n3 px = fx;
   n3 py = fy;
 
-  if(x == 0 || px == 0) {
-    n6 tx = fx >> 3;
-    n6 ty = fy >> 3;
-
-    u32 offset = (ty & 31) << 5 | (tx & 31);
-    if(io.screenSize.bit(0) && (tx & 32)) offset += 32 << 5;
-    if(io.screenSize.bit(1) && (ty & 32)) offset += 32 << 5 + io.screenSize.bit(0);
-    offset = (io.screenBase << 11) + (offset << 1);
-
-    n16 tilemap  = ppu.readVRAM(Half, offset);
-    latch.character = tilemap.bit(0,9);
-    latch.hflip     = tilemap.bit(10);
-    latch.vflip     = tilemap.bit(11);
-    latch.palette   = tilemap.bit(12,15);
+  if(x == 0 || px == 0) linearFetchTileMap();
+  if(x == 0) {
+    linearFetchTileData();
+  } else if(io.colorMode == 0 && (px & 3) == 0) {
+    linearFetchTileData();
+  } else if(io.colorMode == 1 && (px & 1) == 0) {
+    linearFetchTileData();
   }
 
   if(latch.hflip) px = ~px;
-  if(latch.vflip) py = ~py;
 
+  n16 color = latch.data;
   if(io.colorMode == 0) {
-    u32 offset = (io.characterBase << 14) + (latch.character << 5) + (py << 2) + (px >> 1);
-    if(n4 color = ppu.readVRAM_BG(Byte, offset) >> (px & 1 ? 4 : 0)) {
-      output[x].enable = true;
-      output[x].priority = io.priority;
-      output[x].color = latch.palette << 4 | color;
-    }
+    color >>= (px & 3) * 4;
+    color = (n4)color;
   } else {
-    u32 offset = (io.characterBase << 14) + (latch.character << 6) + (py << 3) + (px);
-    if(n8 color = ppu.readVRAM_BG(Byte, offset)) {
-      output[x].enable = true;
-      output[x].priority = io.priority;
-      output[x].color = color;
-    }
+    color >>= (px & 1) * 8;
+    color = (n8)color;
+  }
+
+  if(color) {
+    if(io.colorMode == 0) color |= latch.palette << 4;
+    output[x].enable = true;
+    output[x].priority = io.priority;
+    output[x].color = color;
   }
 
   fx++;
@@ -121,7 +142,7 @@ auto PPU::Background::affineFetchTileMap(u32 x, u32 y) -> void {
   affine.tx = affine.cx >> 3;
   affine.ty = affine.cy >> 3;
 
-  affine.character = ppu.readVRAM(Byte, (io.screenBase << 11) + affine.ty * affine.screenSize + affine.tx);
+  affine.character = ppu.readVRAM_BG(Byte, (io.screenBase << 11) + affine.ty * affine.screenSize + affine.tx);
 }
 
 auto PPU::Background::affineFetchTileData(u32 x, u32 y) -> void {

--- a/ares/gba/ppu/dac.cpp
+++ b/ares/gba/ppu/dac.cpp
@@ -74,6 +74,7 @@ auto PPU::DAC::lowerLayer(u32 x, u32 y) -> void {
 
 inline auto PPU::DAC::pramLookup(Pixel& layer) -> n15 {
   if(layer.directColor) return layer.color;
+  ppu.pramAccessed = true;
   return ppu.pram[layer.color];
 }
 

--- a/ares/gba/ppu/memory.cpp
+++ b/ares/gba/ppu/memory.cpp
@@ -1,20 +1,34 @@
-auto PPU::readVRAM_BG(u32 mode, n32 address) -> n32 {
+auto PPU::releaseBus() -> void {
+  pramAccessed = false;
+  vramAccessedBG = false;
+}
+
+auto PPU::pramContention() -> bool {
+  return ppu.pramAccessed;
+}
+
+auto PPU::vramContention(n32 address) -> bool {
+  address &= 0x1ffff;
+  if(Background::IO::mode < 3 && address >= 0x10000) return false;
+  else if(address >= 0x14000) return false;
+  return ppu.vramAccessedBG;
+}
+
+auto PPU::readVRAM_BG(u32 mode, n32 address) -> n16 {
   if(Background::IO::mode < 3 && address >= 0x10000) return 0;
   else if(address >= 0x14000) return 0;
+  ppu.vramAccessedBG = true;
 
   return readVRAM(mode, address);
 }
 
-auto PPU::readVRAM(u32 mode, n32 address) -> n32 {
+auto PPU::readVRAM(u32 mode, n32 address) -> n16 {
   address &= 0x1ffff;
   if(Background::IO::mode >= 3 && address < 0x1c000 && address >= 0x18000) return 0;
 
   address &= (address & 0x10000) ? 0x17fff : 0x0ffff;
 
-  if(mode & Word) {
-    address &= ~3;
-    return vram[address + 0] << 0 | vram[address + 1] << 8 | vram[address + 2] << 16 | vram[address + 3] << 24;
-  } else if(mode & Half) {
+  if(mode & Half) {
     address &= ~1;
     return vram[address + 0] << 0 | vram[address + 1] << 8;
   } else if(mode & Byte) {
@@ -24,52 +38,39 @@ auto PPU::readVRAM(u32 mode, n32 address) -> n32 {
   unreachable;
 }
 
-auto PPU::writeVRAM(u32 mode, n32 address, n32 word) -> void {
+auto PPU::writeVRAM(u32 mode, n32 address, n16 half) -> void {
   address &= 0x1ffff;
   if(Background::IO::mode >= 3 && address < 0x1c000 && address >= 0x18000) return;
 
   address &= (address & 0x10000) ? 0x17fff : 0x0ffff;
 
-  if(mode & Word) {
-    address &= ~3;
-    vram[address + 0] = word >>  0;
-    vram[address + 1] = word >>  8;
-    vram[address + 2] = word >> 16;
-    vram[address + 3] = word >> 24;
-  } else if(mode & Half) {
+  if(mode & Half) {
     address &= ~1;
-    vram[address + 0] = word >>  0;
-    vram[address + 1] = word >>  8;
+    vram[address + 0] = half >>  0;
+    vram[address + 1] = half >>  8;
   } else if(mode & Byte) {
     //8-bit writes to OBJ section of VRAM are ignored
     if(Background::IO::mode <= 2 && address >= 0x10000) return;
     if(Background::IO::mode <= 5 && address >= 0x14000) return;
 
     address &= ~1;
-    vram[address + 0] = (n8)word;
-    vram[address + 1] = (n8)word;
+    vram[address + 0] = (n8)half;
+    vram[address + 1] = (n8)half;
   }
 }
 
-auto PPU::readPRAM(u32 mode, n32 address) -> n32 {
-  if(mode & Word) return readPRAM(Half, address & ~2) << 0 | readPRAM(Half, address | 2) << 16;
+auto PPU::readPRAM(u32 mode, n32 address) -> n16 {
   if(mode & Byte) return readPRAM(Half, address) >> ((address & 1) * 8);
   return pram[address >> 1 & 511];
 }
 
-auto PPU::writePRAM(u32 mode, n32 address, n32 word) -> void {
-  if(mode & Word) {
-    writePRAM(Half, address & ~2, word >>  0);
-    writePRAM(Half, address |  2, word >> 16);
-    return;
-  }
-
+auto PPU::writePRAM(u32 mode, n32 address, n16 half) -> void {
   if(mode & Byte) {
-    word = (n8)word;
-    return writePRAM(Half, address, word << 8 | word << 0);
+    half = (n8)half;
+    return writePRAM(Half, address, half << 8 | half << 0);
   }
 
-  pram[address >> 1 & 511] = (n16)word;
+  pram[address >> 1 & 511] = (n16)half;
 }
 
 auto PPU::readOAM(u32 mode, n32 address) -> n32 {

--- a/ares/gba/ppu/memory.cpp
+++ b/ares/gba/ppu/memory.cpp
@@ -4,20 +4,20 @@ auto PPU::releaseBus() -> void {
 }
 
 auto PPU::pramContention() -> bool {
-  return ppu.pramAccessed;
+  return pramAccessed;
 }
 
 auto PPU::vramContention(n32 address) -> bool {
   address &= 0x1ffff;
   if(Background::IO::mode < 3 && address >= 0x10000) return false;
   else if(address >= 0x14000) return false;
-  return ppu.vramAccessedBG;
+  return vramAccessedBG;
 }
 
 auto PPU::readVRAM_BG(u32 mode, n32 address) -> n16 {
   if(Background::IO::mode < 3 && address >= 0x10000) return 0;
   else if(address >= 0x14000) return 0;
-  ppu.vramAccessedBG = true;
+  vramAccessedBG = true;
 
   return readVRAM(mode, address);
 }

--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -119,6 +119,7 @@ auto PPU::cycle(u32 y) -> void {
   if constexpr(Cycle >= 46 && Cycle <= 1005 && (Cycle - 46) % 4 == 0) cycleUpperLayer((Cycle - 46) / 4, y);
   if constexpr(Cycle >= 46 && Cycle <= 1005 && (Cycle - 46) % 4 == 2) dac.lowerLayer((Cycle - 46) / 4, y);
   step(1);
+  releaseBus();
 }
 
 auto PPU::main() -> void {
@@ -196,6 +197,7 @@ auto PPU::main() -> void {
         cycleUpperLayer(x, y);
         dac.lowerLayer(x, y);
       }
+      releaseBus();
       step(975);
     }
   } else {
@@ -218,8 +220,8 @@ auto PPU::power() -> void {
   for(u32 n = 0x000; n <= 0x055; n++) bus.io[n] = this;
 
   for(u32 n = 0; n < 96 * 1024; n++) vram[n] = 0x00;
-  for(u32 n = 0; n < 1024; n += 2) writePRAM(n, Half, 0x0000);
-  for(u32 n = 0; n < 1024; n += 2) writeOAM(n, Half, 0x0000);
+  for(u32 n = 0; n < 1024; n += 2) writePRAM(Half, n, 0x0000);
+  for(u32 n = 0; n < 1024; n += 2) writeOAM(Half, n, 0x0000);
 
   io = {};
   for(auto& object : this->object) object = {};

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -53,12 +53,16 @@ struct PPU : Thread, IO {
   auto writeIO(n32 address, n8 byte) -> void;
 
   //memory.cpp
-  auto readVRAM(u32 mode, n32 address) -> n32;
-  auto readVRAM_BG(u32 mode, n32 address) -> n32;
-  auto writeVRAM(u32 mode, n32 address, n32 word) -> void;
+  auto releaseBus() -> void;
+  auto pramContention() -> bool;
+  auto vramContention(n32 address) -> bool;
 
-  auto readPRAM(u32 mode, n32 address) -> n32;
-  auto writePRAM(u32 mode, n32 address, n32 word) -> void;
+  auto readVRAM(u32 mode, n32 address) -> n16;
+  auto readVRAM_BG(u32 mode, n32 address) -> n16;
+  auto writeVRAM(u32 mode, n32 address, n16 half) -> void;
+
+  auto readPRAM(u32 mode, n32 address) -> n16;
+  auto writePRAM(u32 mode, n32 address, n16 half) -> void;
 
   auto readOAM(u32 mode, n32 address) -> n32;
   auto writeOAM(u32 mode, n32 address, n32 word) -> void;
@@ -103,6 +107,8 @@ private:
     auto scanline(u32 y) -> void;
     auto outputPixel(u32 x, u32 y) -> void;
     auto run(u32 x, u32 y) -> void;
+    auto linearFetchTileMap() -> void;
+    auto linearFetchTileData() -> void;
     auto linear(u32 x, u32 y) -> void;
     auto affineFetchTileMap(u32 x, u32 y) -> void;
     auto affineFetchTileData(u32 x, u32 y) -> void;
@@ -152,6 +158,8 @@ private:
       n1 hflip;
       n1 vflip;
       n4 palette;
+
+      n16 data;
     } latch;
 
     struct Affine {
@@ -292,6 +300,9 @@ private:
     i16 pc;
     i16 pd;
   } objectParam[32];
+
+  bool pramAccessed;
+  bool vramAccessedBG;
 };
 
 extern PPU ppu;

--- a/ares/gba/ppu/serialization.cpp
+++ b/ares/gba/ppu/serialization.cpp
@@ -24,6 +24,9 @@ auto PPU::serialize(serializer& s) -> void {
   s(dac);
   for(auto& object : this->object) s(object);
   for(auto& param : this->objectParam) s(param);
+
+  s(pramAccessed);
+  s(vramAccessedBG);
 }
 
 auto PPU::Background::serialize(serializer& s) -> void {

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v141.5";
+static const string SerializerVersion = "v141.6";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Since the timing of these stalls is dependent on PPU memory access timings, this change should only impact the pixel accuracy setting.