### PR TITLE
mia, desktop-ui: Emit error if database files not found

### DIFF
--- a/desktop-ui/emulator/emulator.cpp
+++ b/desktop-ui/emulator/emulator.cpp
@@ -57,7 +57,11 @@ auto Emulator::region() -> string {
 auto Emulator::load(const string& location) -> bool {
   if(inode::exists(location)) locationQueue.append(location);
 
-  if(!load()) return false;
+  if(!load()) {
+    error("Failed to load system! Database files may have been incorrectly \n"
+          "installed. Make sure you have packaged or installed ares correctly.");
+    return false;
+  }
   setBoolean("Color Emulation", settings.video.colorEmulation);
   setBoolean("Deep Black Boost", settings.video.deepBlackBoost);
   setBoolean("Interframe Blending", settings.video.interframeBlending);

--- a/mia/medium/arcade.cpp
+++ b/mia/medium/arcade.cpp
@@ -6,6 +6,8 @@ struct Arcade : Mame {
 };
 
 auto Arcade::load(string location) -> bool {
+  auto foundDatabase = Medium::loadDatabase();
+  if(!foundDatabase) return false;
   manifest = manifestDatabaseArcade(Medium::name(location));
   if(!manifest) return false;
 

--- a/mia/medium/bs-memory.cpp
+++ b/mia/medium/bs-memory.cpp
@@ -18,6 +18,8 @@ auto BSMemory::load(string location) -> bool {
 
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
+  auto foundDatabase = Medium::loadDatabase();
+  if(!foundDatabase) return false;
   this->manifest = Medium::manifestDatabase(sha256);
   if(!manifest) manifest = analyze(rom);
   auto document = BML::unserialize(manifest);

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -96,6 +96,8 @@ auto Famicom::analyze(vector<u8>& data) -> string {
   }
 
   string digest = Hash::SHA256(data).digest();
+  auto foundDatabase = Medium::loadDatabase();
+  if(!foundDatabase) return {};
   string manifest = Medium::manifestDatabase(digest);
   if(manifest) return manifest;
 

--- a/mia/medium/medium.cpp
+++ b/mia/medium/medium.cpp
@@ -82,19 +82,22 @@ auto Medium::create(string name) -> shared_pointer<Pak> {
   return {};
 }
 
-auto Medium::loadDatabase() -> void {
+auto Medium::loadDatabase() -> bool {
   //load the database on the first time it's needed for a given media type
-  bool found = false;
   for(auto& database : Media::databases) {
-    if(database.name == name()) found = true;
+    if(database.name == name()) return true;
   }
 
-  if(!found) {
-    Database database;
-    database.name = name();
-    database.list = BML::unserialize(file::read(locate({"Database/", name(), ".bml"})));
+  Database database;
+  database.name = name();
+  auto databaseFile = locate({"Database/", name(), ".bml"});
+  if(inode::exists(databaseFile)) {
+    database.list = BML::unserialize(file::read(databaseFile));
     Media::databases.append(std::move(database));
+    return true;
   }
+
+  return false;
 }
 
 //Retrieve all entries in game database

--- a/mia/medium/medium.hpp
+++ b/mia/medium/medium.hpp
@@ -5,7 +5,7 @@ struct Database {
 
 struct Medium : Pak {
   static auto create(string name) -> shared_pointer<Pak>;
-  auto loadDatabase() -> void;
+  auto loadDatabase() -> bool;
   auto database() -> Database;
   auto manifestDatabase(string sha256) -> string;
   auto manifestDatabaseArcade(string name) -> string;

--- a/mia/medium/msx.cpp
+++ b/mia/medium/msx.cpp
@@ -23,6 +23,8 @@ auto MSX::load(string location) -> bool {
 
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
+  auto foundDatabase = Medium::loadDatabase();
+  if(!foundDatabase) return false;
   this->manifest = Medium::manifestDatabase(sha256);
   if(!manifest) manifest = analyze(rom);
   auto document = BML::unserialize(manifest);

--- a/mia/medium/neo-geo.cpp
+++ b/mia/medium/neo-geo.cpp
@@ -66,6 +66,8 @@ auto NeoGeo::load(string location) -> bool {
   vector<u8> voiceAROM;     //V ROM (ADPCM-A voice samples)
   vector<u8> voiceBROM;     //V ROM (ADPCM-B voice samples)
 
+  auto foundDatabase = Medium::loadDatabase();
+  if(!foundDatabase) return false;
   this->info = BML::unserialize(manifestDatabaseArcade(Medium::name(location)));
 
   if(file::exists(location)) {

--- a/mia/medium/sufami-turbo.cpp
+++ b/mia/medium/sufami-turbo.cpp
@@ -17,6 +17,8 @@ auto SufamiTurbo::load(string location) -> bool {
 
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
+  auto foundDatabase = Medium::loadDatabase();
+  if(!foundDatabase) return false;
   this->manifest = Medium::manifestDatabase(sha256);
   if(!manifest) manifest = analyze(rom);
   auto document = BML::unserialize(manifest);

--- a/mia/medium/super-famicom.cpp
+++ b/mia/medium/super-famicom.cpp
@@ -84,6 +84,8 @@ auto SuperFamicom::load(string location) -> bool {
   
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
+  auto foundDatabase = Medium::loadDatabase();
+  if(!foundDatabase) return false;
   this->manifest = Medium::manifestDatabase(sha256);
   
   if(!manifest) {


### PR DESCRIPTION
For each emulator core with a `.bml` file in the Database folder packaged with ares, this PR adds a separate check in their mia `load` functions to verify that their database file exists on disk. If it does not, we bail out of the loading process.

Meanwhile, in desktop-ui, if loading failed, we will now throw up an error.

This PR stops short of adding fully robust error handling to the load routines; the error message we throw up is generalized, and will appear for anything that causes loading to fail, not just specifically database files not being found. I think that the database files should be by far the most common cause of load failure, so this seems OK to me for now, but could certainly be improved in the future to provide more specific errors. I obviously welcome feedback on how to handle any aspect of this better.