### PR TITLE
CI: Run new CI on pull requests

### DIFF
--- a/.github/workflows/build_new.yml
+++ b/.github/workflows/build_new.yml
@@ -1,6 +1,10 @@
 name: Build (New)
 on:
-  push
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+    types: [ opened, synchronize, reopened ]
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
Run the new CI on pull requests (and not just the old one) so we can catch bugs and failures, take advantage of new inline annotations, etc.

Working on a slight refactor of CI in general to make it better-organized, but seems worth PRing this first before that is complete.