### PR TITLE
m68000: fix linking error

### DIFF
--- a/tests/m68000/CMakeLists.txt
+++ b/tests/m68000/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(m68000 m68000.cpp ../../ares/component/processor/m68000/m68000.cpp)
+add_executable(m68000 m68000.cpp)
 
 target_include_directories(m68000 PRIVATE ${CMAKE_SOURCE_DIR})
 


### PR DESCRIPTION
processor/m68000/m68000.cpp is already compiled into the ares static library. It shouldn't be built directly by the m68000 test harness.