### PR TITLE
arm7tdmi: write to rh after rl in multiply long instructions

### DIFF
--- a/ares/component/processor/arm7tdmi/instructions-arm.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-arm.cpp
@@ -302,8 +302,8 @@ auto ARM7TDMI::armInstructionMultiplyLong
   n64 rd = rm * rs;
   if(accumulate) rd += (n64)r(h) << 32 | (n64)r(l) << 0;
 
-  r(h) = rd >> 32;
   r(l) = rd >>  0;
+  r(h) = rd >> 32;
 
   if(save) {
     cpsr().z = rd == 0;


### PR DESCRIPTION
Tested on hardware, and verified that when rh and rl refer to the same register, the write to rh overwrites the value written to rl.