### PR TITLE
ym2612: fixing the bugs

### DIFF
--- a/ares/component/audio/ym2612/channel.cpp
+++ b/ares/component/audio/ym2612/channel.cpp
@@ -132,7 +132,7 @@ auto YM2612::Channel::Operator::updateLevel() -> void {
   bool invert = ssg.attack != ssg.invert && envelope.state != Release;
   n10 value = ssg.enable && invert ? 0x200 - envelope.value : 0 + envelope.value;
 
-  outputLevel = ((totalLevel << 3) + value + (lfoEnable ? lfo << 1 >> depth : 0)) << 3;
+  outputLevel = (totalLevel << 3) + value + (lfo << 1 >> depth) << 3;
 }
 
 auto YM2612::Channel::power() -> void {

--- a/ares/component/audio/ym2612/io.cpp
+++ b/ares/component/audio/ym2612/io.cpp
@@ -14,8 +14,10 @@ auto YM2612::writeData(n8 data) -> void {
   case 0x022: {
     lfo.rate = data.bit(0,2);
     lfo.enable = data.bit(3);
-    lfo.clock = 0;
-    lfo.divider = 0;
+    if(!lfo.enable) {
+      lfo.clock = 0;
+      lfo.divider = 0;
+    }
     break;
   }
 

--- a/ares/component/audio/ym2612/io.cpp
+++ b/ares/component/audio/ym2612/io.cpp
@@ -116,10 +116,10 @@ auto YM2612::writeData(n8 data) -> void {
     break;
   }
 
-  //key scaling, attack rate
+  //rate scaling, attack rate
   case 0x050: {
     op.envelope.attackRate = data.bit(0,4);
-    op.envelope.keyScale = data.bit(6,7);
+    op.envelope.rateScaling = data.bit(6,7);
     channel[index].updateEnvelope();
     channel[index].updatePhase();
     break;

--- a/ares/component/audio/ym2612/serialization.cpp
+++ b/ares/component/audio/ym2612/serialization.cpp
@@ -44,6 +44,7 @@ auto YM2612::Channel::Operator::serialize(serializer& s) -> void {
   s(keyOn);
   s(keyLine);
   s(lfoEnable);
+  s(keyScale);
   s(detune);
   s(multiple);
   s(totalLevel);
@@ -68,7 +69,7 @@ auto YM2612::Channel::Operator::serialize(serializer& s) -> void {
   s(envelope.divider);
   s(envelope.steps);
   s(envelope.value);
-  s(envelope.keyScale);
+  s(envelope.rateScaling);
   s(envelope.attackRate);
   s(envelope.decayRate);
   s(envelope.sustainRate);

--- a/ares/component/audio/ym2612/ym2612.cpp
+++ b/ares/component/audio/ym2612/ym2612.cpp
@@ -21,7 +21,7 @@ auto YM2612::clock() -> array<i16[2]> {
     if(!++envelope.clock) ++envelope.clock; // 12-bit counter: 1..4095 - zero-value is skipped (confirmed behavior)
   }
 
-  if(lfo.enable && ++lfo.divider == lfoDividers[lfo.rate]) {
+  if(lfo.enable && ++lfo.divider >= lfoDividers[lfo.rate]) {
     lfo.divider = 0;
     lfo.clock++;
     for(auto& channel : channels) {

--- a/ares/component/audio/ym2612/ym2612.cpp
+++ b/ares/component/audio/ym2612/ym2612.cpp
@@ -13,6 +13,25 @@ auto YM2612::clock() -> array<i16[2]> {
   s32 left  = 0;
   s32 right = 0;
 
+  timerA.run();
+  timerB.run();
+
+  if(++envelope.divider == 3) {
+    envelope.divider = 0;
+    if(!++envelope.clock) ++envelope.clock; // 12-bit counter: 1..4095 - zero-value is skipped (confirmed behavior)
+  }
+
+  if(lfo.enable && ++lfo.divider == lfoDividers[lfo.rate]) {
+    lfo.divider = 0;
+    lfo.clock++;
+    for(auto& channel : channels) {
+      for(auto& op : channel.operators) {
+        op.updatePhase();  //due to vibrato
+        op.updateLevel();  //due to tremolo
+      }
+    }
+  }
+
   for(auto& channel : channels) {
     auto& op = channel.operators;
 
@@ -30,11 +49,17 @@ auto YM2612::clock() -> array<i16[2]> {
       return y < 0x1a00 ? pow2[y & 0x1ff] << 2 >> (y >> 9) : 0; // -78 dB floor
     };
 
-    s32 feedback = modMask & op[0].prior + op[0].priorBuffer >> 9 - channel.feedback;
-    s32 accumulator = 0;
-
     op[0].priorBuffer = op[0].prior; // only need to buffer the output for feedback
     for(auto n : range(4)) op[n].prior = op[n].output;
+
+    for(auto& op : channel.operators) {
+      op.runPhase();
+      if(envelope.divider) continue;
+      op.runEnvelope();
+    }
+
+    s32 feedback = modMask & op[0].prior + op[0].priorBuffer >> 9 - channel.feedback;
+    s32 accumulator = 0;
 
     op[0].output = wave(0, feedback * (channel.feedback > 0));
 
@@ -120,33 +145,6 @@ auto YM2612::clock() -> array<i16[2]> {
     // DAC output (ym3438 fix)
     //if(channel.leftEnable ) left  += voiceData;
     //if(channel.rightEnable) right += voiceData;
-  }
-
-  timerA.run();
-  timerB.run();
-
-  if(lfo.enable && ++lfo.divider == lfoDividers[lfo.rate]) {
-    lfo.divider = 0;
-    lfo.clock++;
-    for(auto& channel : channels) {
-      for(auto& op : channel.operators) {
-        op.updatePhase();  //due to vibrato
-        op.updateLevel();  //due to tremolo
-      }
-    }
-  }
-
-  if(++envelope.divider == 3) {
-    envelope.divider = 0;
-    if(!++envelope.clock) ++envelope.clock; // 12-bit counter: 1..4095 - zero-value is skipped (confirmed behavior)
-  }
-
-  for(auto& channel : channels) {
-    for(auto& op : channel.operators) {
-      op.runPhase();
-      if(envelope.divider) continue;
-      op.runEnvelope();
-    }
   }
 
   return {sclamp<16>(left), sclamp<16>(right)};

--- a/ares/component/audio/ym2612/ym2612.hpp
+++ b/ares/component/audio/ym2612/ym2612.hpp
@@ -107,6 +107,7 @@ protected:
       n1 keyOn = 0;
       n1 keyLine = 0;
       n1 lfoEnable = 0;
+      n5 keyScale = 0;
       n3 detune = 0;
       n4 multiple = 0;
       n7 totalLevel = 0;
@@ -140,7 +141,7 @@ protected:
         n32 steps = 0;
         n10 value = 0x3ff;
 
-        n2  keyScale = 0;
+        n2  rateScaling = 0;
         n5  attackRate = 0;
         n5  decayRate = 0;
         n5  sustainRate = 0;

--- a/ares/md/system/serialization.cpp
+++ b/ares/md/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v141";
+static const string SerializerVersion = "v141.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
1. The cycle update order needed clean up, mostly to fix feedback.
2. Envelope update function was also reordered to avoid double update issue.
3. LFO behavior was corrected (should apply proper attenuation when disabled).
4. To avoid potential update issue, rate scaling was lightly refactored. Avoids recalc of key scale factor and renames keyScale to rateScaling (RS) for clarity.

Related issues: #1159, #1112
