### PR TITLE
CI: fix macOS CI PR runs

### DIFF
--- a/.github/workflows/build_new.yml
+++ b/.github/workflows/build_new.yml
@@ -80,7 +80,7 @@ jobs:
     - name: "macOS: Import Certificate"
       if: runner.os == 'macOS'
       uses: apple-actions/import-codesign-certs@v3
-      continue-on-error: ${{ github.repository != 'ares-emulator/ares' }}
+      continue-on-error: ${{ github.repository != 'ares-emulator/ares' || needs.pr-check.outputs.number != 'null' }}
       with:
         p12-file-base64: ${{ secrets.MACOS_CERTIFICATE_DATA }}
         p12-password: ${{ secrets.MACOS_CERTIFICATE_PASSPHRASE }}
@@ -131,7 +131,7 @@ jobs:
         timestampUrl: 'http://timestamp.digicert.com'
     - name: "macOS: notarize"
       if: runner.os == 'macOS' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
-      continue-on-error: ${{ github.repository != 'ares-emulator/ares' }}
+      continue-on-error: ${{ github.repository != 'ares-emulator/ares' || needs.pr-check.outputs.number != 'null' }}
       run: |
         ditto -c -k --keepParent ${{ github.workspace }}/build/desktop-ui/RelWithDebInfo/ares.app /tmp/ares.zip
         xcrun notarytool submit /tmp/ares.zip --apple-id "$MACOS_NOTARIZATION_USERNAME" --password "$MACOS_NOTARIZATION_PASSWORD" --team-id "$MACOS_NOTARIZATION_TEAMID" --wait


### PR DESCRIPTION
Fix macOS CI on pull requests by persisting if we fail to import the certificate (as expected). Notarization should expectedly fail as well on pull requests, if it tries to run.

(Whether CI succeeds on this is the testing)