### PR TITLE
build: Remove redundant linking under gcc for test harnesses

### DIFF
--- a/tests/i8080/CMakeLists.txt
+++ b/tests/i8080/CMakeLists.txt
@@ -4,15 +4,6 @@ target_include_directories(i8080 PRIVATE ${CMAKE_SOURCE_DIR})
 
 target_link_libraries(i8080 PRIVATE ares::ares)
 
-if(OS_WINDOWS)
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_link_libraries(
-      i8080
-      PRIVATE nall
-    )
-  endif()
-endif()
-
 set_target_properties(i8080 PROPERTIES FOLDER tests PREFIX "")
 target_enable_subproject(i8080 "i8080 processor test harness")
 set(CONSOLE TRUE)

--- a/tests/m68000/CMakeLists.txt
+++ b/tests/m68000/CMakeLists.txt
@@ -4,15 +4,6 @@ target_include_directories(m68000 PRIVATE ${CMAKE_SOURCE_DIR})
 
 target_link_libraries(m68000 PRIVATE ares::ares)
 
-if(OS_WINDOWS)
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_link_libraries(
-      m68000
-      PRIVATE nall
-    )
-  endif()
-endif()
-
 set_target_properties(m68000 PROPERTIES FOLDER tests PREFIX "")
 target_enable_subproject(m68000 "m68000 processor test harness")
 set(CONSOLE TRUE)


### PR DESCRIPTION
After https://github.com/ares-emulator/ares/pull/1774 the workaround for the Windows variant of `main` being discarded early by `ld` is no longer necessary.