### PR TITLE
[MD/32X] Force PAL region when (PAL) or (Europe) are in ROM name

### DIFF
--- a/mia/medium/mega-32x.cpp
+++ b/mia/medium/mega-32x.cpp
@@ -149,7 +149,7 @@ auto Mega32X::analyze(vector<u8>& rom) -> string {
     regions.append("PAL");
   }
 
-  //Shadow Squadron - Stellar Assualt is missing NTSC-U region
+  //Shadow Squadron - Stellar Assault is missing NTSC-U region in header
   if(hash == "2f9b6017258fbb1c37d81df07c68d5255495d3bf76d9c7b680ff66bccf665750") {
     regions.append("NTSC-U");
   }

--- a/mia/medium/mega-32x.cpp
+++ b/mia/medium/mega-32x.cpp
@@ -143,6 +143,17 @@ auto Mega32X::analyze(vector<u8>& rom) -> string {
     regions.append("NTSC-J", "NTSC-U", "PAL");
   }
 
+  // FIFA Soccer 96 and Mortal Kombat II have an incorrect header, so force PAL based on name
+  if(location.ifind("(Europe)") || location.ifind("(PAL)")) {
+    regions.reset();
+    regions.append("PAL");
+  }
+
+  //Shadow Squadron - Stellar Assualt is missing NTSC-U region
+  if(hash == "2f9b6017258fbb1c37d81df07c68d5255495d3bf76d9c7b680ff66bccf665750") {
+    regions.append("NTSC-U");
+  }
+
   string domesticName;
   domesticName.resize(48);
   memory::copy(domesticName.get(), &rom[0x0120], domesticName.size());

--- a/mia/medium/mega-drive.cpp
+++ b/mia/medium/mega-drive.cpp
@@ -280,8 +280,8 @@ auto MegaDrive::analyzeRegion(vector<u8>& rom, string hash) -> void {
     regions.append("NTSC-J", "NTSC-U", "PAL");
   }
 
-  //Alisia Dragoon (Europe)
-  if(hash == "0930b77d0474e99c10690245cac12a6618b6c16420e3575379aba6e715ea797a") {
+  // Many PAL games have incorrect headers, so force PAL based on name
+  if(location.ifind("(Europe)") || location.ifind("(PAL)")) {
     regions.reset();
     regions.append("PAL");
   }


### PR DESCRIPTION
There are numerous headers in Mega Drive & 32X games that are not correct resulting in PAL games to run at 60Hz instead of 50Hz. This corrects this issue by using the same technique the Atari 2600 core uses which is to look for "(PAL)" or "(Europe)" in the ROM name which will then force the game to run as a PAL game. 

This also addresses the 32X game Shadow Squadron - Stellar Assault which is supposed to be an NTSC-U and PAL game, but only has PAL in the header so it could only run at 50Hz. This adds NTSC-U as an option (leaving PAL as the default), but can be selected using the "Prefer US" boot option so it can run at 60Hz. 

Addresses issues: 
https://github.com/ares-emulator/ares/issues/1066
https://github.com/ares-emulator/ares/issues/1067

And yes, I'm aware I submitted an additional commit cause I spelled Assault wrong in the comment, and managed to spell it wrong again in the commit message. 🤦‍♂️