### PR TITLE
mia, desktop-ui: Add basic error handling to ROM loading

### DIFF
--- a/ares/ares/ares.hpp
+++ b/ares/ares/ares.hpp
@@ -79,3 +79,33 @@ namespace ares {
 #include <ares/memory/fixed-allocator.hpp>
 #include <ares/memory/readable.hpp>
 #include <ares/memory/writable.hpp>
+
+enum ResultEnum {
+  successful,
+  noFileSelected,
+  databaseNotFound,
+  romNotFoundInDatabase,
+  romNotFound,
+  invalidRom,
+  couldNotParseManifest,
+  noFirmware,
+  otherError
+};
+
+struct LoadResult {
+  ResultEnum result;
+  
+  string info;
+  string firmwareType;
+  string firmwareSystemName;
+  string firmwareRegion;
+  
+  LoadResult(ResultEnum r) : result(r), info(0) {}
+  
+  bool operator==(const LoadResult& other) {
+    return result == other.result;
+  }
+  bool operator!=(const LoadResult& other) {
+    return result != other.result;
+  }
+};

--- a/ares/ares/ares.hpp
+++ b/ares/ares/ares.hpp
@@ -79,33 +79,3 @@ namespace ares {
 #include <ares/memory/fixed-allocator.hpp>
 #include <ares/memory/readable.hpp>
 #include <ares/memory/writable.hpp>
-
-enum ResultEnum {
-  successful,
-  noFileSelected,
-  databaseNotFound,
-  romNotFoundInDatabase,
-  romNotFound,
-  invalidRom,
-  couldNotParseManifest,
-  noFirmware,
-  otherError
-};
-
-struct LoadResult {
-  ResultEnum result;
-  
-  string info;
-  string firmwareType;
-  string firmwareSystemName;
-  string firmwareRegion;
-  
-  LoadResult(ResultEnum r) : result(r), info(0) {}
-  
-  bool operator==(const LoadResult& other) {
-    return result == other.result;
-  }
-  bool operator!=(const LoadResult& other) {
-    return result != other.result;
-  }
-};

--- a/desktop-ui/emulator/arcade.cpp
+++ b/desktop-ui/emulator/arcade.cpp
@@ -1,6 +1,6 @@
 struct Arcade : Emulator {
   Arcade();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
   auto group() -> string override { return "Arcade"; }
@@ -33,17 +33,21 @@ Arcade::Arcade() {
   }
 }
 
-auto Arcade::load() -> bool {
+auto Arcade::load() -> LoadResult {
   game = mia::Medium::create("Arcade");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   system = mia::System::create("Arcade");
-  if(!system->load()) return false;
+  result = system->load();
+  if(result != LoadResult(successful)) return result;
 
   //Determine from the game manifest which core to use for the given arcade rom
 #ifdef CORE_SG
   if(game->pak->attribute("board") == "sega/sg1000a") {
-    if(!ares::SG1000::load(root, {"[Sega] SG-1000A"})) return false;
+    if(!ares::SG1000::load(root, {"[Sega] SG-1000A"})) return LoadResult(otherError);
     systemPakName = "SG-1000A";
     gamePakName = "Arcade Cartridge";
 
@@ -51,11 +55,11 @@ auto Arcade::load() -> bool {
       port->allocate();
       port->connect();
     }
-    return true;
+    return LoadResult(successful);
   }
 #endif
 
-  return false;
+  return LoadResult(otherError);
 }
 
 auto Arcade::save() -> bool {

--- a/desktop-ui/emulator/arcade.cpp
+++ b/desktop-ui/emulator/arcade.cpp
@@ -36,18 +36,18 @@ Arcade::Arcade() {
 auto Arcade::load() -> LoadResult {
   game = mia::Medium::create("Arcade");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("Arcade");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   //Determine from the game manifest which core to use for the given arcade rom
 #ifdef CORE_SG
   if(game->pak->attribute("board") == "sega/sg1000a") {
-    if(!ares::SG1000::load(root, {"[Sega] SG-1000A"})) return LoadResult(otherError);
+    if(!ares::SG1000::load(root, {"[Sega] SG-1000A"})) return otherError;
     systemPakName = "SG-1000A";
     gamePakName = "Arcade Cartridge";
 
@@ -55,11 +55,11 @@ auto Arcade::load() -> LoadResult {
       port->allocate();
       port->connect();
     }
-    return LoadResult(successful);
+    return successful;
   }
 #endif
 
-  return LoadResult(otherError);
+  return otherError;
 }
 
 auto Arcade::save() -> bool {

--- a/desktop-ui/emulator/atari-2600.cpp
+++ b/desktop-ui/emulator/atari-2600.cpp
@@ -41,16 +41,16 @@ Atari2600::Atari2600() {
 auto Atari2600::load() -> LoadResult {
   game = mia::Medium::create("Atari 2600");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return couldNotParseManifest;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("Atari 2600");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   auto region = Emulator::region();
-  if(!ares::Atari2600::load(root, {"[Atari] Atari 2600 (", region, ")"})) return LoadResult(otherError);
+  if(!ares::Atari2600::load(root, {"[Atari] Atari 2600 (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -67,7 +67,7 @@ auto Atari2600::load() -> LoadResult {
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Atari2600::save() -> bool {

--- a/desktop-ui/emulator/colecovision.cpp
+++ b/desktop-ui/emulator/colecovision.cpp
@@ -42,12 +42,12 @@ ColecoVision::ColecoVision() {
 auto ColecoVision::load() -> LoadResult {
   game = mia::Medium::create("ColecoVision");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("ColecoVision");
-  if(system->load(firmware[0].location) != LoadResult(successful)) {
+  if(system->load(firmware[0].location) != successful) {
     result.firmwareSystemName = "ColecoVision";
     result.firmwareType = firmware[0].type;
     result.firmwareRegion = firmware[0].region;
@@ -56,7 +56,7 @@ auto ColecoVision::load() -> LoadResult {
   }
 
   auto region = Emulator::region();
-  if(!ares::ColecoVision::load(root, {"[Coleco] ColecoVision (", region, ")"})) return LoadResult(otherError);
+  if(!ares::ColecoVision::load(root, {"[Coleco] ColecoVision (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -73,7 +73,7 @@ auto ColecoVision::load() -> LoadResult {
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto ColecoVision::save() -> bool {

--- a/desktop-ui/emulator/emulator.hpp
+++ b/desktop-ui/emulator/emulator.hpp
@@ -19,13 +19,13 @@ struct Emulator {
   auto setOverscan(bool value) -> bool;
   auto setColorBleed(bool value) -> bool;
   auto error(const string& text) -> void;
-  auto errorFirmware(const Firmware&, string system = "") -> void;
   auto load(mia::Pak& node, string name) -> bool;
   auto save(mia::Pak& node, string name) -> bool;
   virtual auto input(ares::Node::Input::Input) -> void;
   auto inputKeyboard(string name) -> bool;
+  auto handleLoadResult(LoadResult result) -> void;
   virtual auto load(Menu) -> void {}
-  virtual auto load() -> bool = 0;
+  virtual auto load() -> LoadResult = 0;
   virtual auto save() -> bool { return true; }
   virtual auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> = 0;
   virtual auto notify(const string& message) -> void {}

--- a/desktop-ui/emulator/famicom-disk-system.cpp
+++ b/desktop-ui/emulator/famicom-disk-system.cpp
@@ -68,13 +68,13 @@ auto FamicomDiskSystem::load(Menu menu) -> void {
 auto FamicomDiskSystem::load() -> LoadResult {
   game = mia::Medium::create("Famicom Disk System");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   bios = mia::Medium::create("Famicom");
   result = bios->load(firmware[0].location);
-  if(result != LoadResult(successful)) {
+  if(result != successful) {
     result.firmwareSystemName = "Famicom";
     result.firmwareType = firmware[0].type;
     result.firmwareRegion = firmware[0].region;
@@ -84,9 +84,9 @@ auto FamicomDiskSystem::load() -> LoadResult {
 
   system = mia::System::create("Famicom");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
-  if(!ares::Famicom::load(root, "[Nintendo] Famicom (NTSC-J)")) return LoadResult(otherError);
+  if(!ares::Famicom::load(root, "[Nintendo] Famicom (NTSC-J)")) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -112,7 +112,7 @@ auto FamicomDiskSystem::load() -> LoadResult {
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto FamicomDiskSystem::save() -> bool {

--- a/desktop-ui/emulator/famicom.cpp
+++ b/desktop-ui/emulator/famicom.cpp
@@ -38,16 +38,16 @@ Famicom::Famicom() {
 auto Famicom::load() -> LoadResult {
   game = mia::Medium::create("Famicom");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("Famicom");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   auto region = Emulator::region();
-  if(!ares::Famicom::load(root, {"[Nintendo] Famicom (", region, ")"})) return LoadResult(otherError);
+  if(!ares::Famicom::load(root, {"[Nintendo] Famicom (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -71,7 +71,7 @@ auto Famicom::load() -> LoadResult {
     }
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Famicom::save() -> bool {

--- a/desktop-ui/emulator/famicom.cpp
+++ b/desktop-ui/emulator/famicom.cpp
@@ -1,6 +1,6 @@
 struct Famicom : Emulator {
   Famicom();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
 };
@@ -35,15 +35,19 @@ Famicom::Famicom() {
   }
 }
 
-auto Famicom::load() -> bool {
+auto Famicom::load() -> LoadResult {
   game = mia::Medium::create("Famicom");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   system = mia::System::create("Famicom");
-  if(!system->load()) return false;
+  result = system->load();
+  if(result != LoadResult(successful)) return result;
 
   auto region = Emulator::region();
-  if(!ares::Famicom::load(root, {"[Nintendo] Famicom (", region, ")"})) return false;
+  if(!ares::Famicom::load(root, {"[Nintendo] Famicom (", region, ")"})) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -67,7 +71,7 @@ auto Famicom::load() -> bool {
     }
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto Famicom::save() -> bool {

--- a/desktop-ui/emulator/game-boy-advance.cpp
+++ b/desktop-ui/emulator/game-boy-advance.cpp
@@ -53,12 +53,12 @@ auto GameBoyAdvance::load(Menu menu) -> void {
 auto GameBoyAdvance::load() -> LoadResult {
   game = mia::Medium::create("Game Boy Advance");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("Game Boy Advance");
-  if(system->load(firmware[0].location) != LoadResult(successful)) {
+  if(system->load(firmware[0].location) != successful) {
     result.firmwareSystemName = "Game Boy Advance";
     result.firmwareType = firmware[0].type;
     result.firmwareRegion = firmware[0].region;
@@ -68,14 +68,14 @@ auto GameBoyAdvance::load() -> LoadResult {
 
   ares::GameBoyAdvance::option("Pixel Accuracy", settings.video.pixelAccuracy);
 
-  if(!ares::GameBoyAdvance::load(root, "[Nintendo] Game Boy Advance")) return LoadResult(otherError);
+  if(!ares::GameBoyAdvance::load(root, "[Nintendo] Game Boy Advance")) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto GameBoyAdvance::save() -> bool {

--- a/desktop-ui/emulator/game-boy-color.cpp
+++ b/desktop-ui/emulator/game-boy-color.cpp
@@ -30,15 +30,15 @@ GameBoyColor::GameBoyColor() {
 auto GameBoyColor::load() -> LoadResult {
   game = mia::Medium::create("Game Boy Color");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("Game Boy Color");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
-  if(!ares::GameBoy::load(root, "[Nintendo] Game Boy Color")) return LoadResult(otherError);
+  if(!ares::GameBoy::load(root, "[Nintendo] Game Boy Color")) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -49,7 +49,7 @@ auto GameBoyColor::load() -> LoadResult {
     fastBoot->setValue(settings.boot.fast);
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto GameBoyColor::save() -> bool {

--- a/desktop-ui/emulator/game-boy-color.cpp
+++ b/desktop-ui/emulator/game-boy-color.cpp
@@ -1,6 +1,6 @@
 struct GameBoyColor : Emulator {
   GameBoyColor();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
 };
@@ -27,14 +27,18 @@ GameBoyColor::GameBoyColor() {
   }
 }
 
-auto GameBoyColor::load() -> bool {
+auto GameBoyColor::load() -> LoadResult {
   game = mia::Medium::create("Game Boy Color");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   system = mia::System::create("Game Boy Color");
-  if(!system->load()) return false;
+  result = system->load();
+  if(result != LoadResult(successful)) return result;
 
-  if(!ares::GameBoy::load(root, "[Nintendo] Game Boy Color")) return false;
+  if(!ares::GameBoy::load(root, "[Nintendo] Game Boy Color")) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -45,7 +49,7 @@ auto GameBoyColor::load() -> bool {
     fastBoot->setValue(settings.boot.fast);
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto GameBoyColor::save() -> bool {

--- a/desktop-ui/emulator/game-boy.cpp
+++ b/desktop-ui/emulator/game-boy.cpp
@@ -31,15 +31,15 @@ GameBoy::GameBoy() {
 auto GameBoy::load() -> LoadResult {
   game = mia::Medium::create("Game Boy");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("Game Boy");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
-  if(!ares::GameBoy::load(root, "[Nintendo] Game Boy")) return LoadResult(otherError);
+  if(!ares::GameBoy::load(root, "[Nintendo] Game Boy")) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -50,7 +50,7 @@ auto GameBoy::load() -> LoadResult {
     fastBoot->setValue(settings.boot.fast);
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto GameBoy::load(Menu menu) -> void {

--- a/desktop-ui/emulator/game-gear.cpp
+++ b/desktop-ui/emulator/game-gear.cpp
@@ -30,30 +30,24 @@ GameGear::GameGear() {
 auto GameGear::load() -> LoadResult {
   game = mia::Medium::create("Game Gear");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   auto region = Emulator::region();
 
   system = mia::System::create("Game Gear");
   result = system->load(firmware[0].location);
-  if(result != LoadResult(successful)) {
-    result.firmwareSystemName = "Game Gear";
-    result.firmwareType = firmware[0].type;
-    result.firmwareRegion = firmware[0].region;
-    result.result = noFirmware;
-    return result;
-  }
+  if(result != successful) return otherError;
 
-  if(!ares::MasterSystem::load(root, {"[Sega] Game Gear (", region, ")"})) return LoadResult(otherError);
+  if(!ares::MasterSystem::load(root, {"[Sega] Game Gear (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto GameGear::save() -> bool {

--- a/desktop-ui/emulator/game-gear.cpp
+++ b/desktop-ui/emulator/game-gear.cpp
@@ -1,6 +1,6 @@
 struct GameGear : Emulator {
   GameGear();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
 };
@@ -27,23 +27,33 @@ GameGear::GameGear() {
   }
 }
 
-auto GameGear::load() -> bool {
+auto GameGear::load() -> LoadResult {
   game = mia::Medium::create("Game Gear");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   auto region = Emulator::region();
 
   system = mia::System::create("Game Gear");
-  if(!system->load(firmware[0].location)) return false;
+  result = system->load(firmware[0].location);
+  if(result != LoadResult(successful)) {
+    result.firmwareSystemName = "Game Gear";
+    result.firmwareType = firmware[0].type;
+    result.firmwareRegion = firmware[0].region;
+    result.result = noFirmware;
+    return result;
+  }
 
-  if(!ares::MasterSystem::load(root, {"[Sega] Game Gear (", region, ")"})) return false;
+  if(!ares::MasterSystem::load(root, {"[Sega] Game Gear (", region, ")"})) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
     port->connect();
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto GameGear::save() -> bool {

--- a/desktop-ui/emulator/master-system.cpp
+++ b/desktop-ui/emulator/master-system.cpp
@@ -93,9 +93,9 @@ MasterSystem::MasterSystem() {
 auto MasterSystem::load() -> LoadResult {
   game = mia::Medium::create("Master System");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   auto region = Emulator::region();
   //if statements below are ordered by lowest to highest priority
@@ -105,16 +105,10 @@ auto MasterSystem::load() -> LoadResult {
 
   system = mia::System::create("Master System");
   result = system->load(firmware[regionID].location);
-  if(result != LoadResult(successful)) {
-    result.firmwareSystemName = "Master System";
-    result.firmwareType = firmware[regionID].type;
-    result.firmwareRegion = firmware[regionID].region;
-    result.result = noFirmware;
-    return result;
-  }
-  if(!game->pak && !system->pak->read("bios.rom")) return LoadResult(otherError);
+  if(result != successful) return otherError;
+  if(!game->pak && !system->pak->read("bios.rom")) return otherError;
 
-  if(!ares::MasterSystem::load(root, {"[Sega] Master System (", region, ")"})) return LoadResult(otherError);
+  if(!ares::MasterSystem::load(root, {"[Sega] Master System (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -140,7 +134,7 @@ auto MasterSystem::load() -> LoadResult {
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MasterSystem::save() -> bool {

--- a/desktop-ui/emulator/mega-32x.cpp
+++ b/desktop-ui/emulator/mega-32x.cpp
@@ -46,9 +46,9 @@ Mega32X::Mega32X() {
 auto Mega32X::load() -> LoadResult {
   game = mia::Medium::create("Mega 32X");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
   
   auto region = Emulator::region();
   //if statements below are ordered by lowest to highest priority
@@ -63,11 +63,11 @@ auto Mega32X::load() -> LoadResult {
     for(auto& emulator : emulators) {
       if(emulator->name == "Mega CD") firmware = emulator->firmware;
     }
-    if(!firmware) return LoadResult(otherError);  //should never occur
+    if(!firmware) return otherError;  //should never occur
     name = "Mega CD 32X";
     system = mia::System::create("Mega CD 32X");
     result = system->load(firmware[regionID].location);
-    if(result != LoadResult(successful)) {
+    if(result != successful) {
       result.firmwareSystemName = "Mega CD 32X";
       result.firmwareType = firmware[regionID].type;
       result.firmwareRegion = firmware[regionID].region;
@@ -76,17 +76,17 @@ auto Mega32X::load() -> LoadResult {
     }
 
     disc = mia::Medium::create("Mega CD");
-    if(disc->load(Emulator::load(disc, configuration.game)) != LoadResult(successful)) disc.reset();
+    if(disc->load(Emulator::load(disc, configuration.game)) != successful) disc.reset();
   } else {
     name = "Mega 32X";
     system = mia::System::create("Mega 32X");
     result = system->load();
-    if(result != LoadResult(successful)) return result;
+    if(result != successful) return result;
   }
 
   ares::MegaDrive::option("Recompiler", !settings.general.forceInterpreter);
 
-  if(!ares::MegaDrive::load(root, {"[Sega] ", name, " (", region, ")"})) return LoadResult(otherError);
+  if(!ares::MegaDrive::load(root, {"[Sega] ", name, " (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -108,7 +108,7 @@ auto Mega32X::load() -> LoadResult {
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Mega32X::save() -> bool {

--- a/desktop-ui/emulator/mega-32x.cpp
+++ b/desktop-ui/emulator/mega-32x.cpp
@@ -1,6 +1,6 @@
 struct Mega32X : Emulator {
   Mega32X();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
 
@@ -43,10 +43,13 @@ Mega32X::Mega32X() {
   }
 }
 
-auto Mega32X::load() -> bool {
+auto Mega32X::load() -> LoadResult {
   game = mia::Medium::create("Mega 32X");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
-
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
+  
   auto region = Emulator::region();
   //if statements below are ordered by lowest to highest priority
   if(region == "PAL"   ) regionID = 2;
@@ -60,22 +63,30 @@ auto Mega32X::load() -> bool {
     for(auto& emulator : emulators) {
       if(emulator->name == "Mega CD") firmware = emulator->firmware;
     }
-    if(!firmware) return false;  //should never occur
+    if(!firmware) return LoadResult(otherError);  //should never occur
     name = "Mega CD 32X";
     system = mia::System::create("Mega CD 32X");
-    if(!system->load(firmware[regionID].location)) return errorFirmware(firmware[regionID], "Mega CD"), false;
+    result = system->load(firmware[regionID].location);
+    if(result != LoadResult(successful)) {
+      result.firmwareSystemName = "Mega CD 32X";
+      result.firmwareType = firmware[regionID].type;
+      result.firmwareRegion = firmware[regionID].region;
+      result.result = noFirmware;
+      return result;
+    }
 
     disc = mia::Medium::create("Mega CD");
-    if(!disc->load(Emulator::load(disc, configuration.game))) disc.reset();
+    if(disc->load(Emulator::load(disc, configuration.game)) != LoadResult(successful)) disc.reset();
   } else {
     name = "Mega 32X";
     system = mia::System::create("Mega 32X");
-    if(!system->load()) return false;
+    result = system->load();
+    if(result != LoadResult(successful)) return result;
   }
 
   ares::MegaDrive::option("Recompiler", !settings.general.forceInterpreter);
 
-  if(!ares::MegaDrive::load(root, {"[Sega] ", name, " (", region, ")"})) return false;
+  if(!ares::MegaDrive::load(root, {"[Sega] ", name, " (", region, ")"})) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -97,7 +108,7 @@ auto Mega32X::load() -> bool {
     port->connect();
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto Mega32X::save() -> bool {

--- a/desktop-ui/emulator/mega-cd-32x.cpp
+++ b/desktop-ui/emulator/mega-cd-32x.cpp
@@ -1,6 +1,6 @@
 struct MegaCD32X : Emulator {
   MegaCD32X();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto load(Menu) -> void override;
   auto unload() -> void override;
   auto save() -> bool override;
@@ -45,9 +45,12 @@ MegaCD32X::MegaCD32X() {
   }
 }
 
-auto MegaCD32X::load() -> bool {
+auto MegaCD32X::load() -> LoadResult {
   game = mia::Medium::create("Mega CD");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   auto region = Emulator::region();
   //if statements below are ordered by lowest to highest priority
@@ -60,14 +63,21 @@ auto MegaCD32X::load() -> bool {
   for(auto& emulator : emulators) {
     if(emulator->name == "Mega CD") firmware = emulator->firmware;
   }
-  if(!firmware) return false;  //should never occur
+  if(!firmware) return LoadResult(noFirmware);  //should never occur
 
   system = mia::System::create("Mega CD 32X");
-  if(!system->load(firmware[regionID].location)) return errorFirmware(firmware[regionID], "Mega CD"), false;
+  result = system->load(firmware[regionID].location);
+  if(result != LoadResult(successful)) {
+    result.firmwareSystemName = "Mega CD 32X";
+    result.firmwareType = firmware[regionID].type;
+    result.firmwareRegion = firmware[regionID].region;
+    result.result = noFirmware;
+    return result;
+  }
 
   ares::MegaDrive::option("Recompiler", !settings.general.forceInterpreter);
 
-  if(!ares::MegaDrive::load(root, {"[Sega] Mega CD 32X (", region, ")"})) return false;
+  if(!ares::MegaDrive::load(root, {"[Sega] Mega CD 32X (", region, ")"})) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -98,7 +108,7 @@ auto MegaCD32X::load() -> bool {
 
   discTrayTimer = Timer{};
 
-  return true;
+  return LoadResult(successful);
 }
 
 
@@ -110,7 +120,7 @@ auto MegaCD32X::load(Menu menu) -> void {
     auto tray = root->find<ares::Node::Port>("Mega CD/Disc Tray");
     tray->disconnect();
 
-    if(!game->load(Emulator::load(game, configuration.game))) {
+    if(game->load(Emulator::load(game, configuration.game)) != LoadResult(successful)) {
       return;
     }
 

--- a/desktop-ui/emulator/mega-cd-32x.cpp
+++ b/desktop-ui/emulator/mega-cd-32x.cpp
@@ -48,9 +48,9 @@ MegaCD32X::MegaCD32X() {
 auto MegaCD32X::load() -> LoadResult {
   game = mia::Medium::create("Mega CD");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   auto region = Emulator::region();
   //if statements below are ordered by lowest to highest priority
@@ -63,12 +63,12 @@ auto MegaCD32X::load() -> LoadResult {
   for(auto& emulator : emulators) {
     if(emulator->name == "Mega CD") firmware = emulator->firmware;
   }
-  if(!firmware) return LoadResult(noFirmware);  //should never occur
+  if(!firmware) return otherError;  //should never occur
 
   system = mia::System::create("Mega CD 32X");
   result = system->load(firmware[regionID].location);
-  if(result != LoadResult(successful)) {
-    result.firmwareSystemName = "Mega CD 32X";
+  if(result != successful) {
+    result.firmwareSystemName = "Mega CD";
     result.firmwareType = firmware[regionID].type;
     result.firmwareRegion = firmware[regionID].region;
     result.result = noFirmware;
@@ -77,7 +77,7 @@ auto MegaCD32X::load() -> LoadResult {
 
   ares::MegaDrive::option("Recompiler", !settings.general.forceInterpreter);
 
-  if(!ares::MegaDrive::load(root, {"[Sega] Mega CD 32X (", region, ")"})) return LoadResult(otherError);
+  if(!ares::MegaDrive::load(root, {"[Sega] Mega CD 32X (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -108,7 +108,7 @@ auto MegaCD32X::load() -> LoadResult {
 
   discTrayTimer = Timer{};
 
-  return LoadResult(successful);
+  return successful;
 }
 
 
@@ -120,7 +120,7 @@ auto MegaCD32X::load(Menu menu) -> void {
     auto tray = root->find<ares::Node::Port>("Mega CD/Disc Tray");
     tray->disconnect();
 
-    if(game->load(Emulator::load(game, configuration.game)) != LoadResult(successful)) {
+    if(game->load(Emulator::load(game, configuration.game)) != successful) {
       return;
     }
 

--- a/desktop-ui/emulator/mega-cd.cpp
+++ b/desktop-ui/emulator/mega-cd.cpp
@@ -1,6 +1,6 @@
 struct MegaCD : Emulator {
   MegaCD();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto load(Menu) -> void override;
   auto unload() -> void override;
   auto save() -> bool override;
@@ -60,9 +60,12 @@ MegaCD::MegaCD() {
   }
 }
 
-auto MegaCD::load() -> bool {
+auto MegaCD::load() -> LoadResult {
   game = mia::Medium::create("Mega CD");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   auto region = Emulator::region();
   //if statements below are ordered by lowest to highest priority
@@ -71,9 +74,16 @@ auto MegaCD::load() -> bool {
   if(region == "NTSC-U") regionID = 0;
 
   system = mia::System::create("Mega CD");
-  if(!system->load(firmware[regionID].location)) return errorFirmware(firmware[regionID]), false;
+  result = system->load(firmware[regionID].location);
+  if(result != LoadResult(successful)) {
+    result.firmwareSystemName = "Mega CD";
+    result.firmwareType = firmware[regionID].type;
+    result.firmwareRegion = firmware[regionID].region;
+    result.result = noFirmware;
+    return result;
+  }
 
-  if(!ares::MegaDrive::load(root, {"[Sega] Mega CD (", region, ")"})) return false;
+  if(!ares::MegaDrive::load(root, {"[Sega] Mega CD (", region, ")"})) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -104,7 +114,7 @@ auto MegaCD::load() -> bool {
 
   discTrayTimer = Timer{};
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto MegaCD::load(Menu menu) -> void {
@@ -115,7 +125,7 @@ auto MegaCD::load(Menu menu) -> void {
     auto tray = root->find<ares::Node::Port>("Mega CD/Disc Tray");
     tray->disconnect();
 
-    if(!game->load(Emulator::load(game, configuration.game))) {
+    if(game->load(Emulator::load(game, configuration.game)) != LoadResult(successful)) {
       return;
     }
 

--- a/desktop-ui/emulator/mega-cd.cpp
+++ b/desktop-ui/emulator/mega-cd.cpp
@@ -63,9 +63,9 @@ MegaCD::MegaCD() {
 auto MegaCD::load() -> LoadResult {
   game = mia::Medium::create("Mega CD");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   auto region = Emulator::region();
   //if statements below are ordered by lowest to highest priority
@@ -75,7 +75,7 @@ auto MegaCD::load() -> LoadResult {
 
   system = mia::System::create("Mega CD");
   result = system->load(firmware[regionID].location);
-  if(result != LoadResult(successful)) {
+  if(result != successful) {
     result.firmwareSystemName = "Mega CD";
     result.firmwareType = firmware[regionID].type;
     result.firmwareRegion = firmware[regionID].region;
@@ -83,7 +83,7 @@ auto MegaCD::load() -> LoadResult {
     return result;
   }
 
-  if(!ares::MegaDrive::load(root, {"[Sega] Mega CD (", region, ")"})) return LoadResult(otherError);
+  if(!ares::MegaDrive::load(root, {"[Sega] Mega CD (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -114,7 +114,7 @@ auto MegaCD::load() -> LoadResult {
 
   discTrayTimer = Timer{};
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MegaCD::load(Menu menu) -> void {
@@ -125,7 +125,7 @@ auto MegaCD::load(Menu menu) -> void {
     auto tray = root->find<ares::Node::Port>("Mega CD/Disc Tray");
     tray->disconnect();
 
-    if(game->load(Emulator::load(game, configuration.game)) != LoadResult(successful)) {
+    if(game->load(Emulator::load(game, configuration.game)) != successful) {
       return;
     }
 

--- a/desktop-ui/emulator/mega-drive.cpp
+++ b/desktop-ui/emulator/mega-drive.cpp
@@ -57,9 +57,9 @@ MegaDrive::MegaDrive() {
 auto MegaDrive::load() -> LoadResult {
   game = mia::Medium::create("Mega Drive");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   auto region = Emulator::region();
   //if statements below are ordered by lowest to highest priority
@@ -74,11 +74,11 @@ auto MegaDrive::load() -> LoadResult {
     for(auto& emulator : emulators) {
       if(emulator->name == "Mega CD") firmware = emulator->firmware;
     }
-    if(!firmware) return LoadResult(otherError);  //should never occur
+    if(!firmware) return otherError;  //should never occur
     name = "Mega CD";
     system = mia::System::create("Mega CD");
     result = system->load(firmware[regionID].location);
-    if(result != LoadResult(successful)) {
+    if(result != successful) {
       result.firmwareSystemName = "Mega CD";
       result.firmwareType = firmware[regionID].type;
       result.firmwareRegion = firmware[regionID].region;
@@ -87,17 +87,17 @@ auto MegaDrive::load() -> LoadResult {
     }
 
     disc = mia::Medium::create("Mega CD");
-    if(disc->load(Emulator::load(disc, configuration.game)) != LoadResult(successful)) disc.reset();
+    if(disc->load(Emulator::load(disc, configuration.game)) != successful) disc.reset();
   } else {
     name = "Mega Drive";
     system = mia::System::create("Mega Drive");
     result = system->load();
-    if(result != LoadResult(successful)) return result;
+    if(result != successful) return result;
   }
 
   ares::MegaDrive::option("TMSS", settings.megadrive.tmss);
 
-  if(!ares::MegaDrive::load(root, {"[Sega] ", name, " (", region, ")"})) return LoadResult(otherError);
+  if(!ares::MegaDrive::load(root, {"[Sega] ", name, " (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -119,7 +119,7 @@ auto MegaDrive::load() -> LoadResult {
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MegaDrive::save() -> bool {

--- a/desktop-ui/emulator/msx.cpp
+++ b/desktop-ui/emulator/msx.cpp
@@ -40,14 +40,14 @@ MSX::MSX() {
 auto MSX::load() -> LoadResult {
   game = mia::Medium::create("MSX");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
   bool isTape = game->pak->attribute("tape").boolean();
 
   system = mia::System::create("MSX");
   result = system->load(firmware[0].location);
-  if(result != LoadResult(successful)) {
+  if(result != successful) {
     result.firmwareSystemName = "MSX";
     result.firmwareType = firmware[0].type;
     result.firmwareRegion = firmware[0].region;
@@ -56,7 +56,7 @@ auto MSX::load() -> LoadResult {
   }
 
   auto region = Emulator::region();
-  if(!ares::MSX::load(root, {"[Microsoft] MSX (", region, ")"})) return LoadResult(otherError);
+  if(!ares::MSX::load(root, {"[Microsoft] MSX (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -86,7 +86,7 @@ auto MSX::load() -> LoadResult {
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MSX::load(Menu menu) -> void {

--- a/desktop-ui/emulator/msx2.cpp
+++ b/desktop-ui/emulator/msx2.cpp
@@ -34,9 +34,9 @@ MSX2::MSX2() {
 auto MSX2::load() -> LoadResult {
   game = mia::Medium::create("MSX2");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
   bool isTape = game->pak->attribute("tape").boolean();
 
   system = mia::System::create("MSX2");
@@ -49,7 +49,7 @@ auto MSX2::load() -> LoadResult {
   }
 
   auto region = Emulator::region();
-  if(!ares::MSX::load(root, {"[Microsoft] MSX2 (", region, ")"})) return LoadResult(otherError);
+  if(!ares::MSX::load(root, {"[Microsoft] MSX2 (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -76,7 +76,7 @@ auto MSX2::load() -> LoadResult {
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MSX2::save() -> bool {

--- a/desktop-ui/emulator/msx2.cpp
+++ b/desktop-ui/emulator/msx2.cpp
@@ -1,6 +1,6 @@
 struct MSX2 : MSX {
   MSX2();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
   auto input(ares::Node::Input::Input) -> void override;
@@ -31,18 +31,25 @@ MSX2::MSX2() {
   }
 }
 
-auto MSX2::load() -> bool {
+auto MSX2::load() -> LoadResult {
   game = mia::Medium::create("MSX2");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
   bool isTape = game->pak->attribute("tape").boolean();
 
   system = mia::System::create("MSX2");
   if(!system->loadMultiple({firmware[0].location, firmware[1].location})) {
-    return errorFirmware(firmware[0]), false;
+    result.result = noFirmware;
+    result.firmwareType = firmware[0].type;
+    result.firmwareRegion = firmware[0].region;
+    result.firmwareSystemName = "MSX2";
+    return result;
   }
 
   auto region = Emulator::region();
-  if(!ares::MSX::load(root, {"[Microsoft] MSX2 (", region, ")"})) return false;
+  if(!ares::MSX::load(root, {"[Microsoft] MSX2 (", region, ")"})) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -69,7 +76,7 @@ auto MSX2::load() -> bool {
     port->connect();
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto MSX2::save() -> bool {

--- a/desktop-ui/emulator/myvision.cpp
+++ b/desktop-ui/emulator/myvision.cpp
@@ -45,24 +45,24 @@ MyVision::MyVision() {
 auto MyVision::load() -> LoadResult {
   game = mia::Medium::create("MyVision");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("MyVision");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   if (!ares::MyVision::load(root, {
       "[Nichibutsu] MyVision"
-  })) return LoadResult(otherError);
+  })) return otherError;
 
   if (auto port = root -> find < ares::Node::Port > ("Cartridge Slot")) {
     port -> allocate();
     port -> connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MyVision::save() -> bool {

--- a/desktop-ui/emulator/neo-geo-aes.cpp
+++ b/desktop-ui/emulator/neo-geo-aes.cpp
@@ -1,6 +1,6 @@
 struct NeoGeoAES : Emulator {
   NeoGeoAES();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
   auto arcade() -> bool override { return true; }
@@ -34,14 +34,24 @@ NeoGeoAES::NeoGeoAES() {
   }
 }
 
-auto NeoGeoAES::load() -> bool {
+auto NeoGeoAES::load() -> LoadResult {
   game = mia::Medium::create("Neo Geo");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   system = mia::System::create("Neo Geo AES");
-  if(!system->load(firmware[0].location)) return errorFirmware(firmware[0]), false;
+  result = system->load(firmware[0].location);
+  if(result != LoadResult(successful)) {
+    result.firmwareSystemName = "Neo Geo AES";
+    result.firmwareType = firmware[0].type;
+    result.firmwareRegion = firmware[0].region;
+    result.result = noFirmware;
+    return result;
+  }
 
-  if(!ares::NeoGeo::load(root, "[SNK] Neo Geo AES")) return false;
+  if(!ares::NeoGeo::load(root, "[SNK] Neo Geo AES")) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -63,7 +73,7 @@ auto NeoGeoAES::load() -> bool {
     port->connect();
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto NeoGeoAES::save() -> bool {

--- a/desktop-ui/emulator/neo-geo-aes.cpp
+++ b/desktop-ui/emulator/neo-geo-aes.cpp
@@ -37,13 +37,13 @@ NeoGeoAES::NeoGeoAES() {
 auto NeoGeoAES::load() -> LoadResult {
   game = mia::Medium::create("Neo Geo");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("Neo Geo AES");
   result = system->load(firmware[0].location);
-  if(result != LoadResult(successful)) {
+  if(result != successful) {
     result.firmwareSystemName = "Neo Geo AES";
     result.firmwareType = firmware[0].type;
     result.firmwareRegion = firmware[0].region;
@@ -51,7 +51,7 @@ auto NeoGeoAES::load() -> LoadResult {
     return result;
   }
 
-  if(!ares::NeoGeo::load(root, "[SNK] Neo Geo AES")) return LoadResult(otherError);
+  if(!ares::NeoGeo::load(root, "[SNK] Neo Geo AES")) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -73,7 +73,7 @@ auto NeoGeoAES::load() -> LoadResult {
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto NeoGeoAES::save() -> bool {

--- a/desktop-ui/emulator/neo-geo-mvs.cpp
+++ b/desktop-ui/emulator/neo-geo-mvs.cpp
@@ -38,13 +38,13 @@ NeoGeoMVS::NeoGeoMVS() {
 auto NeoGeoMVS::load() -> LoadResult {
   game = mia::Medium::create("Neo Geo");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("Neo Geo MVS");
   result = system->load(firmware[0].location);
-  if(result != LoadResult(successful)) {
+  if(result != successful) {
     result.firmwareSystemName = "Neo Geo MVS";
     result.firmwareType = firmware[0].type;
     result.firmwareRegion = firmware[0].region;
@@ -52,7 +52,7 @@ auto NeoGeoMVS::load() -> LoadResult {
     return result;
   }
 
-  if(!ares::NeoGeo::load(root, "[SNK] Neo Geo MVS")) return LoadResult(otherError);
+  if(!ares::NeoGeo::load(root, "[SNK] Neo Geo MVS")) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -74,7 +74,7 @@ auto NeoGeoMVS::load() -> LoadResult {
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto NeoGeoMVS::save() -> bool {

--- a/desktop-ui/emulator/neo-geo-mvs.cpp
+++ b/desktop-ui/emulator/neo-geo-mvs.cpp
@@ -1,6 +1,6 @@
 struct NeoGeoMVS : Emulator {
   NeoGeoMVS();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
   auto group() -> string override { return "Arcade"; }
@@ -35,14 +35,24 @@ NeoGeoMVS::NeoGeoMVS() {
   }
 }
 
-auto NeoGeoMVS::load() -> bool {
+auto NeoGeoMVS::load() -> LoadResult {
   game = mia::Medium::create("Neo Geo");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   system = mia::System::create("Neo Geo MVS");
-  if(!system->load(firmware[0].location)) return errorFirmware(firmware[0]), false;
+  result = system->load(firmware[0].location);
+  if(result != LoadResult(successful)) {
+    result.firmwareSystemName = "Neo Geo MVS";
+    result.firmwareType = firmware[0].type;
+    result.firmwareRegion = firmware[0].region;
+    result.result = noFirmware;
+    return result;
+  }
 
-  if(!ares::NeoGeo::load(root, "[SNK] Neo Geo MVS")) return false;
+  if(!ares::NeoGeo::load(root, "[SNK] Neo Geo MVS")) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -64,7 +74,7 @@ auto NeoGeoMVS::load() -> bool {
     port->connect();
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto NeoGeoMVS::save() -> bool {

--- a/desktop-ui/emulator/neo-geo-pocket-color.cpp
+++ b/desktop-ui/emulator/neo-geo-pocket-color.cpp
@@ -1,6 +1,6 @@
 struct NeoGeoPocketColor : Emulator {
   NeoGeoPocketColor();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
 };
@@ -29,14 +29,24 @@ NeoGeoPocketColor::NeoGeoPocketColor() {
   }
 }
 
-auto NeoGeoPocketColor::load() -> bool {
+auto NeoGeoPocketColor::load() -> LoadResult {
   game = mia::Medium::create("Neo Geo Pocket Color");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   system = mia::System::create("Neo Geo Pocket Color");
-  if(!system->load(firmware[0].location)) return errorFirmware(firmware[0]), false;
+  result = system->load(firmware[0].location);
+  if(result != LoadResult(successful)) {
+    result.firmwareSystemName = "Neo Geo Pocket Color";
+    result.firmwareType = firmware[0].type;
+    result.firmwareRegion = firmware[0].region;
+    result.result = noFirmware;
+    return result;
+  }
 
-  if(!ares::NeoGeoPocket::load(root, "[SNK] Neo Geo Pocket Color")) return false;
+  if(!ares::NeoGeoPocket::load(root, "[SNK] Neo Geo Pocket Color")) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -47,7 +57,7 @@ auto NeoGeoPocketColor::load() -> bool {
     fastBoot->setValue(settings.boot.fast);
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto NeoGeoPocketColor::save() -> bool {

--- a/desktop-ui/emulator/neo-geo-pocket-color.cpp
+++ b/desktop-ui/emulator/neo-geo-pocket-color.cpp
@@ -32,13 +32,13 @@ NeoGeoPocketColor::NeoGeoPocketColor() {
 auto NeoGeoPocketColor::load() -> LoadResult {
   game = mia::Medium::create("Neo Geo Pocket Color");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("Neo Geo Pocket Color");
   result = system->load(firmware[0].location);
-  if(result != LoadResult(successful)) {
+  if(result != successful) {
     result.firmwareSystemName = "Neo Geo Pocket Color";
     result.firmwareType = firmware[0].type;
     result.firmwareRegion = firmware[0].region;
@@ -46,7 +46,7 @@ auto NeoGeoPocketColor::load() -> LoadResult {
     return result;
   }
 
-  if(!ares::NeoGeoPocket::load(root, "[SNK] Neo Geo Pocket Color")) return LoadResult(otherError);
+  if(!ares::NeoGeoPocket::load(root, "[SNK] Neo Geo Pocket Color")) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -57,7 +57,7 @@ auto NeoGeoPocketColor::load() -> LoadResult {
     fastBoot->setValue(settings.boot.fast);
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto NeoGeoPocketColor::save() -> bool {

--- a/desktop-ui/emulator/neo-geo-pocket.cpp
+++ b/desktop-ui/emulator/neo-geo-pocket.cpp
@@ -32,13 +32,13 @@ NeoGeoPocket::NeoGeoPocket() {
 auto NeoGeoPocket::load() -> LoadResult {
   game = mia::Medium::create("Neo Geo Pocket");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("Neo Geo Pocket");
   result = system->load(firmware[0].location);
-  if(result != LoadResult(successful)) {
+  if(result != successful) {
     result.firmwareSystemName = "Neo Geo Pocket";
     result.firmwareType = firmware[0].type;
     result.firmwareRegion = firmware[0].region;
@@ -46,7 +46,7 @@ auto NeoGeoPocket::load() -> LoadResult {
     return result;
   }
 
-  if(!ares::NeoGeoPocket::load(root, "[SNK] Neo Geo Pocket")) return LoadResult(otherError);;
+  if(!ares::NeoGeoPocket::load(root, "[SNK] Neo Geo Pocket")) return otherError;;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -57,7 +57,7 @@ auto NeoGeoPocket::load() -> LoadResult {
     fastBoot->setValue(settings.boot.fast);
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto NeoGeoPocket::save() -> bool {

--- a/desktop-ui/emulator/neo-geo-pocket.cpp
+++ b/desktop-ui/emulator/neo-geo-pocket.cpp
@@ -1,6 +1,6 @@
 struct NeoGeoPocket : Emulator {
   NeoGeoPocket();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
 };
@@ -29,14 +29,24 @@ NeoGeoPocket::NeoGeoPocket() {
   }
 }
 
-auto NeoGeoPocket::load() -> bool {
+auto NeoGeoPocket::load() -> LoadResult {
   game = mia::Medium::create("Neo Geo Pocket");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   system = mia::System::create("Neo Geo Pocket");
-  if(!system->load(firmware[0].location)) return errorFirmware(firmware[0]), false;
+  result = system->load(firmware[0].location);
+  if(result != LoadResult(successful)) {
+    result.firmwareSystemName = "Neo Geo Pocket";
+    result.firmwareType = firmware[0].type;
+    result.firmwareRegion = firmware[0].region;
+    result.result = noFirmware;
+    return result;
+  }
 
-  if(!ares::NeoGeoPocket::load(root, "[SNK] Neo Geo Pocket")) return false;
+  if(!ares::NeoGeoPocket::load(root, "[SNK] Neo Geo Pocket")) return LoadResult(otherError);;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -47,7 +57,7 @@ auto NeoGeoPocket::load() -> bool {
     fastBoot->setValue(settings.boot.fast);
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto NeoGeoPocket::save() -> bool {

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -57,9 +57,9 @@ Nintendo64::Nintendo64() {
 auto Nintendo64::load() -> LoadResult {
   game = mia::Medium::create("Nintendo 64");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   auto region = Emulator::region();
 
@@ -70,16 +70,16 @@ auto Nintendo64::load() -> LoadResult {
     for(auto& emulator : emulators) {
       if(emulator->name == "Nintendo 64DD") firmware = emulator->firmware;
     }
-    if(!firmware) return LoadResult(noFirmware);  //should never occur
+    if(!firmware) return otherError;  //should never occur
     name = "Nintendo 64DD";
 
     disk = mia::Medium::create("Nintendo 64DD");
-    if(disk->load(Emulator::load(disk, configuration.game)) != LoadResult(successful)) {
+    if(disk->load(Emulator::load(disk, configuration.game)) != successful) {
       disk.reset();
       name = "Nintendo 64";
       system = mia::System::create("Nintendo 64");
       result = system->load();
-      if(result != LoadResult(successful)) return result;
+      if(result != successful) return result;
     } else {
       region = disk->pak->attribute("region");
       //if statements below are ordered by lowest to highest priority
@@ -89,7 +89,7 @@ auto Nintendo64::load() -> LoadResult {
 
       system = mia::System::create(name);
       result = system->load(firmware[regionID].location);
-      if(result != LoadResult(successful)) {
+      if(result != successful) {
         result.firmwareSystemName = "Nintendo 64";
         result.firmwareType = firmware[regionID].type;
         result.firmwareRegion = firmware[regionID].region;
@@ -101,7 +101,7 @@ auto Nintendo64::load() -> LoadResult {
     name = "Nintendo 64";
     system = mia::System::create("Nintendo 64");
     result = system->load();
-    if(result != LoadResult(successful)) return result;
+    if(result != successful) return result;
   }
 
   ares::Nintendo64::option("Quality", settings.video.quality);
@@ -117,7 +117,7 @@ auto Nintendo64::load() -> LoadResult {
   ares::Nintendo64::option("Recompiler", !settings.general.forceInterpreter);
   ares::Nintendo64::option("Expansion Pak", settings.nintendo64.expansionPak);
 
-  if(!ares::Nintendo64::load(root, {"[Nintendo] ", name, " (", region, ")"})) return LoadResult(otherError);
+  if(!ares::Nintendo64::load(root, {"[Nintendo] ", name, " (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -147,7 +147,7 @@ auto Nintendo64::load() -> LoadResult {
           if(auto slot = transferPak->find<ares::Node::Port>("Cartridge Slot")) {
             gb = mia::Medium::create("Game Boy");
             string tmpPath;
-            if(gb->load(Emulator::load(gb, tmpPath)) == LoadResult(successful)) {
+            if(gb->load(Emulator::load(gb, tmpPath)) == successful) {
               slot->allocate();
               slot->connect();
               transferPakConnected = true;
@@ -177,7 +177,7 @@ auto Nintendo64::load() -> LoadResult {
 
   diskInsertTimer = Timer{};
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Nintendo64::load(Menu menu) -> void {
@@ -189,7 +189,7 @@ auto Nintendo64::load(Menu menu) -> void {
       auto drive = root->find<ares::Node::Port>("Nintendo 64DD/Disk Drive");
       drive->disconnect();
 
-      if(disk->load(Emulator::load(disk, configuration.game)) != LoadResult(successful)) {
+      if(disk->load(Emulator::load(disk, configuration.game)) != successful) {
         return;
       }
 
@@ -290,7 +290,7 @@ auto Nintendo64::portMenu(Menu& portMenu, ares::Node::Port port) -> void {
           if(auto slot = transferPak->find<ares::Node::Port>("Cartridge Slot")) {
             emulator->gb = mia::Medium::create("Game Boy");
             string tmpPath;
-            if(emulator->gb->load(emulator->load(emulator->gb, tmpPath)) == LoadResult(successful)) {
+            if(emulator->gb->load(emulator->load(emulator->gb, tmpPath)) == successful) {
               slot->allocate();
               slot->connect();
             } else {

--- a/desktop-ui/emulator/nintendo-64dd.cpp
+++ b/desktop-ui/emulator/nintendo-64dd.cpp
@@ -1,6 +1,6 @@
 struct Nintendo64DD : Nintendo64 {
   Nintendo64DD();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto load(Menu) -> void override;
   auto unload() -> void override;
   auto save() -> bool override;
@@ -56,9 +56,12 @@ Nintendo64DD::Nintendo64DD() {
   }
 }
 
-auto Nintendo64DD::load() -> bool {
+auto Nintendo64DD::load() -> LoadResult {
   game = mia::Medium::create("Nintendo 64DD");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   auto region = game->pak->attribute("region");
   //if statements below are ordered by lowest to highest priority
@@ -67,7 +70,14 @@ auto Nintendo64DD::load() -> bool {
   if (region == "NTSC-J"  ) regionID = 0;
 
   system = mia::System::create("Nintendo 64DD");
-  if(!system->load(firmware[regionID].location)) return errorFirmware(firmware[regionID]), false;
+  result = system->load(firmware[regionID].location);
+  if(result != LoadResult(successful)) {
+    result.firmwareSystemName = "Nintendo 64DD";
+    result.firmwareType = firmware[regionID].type;
+    result.firmwareRegion = firmware[regionID].region;
+    result.result = noFirmware;
+    return result;
+  }
 
   ares::Nintendo64::option("Quality", settings.video.quality);
   ares::Nintendo64::option("Supersampling", settings.video.supersampling);
@@ -82,7 +92,7 @@ auto Nintendo64DD::load() -> bool {
   ares::Nintendo64::option("Recompiler", !settings.general.forceInterpreter);
   ares::Nintendo64::option("Expansion Pak", settings.nintendo64.expansionPak);
 
-  if(!ares::Nintendo64::load(root, {"[Nintendo] Nintendo 64DD (", region, ")"})) return false;
+  if(!ares::Nintendo64::load(root, {"[Nintendo] Nintendo 64DD (", region, ")"})) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Nintendo 64DD/Disk Drive")) {
     port->allocate();
@@ -104,7 +114,7 @@ auto Nintendo64DD::load() -> bool {
           if(auto slot = transferPak->find<ares::Node::Port>("Cartridge Slot")) {
             gb = mia::Medium::create("Game Boy");
             string tmpPath;
-            if(gb->load(Emulator::load(gb, tmpPath))) {
+            if(gb->load(Emulator::load(gb, tmpPath)) == LoadResult(successful)) {
               slot->allocate();
               slot->connect();
               transferPakConnected = true;
@@ -134,7 +144,7 @@ auto Nintendo64DD::load() -> bool {
 
   diskInsertTimer = Timer{};
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto Nintendo64DD::load(Menu menu) -> void {
@@ -145,7 +155,7 @@ auto Nintendo64DD::load(Menu menu) -> void {
     auto drive = root->find<ares::Node::Port>("Nintendo 64DD/Disk Drive");
     drive->disconnect();
 
-    if(!game->load(Emulator::load(game, configuration.game))) {
+    if(game->load(Emulator::load(game, configuration.game)) != LoadResult(successful)) {
       return;
     }
 

--- a/desktop-ui/emulator/nintendo-64dd.cpp
+++ b/desktop-ui/emulator/nintendo-64dd.cpp
@@ -59,9 +59,9 @@ Nintendo64DD::Nintendo64DD() {
 auto Nintendo64DD::load() -> LoadResult {
   game = mia::Medium::create("Nintendo 64DD");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   auto region = game->pak->attribute("region");
   //if statements below are ordered by lowest to highest priority
@@ -71,7 +71,7 @@ auto Nintendo64DD::load() -> LoadResult {
 
   system = mia::System::create("Nintendo 64DD");
   result = system->load(firmware[regionID].location);
-  if(result != LoadResult(successful)) {
+  if(result != successful) {
     result.firmwareSystemName = "Nintendo 64DD";
     result.firmwareType = firmware[regionID].type;
     result.firmwareRegion = firmware[regionID].region;
@@ -92,7 +92,7 @@ auto Nintendo64DD::load() -> LoadResult {
   ares::Nintendo64::option("Recompiler", !settings.general.forceInterpreter);
   ares::Nintendo64::option("Expansion Pak", settings.nintendo64.expansionPak);
 
-  if(!ares::Nintendo64::load(root, {"[Nintendo] Nintendo 64DD (", region, ")"})) return LoadResult(otherError);
+  if(!ares::Nintendo64::load(root, {"[Nintendo] Nintendo 64DD (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Nintendo 64DD/Disk Drive")) {
     port->allocate();
@@ -114,7 +114,7 @@ auto Nintendo64DD::load() -> LoadResult {
           if(auto slot = transferPak->find<ares::Node::Port>("Cartridge Slot")) {
             gb = mia::Medium::create("Game Boy");
             string tmpPath;
-            if(gb->load(Emulator::load(gb, tmpPath)) == LoadResult(successful)) {
+            if(gb->load(Emulator::load(gb, tmpPath)) == successful) {
               slot->allocate();
               slot->connect();
               transferPakConnected = true;
@@ -144,7 +144,7 @@ auto Nintendo64DD::load() -> LoadResult {
 
   diskInsertTimer = Timer{};
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Nintendo64DD::load(Menu menu) -> void {
@@ -155,7 +155,7 @@ auto Nintendo64DD::load(Menu menu) -> void {
     auto drive = root->find<ares::Node::Port>("Nintendo 64DD/Disk Drive");
     drive->disconnect();
 
-    if(game->load(Emulator::load(game, configuration.game)) != LoadResult(successful)) {
+    if(game->load(Emulator::load(game, configuration.game)) != successful) {
       return;
     }
 

--- a/desktop-ui/emulator/pc-engine-cd.cpp
+++ b/desktop-ui/emulator/pc-engine-cd.cpp
@@ -23,9 +23,9 @@ PCEngineCD::PCEngineCD() {
 auto PCEngineCD::load() -> LoadResult {
   game = mia::Medium::create("PC Engine CD");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   auto region = Emulator::region();
   //if statements below are ordered by lowest to highest priority
@@ -43,7 +43,7 @@ auto PCEngineCD::load() -> LoadResult {
 
   bios = mia::Medium::create("PC Engine");
   result = bios->load(firmware[biosID].location);
-  if(result != LoadResult(successful)) {
+  if(result != successful) {
     result.firmwareSystemName = "PC Engine";
     result.firmwareType = firmware[biosID].type;
     result.firmwareRegion = firmware[biosID].region;
@@ -53,12 +53,12 @@ auto PCEngineCD::load() -> LoadResult {
 
   system = mia::System::create("PC Engine");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   ares::PCEngine::option("Pixel Accuracy", settings.video.pixelAccuracy);
 
   auto name = region == "NTSC-J" ? "PC Engine Duo" : "TurboDuo";
-  if(!ares::PCEngine::load(root, {"[NEC] ", name, " (", region, ")"})) return LoadResult(otherError);
+  if(!ares::PCEngine::load(root, {"[NEC] ", name, " (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -72,7 +72,7 @@ auto PCEngineCD::load() -> LoadResult {
 
   connectPorts();
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto PCEngineCD::save() -> bool {

--- a/desktop-ui/emulator/pc-engine.cpp
+++ b/desktop-ui/emulator/pc-engine.cpp
@@ -90,19 +90,19 @@ auto PCEngine::connectPorts() -> void {
 auto PCEngine::load() -> LoadResult {
   game = mia::Medium::create("PC Engine");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("PC Engine");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   ares::PCEngine::option("Pixel Accuracy", settings.video.pixelAccuracy);
 
   auto region = Emulator::region();
   string name = region == "NTSC-J" ? "PC Engine" : "TurboGrafx 16";
-  if(!ares::PCEngine::load(root, {"[NEC] ", name, " (", region, ")"})) return LoadResult(otherError);
+  if(!ares::PCEngine::load(root, {"[NEC] ", name, " (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -111,7 +111,7 @@ auto PCEngine::load() -> LoadResult {
 
   connectPorts();
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto PCEngine::save() -> bool {

--- a/desktop-ui/emulator/playstation.cpp
+++ b/desktop-ui/emulator/playstation.cpp
@@ -78,9 +78,9 @@ PlayStation::PlayStation() {
 auto PlayStation::load() -> LoadResult {
   game = mia::Medium::create("PlayStation");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   auto region = Emulator::region();
   //if statements below are ordered by lowest to highest priority
@@ -90,7 +90,7 @@ auto PlayStation::load() -> LoadResult {
 
   system = mia::System::create("PlayStation");
   result = system->load(firmware[regionID].location);
-  if(result != LoadResult(successful)) {
+  if(result != successful) {
     result.firmwareSystemName = "PlayStation";
     result.firmwareType = firmware[regionID].type;
     result.firmwareRegion = firmware[regionID].region;
@@ -100,7 +100,7 @@ auto PlayStation::load() -> LoadResult {
 
   ares::PlayStation::option("Recompiler", !settings.general.forceInterpreter);
 
-  if(!ares::PlayStation::load(root, {"[Sony] PlayStation (", region, ")"})) return LoadResult(otherError);
+  if(!ares::PlayStation::load(root, {"[Sony] PlayStation (", region, ")"})) return otherError;
 
   if(auto fastBoot = root->find<ares::Node::Setting::Boolean>("Fast Boot")) {
     fastBoot->setValue(settings.boot.fast);
@@ -131,7 +131,7 @@ auto PlayStation::load() -> LoadResult {
 
   discTrayTimer = Timer{};
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto PlayStation::load(Menu menu) -> void {
@@ -142,7 +142,7 @@ auto PlayStation::load(Menu menu) -> void {
     auto tray = root->find<ares::Node::Port>("PlayStation/Disc Tray");
     tray->disconnect();
 
-    if(game->load(Emulator::load(game, configuration.game)) != LoadResult(successful)) {
+    if(game->load(Emulator::load(game, configuration.game)) != successful) {
       return;
     }
 

--- a/desktop-ui/emulator/pocket-challenge-v2.cpp
+++ b/desktop-ui/emulator/pocket-challenge-v2.cpp
@@ -37,24 +37,24 @@ auto PocketChallengeV2::load(Menu menu) -> void {
 auto PocketChallengeV2::load() -> LoadResult {
   game = mia::Medium::create("Pocket Challenge V2");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("Pocket Challenge V2");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   ares::WonderSwan::option("Pixel Accuracy", settings.video.pixelAccuracy);
 
-  if(!ares::WonderSwan::load(root, "[Benesse] Pocket Challenge V2")) return LoadResult(otherError);
+  if(!ares::WonderSwan::load(root, "[Benesse] Pocket Challenge V2")) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto PocketChallengeV2::save() -> bool {

--- a/desktop-ui/emulator/pocket-challenge-v2.cpp
+++ b/desktop-ui/emulator/pocket-challenge-v2.cpp
@@ -1,7 +1,7 @@
 struct PocketChallengeV2 : Emulator {
   PocketChallengeV2();
   auto load(Menu) -> void override;
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
 };
@@ -34,23 +34,27 @@ auto PocketChallengeV2::load(Menu menu) -> void {
   //as such, neither the ares::WonderSwan core nor desktop-ui provide an orientation setting.
 }
 
-auto PocketChallengeV2::load() -> bool {
+auto PocketChallengeV2::load() -> LoadResult {
   game = mia::Medium::create("Pocket Challenge V2");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   system = mia::System::create("Pocket Challenge V2");
-  if(!system->load()) return false;
+  result = system->load();
+  if(result != LoadResult(successful)) return result;
 
   ares::WonderSwan::option("Pixel Accuracy", settings.video.pixelAccuracy);
 
-  if(!ares::WonderSwan::load(root, "[Benesse] Pocket Challenge V2")) return false;
+  if(!ares::WonderSwan::load(root, "[Benesse] Pocket Challenge V2")) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
     port->connect();
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto PocketChallengeV2::save() -> bool {

--- a/desktop-ui/emulator/saturn.cpp
+++ b/desktop-ui/emulator/saturn.cpp
@@ -19,9 +19,9 @@ Saturn::Saturn() {
 auto Saturn::load() -> LoadResult {
   game = mia::Medium::create("Saturn");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   auto region = Emulator::region();
   //if statements below are ordered by lowest to highest priority
@@ -31,7 +31,7 @@ auto Saturn::load() -> LoadResult {
 
   system = mia::System::create("Saturn");
   result = system->load(firmware[regionID].location);
-  if(result != LoadResult(successful)) {
+  if(result != successful) {
     result.firmwareSystemName = "Saturn";
     result.firmwareType = firmware[regionID].type;
     result.firmwareRegion = firmware[regionID].region;
@@ -39,7 +39,7 @@ auto Saturn::load() -> LoadResult {
     return result;
   }
 
-  if(!ares::Saturn::load(root, {"[Sega] Saturn (", region, ")"})) return LoadResult(otherError);
+  if(!ares::Saturn::load(root, {"[Sega] Saturn (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Saturn/Disc Tray")) {
     port->allocate();

--- a/desktop-ui/emulator/sg-1000.cpp
+++ b/desktop-ui/emulator/sg-1000.cpp
@@ -28,16 +28,16 @@ SG1000::SG1000() {
 auto SG1000::load() -> LoadResult {
   game = mia::Medium::create("SG-1000");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("SG-1000");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   auto region = Emulator::region();
-  if(!ares::SG1000::load(root, {"[Sega] SG-1000 (", region, ")"})) return LoadResult(otherError);
+  if(!ares::SG1000::load(root, {"[Sega] SG-1000 (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -54,7 +54,7 @@ auto SG1000::load() -> LoadResult {
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto SG1000::save() -> bool {

--- a/desktop-ui/emulator/super-famicom.cpp
+++ b/desktop-ui/emulator/super-famicom.cpp
@@ -96,18 +96,18 @@ SuperFamicom::SuperFamicom() {
 auto SuperFamicom::load() -> LoadResult {
   game = mia::Medium::create("Super Famicom");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("Super Famicom");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   ares::SuperFamicom::option("Pixel Accuracy", settings.video.pixelAccuracy);
 
   auto region = Emulator::region();
-  if(!ares::SuperFamicom::load(root, {"[Nintendo] Super Famicom (", region, ")"})) return LoadResult(otherError);
+  if(!ares::SuperFamicom::load(root, {"[Nintendo] Super Famicom (", region, ")"})) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     auto cartridge = port->allocate();
@@ -115,7 +115,7 @@ auto SuperFamicom::load() -> LoadResult {
 
     if(auto slot = cartridge->find<ares::Node::Port>("Super Game Boy/Cartridge Slot")) {
       gb = mia::Medium::create("Game Boy");
-      if(gb->load(Emulator::load(gb, settings.paths.superFamicom.gameBoy)) != LoadResult(successful)) {
+      if(gb->load(Emulator::load(gb, settings.paths.superFamicom.gameBoy)) != successful) {
         slot->allocate();
         slot->connect();
       } else {
@@ -125,7 +125,7 @@ auto SuperFamicom::load() -> LoadResult {
 
     if(auto slot = cartridge->find<ares::Node::Port>("BS Memory Slot")) {
       bs = mia::Medium::create("BS Memory");
-      if(bs->load(Emulator::load(bs, settings.paths.superFamicom.bsMemory)) != LoadResult(successful)) {
+      if(bs->load(Emulator::load(bs, settings.paths.superFamicom.bsMemory)) != successful) {
         slot->allocate();
         slot->connect();
       } else {
@@ -135,7 +135,7 @@ auto SuperFamicom::load() -> LoadResult {
 
     if(auto slot = cartridge->find<ares::Node::Port>("Sufami Turbo Slot A")) {
       stA = mia::Medium::create("Sufami Turbo");
-      if(stA->load(Emulator::load(stA, settings.paths.superFamicom.sufamiTurbo)) != LoadResult(successful)) {
+      if(stA->load(Emulator::load(stA, settings.paths.superFamicom.sufamiTurbo)) != successful) {
         slot->allocate();
         slot->connect();
       } else {
@@ -145,7 +145,7 @@ auto SuperFamicom::load() -> LoadResult {
 
     if(auto slot = cartridge->find<ares::Node::Port>("Sufami Turbo Slot B")) {
       stB = mia::Medium::create("Sufami Turbo");
-      if(stB->load(Emulator::load(stB, settings.paths.superFamicom.sufamiTurbo)) != LoadResult(successful)) {
+      if(stB->load(Emulator::load(stB, settings.paths.superFamicom.sufamiTurbo)) != successful) {
         slot->allocate();
         slot->connect();
       } else {
@@ -164,7 +164,7 @@ auto SuperFamicom::load() -> LoadResult {
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto SuperFamicom::save() -> bool {

--- a/desktop-ui/emulator/supergrafx-cd.cpp
+++ b/desktop-ui/emulator/supergrafx-cd.cpp
@@ -20,13 +20,13 @@ SuperGrafxCD::SuperGrafxCD() {
 auto SuperGrafxCD::load() -> LoadResult {
   game = mia::Medium::create("PC Engine CD");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   bios = mia::Medium::create("PC Engine");
   result = bios->load(firmware[0].location);
-  if(result != LoadResult(successful)) {
+  if(result != successful) {
     result.firmwareSystemName = "SuperGrafx CD";
     result.firmwareType = firmware[0].type;
     result.firmwareRegion = firmware[0].region;
@@ -36,11 +36,11 @@ auto SuperGrafxCD::load() -> LoadResult {
 
   system = mia::System::create("SuperGrafx");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   ares::PCEngine::option("Pixel Accuracy", settings.video.pixelAccuracy);
 
-  if(!ares::PCEngine::load(root, "[NEC] SuperGrafx (NTSC-J)")) return LoadResult(otherError);
+  if(!ares::PCEngine::load(root, "[NEC] SuperGrafx (NTSC-J)")) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -54,7 +54,7 @@ auto SuperGrafxCD::load() -> LoadResult {
 
   connectPorts();
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto SuperGrafxCD::save() -> bool {

--- a/desktop-ui/emulator/supergrafx-cd.cpp
+++ b/desktop-ui/emulator/supergrafx-cd.cpp
@@ -1,6 +1,6 @@
 struct SuperGrafxCD : PCEngine {
   SuperGrafxCD();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
 
@@ -17,19 +17,30 @@ SuperGrafxCD::SuperGrafxCD() {
   allocatePorts();
 }
 
-auto SuperGrafxCD::load() -> bool {
+auto SuperGrafxCD::load() -> LoadResult {
   game = mia::Medium::create("PC Engine CD");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   bios = mia::Medium::create("PC Engine");
-  if(!bios->load(firmware[0].location)) return errorFirmware(firmware[0]), false;
+  result = bios->load(firmware[0].location);
+  if(result != LoadResult(successful)) {
+    result.firmwareSystemName = "SuperGrafx CD";
+    result.firmwareType = firmware[0].type;
+    result.firmwareRegion = firmware[0].region;
+    result.result = noFirmware;
+    return result;
+  }
 
   system = mia::System::create("SuperGrafx");
-  if(!system->load()) return false;
+  result = system->load();
+  if(result != LoadResult(successful)) return result;
 
   ares::PCEngine::option("Pixel Accuracy", settings.video.pixelAccuracy);
 
-  if(!ares::PCEngine::load(root, "[NEC] SuperGrafx (NTSC-J)")) return false;
+  if(!ares::PCEngine::load(root, "[NEC] SuperGrafx (NTSC-J)")) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -43,7 +54,7 @@ auto SuperGrafxCD::load() -> bool {
 
   connectPorts();
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto SuperGrafxCD::save() -> bool {

--- a/desktop-ui/emulator/supergrafx.cpp
+++ b/desktop-ui/emulator/supergrafx.cpp
@@ -15,17 +15,17 @@ SuperGrafx::SuperGrafx() {
 auto SuperGrafx::load() -> LoadResult {
   game = mia::Medium::create("SuperGrafx");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("SuperGrafx");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   ares::PCEngine::option("Pixel Accuracy", settings.video.pixelAccuracy);
 
-  if(!ares::PCEngine::load(root, "[NEC] SuperGrafx (NTSC-J)")) return LoadResult(otherError);
+  if(!ares::PCEngine::load(root, "[NEC] SuperGrafx (NTSC-J)")) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -34,7 +34,7 @@ auto SuperGrafx::load() -> LoadResult {
 
   connectPorts();
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto SuperGrafx::save() -> bool {

--- a/desktop-ui/emulator/supergrafx.cpp
+++ b/desktop-ui/emulator/supergrafx.cpp
@@ -1,6 +1,6 @@
 struct SuperGrafx : PCEngine {
   SuperGrafx();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
 };
@@ -12,16 +12,20 @@ SuperGrafx::SuperGrafx() {
   allocatePorts();
 }
 
-auto SuperGrafx::load() -> bool {
+auto SuperGrafx::load() -> LoadResult {
   game = mia::Medium::create("SuperGrafx");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   system = mia::System::create("SuperGrafx");
-  if(!system->load()) return false;
+  result = system->load();
+  if(result != LoadResult(successful)) return result;
 
   ares::PCEngine::option("Pixel Accuracy", settings.video.pixelAccuracy);
 
-  if(!ares::PCEngine::load(root, "[NEC] SuperGrafx (NTSC-J)")) return false;
+  if(!ares::PCEngine::load(root, "[NEC] SuperGrafx (NTSC-J)")) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
@@ -30,7 +34,7 @@ auto SuperGrafx::load() -> bool {
 
   connectPorts();
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto SuperGrafx::save() -> bool {

--- a/desktop-ui/emulator/wonderswan-color.cpp
+++ b/desktop-ui/emulator/wonderswan-color.cpp
@@ -1,7 +1,7 @@
 struct WonderSwanColor : Emulator {
   WonderSwanColor();
   auto load(Menu) -> void override;
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
 };
@@ -57,23 +57,27 @@ auto WonderSwanColor::load(Menu menu) -> void {
   }
 }
 
-auto WonderSwanColor::load() -> bool {
+auto WonderSwanColor::load() -> LoadResult {
   game = mia::Medium::create("WonderSwan Color");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   system = mia::System::create("WonderSwan Color");
-  if(!system->load()) return false;
+  result = system->load();
+  if(result != LoadResult(successful)) return result;
 
   ares::WonderSwan::option("Pixel Accuracy", settings.video.pixelAccuracy);
 
-  if(!ares::WonderSwan::load(root, "[Bandai] WonderSwan Color")) return false;
+  if(!ares::WonderSwan::load(root, "[Bandai] WonderSwan Color")) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
     port->connect();
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto WonderSwanColor::save() -> bool {

--- a/desktop-ui/emulator/wonderswan-color.cpp
+++ b/desktop-ui/emulator/wonderswan-color.cpp
@@ -60,24 +60,24 @@ auto WonderSwanColor::load(Menu menu) -> void {
 auto WonderSwanColor::load() -> LoadResult {
   game = mia::Medium::create("WonderSwan Color");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("WonderSwan Color");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   ares::WonderSwan::option("Pixel Accuracy", settings.video.pixelAccuracy);
 
-  if(!ares::WonderSwan::load(root, "[Bandai] WonderSwan Color")) return LoadResult(otherError);
+  if(!ares::WonderSwan::load(root, "[Bandai] WonderSwan Color")) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto WonderSwanColor::save() -> bool {

--- a/desktop-ui/emulator/wonderswan.cpp
+++ b/desktop-ui/emulator/wonderswan.cpp
@@ -60,24 +60,24 @@ auto WonderSwan::load(Menu menu) -> void {
 auto WonderSwan::load() -> LoadResult {
   game = mia::Medium::create("WonderSwan");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("WonderSwan");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   ares::WonderSwan::option("Pixel Accuracy", settings.video.pixelAccuracy);
 
-  if(!ares::WonderSwan::load(root, "[Bandai] WonderSwan")) return LoadResult(otherError);
+  if(!ares::WonderSwan::load(root, "[Bandai] WonderSwan")) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto WonderSwan::save() -> bool {

--- a/desktop-ui/emulator/zx-spectrum-128.cpp
+++ b/desktop-ui/emulator/zx-spectrum-128.cpp
@@ -12,15 +12,15 @@ ZXSpectrum128::ZXSpectrum128() {
 auto ZXSpectrum128::load() -> LoadResult {
   game = mia::Medium::create("ZX Spectrum");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("ZX Spectrum 128");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
-  if(!ares::ZXSpectrum::load(root, "[Sinclair] ZX Spectrum 128")) return LoadResult(otherError);
+  if(!ares::ZXSpectrum::load(root, "[Sinclair] ZX Spectrum 128")) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Tape Deck/Tray")) {
     port->allocate();
@@ -32,7 +32,7 @@ auto ZXSpectrum128::load() -> LoadResult {
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto ZXSpectrum128::pak(ares::Node::Object node) -> shared_pointer<vfs::directory> {

--- a/desktop-ui/emulator/zx-spectrum-128.cpp
+++ b/desktop-ui/emulator/zx-spectrum-128.cpp
@@ -1,6 +1,6 @@
 struct ZXSpectrum128 : ZXSpectrum {
   ZXSpectrum128();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
 };
 
@@ -9,14 +9,18 @@ ZXSpectrum128::ZXSpectrum128() {
   name = "ZX Spectrum 128";
 }
 
-auto ZXSpectrum128::load() -> bool {
+auto ZXSpectrum128::load() -> LoadResult {
   game = mia::Medium::create("ZX Spectrum");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   system = mia::System::create("ZX Spectrum 128");
-  if(!system->load()) return false;
+  result = system->load();
+  if(result != LoadResult(successful)) return result;
 
-  if(!ares::ZXSpectrum::load(root, "[Sinclair] ZX Spectrum 128")) return false;
+  if(!ares::ZXSpectrum::load(root, "[Sinclair] ZX Spectrum 128")) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Tape Deck/Tray")) {
     port->allocate();
@@ -28,7 +32,7 @@ auto ZXSpectrum128::load() -> bool {
     port->connect();
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto ZXSpectrum128::pak(ares::Node::Object node) -> shared_pointer<vfs::directory> {

--- a/desktop-ui/emulator/zx-spectrum.cpp
+++ b/desktop-ui/emulator/zx-spectrum.cpp
@@ -15,15 +15,15 @@ ZXSpectrum::ZXSpectrum() {
 auto ZXSpectrum::load() -> LoadResult {
   game = mia::Medium::create("ZX Spectrum");
   string location = Emulator::load(game, configuration.game);
-  if(!location) return LoadResult(noFileSelected);
+  if(!location) return noFileSelected;
   LoadResult result = game->load(location);
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
   system = mia::System::create("ZX Spectrum");
   result = system->load();
-  if(result != LoadResult(successful)) return result;
+  if(result != successful) return result;
 
-  if(!ares::ZXSpectrum::load(root, "[Sinclair] ZX Spectrum")) return LoadResult(otherError);
+  if(!ares::ZXSpectrum::load(root, "[Sinclair] ZX Spectrum")) return otherError;
 
   if(auto port = root->find<ares::Node::Port>("Tape Deck/Tray")) {
     port->allocate();
@@ -35,7 +35,7 @@ auto ZXSpectrum::load() -> LoadResult {
     port->connect();
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto ZXSpectrum::load(Menu menu) -> void {

--- a/desktop-ui/emulator/zx-spectrum.cpp
+++ b/desktop-ui/emulator/zx-spectrum.cpp
@@ -1,6 +1,6 @@
 struct ZXSpectrum : Emulator {
   ZXSpectrum();
-  auto load() -> bool override;
+  auto load() -> LoadResult override;
   auto load(Menu) -> void override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> shared_pointer<vfs::directory> override;
@@ -12,14 +12,18 @@ ZXSpectrum::ZXSpectrum() {
   name = "ZX Spectrum";
 }
 
-auto ZXSpectrum::load() -> bool {
+auto ZXSpectrum::load() -> LoadResult {
   game = mia::Medium::create("ZX Spectrum");
-  if(!game->load(Emulator::load(game, configuration.game))) return false;
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return LoadResult(noFileSelected);
+  LoadResult result = game->load(location);
+  if(result != LoadResult(successful)) return result;
 
   system = mia::System::create("ZX Spectrum");
-  if(!system->load()) return false;
+  result = system->load();
+  if(result != LoadResult(successful)) return result;
 
-  if(!ares::ZXSpectrum::load(root, "[Sinclair] ZX Spectrum")) return false;
+  if(!ares::ZXSpectrum::load(root, "[Sinclair] ZX Spectrum")) return LoadResult(otherError);
 
   if(auto port = root->find<ares::Node::Port>("Tape Deck/Tray")) {
     port->allocate();
@@ -31,7 +35,7 @@ auto ZXSpectrum::load() -> bool {
     port->connect();
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto ZXSpectrum::load(Menu menu) -> void {

--- a/mia/CMakeLists.txt
+++ b/mia/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(mia STATIC mia.cpp resource/resource.cpp)
+add_library(mia STATIC mia.cpp mia.hpp resource/resource.cpp)
 add_library(ares::mia ALIAS mia)
 
 target_sources(

--- a/mia/medium/arcade.cpp
+++ b/mia/medium/arcade.cpp
@@ -1,23 +1,23 @@
 struct Arcade : Mame {
   auto name() -> string override { return "Arcade"; }
   auto extensions() -> vector<string> override { return {}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto Arcade::load(string location) -> bool {
+auto Arcade::load(string location) -> LoadResult {
   auto foundDatabase = Medium::loadDatabase();
-  if(!foundDatabase) return false;
+  if(!foundDatabase) return LoadResult(databaseNotFound);
   manifest = manifestDatabaseArcade(Medium::name(location));
-  if(!manifest) return false;
+  if(!manifest) return LoadResult(romNotFoundInDatabase);
 
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   //Sega SG-1000 based arcade
   if(document["game/board"].string() == "sega/sg1000a") {
     vector<u8> rom = loadRoms(location, document, "maincpu");
-    if(!rom) return false;
+    if(!rom) return romNotFound;
 
     this->location = location;
 
@@ -28,10 +28,10 @@ auto Arcade::load(string location) -> bool {
     pak->append("manifest.bml", manifest);
     pak->append("program.rom",  rom);
 
-    return true;
+    return LoadResult(successful);
   }
 
-  return false;
+  return LoadResult(otherError);
 }
 
 auto Arcade::save(string location) -> bool {

--- a/mia/medium/arcade.cpp
+++ b/mia/medium/arcade.cpp
@@ -7,17 +7,17 @@ struct Arcade : Mame {
 
 auto Arcade::load(string location) -> LoadResult {
   auto foundDatabase = Medium::loadDatabase();
-  if(!foundDatabase) return LoadResult(databaseNotFound);
+  if(!foundDatabase) return { databaseNotFound, "Arcade.bml" };
   manifest = manifestDatabaseArcade(Medium::name(location));
-  if(!manifest) return LoadResult(romNotFoundInDatabase);
+  if(!manifest) return romNotFoundInDatabase;
 
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   //Sega SG-1000 based arcade
   if(document["game/board"].string() == "sega/sg1000a") {
     vector<u8> rom = loadRoms(location, document, "maincpu");
-    if(!rom) return romNotFound;
+    if(!rom) return { invalidROM, "Ensure your ROM is in a MAME-compatible .zip format." };
 
     this->location = location;
 
@@ -28,10 +28,10 @@ auto Arcade::load(string location) -> LoadResult {
     pak->append("manifest.bml", manifest);
     pak->append("program.rom",  rom);
 
-    return LoadResult(successful);
+    return successful;
   }
 
-  return LoadResult(otherError);
+  return otherError;
 }
 
 auto Arcade::save(string location) -> bool {

--- a/mia/medium/atari-2600.cpp
+++ b/mia/medium/atari-2600.cpp
@@ -1,28 +1,28 @@
 struct Atari2600 : Cartridge {
   auto name() -> string override { return "Atari 2600"; }
   auto extensions() -> vector<string> override { return {"a26", "bin"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& rom, string location) -> string;
 
   auto match(vector<u8>& rom, vector<u8> pattern, u8 target_matches = 1) -> bool;
 };
 
-auto Atari2600::load(string location) -> bool {
+auto Atari2600::load(string location) -> LoadResult {
   vector<u8> rom;
   if(directory::exists(location)) {
     append(rom, {location, "program.rom"});
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return false;
+  if(!rom) return LoadResult(romNotFound);
 
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
   this->manifest = Medium::manifestDatabase(sha256);
   if(!manifest) manifest = analyze(rom, location);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
@@ -31,7 +31,7 @@ auto Atari2600::load(string location) -> bool {
   pak->append("manifest.bml", manifest);
   pak->append("program.rom",  rom);
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto Atari2600::save(string location) -> bool {

--- a/mia/medium/atari-2600.cpp
+++ b/mia/medium/atari-2600.cpp
@@ -15,14 +15,14 @@ auto Atari2600::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
 
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
   this->manifest = Medium::manifestDatabase(sha256);
   if(!manifest) manifest = analyze(rom, location);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
@@ -31,7 +31,7 @@ auto Atari2600::load(string location) -> LoadResult {
   pak->append("manifest.bml", manifest);
   pak->append("program.rom",  rom);
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Atari2600::save(string location) -> bool {

--- a/mia/medium/bs-memory.cpp
+++ b/mia/medium/bs-memory.cpp
@@ -14,16 +14,16 @@ auto BSMemory::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
 
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
   auto foundDatabase = Medium::loadDatabase();
-  if(!foundDatabase) return LoadResult(databaseNotFound);
+  if(!foundDatabase) return { databaseNotFound, "BS Memory.bml" };
   this->manifest = Medium::manifestDatabase(sha256);
   if(!manifest) manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title", document["game/title"].string());
@@ -36,7 +36,7 @@ auto BSMemory::load(string location) -> LoadResult {
     Pak::load("program.flash", ".sav");
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto BSMemory::save(string location) -> bool {

--- a/mia/medium/colecovision.cpp
+++ b/mia/medium/colecovision.cpp
@@ -13,12 +13,12 @@ auto ColecoVision::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("board",  document["game/board" ].string());
@@ -27,7 +27,7 @@ auto ColecoVision::load(string location) -> LoadResult {
   pak->append("manifest.bml", manifest);
   pak->append("program.rom",  rom);
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto ColecoVision::save(string location) -> bool {

--- a/mia/medium/famicom-disk-system.cpp
+++ b/mia/medium/famicom-disk-system.cpp
@@ -1,13 +1,13 @@
 struct FamicomDiskSystem : FloppyDisk {
   auto name() -> string override { return "Famicom Disk System"; }
   auto extensions() -> vector<string> override { return {"fds"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze() -> string;
   auto transform(array_view<u8> input) -> vector<u8>;
 };
 
-auto FamicomDiskSystem::load(string location) -> bool {
+auto FamicomDiskSystem::load(string location) -> LoadResult {
   if(directory::exists(location)) {
     this->location = location;
     this->manifest = analyze();
@@ -42,14 +42,14 @@ auto FamicomDiskSystem::load(string location) -> bool {
     }
   }
 
-  if(!pak) return false;
+  if(!pak) return LoadResult(romNotFound);
 
   Pak::load("disk1.sideA", ".d1a");
   Pak::load("disk1.sideB", ".d1b");
   Pak::load("disk2.sideA", ".d2a");
   Pak::load("disk2.sideB", ".d2b");
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto FamicomDiskSystem::save(string location) -> bool {

--- a/mia/medium/famicom-disk-system.cpp
+++ b/mia/medium/famicom-disk-system.cpp
@@ -42,14 +42,14 @@ auto FamicomDiskSystem::load(string location) -> LoadResult {
     }
   }
 
-  if(!pak) return LoadResult(romNotFound);
+  if(!pak) return romNotFound;
 
   Pak::load("disk1.sideA", ".d1a");
   Pak::load("disk1.sideB", ".d1b");
   Pak::load("disk2.sideA", ".d2a");
   Pak::load("disk2.sideB", ".d2b");
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto FamicomDiskSystem::save(string location) -> bool {

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -18,12 +18,12 @@ auto Famicom::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title", document["game/title"].string());
@@ -70,7 +70,7 @@ auto Famicom::load(string location) -> LoadResult {
     Medium::load(node, ".chr");
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Famicom::save(string location) -> bool {

--- a/mia/medium/game-boy-advance.cpp
+++ b/mia/medium/game-boy-advance.cpp
@@ -1,25 +1,25 @@
 struct GameBoyAdvance : Cartridge {
   auto name() -> string override { return "Game Boy Advance"; }
   auto extensions() -> vector<string> override { return {"gba"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& rom) -> string;
 };
 
-auto GameBoyAdvance::load(string location) -> bool {
+auto GameBoyAdvance::load(string location) -> LoadResult {
   vector<u8> rom;
   if(directory::exists(location)) {
     append(rom, {location, "program.rom"});
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return false;
+  if(!rom) return LoadResult(romNotFound);
 
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("title", document["game/title"].string());
@@ -45,7 +45,7 @@ auto GameBoyAdvance::load(string location) -> bool {
   }
   pak->setAttribute("mirror", mirror);
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto GameBoyAdvance::save(string location) -> bool {

--- a/mia/medium/game-boy-advance.cpp
+++ b/mia/medium/game-boy-advance.cpp
@@ -13,13 +13,13 @@ auto GameBoyAdvance::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
 
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title", document["game/title"].string());
@@ -45,7 +45,7 @@ auto GameBoyAdvance::load(string location) -> LoadResult {
   }
   pak->setAttribute("mirror", mirror);
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto GameBoyAdvance::save(string location) -> bool {

--- a/mia/medium/game-boy.cpp
+++ b/mia/medium/game-boy.cpp
@@ -13,12 +13,12 @@ auto GameBoy::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title", document["game/title"].string());
@@ -42,7 +42,7 @@ auto GameBoy::load(string location) -> LoadResult {
     Medium::load(node, ".rtc");
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto GameBoy::save(string location) -> bool {

--- a/mia/medium/game-boy.cpp
+++ b/mia/medium/game-boy.cpp
@@ -1,24 +1,24 @@
 struct GameBoy : Cartridge {
   auto name() -> string override { return "Game Boy"; }
   auto extensions() -> vector<string> override { return {"gb"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& rom) -> string;
 };
 
-auto GameBoy::load(string location) -> bool {
+auto GameBoy::load(string location) -> LoadResult {
   vector<u8> rom;
   if(directory::exists(location)) {
     append(rom, {location, "program.rom"});
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return false;
+  if(!rom) return LoadResult(romNotFound);
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("title", document["game/title"].string());
@@ -42,7 +42,7 @@ auto GameBoy::load(string location) -> bool {
     Medium::load(node, ".rtc");
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto GameBoy::save(string location) -> bool {

--- a/mia/medium/game-gear.cpp
+++ b/mia/medium/game-gear.cpp
@@ -13,13 +13,13 @@ auto GameGear::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   } else {
-    return LoadResult(romNotFound);
+    return romNotFound;
   }
 
   this->location = location;
   this->manifest = analyze(rom, location);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("board",  document["game/board" ].string());
@@ -33,7 +33,7 @@ auto GameGear::load(string location) -> LoadResult {
     Medium::load(node, ".ram");
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto GameGear::save(string location) -> bool {

--- a/mia/medium/game-gear.cpp
+++ b/mia/medium/game-gear.cpp
@@ -1,25 +1,25 @@
 struct GameGear : Cartridge {
   auto name() -> string override { return "Game Gear"; }
   auto extensions() -> vector<string> override { return {"gg"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& rom, string location) -> string;
 };
 
-auto GameGear::load(string location) -> bool {
+auto GameGear::load(string location) -> LoadResult {
   vector<u8> rom;
   if(directory::exists(location)) {
     append(rom, {location, "program.rom"});
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   } else {
-    return false;
+    return LoadResult(romNotFound);
   }
 
   this->location = location;
   this->manifest = analyze(rom, location);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("board",  document["game/board" ].string());
@@ -33,7 +33,7 @@ auto GameGear::load(string location) -> bool {
     Medium::load(node, ".ram");
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto GameGear::save(string location) -> bool {

--- a/mia/medium/mame.cpp
+++ b/mia/medium/mame.cpp
@@ -8,9 +8,8 @@ auto Mame::loadRoms(string location, Markup::Node& info, string sectionName) -> 
   vector<u8> output;
 
   Decode::ZIP archive;
-  if(!archive.open(location)) {
-    return output;
-  }
+  if(!location.iendsWith(".zip")) return output;
+  if(!archive.open(location)) return output;
 
   string filename = {};
   vector<u8> input = {};

--- a/mia/medium/master-system.cpp
+++ b/mia/medium/master-system.cpp
@@ -13,13 +13,13 @@ auto MasterSystem::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   } else {
-    return LoadResult(romNotFound);
+    return romNotFound;
   }
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("board",  document["game/board" ].string());
@@ -34,7 +34,7 @@ auto MasterSystem::load(string location) -> LoadResult {
     Medium::load(node, ".ram");
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MasterSystem::save(string location) -> bool {

--- a/mia/medium/master-system.cpp
+++ b/mia/medium/master-system.cpp
@@ -1,25 +1,25 @@
 struct MasterSystem : Cartridge {
   auto name() -> string override { return "Master System"; }
   auto extensions() -> vector<string> override { return {"ms", "sms"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& rom) -> string;
 };
 
-auto MasterSystem::load(string location) -> bool {
+auto MasterSystem::load(string location) -> LoadResult {
   vector<u8> rom;
   if(directory::exists(location)) {
     append(rom, {location, "program.rom"});
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   } else {
-    return false;
+    return LoadResult(romNotFound);
   }
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("board",  document["game/board" ].string());
@@ -34,7 +34,7 @@ auto MasterSystem::load(string location) -> bool {
     Medium::load(node, ".ram");
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto MasterSystem::save(string location) -> bool {

--- a/mia/medium/mega-32x.cpp
+++ b/mia/medium/mega-32x.cpp
@@ -32,12 +32,12 @@ auto Mega32X::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title",    document["game/title"].string());
@@ -67,7 +67,7 @@ auto Mega32X::load(string location) -> LoadResult {
     }
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Mega32X::save(string location) -> bool {

--- a/mia/medium/mega-32x.cpp
+++ b/mia/medium/mega-32x.cpp
@@ -1,7 +1,7 @@
 struct Mega32X : Cartridge {
   auto name() -> string override { return "Mega 32X"; }
   auto extensions() -> vector<string> override { return {"32x"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& rom) -> string;
   auto analyzeStorage(vector<u8>& rom, string hash) -> void;
@@ -25,19 +25,19 @@ struct Mega32X : Cartridge {
   } eeprom;
 };
 
-auto Mega32X::load(string location) -> bool {
+auto Mega32X::load(string location) -> LoadResult {
   vector<u8> rom;
   if(directory::exists(location)) {
     append(rom, {location, "program.rom"});
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return false;
+  if(!rom) return LoadResult(romNotFound);
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("title",    document["game/title"].string());
@@ -67,7 +67,7 @@ auto Mega32X::load(string location) -> bool {
     }
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto Mega32X::save(string location) -> bool {

--- a/mia/medium/mega-cd.cpp
+++ b/mia/medium/mega-cd.cpp
@@ -7,12 +7,12 @@ struct MegaCD : CompactDisc {
 };
 
 auto MegaCD::load(string location) -> LoadResult {
-  if(!inode::exists(location)) return LoadResult(romNotFound);
+  if(!inode::exists(location)) return romNotFound;
 
   this->location = location;
   this->manifest = analyze(location);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
@@ -27,7 +27,7 @@ auto MegaCD::load(string location) -> LoadResult {
     pak->append("cd.rom", vfs::cdrom::open(location));
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MegaCD::save(string location) -> bool {

--- a/mia/medium/mega-cd.cpp
+++ b/mia/medium/mega-cd.cpp
@@ -1,18 +1,18 @@
 struct MegaCD : CompactDisc {
   auto name() -> string override { return "Mega CD"; }
   auto extensions() -> vector<string> override { return {"cue", "chd"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(string location) -> string;
 };
 
-auto MegaCD::load(string location) -> bool {
-  if(!inode::exists(location)) return false;
+auto MegaCD::load(string location) -> LoadResult {
+  if(!inode::exists(location)) return LoadResult(romNotFound);
 
   this->location = location;
   this->manifest = analyze(location);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
@@ -27,7 +27,7 @@ auto MegaCD::load(string location) -> bool {
     pak->append("cd.rom", vfs::cdrom::open(location));
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto MegaCD::save(string location) -> bool {

--- a/mia/medium/mega-drive.cpp
+++ b/mia/medium/mega-drive.cpp
@@ -44,12 +44,12 @@ auto MegaDrive::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title",    document["game/title"].string());
@@ -100,7 +100,7 @@ auto MegaDrive::load(string location) -> LoadResult {
     pak->setAttribute("jcart", true);
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MegaDrive::save(string location) -> bool {

--- a/mia/medium/mega-drive.cpp
+++ b/mia/medium/mega-drive.cpp
@@ -1,7 +1,7 @@
 struct MegaDrive : Cartridge {
   auto name() -> string override { return "Mega Drive"; }
   auto extensions() -> vector<string> override { return {"md", "gen", "bin"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& rom) -> string;
   auto analyzeStorage(vector<u8>& rom, string hash) -> void;
@@ -37,19 +37,19 @@ struct MegaDrive : Cartridge {
   } peripherals;
 };
 
-auto MegaDrive::load(string location) -> bool {
+auto MegaDrive::load(string location) -> LoadResult {
   vector<u8> rom;
   if(directory::exists(location)) {
     append(rom, {location, "program.rom"});
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return false;
+  if(!rom) return LoadResult(romNotFound);
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("title",    document["game/title"].string());
@@ -100,7 +100,7 @@ auto MegaDrive::load(string location) -> bool {
     pak->setAttribute("jcart", true);
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto MegaDrive::save(string location) -> bool {

--- a/mia/medium/msx.cpp
+++ b/mia/medium/msx.cpp
@@ -19,16 +19,16 @@ auto MSX::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
 
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
   auto foundDatabase = Medium::loadDatabase();
-  if(!foundDatabase) return LoadResult(databaseNotFound);
+  if(!foundDatabase) return { databaseNotFound, "MSX.bml" };
   this->manifest = Medium::manifestDatabase(sha256);
   if(!manifest) manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
@@ -38,7 +38,7 @@ auto MSX::load(string location) -> LoadResult {
   pak->append("manifest.bml", manifest);
   pak->append("program.rom",  rom);
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MSX::save(string location) -> bool {
@@ -142,12 +142,12 @@ auto MSX::analyze(vector<u8>& rom) -> string {
 
 
 auto MSX::loadTape(string location) -> LoadResult {
-  if(!inode::exists(location)) return LoadResult(romNotFound);
+  if(!inode::exists(location)) return romNotFound;
 
   this->location = location;
   this->manifest = analyzeTape(location);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title",      document["game/title"].string());
@@ -177,7 +177,7 @@ auto MSX::loadTape(string location) -> LoadResult {
     }
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MSX::analyzeTape(string location) -> string {

--- a/mia/medium/msx.cpp
+++ b/mia/medium/msx.cpp
@@ -1,14 +1,14 @@
 struct MSX : Cartridge {
   auto name() -> string override { return "MSX"; }
   auto extensions() -> vector<string> override { return {"msx", "rom", "wav"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& rom) -> string;
-  auto loadTape(string location) -> bool;
+  auto loadTape(string location) -> LoadResult;
   auto analyzeTape(string location) -> string;
 };
 
-auto MSX::load(string location) -> bool {
+auto MSX::load(string location) -> LoadResult {
   if(location.iendsWith(".wav")) {
     return loadTape(location);
   }
@@ -19,16 +19,16 @@ auto MSX::load(string location) -> bool {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return false;
+  if(!rom) return LoadResult(romNotFound);
 
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
   auto foundDatabase = Medium::loadDatabase();
-  if(!foundDatabase) return false;
+  if(!foundDatabase) return LoadResult(databaseNotFound);
   this->manifest = Medium::manifestDatabase(sha256);
   if(!manifest) manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
@@ -38,7 +38,7 @@ auto MSX::load(string location) -> bool {
   pak->append("manifest.bml", manifest);
   pak->append("program.rom",  rom);
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto MSX::save(string location) -> bool {
@@ -141,13 +141,13 @@ auto MSX::analyze(vector<u8>& rom) -> string {
 }
 
 
-auto MSX::loadTape(string location) -> bool {
-  if(!inode::exists(location)) return false;
+auto MSX::loadTape(string location) -> LoadResult {
+  if(!inode::exists(location)) return LoadResult(romNotFound);
 
   this->location = location;
   this->manifest = analyzeTape(location);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("title",      document["game/title"].string());
@@ -177,7 +177,7 @@ auto MSX::loadTape(string location) -> bool {
     }
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto MSX::analyzeTape(string location) -> string {

--- a/mia/medium/myvision.cpp
+++ b/mia/medium/myvision.cpp
@@ -16,20 +16,20 @@ auto MyVision::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
 
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
   pak->append("manifest.bml", manifest);
   pak->append("program.rom",  rom);
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MyVision::save(string location) -> bool {

--- a/mia/medium/myvision.cpp
+++ b/mia/medium/myvision.cpp
@@ -4,32 +4,32 @@
 struct MyVision : Cartridge {
   auto name() -> string override { return "MyVision"; }
   auto extensions() -> vector<string> override { return {"myv"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& rom) -> string;
 };
 
-auto MyVision::load(string location) -> bool {
+auto MyVision::load(string location) -> LoadResult {
   vector<u8> rom;
   if(directory::exists(location)) {
     append(rom, {location, "program.rom"});
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return false;
+  if(!rom) return LoadResult(romNotFound);
 
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
   pak->append("manifest.bml", manifest);
   pak->append("program.rom",  rom);
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto MyVision::save(string location) -> bool {

--- a/mia/medium/neo-geo-pocket.cpp
+++ b/mia/medium/neo-geo-pocket.cpp
@@ -1,25 +1,25 @@
 struct NeoGeoPocket : Cartridge {
   auto name() -> string override { return "Neo Geo Pocket"; }
   auto extensions() -> vector<string> override { return {"ngp"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& rom) -> string;
   auto label(vector<u8>& data) -> string;
 };
 
-auto NeoGeoPocket::load(string location) -> bool {
+auto NeoGeoPocket::load(string location) -> LoadResult {
   vector<u8> rom;
   if(directory::exists(location)) {
     append(rom, {location, "program.flash"});
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return false;
+  if(!rom) return LoadResult(romNotFound);
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("title", document["game/title"].string());
@@ -28,7 +28,7 @@ auto NeoGeoPocket::load(string location) -> bool {
 
   Pak::load("program.flash", ".sav");
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto NeoGeoPocket::save(string location) -> bool {

--- a/mia/medium/neo-geo-pocket.cpp
+++ b/mia/medium/neo-geo-pocket.cpp
@@ -14,12 +14,12 @@ auto NeoGeoPocket::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title", document["game/title"].string());
@@ -28,7 +28,7 @@ auto NeoGeoPocket::load(string location) -> LoadResult {
 
   Pak::load("program.flash", ".sav");
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto NeoGeoPocket::save(string location) -> bool {

--- a/mia/medium/neo-geo.cpp
+++ b/mia/medium/neo-geo.cpp
@@ -67,7 +67,7 @@ auto NeoGeo::load(string location) -> LoadResult {
   vector<u8> voiceBROM;     //V ROM (ADPCM-B voice samples)
 
   auto foundDatabase = Medium::loadDatabase();
-  if(!foundDatabase) return LoadResult(databaseNotFound);
+  if(!foundDatabase) return { databaseNotFound, "Neo Geo.bml" };
   this->info = BML::unserialize(manifestDatabaseArcade(Medium::name(location)));
 
   if(file::exists(location)) {
@@ -78,12 +78,14 @@ auto NeoGeo::load(string location) -> LoadResult {
     voiceAROM    = NeoGeo::read(location, "voice-a.rom");
     voiceBROM    = NeoGeo::read(location, "voice-b.rom");
   }
+  
+  string invalidRomInfo = "Ensure your ROM is in a MAME-compatible .zip format.";
 
-  if(!programROM  ) return LoadResult(romNotFound);
-  if(!musicROM    ) return LoadResult(romNotFound);
-  if(!characterROM) return LoadResult(romNotFound);
-  if(!staticROM   ) return LoadResult(romNotFound);
-  if(!voiceAROM   ) return LoadResult(romNotFound);
+  if(!programROM  ) return { invalidROM, invalidRomInfo };
+  if(!musicROM    ) return { invalidROM, invalidRomInfo };
+  if(!characterROM) return { invalidROM, invalidRomInfo };
+  if(!staticROM   ) return { invalidROM, invalidRomInfo };
+  if(!voiceAROM   ) return { invalidROM, invalidRomInfo };
   //voiceB is optional
 
   //many games have encrypted roms, so let's decrypt them here
@@ -101,7 +103,7 @@ auto NeoGeo::load(string location) -> LoadResult {
   this->location = location;
   this->manifest = analyze(programROM, musicROM, characterROM, staticROM, voiceAROM, voiceBROM);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("sha256",  sha256);
@@ -114,7 +116,7 @@ auto NeoGeo::load(string location) -> LoadResult {
   pak->append("static.rom",    staticROM);
   pak->append("voice-a.rom",   voiceAROM);
   pak->append("voice-b.rom",   voiceBROM);
-  return LoadResult(successful);
+  return successful;
 }
 
 auto NeoGeo::save(string location) -> bool {

--- a/mia/medium/neo-geo.cpp
+++ b/mia/medium/neo-geo.cpp
@@ -6,7 +6,7 @@ struct NeoGeo : Mame {
   auto name() -> string override { return "Neo Geo"; }
   auto extensions() -> vector<string> override { return {"ng"}; }
   auto read(string location, string match) -> vector<u8>;
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto board() -> string;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& p, vector<u8>& m, vector<u8>& c, vector<u8>& s, vector<u8>& vA, vector<u8>& vB) -> string;
@@ -58,7 +58,7 @@ auto NeoGeo::read(string location, string match) -> vector<u8> {
   return {};
 }
 
-auto NeoGeo::load(string location) -> bool {
+auto NeoGeo::load(string location) -> LoadResult {
   vector<u8> programROM;    //P ROM (68K CPU program)
   vector<u8> musicROM;      //M ROM (Z80 APU program)
   vector<u8> characterROM;  //C ROM (sprite and background character graphics)
@@ -67,7 +67,7 @@ auto NeoGeo::load(string location) -> bool {
   vector<u8> voiceBROM;     //V ROM (ADPCM-B voice samples)
 
   auto foundDatabase = Medium::loadDatabase();
-  if(!foundDatabase) return false;
+  if(!foundDatabase) return LoadResult(databaseNotFound);
   this->info = BML::unserialize(manifestDatabaseArcade(Medium::name(location)));
 
   if(file::exists(location)) {
@@ -79,11 +79,11 @@ auto NeoGeo::load(string location) -> bool {
     voiceBROM    = NeoGeo::read(location, "voice-b.rom");
   }
 
-  if(!programROM  ) return false;
-  if(!musicROM    ) return false;
-  if(!characterROM) return false;
-  if(!staticROM   ) return false;
-  if(!voiceAROM   ) return false;
+  if(!programROM  ) return LoadResult(romNotFound);
+  if(!musicROM    ) return LoadResult(romNotFound);
+  if(!characterROM) return LoadResult(romNotFound);
+  if(!staticROM   ) return LoadResult(romNotFound);
+  if(!voiceAROM   ) return LoadResult(romNotFound);
   //voiceB is optional
 
   //many games have encrypted roms, so let's decrypt them here
@@ -101,7 +101,7 @@ auto NeoGeo::load(string location) -> bool {
   this->location = location;
   this->manifest = analyze(programROM, musicROM, characterROM, staticROM, voiceAROM, voiceBROM);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("sha256",  sha256);
@@ -114,7 +114,7 @@ auto NeoGeo::load(string location) -> bool {
   pak->append("static.rom",    staticROM);
   pak->append("voice-a.rom",   voiceAROM);
   pak->append("voice-b.rom",   voiceBROM);
-  return true;
+  return LoadResult(successful);
 }
 
 auto NeoGeo::save(string location) -> bool {

--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -1,7 +1,7 @@
 struct Nintendo64 : Cartridge {
   auto name() -> string override { return "Nintendo 64"; }
   auto extensions() -> vector<string> override { return {"n64", "v64", "z64"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& rom) -> string;
   auto ipl2checksum(u32 seed, array_view<u8> rom) -> u64;
@@ -82,21 +82,21 @@ auto Nintendo64::ipl2checksum(u32 seed, array_view<u8> rom) -> u64 {
   return checksum & 0xffffffffffffull;
 }
 
-auto Nintendo64::load(string location) -> bool {
+auto Nintendo64::load(string location) -> LoadResult {
   vector<u8> rom;
   if(directory::exists(location)) {
     append(rom, {location, "program.rom"});
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return false;
+  if(!rom) return LoadResult(romNotFound);
 
 
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("id",     document["game/id"].string());
@@ -123,7 +123,7 @@ auto Nintendo64::load(string location) -> bool {
     Medium::load(node, ".rtc");
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto Nintendo64::save(string location) -> bool {

--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -89,14 +89,14 @@ auto Nintendo64::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
 
 
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("id",     document["game/id"].string());
@@ -123,7 +123,7 @@ auto Nintendo64::load(string location) -> LoadResult {
     Medium::load(node, ".rtc");
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Nintendo64::save(string location) -> bool {

--- a/mia/medium/nintendo-64dd.cpp
+++ b/mia/medium/nintendo-64dd.cpp
@@ -17,17 +17,17 @@ auto Nintendo64DD::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     input = FloppyDisk::read(location);
   }
-  if(!input) return LoadResult(romNotFound);
+  if(!input) return romNotFound;
 
   array_view<u8> view{input};
   auto errorTable = createErrorTable(view);
-  if(!errorTable) return LoadResult(invalidRom);
+  if(!errorTable) return invalidROM;
   auto sizeValid = sizeCheck(view);
-  if(!sizeValid) return LoadResult(invalidRom);
+  if(!sizeValid) return invalidROM;
   this->location = location;
   this->manifest = analyze(input, errorTable);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
   pak = shared_pointer{new vfs::directory};
   pak->setAttribute("title", document["game/title"].string());
   pak->setAttribute("region", document["game/region"].string());
@@ -38,11 +38,11 @@ auto Nintendo64DD::load(string location) -> LoadResult {
     pak->append("program.disk", output);
   }
 
-  if(!pak) return LoadResult(otherError);
+  if(!pak) return otherError;
 
   Pak::load("program.disk", ".disk");
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Nintendo64DD::save(string location) -> bool {

--- a/mia/medium/pc-engine-cd.cpp
+++ b/mia/medium/pc-engine-cd.cpp
@@ -7,12 +7,12 @@ struct PCEngineCD : CompactDisc {
 };
 
 auto PCEngineCD::load(string location) -> LoadResult {
-  if(!inode::exists(location)) return LoadResult(romNotFound);
+  if(!inode::exists(location)) return romNotFound;
 
   this->location = location;
   this->manifest = analyze(location);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
@@ -27,7 +27,7 @@ auto PCEngineCD::load(string location) -> LoadResult {
     pak->append("cd.rom", vfs::cdrom::open(location));
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto PCEngineCD::save(string location) -> bool {

--- a/mia/medium/pc-engine-cd.cpp
+++ b/mia/medium/pc-engine-cd.cpp
@@ -1,18 +1,18 @@
 struct PCEngineCD : CompactDisc {
   auto name() -> string override { return "PC Engine CD"; }
   auto extensions() -> vector<string> override { return {"cue", "chd"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(string location) -> string;
 };
 
-auto PCEngineCD::load(string location) -> bool {
-  if(!inode::exists(location)) return false;
+auto PCEngineCD::load(string location) -> LoadResult {
+  if(!inode::exists(location)) return LoadResult(romNotFound);
 
   this->location = location;
   this->manifest = analyze(location);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
@@ -27,7 +27,7 @@ auto PCEngineCD::load(string location) -> bool {
     pak->append("cd.rom", vfs::cdrom::open(location));
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto PCEngineCD::save(string location) -> bool {

--- a/mia/medium/pc-engine.cpp
+++ b/mia/medium/pc-engine.cpp
@@ -13,12 +13,12 @@ auto PCEngine::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
@@ -37,7 +37,7 @@ auto PCEngine::load(string location) -> LoadResult {
     Medium::load(node, ".wram");
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto PCEngine::save(string location) -> bool {

--- a/mia/medium/pc-engine.cpp
+++ b/mia/medium/pc-engine.cpp
@@ -1,24 +1,24 @@
 struct PCEngine : Cartridge {
   auto name() -> string override { return "PC Engine"; }
   auto extensions() -> vector<string> override { return {"pce"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& rom) -> string;
 };
 
-auto PCEngine::load(string location) -> bool {
+auto PCEngine::load(string location) -> LoadResult {
   vector<u8> rom;
   if(directory::exists(location)) {
     append(rom, {location, "program.rom"});
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return false;
+  if(!rom) return LoadResult(romNotFound);
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
@@ -37,7 +37,7 @@ auto PCEngine::load(string location) -> bool {
     Medium::load(node, ".wram");
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto PCEngine::save(string location) -> bool {

--- a/mia/medium/playstation.cpp
+++ b/mia/medium/playstation.cpp
@@ -8,12 +8,12 @@ struct PlayStation : CompactDisc {
 };
 
 auto PlayStation::load(string location) -> LoadResult {
-  if(!inode::exists(location)) return LoadResult(romNotFound);
+  if(!inode::exists(location)) return romNotFound;
 
   this->location = location;
   this->manifest = analyze(location);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
@@ -36,7 +36,7 @@ auto PlayStation::load(string location) -> LoadResult {
     }
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto PlayStation::save(string location) -> bool {

--- a/mia/medium/playstation.cpp
+++ b/mia/medium/playstation.cpp
@@ -1,19 +1,19 @@
 struct PlayStation : CompactDisc {
   auto name() -> string override { return "PlayStation"; }
   auto extensions() -> vector<string> override { return {"cue", "chd", "exe"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(string location) -> string;
   auto cdFromExecutable(string location) -> vector<u8>;
 };
 
-auto PlayStation::load(string location) -> bool {
-  if(!inode::exists(location)) return false;
+auto PlayStation::load(string location) -> LoadResult {
+  if(!inode::exists(location)) return LoadResult(romNotFound);
 
   this->location = location;
   this->manifest = analyze(location);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
@@ -36,7 +36,7 @@ auto PlayStation::load(string location) -> bool {
     }
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto PlayStation::save(string location) -> bool {

--- a/mia/medium/saturn.cpp
+++ b/mia/medium/saturn.cpp
@@ -1,18 +1,18 @@
 struct Saturn : CompactDisc {
   auto name() -> string override { return "Saturn"; }
   auto extensions() -> vector<string> override { return {"cue", "chd"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(string location) -> string;
 };
 
-auto Saturn::load(string location) -> bool {
-  if(!inode::exists(location)) return false;
+auto Saturn::load(string location) -> LoadResult {
+  if(!inode::exists(location)) return LoadResult(romNotFound);
 
   this->location = location;
   this->manifest = analyze(location);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
@@ -26,7 +26,7 @@ auto Saturn::load(string location) -> bool {
     pak->append("cd.rom", vfs::cdrom::open(location));
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto Saturn::save(string location) -> bool {

--- a/mia/medium/saturn.cpp
+++ b/mia/medium/saturn.cpp
@@ -7,12 +7,12 @@ struct Saturn : CompactDisc {
 };
 
 auto Saturn::load(string location) -> LoadResult {
-  if(!inode::exists(location)) return LoadResult(romNotFound);
+  if(!inode::exists(location)) return romNotFound;
 
   this->location = location;
   this->manifest = analyze(location);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title",  document["game/title"].string());
@@ -26,7 +26,7 @@ auto Saturn::load(string location) -> LoadResult {
     pak->append("cd.rom", vfs::cdrom::open(location));
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Saturn::save(string location) -> bool {

--- a/mia/medium/sg-1000.cpp
+++ b/mia/medium/sg-1000.cpp
@@ -13,12 +13,12 @@ auto SG1000::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("board",  document["game/board" ].string());  
@@ -31,7 +31,7 @@ auto SG1000::load(string location) -> LoadResult {
     Medium::load(node, ".ram");
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto SG1000::save(string location) -> bool {

--- a/mia/medium/sg-1000.cpp
+++ b/mia/medium/sg-1000.cpp
@@ -1,24 +1,24 @@
 struct SG1000 : Cartridge {
   auto name() -> string override { return "SG-1000"; }
   auto extensions() -> vector<string> override { return {"sg1000", "sg"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& rom) -> string;
 };
 
-auto SG1000::load(string location) -> bool {
+auto SG1000::load(string location) -> LoadResult {
   vector<u8> rom;
   if(directory::exists(location)) {
     append(rom, {location, "program.rom"});
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return false;
+  if(!rom) return LoadResult(romNotFound);
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("board",  document["game/board" ].string());  
@@ -31,7 +31,7 @@ auto SG1000::load(string location) -> bool {
     Medium::load(node, ".ram");
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto SG1000::save(string location) -> bool {

--- a/mia/medium/sufami-turbo.cpp
+++ b/mia/medium/sufami-turbo.cpp
@@ -1,28 +1,28 @@
 struct SufamiTurbo : Cartridge {
   auto name() -> string override { return "Sufami Turbo"; }
   auto extensions() -> vector<string> override { return {"st"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& data) -> string;
 };
 
-auto SufamiTurbo::load(string location) -> bool {
+auto SufamiTurbo::load(string location) -> LoadResult {
   vector<u8> rom;
   if(directory::exists(location)) {
     append(rom, {location, "program.rom"});
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return false;
+  if(!rom) return LoadResult(romNotFound);
 
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
   auto foundDatabase = Medium::loadDatabase();
-  if(!foundDatabase) return false;
+  if(!foundDatabase) return LoadResult(databaseNotFound);
   this->manifest = Medium::manifestDatabase(sha256);
   if(!manifest) manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("title", document["game/title"].string());
@@ -33,7 +33,7 @@ auto SufamiTurbo::load(string location) -> bool {
     Medium::load(node, ".ram");
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto SufamiTurbo::save(string location) -> bool {

--- a/mia/medium/sufami-turbo.cpp
+++ b/mia/medium/sufami-turbo.cpp
@@ -13,16 +13,16 @@ auto SufamiTurbo::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
 
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
   auto foundDatabase = Medium::loadDatabase();
-  if(!foundDatabase) return LoadResult(databaseNotFound);
+  if(!foundDatabase) return { databaseNotFound, "Sufami Turbo.bml" };
   this->manifest = Medium::manifestDatabase(sha256);
   if(!manifest) manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title", document["game/title"].string());
@@ -33,7 +33,7 @@ auto SufamiTurbo::load(string location) -> LoadResult {
     Medium::load(node, ".ram");
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto SufamiTurbo::save(string location) -> bool {

--- a/mia/medium/super-famicom.cpp
+++ b/mia/medium/super-famicom.cpp
@@ -75,7 +75,7 @@ auto SuperFamicom::load(string location) -> LoadResult {
     directory = Location::dir(location);
   }
   
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
   
   //append firmware to the ROM if it is missing
   auto tmp_manifest = analyze(rom);
@@ -85,7 +85,7 @@ auto SuperFamicom::load(string location) -> LoadResult {
   this->sha256   = Hash::SHA256(rom).digest();
   this->location = location;
   auto foundDatabase = Medium::loadDatabase();
-  if(!foundDatabase) return LoadResult(databaseNotFound);
+  if(!foundDatabase) return { databaseNotFound, "Super Famicom.bml" };
   this->manifest = Medium::manifestDatabase(sha256);
   
   if(!manifest) {
@@ -102,7 +102,7 @@ auto SuperFamicom::load(string location) -> LoadResult {
   
   if(!manifest) manifest = analyze(rom);
   document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title", document["game/title"].string());
@@ -182,7 +182,7 @@ auto SuperFamicom::load(string location) -> LoadResult {
     Medium::load(node, ".dram");
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto SuperFamicom::save(string location) -> bool {

--- a/mia/medium/wonderswan.cpp
+++ b/mia/medium/wonderswan.cpp
@@ -14,12 +14,12 @@ auto WonderSwan::load(string location) -> LoadResult {
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return LoadResult(romNotFound);
+  if(!rom) return romNotFound;
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title", document["game/title"].string());
@@ -43,7 +43,7 @@ auto WonderSwan::load(string location) -> LoadResult {
     Medium::load(node, ".rtc");
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto WonderSwan::save(string location) -> bool {

--- a/mia/medium/wonderswan.cpp
+++ b/mia/medium/wonderswan.cpp
@@ -1,25 +1,25 @@
 struct WonderSwan : Cartridge {
   auto name() -> string override { return "WonderSwan"; }
   auto extensions() -> vector<string> override { return {"ws"}; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(vector<u8>& rom) -> string;
   virtual auto mapper(vector<u8>& rom) -> string;
 };
 
-auto WonderSwan::load(string location) -> bool {
+auto WonderSwan::load(string location) -> LoadResult {
   vector<u8> rom;
   if(directory::exists(location)) {
     append(rom, {location, "program.rom"});
   } else if(file::exists(location)) {
     rom = Cartridge::read(location);
   }
-  if(!rom) return false;
+  if(!rom) return LoadResult(romNotFound);
 
   this->location = location;
   this->manifest = analyze(rom);
   auto document = BML::unserialize(manifest);
-  if(!document) return false;
+  if(!document) return LoadResult(couldNotParseManifest);
 
   pak = new vfs::directory;
   pak->setAttribute("title", document["game/title"].string());
@@ -43,7 +43,7 @@ auto WonderSwan::load(string location) -> bool {
     Medium::load(node, ".rtc");
   }
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto WonderSwan::save(string location) -> bool {

--- a/mia/medium/zx-spectrum.cpp
+++ b/mia/medium/zx-spectrum.cpp
@@ -9,22 +9,22 @@ struct ZXSpectrum : Medium {
 };
 
 auto ZXSpectrum::load(string location) -> LoadResult {
-  if(!inode::exists(location)) return LoadResult(romNotFound);
+  if(!inode::exists(location)) return romNotFound;
 
   if(location.iendsWith(".tap") || location.iendsWith(".tzx")) return loadTzx(location);
   if(location.iendsWith(".wav")) return loadWav(location);
-  return LoadResult(invalidRom);
+  return invalidROM;
 }
 
 auto ZXSpectrum::loadTzx(string location) -> LoadResult {
   this->location = location;
   this->manifest = analyze(location);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   vector<u8> input = file::read(location);
   TZXFile tzx;
-  if(tzx.DecodeFile(input.data(), input.size()) == FileTypeUndetermined) return LoadResult(invalidRom);
+  if(tzx.DecodeFile(input.data(), input.size()) == FileTypeUndetermined) return invalidROM;
   tzx.GenerateAudioData();
 
   pak = new vfs::directory;
@@ -45,14 +45,14 @@ auto ZXSpectrum::loadTzx(string location) -> LoadResult {
   }
   pak->append("program.tape", output);
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto ZXSpectrum::loadWav(string location) -> LoadResult {
   this->location = location;
   this->manifest = analyze(location);
   auto document = BML::unserialize(manifest);
-  if(!document) return LoadResult(couldNotParseManifest);
+  if(!document) return couldNotParseManifest;
 
   pak = new vfs::directory;
   pak->setAttribute("title",      document["game/title"].string());
@@ -80,7 +80,7 @@ auto ZXSpectrum::loadWav(string location) -> LoadResult {
     }
   }
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto ZXSpectrum::save(string location) -> bool {

--- a/mia/mia.cpp
+++ b/mia/mia.cpp
@@ -144,7 +144,7 @@ auto identify(const string& filename) -> string {
   for(auto& medium : media) {
     auto pak = mia::Medium::create(medium);
     if(pak->extensions().find(extension)) {
-      if(pak->load(filename) != LoadResult(successful)) continue; // Skip medium that the system cannot load
+      if(pak->load(filename) != successful) continue; // Skip medium that the system cannot load
       if(pak->pak->attribute("audio").boolean()) continue; // Skip audio-only media to give the next system a chance to match
       return pak->name();
     }
@@ -154,7 +154,7 @@ auto identify(const string& filename) -> string {
 }
 
 auto import(shared_pointer<Pak> pak, const string& filename) -> bool {
-  if(pak->load(filename) == LoadResult(successful)) {
+  if(pak->load(filename) == successful) {
     string pathname = {Path::user(), "Emulation/", pak->name(), "/", Location::prefix(filename), ".", pak->extensions().first(), "/"};
     if(!directory::create(pathname)) return false;
     for(auto& node : *pak->pak) {
@@ -194,7 +194,7 @@ auto main(Arguments arguments) -> void {
     if(!pak) return;
 
     if(string manifest; arguments.take("--manifest", manifest)) {
-      if(pak->load(manifest) == LoadResult(successful)) {
+      if(pak->load(manifest) == successful) {
         if(auto fp = pak->pak->read("manifest.bml")) return print(fp->reads());
       }
       return;

--- a/mia/mia.cpp
+++ b/mia/mia.cpp
@@ -144,7 +144,7 @@ auto identify(const string& filename) -> string {
   for(auto& medium : media) {
     auto pak = mia::Medium::create(medium);
     if(pak->extensions().find(extension)) {
-      if(!pak->load(filename)) continue; // Skip medium that the system cannot load
+      if(pak->load(filename) != LoadResult(successful)) continue; // Skip medium that the system cannot load
       if(pak->pak->attribute("audio").boolean()) continue; // Skip audio-only media to give the next system a chance to match
       return pak->name();
     }
@@ -154,7 +154,7 @@ auto identify(const string& filename) -> string {
 }
 
 auto import(shared_pointer<Pak> pak, const string& filename) -> bool {
-  if(pak->load(filename)) {
+  if(pak->load(filename) == LoadResult(successful)) {
     string pathname = {Path::user(), "Emulation/", pak->name(), "/", Location::prefix(filename), ".", pak->extensions().first(), "/"};
     if(!directory::create(pathname)) return false;
     for(auto& node : *pak->pak) {
@@ -194,7 +194,7 @@ auto main(Arguments arguments) -> void {
     if(!pak) return;
 
     if(string manifest; arguments.take("--manifest", manifest)) {
-      if(pak->load(manifest)) {
+      if(pak->load(manifest) == LoadResult(successful)) {
         if(auto fp = pak->pak->read("manifest.bml")) return print(fp->reads());
       }
       return;

--- a/mia/mia.hpp
+++ b/mia/mia.hpp
@@ -33,4 +33,5 @@ namespace mia {
   auto construct() -> void;
   auto identify(const string& filename) -> string;
   auto import(shared_pointer<Pak>, const string& filename) -> bool;
+
 }

--- a/mia/mia.hpp
+++ b/mia/mia.hpp
@@ -17,6 +17,38 @@ using namespace hiro;
 #include <ares/resource/resource.hpp>
 #include <mia/resource/resource.hpp>
 
+enum ResultEnum {
+  successful,
+  noFileSelected,
+  databaseNotFound,
+  romNotFoundInDatabase,
+  romNotFound,
+  invalidROM,
+  couldNotParseManifest,
+  noFirmware,
+  otherError
+};
+
+struct LoadResult {
+  ResultEnum result;
+
+  string info;
+  string firmwareType;
+  string firmwareSystemName;
+  string firmwareRegion;
+
+  LoadResult(ResultEnum r) : result(r) {}
+
+  LoadResult(ResultEnum r, string i) : result(r), info(i) {}
+
+  bool operator==(const LoadResult& other) {
+    return result == other.result;
+  }
+  bool operator!=(const LoadResult& other) {
+    return result != other.result;
+  }
+};
+
 namespace mia {
   #include "settings/settings.hpp"
   #include "pak/pak.hpp"

--- a/mia/pak/pak.hpp
+++ b/mia/pak/pak.hpp
@@ -5,7 +5,7 @@ struct Pak {
   virtual auto type() -> string { return pak->attribute("type"); }
   virtual auto name() -> string { return pak->attribute("name"); }
   virtual auto extensions() -> vector<string> { return {}; }
-  virtual auto load(string location = {}) -> bool { return true; }
+  virtual auto load(string location = {}) -> LoadResult { return LoadResult(successful); }
   virtual auto loadMultiple(vector<string> location = {}) -> bool { return true; }
   virtual auto save(string location = {}) -> bool { return true; }
 

--- a/mia/pak/pak.hpp
+++ b/mia/pak/pak.hpp
@@ -5,7 +5,7 @@ struct Pak {
   virtual auto type() -> string { return pak->attribute("type"); }
   virtual auto name() -> string { return pak->attribute("name"); }
   virtual auto extensions() -> vector<string> { return {}; }
-  virtual auto load(string location = {}) -> LoadResult { return LoadResult(successful); }
+  virtual auto load(string location = {}) -> LoadResult { return successful; }
   virtual auto loadMultiple(vector<string> location = {}) -> bool { return true; }
   virtual auto save(string location = {}) -> bool { return true; }
 

--- a/mia/system/arcade.cpp
+++ b/mia/system/arcade.cpp
@@ -7,7 +7,7 @@ struct Arcade : System {
 auto Arcade::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Arcade::save(string location) -> bool {

--- a/mia/system/arcade.cpp
+++ b/mia/system/arcade.cpp
@@ -1,13 +1,13 @@
 struct Arcade : System {
   auto name() -> string override { return "Arcade"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto Arcade::load(string location) -> bool {
+auto Arcade::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
-  return true;
+  return LoadResult(successful);
 }
 
 auto Arcade::save(string location) -> bool {

--- a/mia/system/atari-2600.cpp
+++ b/mia/system/atari-2600.cpp
@@ -1,13 +1,13 @@
 struct Atari2600 : System {
   auto name() -> string override { return "Atari 2600"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto Atari2600::load(string location) -> bool {
+auto Atari2600::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
-  return true;
+  return LoadResult(successful);
 }
 
 auto Atari2600::save(string location) -> bool {

--- a/mia/system/atari-2600.cpp
+++ b/mia/system/atari-2600.cpp
@@ -7,7 +7,7 @@ struct Atari2600 : System {
 auto Atari2600::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Atari2600::save(string location) -> bool {

--- a/mia/system/colecovision.cpp
+++ b/mia/system/colecovision.cpp
@@ -1,17 +1,17 @@
 struct ColecoVision : System {
   auto name() -> string override { return "ColecoVision"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto ColecoVision::load(string location) -> bool {
+auto ColecoVision::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return false;
+  if(!bios) return LoadResult(romNotFound);
 
   this->location = locate();
   pak = new vfs::directory;
   pak->append("bios.rom", bios);
-  return true;
+  return LoadResult(successful);
 }
 
 auto ColecoVision::save(string location) -> bool {

--- a/mia/system/colecovision.cpp
+++ b/mia/system/colecovision.cpp
@@ -6,12 +6,12 @@ struct ColecoVision : System {
 
 auto ColecoVision::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return LoadResult(romNotFound);
+  if(!bios) return romNotFound;
 
   this->location = locate();
   pak = new vfs::directory;
   pak->append("bios.rom", bios);
-  return LoadResult(successful);
+  return successful;
 }
 
 auto ColecoVision::save(string location) -> bool {

--- a/mia/system/famicom.cpp
+++ b/mia/system/famicom.cpp
@@ -1,13 +1,13 @@
 struct Famicom : System {
   auto name() -> string override { return "Famicom"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto Famicom::load(string location) -> bool {
+auto Famicom::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
-  return true;
+  return LoadResult(successful);
 }
 
 auto Famicom::save(string location) -> bool {

--- a/mia/system/famicom.cpp
+++ b/mia/system/famicom.cpp
@@ -7,7 +7,7 @@ struct Famicom : System {
 auto Famicom::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Famicom::save(string location) -> bool {

--- a/mia/system/game-boy-advance.cpp
+++ b/mia/system/game-boy-advance.cpp
@@ -1,17 +1,17 @@
 struct GameBoyAdvance : System {
   auto name() -> string override { return "Game Boy Advance"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto GameBoyAdvance::load(string location) -> bool {
+auto GameBoyAdvance::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return false;
+  if(!bios) return LoadResult(romNotFound);
 
   this->location = locate();
   pak = new vfs::directory;
   pak->append("bios.rom", bios);
-  return true;
+  return LoadResult(successful);
 }
 
 auto GameBoyAdvance::save(string location) -> bool {

--- a/mia/system/game-boy-advance.cpp
+++ b/mia/system/game-boy-advance.cpp
@@ -6,12 +6,12 @@ struct GameBoyAdvance : System {
 
 auto GameBoyAdvance::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return LoadResult(romNotFound);
+  if(!bios) return romNotFound;
 
   this->location = locate();
   pak = new vfs::directory;
   pak->append("bios.rom", bios);
-  return LoadResult(successful);
+  return successful;
 }
 
 auto GameBoyAdvance::save(string location) -> bool {

--- a/mia/system/game-boy-color.cpp
+++ b/mia/system/game-boy-color.cpp
@@ -1,14 +1,14 @@
 struct GameBoyColor : System {
   auto name() -> string override { return "Game Boy Color"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto GameBoyColor::load(string location) -> bool {
+auto GameBoyColor::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("boot.rom", Resource::GameBoyColor::BootCGB0);
-  return true;
+  return LoadResult(successful);
 }
 
 auto GameBoyColor::save(string location) -> bool {

--- a/mia/system/game-boy-color.cpp
+++ b/mia/system/game-boy-color.cpp
@@ -8,7 +8,7 @@ auto GameBoyColor::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("boot.rom", Resource::GameBoyColor::BootCGB0);
-  return LoadResult(successful);
+  return successful;
 }
 
 auto GameBoyColor::save(string location) -> bool {

--- a/mia/system/game-boy.cpp
+++ b/mia/system/game-boy.cpp
@@ -8,7 +8,7 @@ auto GameBoy::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("boot.rom", Resource::GameBoy::BootDMG1);
-  return LoadResult(successful);
+  return successful;
 }
 
 auto GameBoy::save(string location) -> bool {

--- a/mia/system/game-boy.cpp
+++ b/mia/system/game-boy.cpp
@@ -1,14 +1,14 @@
 struct GameBoy : System {
   auto name() -> string override { return "Game Boy"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto GameBoy::load(string location) -> bool {
+auto GameBoy::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("boot.rom", Resource::GameBoy::BootDMG1);
-  return true;
+  return LoadResult(successful);
 }
 
 auto GameBoy::save(string location) -> bool {

--- a/mia/system/game-gear.cpp
+++ b/mia/system/game-gear.cpp
@@ -1,17 +1,17 @@
 struct GameGear : System {
   auto name() -> string override { return "Game Gear"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto GameGear::load(string location) -> bool {
+auto GameGear::load(string location) -> LoadResult {
   auto bios = Pak::read(location);  //optional
 
   this->location = locate();
   pak = new vfs::directory;
   if(bios) pak->append("bios.rom", bios);
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto GameGear::save(string location) -> bool {

--- a/mia/system/game-gear.cpp
+++ b/mia/system/game-gear.cpp
@@ -11,7 +11,7 @@ auto GameGear::load(string location) -> LoadResult {
   pak = new vfs::directory;
   if(bios) pak->append("bios.rom", bios);
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto GameGear::save(string location) -> bool {

--- a/mia/system/master-system.cpp
+++ b/mia/system/master-system.cpp
@@ -1,17 +1,17 @@
 struct MasterSystem : System {
   auto name() -> string override { return "Master System"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto MasterSystem::load(string location) -> bool {
+auto MasterSystem::load(string location) -> LoadResult {
   auto bios = Pak::read(location);  //optional
 
   this->location = locate();
   pak = new vfs::directory;
   if(bios) pak->append("bios.rom", bios);
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto MasterSystem::save(string location) -> bool {

--- a/mia/system/master-system.cpp
+++ b/mia/system/master-system.cpp
@@ -11,7 +11,7 @@ auto MasterSystem::load(string location) -> LoadResult {
   pak = new vfs::directory;
   if(bios) pak->append("bios.rom", bios);
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MasterSystem::save(string location) -> bool {

--- a/mia/system/mega-32x.cpp
+++ b/mia/system/mega-32x.cpp
@@ -11,7 +11,7 @@ auto Mega32X::load(string location) -> LoadResult {
   pak->append("vector.rom", Resource::Mega32X::Vector);
   pak->append("sh2.boot.mrom", Resource::Mega32X::SH2BootM);
   pak->append("sh2.boot.srom", Resource::Mega32X::SH2BootS);
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Mega32X::save(string location) -> bool {

--- a/mia/system/mega-32x.cpp
+++ b/mia/system/mega-32x.cpp
@@ -1,17 +1,17 @@
 struct Mega32X : System {
   auto name() -> string override { return "Mega 32X"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto Mega32X::load(string location) -> bool {
+auto Mega32X::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("tmss.rom", Resource::MegaDrive::TMSS);
   pak->append("vector.rom", Resource::Mega32X::Vector);
   pak->append("sh2.boot.mrom", Resource::Mega32X::SH2BootM);
   pak->append("sh2.boot.srom", Resource::Mega32X::SH2BootS);
-  return true;
+  return LoadResult(successful);
 }
 
 auto Mega32X::save(string location) -> bool {

--- a/mia/system/mega-cd-32x.cpp
+++ b/mia/system/mega-cd-32x.cpp
@@ -1,6 +1,6 @@
 struct MegaCD32X : System {
   auto name() -> string override { return "Mega CD 32X"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 
   static constexpr u8 bram[64] = {
@@ -11,9 +11,9 @@ struct MegaCD32X : System {
   };
 };
 
-auto MegaCD32X::load(string location) -> bool {
+auto MegaCD32X::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return false;
+  if(!bios) return LoadResult(romNotFound);
 
   this->location = locate();
   pak = new vfs::directory;
@@ -32,7 +32,7 @@ auto MegaCD32X::load(string location) -> bool {
 
   Pak::load("backup.ram", ".bram");
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto MegaCD32X::save(string location) -> bool {

--- a/mia/system/mega-cd-32x.cpp
+++ b/mia/system/mega-cd-32x.cpp
@@ -13,7 +13,7 @@ struct MegaCD32X : System {
 
 auto MegaCD32X::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return LoadResult(romNotFound);
+  if(!bios) return romNotFound;
 
   this->location = locate();
   pak = new vfs::directory;
@@ -32,7 +32,7 @@ auto MegaCD32X::load(string location) -> LoadResult {
 
   Pak::load("backup.ram", ".bram");
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MegaCD32X::save(string location) -> bool {

--- a/mia/system/mega-cd.cpp
+++ b/mia/system/mega-cd.cpp
@@ -13,7 +13,7 @@ struct MegaCD : System {
 
 auto MegaCD::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return LoadResult(romNotFound);
+  if(!bios) return romNotFound;
 
   this->location = locate();
   pak = new vfs::directory;
@@ -29,7 +29,7 @@ auto MegaCD::load(string location) -> LoadResult {
 
   Pak::load("backup.ram", ".bram");
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MegaCD::save(string location) -> bool {

--- a/mia/system/mega-cd.cpp
+++ b/mia/system/mega-cd.cpp
@@ -1,6 +1,6 @@
 struct MegaCD : System {
   auto name() -> string override { return "Mega CD"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 
   static constexpr u8 bram[64] = {
@@ -11,9 +11,9 @@ struct MegaCD : System {
   };
 };
 
-auto MegaCD::load(string location) -> bool {
+auto MegaCD::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return false;
+  if(!bios) return LoadResult(romNotFound);
 
   this->location = locate();
   pak = new vfs::directory;
@@ -29,7 +29,7 @@ auto MegaCD::load(string location) -> bool {
 
   Pak::load("backup.ram", ".bram");
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto MegaCD::save(string location) -> bool {

--- a/mia/system/mega-drive.cpp
+++ b/mia/system/mega-drive.cpp
@@ -8,7 +8,7 @@ auto MegaDrive::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("tmss.rom", Resource::MegaDrive::TMSS);
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MegaDrive::save(string location) -> bool {

--- a/mia/system/mega-drive.cpp
+++ b/mia/system/mega-drive.cpp
@@ -1,14 +1,14 @@
 struct MegaDrive : System {
   auto name() -> string override { return "Mega Drive"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto MegaDrive::load(string location) -> bool {
+auto MegaDrive::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("tmss.rom", Resource::MegaDrive::TMSS);
-  return true;
+  return LoadResult(successful);
 }
 
 auto MegaDrive::save(string location) -> bool {

--- a/mia/system/msx.cpp
+++ b/mia/system/msx.cpp
@@ -6,12 +6,12 @@ struct MSX : System {
 
 auto MSX::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return LoadResult(romNotFound);
+  if(!bios) return romNotFound;
 
   this->location = locate();
   pak = new vfs::directory;
   pak->append("bios.rom", bios);
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MSX::save(string location) -> bool {

--- a/mia/system/msx.cpp
+++ b/mia/system/msx.cpp
@@ -1,17 +1,17 @@
 struct MSX : System {
   auto name() -> string override { return "MSX"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto MSX::load(string location) -> bool {
+auto MSX::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return false;
+  if(!bios) return LoadResult(romNotFound);
 
   this->location = locate();
   pak = new vfs::directory;
   pak->append("bios.rom", bios);
-  return true;
+  return LoadResult(successful);
 }
 
 auto MSX::save(string location) -> bool {

--- a/mia/system/myvision.cpp
+++ b/mia/system/myvision.cpp
@@ -1,15 +1,15 @@
 struct MyVision : System {
   auto name() -> string override { return "MyVision"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto MyVision::load(string location) -> bool {
+auto MyVision::load(string location) -> LoadResult {
 
   this->location = locate();
   pak = new vfs::directory;
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto MyVision::save(string location) -> bool {

--- a/mia/system/myvision.cpp
+++ b/mia/system/myvision.cpp
@@ -9,7 +9,7 @@ auto MyVision::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto MyVision::save(string location) -> bool {

--- a/mia/system/neo-geo-aes.cpp
+++ b/mia/system/neo-geo-aes.cpp
@@ -26,9 +26,9 @@ auto NeoGeoAES::load(string location) -> LoadResult {
     if (bios) pak->append("bios.rom", bios);
   }
 
-  if(pak->count() != 1) return LoadResult(romNotFound);
+  if(pak->count() != 1) return romNotFound;
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto NeoGeoAES::save(string location) -> bool {

--- a/mia/system/neo-geo-aes.cpp
+++ b/mia/system/neo-geo-aes.cpp
@@ -1,11 +1,11 @@
 struct NeoGeoAES : System {
   auto name() -> string override { return "Neo Geo AES"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto endianSwap(vector<u8>&) -> void;
 };
 
-auto NeoGeoAES::load(string location) -> bool {
+auto NeoGeoAES::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
 
@@ -26,9 +26,9 @@ auto NeoGeoAES::load(string location) -> bool {
     if (bios) pak->append("bios.rom", bios);
   }
 
-  if(pak->count() != 1) return false;
+  if(pak->count() != 1) return LoadResult(romNotFound);
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto NeoGeoAES::save(string location) -> bool {

--- a/mia/system/neo-geo-mvs.cpp
+++ b/mia/system/neo-geo-mvs.cpp
@@ -26,9 +26,9 @@ auto NeoGeoMVS::load(string location) -> LoadResult {
     if(bios) pak->append("bios.rom", bios);
   }
 
-  if(pak->count() != 1) return LoadResult(romNotFound);
+  if(pak->count() != 1) return romNotFound;
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto NeoGeoMVS::save(string location) -> bool {

--- a/mia/system/neo-geo-mvs.cpp
+++ b/mia/system/neo-geo-mvs.cpp
@@ -1,11 +1,11 @@
 struct NeoGeoMVS : System {
   auto name() -> string override { return "Neo Geo MVS"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto endianSwap(vector<u8>&) -> void;
 };
 
-auto NeoGeoMVS::load(string location) -> bool {
+auto NeoGeoMVS::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
 
@@ -26,9 +26,9 @@ auto NeoGeoMVS::load(string location) -> bool {
     if(bios) pak->append("bios.rom", bios);
   }
 
-  if(pak->count() != 1) return false;
+  if(pak->count() != 1) return LoadResult(romNotFound);
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto NeoGeoMVS::save(string location) -> bool {

--- a/mia/system/neo-geo-pocket-color.cpp
+++ b/mia/system/neo-geo-pocket-color.cpp
@@ -6,7 +6,7 @@ struct NeoGeoPocketColor : System {
 
 auto NeoGeoPocketColor::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return LoadResult(romNotFound);
+  if(!bios) return romNotFound;
 
   this->location = locate();
   pak = new vfs::directory;
@@ -17,7 +17,7 @@ auto NeoGeoPocketColor::load(string location) -> LoadResult {
   Pak::load("cpu.ram", ".cram");
   Pak::load("apu.ram", ".aram");
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto NeoGeoPocketColor::save(string location) -> bool {

--- a/mia/system/neo-geo-pocket-color.cpp
+++ b/mia/system/neo-geo-pocket-color.cpp
@@ -1,12 +1,12 @@
 struct NeoGeoPocketColor : System {
   auto name() -> string override { return "Neo Geo Pocket Color"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto NeoGeoPocketColor::load(string location) -> bool {
+auto NeoGeoPocketColor::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return false;
+  if(!bios) return LoadResult(romNotFound);
 
   this->location = locate();
   pak = new vfs::directory;
@@ -17,7 +17,7 @@ auto NeoGeoPocketColor::load(string location) -> bool {
   Pak::load("cpu.ram", ".cram");
   Pak::load("apu.ram", ".aram");
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto NeoGeoPocketColor::save(string location) -> bool {

--- a/mia/system/neo-geo-pocket.cpp
+++ b/mia/system/neo-geo-pocket.cpp
@@ -6,7 +6,7 @@ struct NeoGeoPocket : System {
 
 auto NeoGeoPocket::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return LoadResult(romNotFound);
+  if(!bios) return romNotFound;
 
   this->location = locate();
   pak = new vfs::directory;
@@ -17,7 +17,7 @@ auto NeoGeoPocket::load(string location) -> LoadResult {
   Pak::load("cpu.ram", ".cram");
   Pak::load("apu.ram", ".aram");
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto NeoGeoPocket::save(string location) -> bool {

--- a/mia/system/neo-geo-pocket.cpp
+++ b/mia/system/neo-geo-pocket.cpp
@@ -1,12 +1,12 @@
 struct NeoGeoPocket : System {
   auto name() -> string override { return "Neo Geo Pocket"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto NeoGeoPocket::load(string location) -> bool {
+auto NeoGeoPocket::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return false;
+  if(!bios) return LoadResult(romNotFound);
 
   this->location = locate();
   pak = new vfs::directory;
@@ -17,7 +17,7 @@ auto NeoGeoPocket::load(string location) -> bool {
   Pak::load("cpu.ram", ".cram");
   Pak::load("apu.ram", ".aram");
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto NeoGeoPocket::save(string location) -> bool {

--- a/mia/system/nintendo-64.cpp
+++ b/mia/system/nintendo-64.cpp
@@ -10,7 +10,7 @@ auto Nintendo64::load(string location) -> LoadResult {
   pak->append("pif.ntsc.rom", Resource::Nintendo64::PIFNTSC);
   pak->append("pif.pal.rom",  Resource::Nintendo64::PIFPAL );
   pak->append("pif.sm5.rom",  Resource::Nintendo64::PIFSM5 );
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Nintendo64::save(string location) -> bool {

--- a/mia/system/nintendo-64.cpp
+++ b/mia/system/nintendo-64.cpp
@@ -1,16 +1,16 @@
 struct Nintendo64 : System {
   auto name() -> string override { return "Nintendo 64"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto Nintendo64::load(string location) -> bool {
+auto Nintendo64::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("pif.ntsc.rom", Resource::Nintendo64::PIFNTSC);
   pak->append("pif.pal.rom",  Resource::Nintendo64::PIFPAL );
   pak->append("pif.sm5.rom",  Resource::Nintendo64::PIFSM5 );
-  return true;
+  return LoadResult(successful);
 }
 
 auto Nintendo64::save(string location) -> bool {

--- a/mia/system/nintendo-64dd.cpp
+++ b/mia/system/nintendo-64dd.cpp
@@ -1,12 +1,12 @@
 struct Nintendo64DD : System {
   auto name() -> string override { return "Nintendo 64DD"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto Nintendo64DD::load(string location) -> bool {
+auto Nintendo64DD::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return false;
+  if(!bios) return LoadResult(romNotFound);
 
   this->location = locate();
   pak = new vfs::directory;
@@ -21,7 +21,7 @@ auto Nintendo64DD::load(string location) -> bool {
   }
 
   Pak::load("time.rtc", ".rtc");
-  return true;
+  return LoadResult(successful);
 }
 
 auto Nintendo64DD::save(string location) -> bool {

--- a/mia/system/nintendo-64dd.cpp
+++ b/mia/system/nintendo-64dd.cpp
@@ -6,7 +6,7 @@ struct Nintendo64DD : System {
 
 auto Nintendo64DD::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return LoadResult(romNotFound);
+  if(!bios) return romNotFound;
 
   this->location = locate();
   pak = new vfs::directory;
@@ -21,7 +21,7 @@ auto Nintendo64DD::load(string location) -> LoadResult {
   }
 
   Pak::load("time.rtc", ".rtc");
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Nintendo64DD::save(string location) -> bool {

--- a/mia/system/pc-engine.cpp
+++ b/mia/system/pc-engine.cpp
@@ -1,17 +1,17 @@
 struct PCEngine : System {
   auto name() -> string override { return "PC Engine"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto PCEngine::load(string location) -> bool {
+auto PCEngine::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("backup.ram", 2_KiB);
 
   Pak::load("backup.ram", ".bram");
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto PCEngine::save(string location) -> bool {

--- a/mia/system/pc-engine.cpp
+++ b/mia/system/pc-engine.cpp
@@ -11,7 +11,7 @@ auto PCEngine::load(string location) -> LoadResult {
 
   Pak::load("backup.ram", ".bram");
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto PCEngine::save(string location) -> bool {

--- a/mia/system/playstation.cpp
+++ b/mia/system/playstation.cpp
@@ -6,13 +6,13 @@ struct PlayStation : System {
 
 auto PlayStation::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return LoadResult(romNotFound);
+  if(!bios) return romNotFound;
 
   this->location = locate();
   pak = new vfs::directory;
   pak->append("bios.rom", bios);
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto PlayStation::save(string location) -> bool {

--- a/mia/system/playstation.cpp
+++ b/mia/system/playstation.cpp
@@ -1,18 +1,18 @@
 struct PlayStation : System {
   auto name() -> string override { return "PlayStation"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto PlayStation::load(string location) -> bool {
+auto PlayStation::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return false;
+  if(!bios) return LoadResult(romNotFound);
 
   this->location = locate();
   pak = new vfs::directory;
   pak->append("bios.rom", bios);
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto PlayStation::save(string location) -> bool {

--- a/mia/system/pocket-challenge-v2.cpp
+++ b/mia/system/pocket-challenge-v2.cpp
@@ -9,7 +9,7 @@ auto PocketChallengeV2::load(string location) -> LoadResult {
   pak = new vfs::directory;
   pak->append("boot.rom", Resource::PocketChallengeV2::Boot);
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto PocketChallengeV2::save(string location) -> bool {

--- a/mia/system/pocket-challenge-v2.cpp
+++ b/mia/system/pocket-challenge-v2.cpp
@@ -1,15 +1,15 @@
 struct PocketChallengeV2 : System {
   auto name() -> string override { return "Pocket Challenge V2"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto PocketChallengeV2::load(string location) -> bool {
+auto PocketChallengeV2::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("boot.rom", Resource::PocketChallengeV2::Boot);
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto PocketChallengeV2::save(string location) -> bool {

--- a/mia/system/saturn.cpp
+++ b/mia/system/saturn.cpp
@@ -6,13 +6,13 @@ struct Saturn : System {
 
 auto Saturn::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return LoadResult(romNotFound);
+  if(!bios) return romNotFound;
 
   this->location = locate();
   pak = new vfs::directory;
   pak->append("bios.rom", bios);
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto Saturn::save(string location) -> bool {

--- a/mia/system/saturn.cpp
+++ b/mia/system/saturn.cpp
@@ -1,18 +1,18 @@
 struct Saturn : System {
   auto name() -> string override { return "Saturn"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto Saturn::load(string location) -> bool {
+auto Saturn::load(string location) -> LoadResult {
   auto bios = Pak::read(location);
-  if(!bios) return false;
+  if(!bios) return LoadResult(romNotFound);
 
   this->location = locate();
   pak = new vfs::directory;
   pak->append("bios.rom", bios);
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto Saturn::save(string location) -> bool {

--- a/mia/system/sc-3000.cpp
+++ b/mia/system/sc-3000.cpp
@@ -7,7 +7,7 @@ struct SC3000 : System {
 auto SC3000::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
-  return LoadResult(successful);
+  return successful;
 }
 
 auto SC3000::save(string location) -> bool {

--- a/mia/system/sc-3000.cpp
+++ b/mia/system/sc-3000.cpp
@@ -1,13 +1,13 @@
 struct SC3000 : System {
   auto name() -> string override { return "SC-3000"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto SC3000::load(string location) -> bool {
+auto SC3000::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
-  return true;
+  return LoadResult(successful);
 }
 
 auto SC3000::save(string location) -> bool {

--- a/mia/system/sg-1000.cpp
+++ b/mia/system/sg-1000.cpp
@@ -7,7 +7,7 @@ struct SG1000 : System {
 auto SG1000::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
-  return LoadResult(successful);
+  return successful;
 }
 
 auto SG1000::save(string location) -> bool {

--- a/mia/system/sg-1000.cpp
+++ b/mia/system/sg-1000.cpp
@@ -1,13 +1,13 @@
 struct SG1000 : System {
   auto name() -> string override { return "SG-1000"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto SG1000::load(string location) -> bool {
+auto SG1000::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
-  return true;
+  return LoadResult(successful);
 }
 
 auto SG1000::save(string location) -> bool {

--- a/mia/system/super-famicom.cpp
+++ b/mia/system/super-famicom.cpp
@@ -9,9 +9,9 @@ auto SuperFamicom::load(string location) -> LoadResult {
   pak = new vfs::directory;
   pak->append("ipl.rom", Resource::SuperFamicom::IPLROM);
   auto romLocation = mia::locate("Database/Super Famicom Boards.bml");
-  if(!romLocation) return LoadResult(databaseNotFound);
+  if(!romLocation) return { databaseNotFound, "Super Famicom Boards.bml" };
   pak->append("boards.bml", file::read(romLocation));
-  return LoadResult(successful);
+  return successful;
 }
 
 auto SuperFamicom::save(string location) -> bool {

--- a/mia/system/super-famicom.cpp
+++ b/mia/system/super-famicom.cpp
@@ -1,15 +1,17 @@
 struct SuperFamicom : System {
   auto name() -> string override { return "Super Famicom"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto SuperFamicom::load(string location) -> bool {
+auto SuperFamicom::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("ipl.rom", Resource::SuperFamicom::IPLROM);
-  pak->append("boards.bml", file::read(mia::locate("Database/Super Famicom Boards.bml")));
-  return true;
+  auto romLocation = mia::locate("Database/Super Famicom Boards.bml");
+  if(!romLocation) return LoadResult(databaseNotFound);
+  pak->append("boards.bml", file::read(romLocation));
+  return LoadResult(successful);
 }
 
 auto SuperFamicom::save(string location) -> bool {

--- a/mia/system/supergrafx.cpp
+++ b/mia/system/supergrafx.cpp
@@ -11,7 +11,7 @@ auto SuperGrafx::load(string location) -> LoadResult {
 
   Pak::load("backup.ram", ".bram");
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto SuperGrafx::save(string location) -> bool {

--- a/mia/system/supergrafx.cpp
+++ b/mia/system/supergrafx.cpp
@@ -1,17 +1,17 @@
 struct SuperGrafx : System {
   auto name() -> string override { return "SuperGrafx"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto SuperGrafx::load(string location) -> bool {
+auto SuperGrafx::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("backup.ram", 2_KiB);
 
   Pak::load("backup.ram", ".bram");
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto SuperGrafx::save(string location) -> bool {

--- a/mia/system/wonderswan-color.cpp
+++ b/mia/system/wonderswan-color.cpp
@@ -1,10 +1,10 @@
 struct WonderSwanColor : System {
   auto name() -> string override { return "WonderSwan Color"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto WonderSwanColor::load(string location) -> bool {
+auto WonderSwanColor::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("boot.rom", Resource::WonderSwanColor::Boot);
@@ -12,7 +12,7 @@ auto WonderSwanColor::load(string location) -> bool {
 
   Pak::load("save.eeprom", ".eeprom");
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto WonderSwanColor::save(string location) -> bool {

--- a/mia/system/wonderswan-color.cpp
+++ b/mia/system/wonderswan-color.cpp
@@ -12,7 +12,7 @@ auto WonderSwanColor::load(string location) -> LoadResult {
 
   Pak::load("save.eeprom", ".eeprom");
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto WonderSwanColor::save(string location) -> bool {

--- a/mia/system/wonderswan.cpp
+++ b/mia/system/wonderswan.cpp
@@ -1,10 +1,10 @@
 struct WonderSwan : System {
   auto name() -> string override { return "WonderSwan"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto WonderSwan::load(string location) -> bool {
+auto WonderSwan::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("boot.rom", Resource::WonderSwan::Boot);
@@ -12,7 +12,7 @@ auto WonderSwan::load(string location) -> bool {
 
   Pak::load("save.eeprom", ".eeprom");
 
-  return true;
+  return LoadResult(successful);
 }
 
 auto WonderSwan::save(string location) -> bool {

--- a/mia/system/wonderswan.cpp
+++ b/mia/system/wonderswan.cpp
@@ -12,7 +12,7 @@ auto WonderSwan::load(string location) -> LoadResult {
 
   Pak::load("save.eeprom", ".eeprom");
 
-  return LoadResult(successful);
+  return successful;
 }
 
 auto WonderSwan::save(string location) -> bool {

--- a/mia/system/zx-spectrum-128.cpp
+++ b/mia/system/zx-spectrum-128.cpp
@@ -9,7 +9,7 @@ auto ZXSpectrum128::load(string location) -> LoadResult {
   pak = new vfs::directory;
   pak->append("bios.rom", Resource::ZXSpectrum128::BIOS);
   pak->append("sub.rom", Resource::ZXSpectrum128::Sub);
-  return LoadResult(successful);
+  return successful;
 }
 
 auto ZXSpectrum128::save(string location) -> bool {

--- a/mia/system/zx-spectrum-128.cpp
+++ b/mia/system/zx-spectrum-128.cpp
@@ -1,15 +1,15 @@
 struct ZXSpectrum128 : System {
   auto name() -> string override { return "ZX Spectrum 128"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto ZXSpectrum128::load(string location) -> bool {
+auto ZXSpectrum128::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("bios.rom", Resource::ZXSpectrum128::BIOS);
   pak->append("sub.rom", Resource::ZXSpectrum128::Sub);
-  return true;
+  return LoadResult(successful);
 }
 
 auto ZXSpectrum128::save(string location) -> bool {

--- a/mia/system/zx-spectrum.cpp
+++ b/mia/system/zx-spectrum.cpp
@@ -1,14 +1,14 @@
 struct ZXSpectrum : System {
   auto name() -> string override { return "ZX Spectrum"; }
-  auto load(string location) -> bool override;
+  auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
 
-auto ZXSpectrum::load(string location) -> bool {
+auto ZXSpectrum::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("bios.rom", Resource::ZXSpectrum::BIOS);
-  return true;
+  return LoadResult(successful);
 }
 
 auto ZXSpectrum::save(string location) -> bool {

--- a/mia/system/zx-spectrum.cpp
+++ b/mia/system/zx-spectrum.cpp
@@ -8,7 +8,7 @@ auto ZXSpectrum::load(string location) -> LoadResult {
   this->location = locate();
   pak = new vfs::directory;
   pak->append("bios.rom", Resource::ZXSpectrum::BIOS);
-  return LoadResult(successful);
+  return successful;
 }
 
 auto ZXSpectrum::save(string location) -> bool {


### PR DESCRIPTION
> [!NOTE]
> Seeking testers on this to validate that errors appear correctly, are accurate, and we didn't break anything.

### Description

Adds the `LoadResult` type, used to identify and propagate upwards errors encountered when loading ROMs and systems.

Modifies the `mia` and `desktop-ui` load routines to use this type instead of generic booleans, so that if we have a load failure, we can propagate a precise and useful error to the user rather than a vague and possibly mismatched one.

Currently the scope of the error handling is just `mia` and `desktop-ui`; errors encountered when loading in `ares` itself are currently generic "`otherError`"s. `LoadResult` is placed in `mia/mia.hpp` so it is accessible to both `mia` and `desktop-ui`. If LoadResult is added to ares loading in the future, the LoadResult type may need to be moved.