### PR TITLE
ruby: Initialize sRGB option on Metal

### DIFF
--- a/ruby/video/metal/metal.cpp
+++ b/ruby/video/metal/metal.cpp
@@ -590,6 +590,7 @@ private:
     
     initialized = true;
     setNativeFullScreen(self.nativeFullScreen);
+    setForceSRGB(self.forceSRGB);
     return _ready = true;
   }
 


### PR DESCRIPTION
While looking at something else I noticed that we were not respecting the stored value of the "Force sRGB" option on startup. As a result we would always output in sRGB unless the user explicitly modified the option during the session.