### PR TITLE
n64: fix gdb causing MIPS exception on attach

### DIFF
--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -133,6 +133,7 @@ auto System::initDebugHooks() -> void {
   };
 
   GDB::server.hooks.normalizeAddress = [](u64 address) -> u64 {
+    address = (s32)address;
     return cpu.devirtualizeDebug(address);
   };
 


### PR DESCRIPTION
Fixes #1778