### PR TITLE
sfc: adjust overscan numbers

### DIFF
--- a/ares/sfc/ppu-performance/ppu.cpp
+++ b/ares/sfc/ppu-performance/ppu.cpp
@@ -89,19 +89,19 @@ auto PPU::main() -> void {
       screen->setSize(564, height() * 2);
       screen->setViewport(0, 0, 564, height() * 2);
     } else {
-      int x = 24;
-      int y = 16;
-      int w = 564 - 48;
-      int h = height() - 16;
+      int x = 26;
+      int y = 18;
+      int w = 564 - 52;
+      int h = height() - 18;
 
       if(Region::PAL()) {
-        y += 25;
-        h -= 29;
-        w -= 6;
+        x -= 4;
+        y += 24;
+        h -= 31;
 
         if(!io.overscan) {
           y += 16;
-          h -= 16;
+          h -= 15;
         }
       }
 

--- a/ares/sfc/ppu/main.cpp
+++ b/ares/sfc/ppu/main.cpp
@@ -26,19 +26,19 @@ auto PPU::main() -> void {
       screen->setSize(564, height() * 2);
       screen->setViewport(0, 0, 564, height() * 2);
     } else {
-      int x = 24;
-      int y = 16;
-      int w = 564 - 48;
-      int h = height() - 16;
+      int x = 26;
+      int y = 18;
+      int w = 564 - 52;
+      int h = height() - 18;
 
       if(Region::PAL()) {
-        y += 25;
-        h -= 29;
-        w -= 6;
+        x -= 4;
+        y += 24;
+        h -= 31;
 
         if(!io.overscan) {
           y += 16;
-          h -= 16;
+          h -= 15;
         }
       }
 


### PR DESCRIPTION
These coord and offset numbers will hide all empty space (including blanked active lines) without cropping any good pixels on the sides. The output now matches old ares and bsnes. Whether the blanked lines should be shown can be revisited later (most users have no idea what these are and will hate them). SMW USA 1.0, SMW EUR 1.0, and SMW EUR 1.1 were used for testing as each variant triggers each of the 3 modes and the game draws border tiles all around.

Screenshots:

SMW USA 1.0

![smw_u10_overscan](https://github.com/user-attachments/assets/ab087adb-ccbf-4039-935c-876fab46baa8)

![smw_u10_xhideoverscan](https://github.com/user-attachments/assets/3a74120a-8468-4451-842e-495837fa4902)

SMW EUR 1.0

![smw_e10_overscan](https://github.com/user-attachments/assets/b790b84d-3632-434c-9307-8bc35555e995)

![smw_e10_xhideoverscan](https://github.com/user-attachments/assets/e11a179f-0775-4929-be19-3af24347e8c2)

SMW EUR 1.1

![smw_e11_overscan](https://github.com/user-attachments/assets/5ebdb315-3700-4ce4-9bd1-91077c3ff357)

![smw_e11_xhideoverscan](https://github.com/user-attachments/assets/ae07af5a-4acd-419f-b79f-bd4d07aeee63)
