### PR TITLE
build: Miscellaneous fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,15 +34,18 @@ jobs:
     - name: Check Release Tag ☑️
       id: check
       run: |
+          now=$(date +'%Y-%m-%d')
           if [[ ${GITHUB_REF_NAME} == master ]];
           then
             echo "tag=nightly" >> $GITHUB_OUTPUT
-            now=$(date +'%Y-%m-%d')
             versionName="nightly ${now}"
             echo "versionName=${versionName}" >> $GITHUB_OUTPUT
+            echo "description=${{ github.event.head_commit.message }}" >> $GITHUB_OUTPUT
           else
             echo "tag=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
             echo "versionName=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+            description="This is ares ${GITHUB_REF_NAME}, released on ${now}."
+            echo "description=${description}" >> $GITHUB_OUTPUT
           fi
           
     - name: Create Release 🛫
@@ -52,6 +55,7 @@ jobs:
         draft: ${{ github.ref != 'refs/heads/master' }}
         tag_name: ${{ steps.check.outputs.tag }}
         name: ares ${{ steps.check.outputs.versionName }}
+        body: ${{ steps.check.outputs.description }}
         files: |
           ${{ github.workspace }}/ares-macos-universal.zip
           ${{ github.workspace }}/ares-macos-universal-dSYMs.zip

--- a/mia/CMakeLists.txt
+++ b/mia/CMakeLists.txt
@@ -144,6 +144,19 @@ if(ARES_BUILD_OPTIONAL_TARGETS)
       XCODE_EMBED_PLUGINS_REMOVE_HEADERS_ON_COPY YES
       XCODE_EMBED_PLUGINS_CODE_SIGN_ON_COPY YES
   )
+  if(OS_MACOS)
+    set_target_xcode_properties(
+      mia-ui
+      PROPERTIES PRODUCT_BUNDLE_IDENTIFIER dev.ares.mia
+                 PRODUCT_NAME mia
+                 ASSETCATALOG_COMPILER_APPICON_NAME AppIcon
+                 MARKETING_VERSION ${ARES_VERSION}
+                 GENERATE_INFOPLIST_FILE YES
+                 CLANG_ENABLE_OBJC_ARC YES
+                 INFOPLIST_KEY_CFBundleDisplayName "mia"
+                 INFOPLIST_KEY_NSHumanReadableCopyright "(c) 2004-${CURRENT_YEAR} ares team, Near et. al."
+    )
+  endif()
   ares_configure_executable(mia-ui)
   target_enable_subproject(mia-ui "mia (manifest generator) standalone frontend")
   set_target_properties(mia-ui PROPERTIES FOLDER tools PREFIX "")

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -2,6 +2,11 @@ add_library(sljit STATIC sljit/sljit_src/sljitLir.c)
 
 target_include_directories(sljit PUBLIC ../thirdparty)
 target_compile_definitions(sljit PUBLIC SLJIT_HAVE_CONFIG_PRE=1 SLJIT_HAVE_CONFIG_POST=1)
+target_compile_options(
+  sljit
+  PRIVATE
+    $<$<COMPILE_LANG_AND_ID:C,AppleClang,Clang,GNU>:-Wno-conditional-uninitialized>
+)
 
 # lzma
 add_subdirectory(libchdr/deps/lzma-24.05 EXCLUDE_FROM_ALL)


### PR DESCRIPTION
- Fixes the nightly release so that the release body will contain the latest commit message (only the first line). Tagged releases will now also contain a description.
- Ignore a benign warning in sljit that was popping up in build annotations.
- Fix a warning about a conflict in the `mia-ui` domain string on macOS.