### PR TITLE
hiro: fix double character inputs in Windows HexEdit widget

### DIFF
--- a/hiro/windows/application.cpp
+++ b/hiro/windows/application.cpp
@@ -186,9 +186,11 @@ static auto Application_keyboardProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM 
     //TODO: does this really need to be hooked here?
     #if defined(Hiro_Widget)
     if(auto widget = dynamic_cast<mWidget*>(object)) {
-      if(auto self = widget->self()) {
-        if(auto result = self->windowProc(self->hwnd, msg, wparam, lparam)) {
-          return result();
+      if(!dynamic_cast<mHexEdit*>(object)) {
+        if(auto self = widget->self()) {
+          if(auto result = self->windowProc(self->hwnd, msg, wparam, lparam)) {
+            return result();
+          }
         }
       }
     }

--- a/hiro/windows/widget/hex-edit.cpp
+++ b/hiro/windows/widget/hex-edit.cpp
@@ -136,6 +136,7 @@ auto pHexEdit::keyPress(u32 scancode) -> bool {
   }
 
   //convert scancode to hex nibble
+  scancode = pKeyboard::_translate(scancode, 0);
        if(scancode >= '0' && scancode <= '9') scancode = scancode - '0';
   else if(scancode >= 'A' && scancode <= 'F') scancode = scancode - 'A' + 10;
   else if(scancode >= 'a' && scancode <= 'f') scancode = scancode - 'a' + 10;


### PR DESCRIPTION
At some point it might be worth going through the list of widgets to understand which ones require WM_KEYDOWN messages to be forwarded by Application_keyboardProc. For the time being, it's clear the HexEdit widget is not among them, so this change disables forwarding for that widget type.

As an added bonus, this change also makes the number pad functional.