### PR TITLE
fc: adjust overscan numbers

### DIFF
--- a/ares/fc/ppu/ppu.cpp
+++ b/ares/fc/ppu/ppu.cpp
@@ -97,11 +97,14 @@ auto PPU::frame() -> void {
     screen->setViewport(0, 0, 283, displayHeight());
   } else {
     int x = 16;
-    int y = 8;
-    int width = 283 - 33;
-    int height = displayHeight() - 16;
+    int y = 0;
+    int width = 283 - 27;
+    int height = displayHeight() - 2;
 
-    if(Region::PAL()) height -= 48;
+    if(Region::PAL()) {
+      x += 2;
+      height -= 46;
+    }
 
     screen->setSize(width, height);
     screen->setViewport(x, y, width, height);

--- a/ares/fc/ppu/render.cpp
+++ b/ares/fc/ppu/render.cpp
@@ -26,9 +26,7 @@ auto PPU::renderPixel() -> void {
   bool objectPriority = 0;
 
   //PAL systems technically blank the topmost scanline and a 2px column on each side of active display.
-  //This does little else but crop good tiledata and mismatch screenshots with ntsc.
-  //Uncomment the line below to enable.
-  //if(Region::PAL()) if(io.ly == 0 || x < 2 || x > 253) return;
+  if(Region::PAL()) if(io.ly == 0 || x < 2 || x > 253) return;
 
   palette |= latch.tiledataLo & mask ? 1 : 0;
   palette |= latch.tiledataHi & mask ? 2 : 0;

--- a/ares/fc/ppu/render.cpp
+++ b/ares/fc/ppu/render.cpp
@@ -25,8 +25,10 @@ auto PPU::renderPixel() -> void {
   u32  objectPalette = 0;
   bool objectPriority = 0;
 
-  //PAL systems blank the topmost scanline and the first and last 2px of active display
-  if(Region::PAL()) if(io.ly == 0 || x < 2 || x > 254) return;
+  //PAL systems technically blank the topmost scanline and a 2px column on each side of active display.
+  //This does little else but crop good tiledata and mismatch screenshots with ntsc.
+  //Uncomment the line below to enable.
+  //if(Region::PAL()) if(io.ly == 0 || x < 2 || x > 253) return;
 
   palette |= latch.tiledataLo & mask ? 1 : 0;
   palette |= latch.tiledataHi & mask ? 2 : 0;


### PR DESCRIPTION
Overscan=off now shows active display centered and intact for both regions. The pal ppu micromasking behavior was corrected (253 vs 254) and commented out.

SMB2 EUR full frame
![smb2_e_fullframe](https://github.com/user-attachments/assets/3645d6b2-d97e-4f8a-865a-61464da01287)   

before/after

![smb2before](https://github.com/user-attachments/assets/27fa1157-f715-4f92-9814-e1d13da2690a)   ![ares-n](https://github.com/user-attachments/assets/fbed864b-2a05-4c0d-8a6b-8ce83d8a4684)

before/after
![Untitledggg](https://github.com/user-attachments/assets/03f41051-ca9b-4223-940d-d869745ff0a5)    ![Untitledhhh](https://github.com/user-attachments/assets/dd761deb-6a34-4132-903c-433a36d22066)
