### PR TITLE
n64: fix a typo in ISViewer address range

### DIFF
--- a/ares/n64/cartridge/cartridge.cpp
+++ b/ares/n64/cartridge/cartridge.cpp
@@ -47,7 +47,7 @@ auto Cartridge::connect() -> void {
 
   rtc.load();
 
-  if(rom.size <= 0x03fe'ffff) {
+  if(rom.size <= 0x03ff'0000) {
     isviewer.ram.allocate(64_KiB);
     isviewer.tracer = node->append<Node::Debugger::Tracer::Notification>("ISViewer", "Cartridge");
     isviewer.tracer->setAutoLineBreak(false);

--- a/ares/n64/pi/bus.hpp
+++ b/ares/n64/pi/bus.hpp
@@ -44,7 +44,7 @@ inline auto PI::busRead(u32 address) -> u32 {
     if(cartridge.flash) return cartridge.flash.read<Size>(address);
     return unmapped;
   }
-  if(cartridge.isviewer.enabled() && address >= 0x13f0'0000 && address <= 0x13ff'ffff) {
+  if(cartridge.isviewer.enabled() && address >= 0x13ff'0000 && address <= 0x13ff'ffff) {
     return cartridge.isviewer.read<Size>(address);
   }
   if(address <= 0x1000'0000 + cartridge.rom.size - 1) {
@@ -94,7 +94,7 @@ inline auto PI::busWrite(u32 address, u32 data) -> void {
     if(cartridge.flash) return cartridge.flash.write<Size>(address, data);
     return;
   }
-  if(address >= 0x13f0'0000 && address <= 0x13ff'ffff) {
+  if(address >= 0x13ff'0000 && address <= 0x13ff'ffff) {
     if(cartridge.isviewer.enabled()) {
       writeForceFinish(); //Debugging channel for homebrew, be gentle
       return cartridge.isviewer.write<Size>(address, data);      


### PR DESCRIPTION
Added in 14786372. This basically prevented ROM size between 0x3f0'0000 and 0x3ff'0000 to work correctly in Ares.