### PR TITLE
m32x+md fixes

### DIFF
--- a/ares/md/m32x/io-external.cpp
+++ b/ares/md/m32x/io-external.cpp
@@ -87,20 +87,23 @@ auto M32X::readExternalIO(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
 
   //PWM left channel pulse width
   if(address == 0xa15134) {
-    data = pwm.lfifoLatch;
-    data.bit(15) = pwm.lfifo.full();
+    data.bit(0,12) = pwm.lfifoLatch;
+    data.bit(14)   = pwm.lfifo.empty();
+    data.bit(15)   = pwm.lfifo.full();
   }
 
   //PWM right channel pulse width
   if(address == 0xa15136) {
-    data = pwm.rfifoLatch;
-    data.bit(15) = pwm.rfifo.full();
+    data.bit(0,12) = pwm.rfifoLatch;
+    data.bit(14)   = pwm.rfifo.empty();
+    data.bit(15)   = pwm.rfifo.full();
   }
 
   //PWM mono pulse width
   if(address == 0xa15138) {
-    data = pwm.mfifoLatch;
-    data.bit(15) = pwm.lfifo.full() || pwm.rfifo.full();
+    data.bit(0,12) = pwm.mfifoLatch;
+    data.bit(14)   = pwm.lfifo.empty() && pwm.rfifo.empty();
+    data.bit(15)   = pwm.lfifo.full()  || pwm.rfifo.full();
   }
 
   //bitmap mode
@@ -251,8 +254,6 @@ auto M32X::writeExternalIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
     if(lower) {
       pwm.lmode   = data.bit(0,1);
       pwm.rmode   = data.bit(2,3);
-      if(!pwm.lmode) pwm.lsample = 0;
-      if(!pwm.rmode) pwm.rsample = 0;
       pwm.mono    = data.bit(4);
     //pwm.dreqIRQ = data.bit(7) = readonly;
     }
@@ -270,7 +271,7 @@ auto M32X::writeExternalIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
 
   //PWM left channel pulse width
   if(address == 0xa15134) {
-    if(upper) pwm.lfifoLatch.byte(1) = data.byte(1);
+    if(upper) pwm.lfifoLatch.bit(8,11) = data.bit(8,11);
     if(lower) {
       pwm.lfifoLatch.byte(0) = data.byte(0);
       pwm.lfifo.write(pwm.lfifoLatch);
@@ -279,7 +280,7 @@ auto M32X::writeExternalIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
 
   //PWM right channel pulse width
   if(address == 0xa15136) {
-    if(upper) pwm.rfifoLatch.byte(1) = data.byte(1);
+    if(upper) pwm.rfifoLatch.bit(8,11) = data.bit(8,11);
     if(lower) {
       pwm.rfifoLatch.byte(0) = data.byte(0);
       pwm.rfifo.write(pwm.rfifoLatch);
@@ -288,7 +289,7 @@ auto M32X::writeExternalIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
 
   //PWM mono pulse width
   if(address == 0xa15138) {
-    if(upper) pwm.mfifoLatch.byte(1) = data.byte(1);
+    if(upper) pwm.mfifoLatch.bit(8,11) = data.bit(8,11);
     if(lower) {
       pwm.mfifoLatch.byte(0) = data.byte(0);
       pwm.lfifo.write(pwm.mfifoLatch);

--- a/ares/md/m32x/m32x.hpp
+++ b/ares/md/m32x/m32x.hpp
@@ -1,4 +1,5 @@
 //Mega 32X
+#include "nall/dsp/iir/dc-removal.hpp"
 
 struct M32X {
   Node::Object node;
@@ -123,6 +124,7 @@ struct M32X {
 
   struct PWM : Thread {
     Node::Audio::Stream stream;
+    nall::DSP::IIR::DCRemoval dcfilter_l, dcfilter_r;
 
     //pwm.cpp
     auto load(Node::Object) -> void;

--- a/ares/md/m32x/pwm.cpp
+++ b/ares/md/m32x/pwm.cpp
@@ -1,7 +1,6 @@
 auto M32X::PWM::load(Node::Object parent) -> void {
   stream = parent->append<Node::Audio::Stream>("PWM");
   stream->setChannels(2);
-  n12 clocks = cycle - 1;
   updateFrequency();
 }
 
@@ -11,7 +10,8 @@ auto M32X::PWM::unload(Node::Object parent) -> void {
 }
 
 auto M32X::PWM::main() -> void {
-    n12 clocks = cycle - 1;
+    int clocks = cycle > 0 ? cycle-1 : 4095;
+    if(clocks == 0) clocks++;
 
     //check if cycle rate has changed and update sample rate accordingly
     static n12 previousCycle = cycle;
@@ -20,28 +20,42 @@ auto M32X::PWM::main() -> void {
       updateFrequency();
     }
 
-    if (clocks && (lmode.bit(0) ^ lmode.bit(1) || rmode.bit(0) ^ rmode.bit(1))) {
-        if (lmode == 1) lsample = lfifo.read();
-        if (lmode == 2) lsample = rfifo.read();
+    // skip action if cycle == 1 (illegal setting: "PWM will no longer operate")
+    if (cycle != 1 && (lmode.bit(0) ^ lmode.bit(1) || rmode.bit(0) ^ rmode.bit(1))) {
+      lsample = lfifo.read();
+      rsample = rfifo.read();
 
-        if (rmode == 1) rsample = rfifo.read();
-        if (rmode == 2) rsample = lfifo.read();
-
-        lfifoLatch.bit(14) = lfifo.empty();
-        rfifoLatch.bit(14) = rfifo.empty();
-        mfifoLatch.bit(14) = lfifoLatch.bit(14) & rfifoLatch.bit(14);
-
-        if (periods++ == n4(timer - 1)) {
-            periods = 0;
-            m32x.shm.irq.pwm.active = 1;
-            m32x.shs.irq.pwm.active = 1;
-            m32x.shm.dmac.dreq[1] = dreqIRQ;
-            m32x.shs.dmac.dreq[1] = dreqIRQ;
-        }
+      if (periods++ == n4(timer - 1)) {
+        periods = 0;
+        m32x.shm.irq.pwm.active = 1;
+        m32x.shs.irq.pwm.active = 1;
+        m32x.shm.dmac.dreq[1] = dreqIRQ;
+        m32x.shs.dmac.dreq[1] = dreqIRQ;
+      }
     }
 
-    auto left = cycle > 0 ? lsample / (f32)cycle : 0;
-    auto right = cycle > 0 ? rsample / (f32)cycle : 0;
+    i12 outL, outR;
+
+    if (lmode == 0) outL = 0;
+    if (lmode == 1) outL = lsample;
+    if (lmode == 2) outL = rsample;
+    if (lmode == 3) outL = 0; // illegal mode
+
+    if (rmode == 0) outR = 0;
+    if (rmode == 1) outR = rsample;
+    if (rmode == 2) outR = lsample;
+    if (rmode == 3) outR = 0; // illegal mode
+
+    auto left  = outL / (f32)clocks;
+    auto right = outR / (f32)clocks;
+
+    // filter DC offset to normalize output and limit popping
+    left  = dcfilter_l.process(left);
+    right = dcfilter_r.process(right);
+
+    // handle clipping due to improper settings
+    if(abs(left)  > 1.0) left  /= abs(left);
+    if(abs(right) > 1.0) right /= abs(right);
 
     stream->frame(left, right);  // Output the frame without the loop, since the sample rate is adjusted dynamically
 
@@ -67,13 +81,16 @@ auto M32X::PWM::power(bool reset) -> void {
   rsample = 0;
   lfifo.flush();
   rfifo.flush();
-  lfifoLatch = 0x4000; // empty
-  rfifoLatch = 0x4000; // empty
-  mfifoLatch = 0x4000; // empty
+  lfifoLatch = 0;
+  rfifoLatch = 0;
+  mfifoLatch = 0;
   updateFrequency();
+  dcfilter_l.reset();
+  dcfilter_r.reset();
 }
 
 auto M32X::PWM::updateFrequency() -> void {
-  n12 clocks = cycle - 1;
-  stream->setFrequency((system.frequency() * 6) / (7.0 * (2 * (clocks) - 1)));
+  int clocks = cycle > 0 ? cycle-1 : 4095;
+  if(clocks == 0) clocks++;
+  stream->setFrequency((system.frequency() / 7.0) * 3.0 / clocks);
 }

--- a/ares/md/m32x/pwm.cpp
+++ b/ares/md/m32x/pwm.cpp
@@ -10,7 +10,7 @@ auto M32X::PWM::unload(Node::Object parent) -> void {
 }
 
 auto M32X::PWM::main() -> void {
-    int clocks = cycle > 0 ? cycle-1 : 4095;
+    n12 clocks = cycle - 1;
     if(clocks == 0) clocks++;
 
     //check if cycle rate has changed and update sample rate accordingly
@@ -90,7 +90,7 @@ auto M32X::PWM::power(bool reset) -> void {
 }
 
 auto M32X::PWM::updateFrequency() -> void {
-  int clocks = cycle > 0 ? cycle-1 : 4095;
+  n12 clocks = cycle - 1;
   if(clocks == 0) clocks++;
   stream->setFrequency((system.frequency() / 7.0) * 3.0 / clocks);
 }

--- a/ares/md/vdp/vdp.cpp
+++ b/ares/md/vdp/vdp.cpp
@@ -85,11 +85,10 @@ auto VDP::pixels() -> u32* {
 
   if(h40()) {
     // H40 mode has slightly shorter lines, so sides are blanked.
-    // Left side would be 13 wide, but we'll realign to whole pixel (3*4) for sanity.
-    for(auto n: range(12)) output[        n] = 0b101 << 9;
-    for(auto n: range(15)) output[1415-15+n] = 0b101 << 9;
+    for(auto n: range(13)) output[        n] = 0b101 << 9;
+    for(auto n: range(14)) output[1415-14+n] = 0b101 << 9;
 
-    return output+12;
+    return output+13;
   }
 
   return output;


### PR DESCRIPTION
1. Revised pwm emulation, mostly to align with documentation. Not likely to affect much except for rare edge cases. Also, added a dc filter to prevent audio popping in certain situations (like window losing focus), but pops on init are correct behavior. Fixes #937 by implementing byte-wide fifo writes from the SH2 side.
2. Various fixups to 32x io access by the 68k. Fixes #1196 and missing music in Brutal.
3. Follow-up to a previous PR: cram dots were not limited properly, and line buffer adjustment was crashing 32x in certain cases (as reported in the discord).