### PR TITLE
build: More miscellaneous fixes

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,7 @@
 name: Push
 on:
   push:
-    branches: [ master ]
+    branches: [ '*' ]
     tags: [ 'v*' ]
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.head_ref || github.ref }}'

--- a/ares/n64/CMakeLists.txt
+++ b/ares/n64/CMakeLists.txt
@@ -57,25 +57,25 @@ ares_add_sources(
 
 ares_add_sources(
   CORE #
-  n64
+    n64
   INCLUDED #
-  aleck64/aleck64.hpp
-  aleck64/controls.cpp
-  aleck64/debugger.cpp
-  aleck64/serialization.cpp
-  aleck64/io.cpp
-  aleck64/vdp.cpp
-  aleck64/game-config/11beat.hpp
-  aleck64/game-config/doncdoon.hpp
-  aleck64/game-config/kurufev.hpp
-  aleck64/game-config/mayjin3.hpp
-  aleck64/game-config/starsldr.hpp
-  aleck64/game-config/twrshaft.hpp
-  aleck64/game-config/vivdolls.hpp
-  aleck64/game-config/hipai.hpp
-  aleck64/game-config/hipai2.hpp
-  aleck64/game-config/srmvs.hpp
-  aleck64/game-config/mtetrisc.hpp
+    aleck64/aleck64.hpp
+    aleck64/controls.cpp
+    aleck64/debugger.cpp
+    aleck64/serialization.cpp
+    aleck64/io.cpp
+    aleck64/vdp.cpp
+    aleck64/game-config/11beat.hpp
+    aleck64/game-config/doncdoon.hpp
+    aleck64/game-config/kurufev.hpp
+    aleck64/game-config/mayjin3.hpp
+    aleck64/game-config/starsldr.hpp
+    aleck64/game-config/twrshaft.hpp
+    aleck64/game-config/vivdolls.hpp
+    aleck64/game-config/hipai.hpp
+    aleck64/game-config/hipai2.hpp
+    aleck64/game-config/srmvs.hpp
+    aleck64/game-config/mtetrisc.hpp
 )
 
 ares_add_sources(
@@ -114,10 +114,10 @@ ares_add_sources(
 
 ares_add_sources(
   CORE #
-  n64
+    n64
   INCLUDED #
-  controller/aleck64/aleck64.cpp
-  controller/aleck64/aleck64.hpp
+    controller/aleck64/aleck64.cpp
+    controller/aleck64/aleck64.hpp
 )
 
 ares_add_sources(

--- a/cmake/common/compiler_common.cmake
+++ b/cmake/common/compiler_common.cmake
@@ -100,7 +100,7 @@ set(
   -Wno-delete-non-abstract-non-virtual-dtor
 )
 
-set(_ares_gcc_common_options -fwrapv -fno-strict-aliasing -Wno-unused-result)
+set(_ares_gcc_common_options -fwrapv -fno-strict-aliasing -Wno-unused-result -Wno-stringop-overflow)
 
 if(NOT DEFINED CMAKE_COMPILE_WARNING_AS_ERROR)
   set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)

--- a/cmake/windows/compilerconfig.cmake
+++ b/cmake/windows/compilerconfig.cmake
@@ -39,7 +39,10 @@ endif()
 
 add_compile_definitions(_WIN32_WINNT=0x0601) #global
 
-option(ARES_MINGW_USE_DWARF_SYMBOLS "Generate DWARF debug symbols (instead of CodeView) for use with gdb or lldb. Applies to MSYS2/MinGW environments.")
+option(
+  ARES_MINGW_USE_DWARF_SYMBOLS
+  "Generate DWARF debug symbols (instead of CodeView) for use with gdb or lldb. Applies to MSYS2/MinGW environments."
+)
 
 set(
   _ares_msvc_cxx_options
@@ -93,9 +96,13 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     if(NOT DEFINED ARES_MINGW_USE_DWARF_SYMBOLS)
       set(ARES_MINGW_USE_DWARF_SYMBOLS OFF)
     endif()
-            
+
     set(_ares_mingw_clang_debug_compile_options -g "$<IF:$<BOOL:${ARES_MINGW_USE_DWARF_SYMBOLS}>,-gdwarf,-gcodeview>")
-    set(_ares_mingw_clang_debug_link_options -g "$<IF:$<BOOL:${ARES_MINGW_USE_DWARF_SYMBOLS}>,-gdwarf,-fuse-ld=lld;-Wl$<COMMA>--pdb=>")
+    set(
+      _ares_mingw_clang_debug_link_options
+      -g
+      "$<IF:$<BOOL:${ARES_MINGW_USE_DWARF_SYMBOLS}>,-gdwarf,-fuse-ld=lld;-Wl$<COMMA>--pdb=>"
+    )
     add_compile_options("$<$<CONFIG:Debug,RelWithDebInfo>:${_ares_mingw_clang_debug_compile_options}>")
     add_link_options("$<$<CONFIG:Debug,RelWithDebInfo>:${_ares_mingw_clang_debug_link_options}>")
 
@@ -125,7 +132,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   add_compile_options("$<$<COMPILE_LANGUAGE:C,CXX>:${_ares_msvc_cxx_options}>")
-  
+
   if(CMAKE_COMPILE_WARNING_AS_ERROR)
     add_link_options(/WX)
   endif()
@@ -133,12 +140,12 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   if(NOT DEFINED ARES_MINGW_USE_DWARF_SYMBOLS)
     set(ARES_MINGW_USE_DWARF_SYMBOLS ON)
   endif()
-  
+
   set(_ares_mingw_gcc_debug_compile_options -g "$<IF:$<BOOL:${ARES_MINGW_USE_DWARF_SYMBOLS}>,-gdwarf,-gcodeview>")
   set(_ares_mingw_gcc_debug_link_options -g "$<IF:$<BOOL:${ARES_MINGW_USE_DWARF_SYMBOLS}>,-gdwarf,-Wl$<COMMA>--pdb=>")
   add_compile_options("$<$<CONFIG:Debug,RelWithDebInfo>:${_ares_mingw_gcc_debug_compile_options}>")
   add_link_options("$<$<CONFIG:Debug,RelWithDebInfo>:${_ares_mingw_gcc_debug_link_options}>")
-  
+
   add_compile_options(${_ares_gcc_common_options})
 endif()
 

--- a/desktop-ui/cmake/sources.cmake
+++ b/desktop-ui/cmake/sources.cmake
@@ -18,6 +18,7 @@ target_sources(
     program/program.hpp
     program/rewind.cpp
     program/states.cpp
+    program/status.cpp
     program/utility.cpp
 )
 

--- a/hiro/cmake/os-linux.cmake
+++ b/hiro/cmake/os-linux.cmake
@@ -5,7 +5,6 @@ mark_as_advanced(USE_QT5)
 
 if(NOT USE_QT5)
   find_package(GTK REQUIRED)
-  target_compile_definitions(hiro PRIVATE HIRO_GTK)
 
   target_link_libraries(hiro PRIVATE GTK::GTK X11::X11)
 

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -2,11 +2,7 @@ add_library(sljit STATIC sljit/sljit_src/sljitLir.c)
 
 target_include_directories(sljit PUBLIC ../thirdparty)
 target_compile_definitions(sljit PUBLIC SLJIT_HAVE_CONFIG_PRE=1 SLJIT_HAVE_CONFIG_POST=1)
-target_compile_options(
-  sljit
-  PRIVATE
-    $<$<COMPILE_LANG_AND_ID:C,AppleClang,Clang,GNU>:-Wno-conditional-uninitialized>
-)
+target_compile_options(sljit PRIVATE $<$<COMPILE_LANG_AND_ID:C,AppleClang,Clang,GNU>:-Wno-conditional-uninitialized>)
 
 # lzma
 add_subdirectory(libchdr/deps/lzma-24.05 EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Minor changes:

- Run CI for pushes to any branch, not just master. This is mostly relevant for forks, where you will often want CI on WIP branches. Releases still check that they are on the master branch and won't be generated for other branches.

- The GCC `stringop-overflow` heuristic still seems to be buggy, tripping in seemingly irrelevant areas, and in different areas depending on toolchain/OS. Hence, just disable it for now; conforms with legacy behavior.

- Fix a macro redefinition in the GTK CMake code

- Add a missing "included" source to the desktop-ui CMake code so it shows up in IDEs

- `gersemi` formatting pass

Lastly:

Allow generating DWARF symbols in MSYS2/MinGW environments. This is controlled by the cache variable `ARES_MINGW_USE_DWARF_SYMBOLS` (on by default only for GCC, inoperable under MSVC/Clang-CL). This allows for easier use of gdb or lldb for debugging on Windows. The support here is considered incomplete but functional for debugging the main ares executable.

In particular, we do not generate DWARF symbols on Windows in ares-deps, so debugging dynamic dependency issues with gdb or lldb will require self-compiling dependencies. DWARF symbols are also embedded and this PR does not ship them with releases. The "primary" Windows clang build will continue to use CodeView symbols so that releases may be debugged with WinDbg, Visual Studio, etc.

I am not satisfied with this level of support, but I am also not sure whether "full support" for two independent debugging symbol formats on one platform is a reasonable thing or a good idea to maintain. For one thing, ares-deps targets the MSVC ABI for portability, where DWARF symbol availability is limited. Targeting the GNU ABI in ares-deps would mean reconciling multiple independent components' dependence on libc++ that would eventually need to be linked together. This might theoretically be possible but in any case is not undertaken here. Also not undertaken is the extant PDB functionality for stripping into separate files, bundling, copying to the rundir, etc.