### PR TITLE
m32x: make PWM timer interrupt interval bits read-only from the MD side

### DIFF
--- a/ares/md/m32x/io-external.cpp
+++ b/ares/md/m32x/io-external.cpp
@@ -267,8 +267,8 @@ auto M32X::writeExternalIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
     //pwm.dreqIRQ = data.bit(7) = readonly;
     }
     if(upper) {
-      pwm.timer = data.bit(8,11);
-      pwm.periods = 0;
+    //pwm.timer = data.bit(8,11) = readonly;
+    //pwm.periods = 0 = readonly;
     }
   }
 


### PR DESCRIPTION
Per page 24 of the 32X hardware manual, the PWM timer interrupt interval is read-only from the Mega Drive side.

This change fixes incorrect sound effects in Primal Rage. If the 68000 is allowed to write to these bits, it will change the PWM timer interval from 1 to 16 during game boot, which breaks the game's PWM sound driver code.

Primal Rage title screen audio before this change:
[primal-rage-before.webm](https://github.com/user-attachments/assets/0d8a33d1-22fb-4664-a802-00715541e67f)

After:
[primal-rage-after.webm](https://github.com/user-attachments/assets/87a3cdfe-85a4-45e7-8ea8-bc3e5bde4f7a)
