### PR TITLE
Fix build-sdl.sh script error

### DIFF
--- a/thirdparty/SDL/build-sdl.sh
+++ b/thirdparty/SDL/build-sdl.sh
@@ -6,7 +6,7 @@ if [ ! -d "SDL" ]; then
 else
     git -C SDL fetch
 fi
-git -C SDL reset --hard "$(cat HEAD)"
+git -C SDL reset --hard "$(git -C SDL rev-parse HEAD)"
 mkdir -p SDL/build
 pushd SDL/build
 


### PR DESCRIPTION
The SDL build script fails:

```bash
./thirdparty/SDL/build-sdl.sh 
```
```
Cloning into 'SDL'...
remote: Enumerating objects: 193100, done.
remote: Counting objects: 100% (48982/48982), done.
remote: Compressing objects: 100% (1282/1282), done.
remote: Total 193100 (delta 47990), reused 47700 (delta 47700), pack-reused 144118 (from 1)
Receiving objects: 100% (193100/193100), 102.69 MiB | 15.18 MiB/s, done.
Resolving deltas: 100% (147983/147983), done.
cat: HEAD: No such file or directory
fatal: ambiguous argument '': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
````

This change uses the proper git command to get the commit ID for HEAD. Tested successfully.