### PR TITLE
n64: Don't report interrupt exceptions to GDB

### DIFF
--- a/ares/n64/cpu/exceptions.cpp
+++ b/ares/n64/cpu/exceptions.cpp
@@ -1,6 +1,8 @@
 auto CPU::Exception::trigger(u32 code, u32 coprocessor, bool tlbMiss) -> void {
   self.debugger.exception(code);
-  reportGDBException(code, self.ipu.pc); 
+  if (code != 0) {  //ignore interrupt exceptions
+    reportGDBException(code, self.ipu.pc); 
+  }
 
   u64 vectorBase = !self.scc.status.vectorLocation ? (s32)0x8000'0000 : (s32)0xbfc0'0200;
 


### PR DESCRIPTION
Interrupt exceptions fire multiple times per second and having to ack all of them can cause performance issues while debugging.