### PR TITLE
m32x vdp fixes

### DIFF
--- a/ares/md/m32x/bus-internal.cpp
+++ b/ares/md/m32x/bus-internal.cpp
@@ -9,11 +9,11 @@ auto M32X::readInternal(n1 upper, n1 lower, n32 address, n16 data) -> n16 {
     return readInternalIO(upper, lower, address, data);
   }
 
-  if(address >= 0x0200'0000 && address <= 0x023f'ffff) {
+  if(address >= 0x0200'0000 && address <= 0x03ff'ffff) {
     while(dreq.vram) {
       // SH2 ROM accesses stall while RV is set
       if(shm.active()) { shm.internalStep(1); shm.syncM68k(true); }
-	    if(shs.active()) { shs.internalStep(1); shs.syncM68k(true); }
+      if(shs.active()) { shs.internalStep(1); shs.syncM68k(true); }
     }
 
     // TODO: SH2 ROM accesses need to stall while the m68k is on the bus
@@ -21,7 +21,9 @@ auto M32X::readInternal(n1 upper, n1 lower, n32 address, n16 data) -> n16 {
     return cartridge.child->read(upper, lower, address, data);
   }
 
-  if(address >= 0x0400'0000 && address <= 0x0405'ffff) {
+  if(address >= 0x0400'0000 && address <= 0x05ff'ffff) {
+    if (!vdp.framebufferAccess) return data;
+    if(vdp.framebufferEngaged()) { debug(unusual, "[32X FB] SH2 read while FEN==1"); return data; } // wait instead?
     if(shm.active()) shm.internalStep(5); if(shs.active()) shs.internalStep(5);
     return vdp.bbram[address >> 1 & 0xffff];
   }
@@ -38,30 +40,27 @@ auto M32X::writeInternal(n1 upper, n1 lower, n32 address, n16 data) -> void {
     return writeInternalIO(upper, lower, address, data);
   }
 
-  if(address >= 0x0400'0000 && address <= 0x0401'ffff) {
-    if (!vdp.framebufferAccess) return;
-    if(!data && (!upper || !lower)) return;  //8-bit 0x00 writes do not go through
-    if(shm.active()) shm.internalStep(4); if(shs.active()) shs.internalStep(4);
-    if(upper) vdp.bbram[address >> 1 & 0xffff].byte(1) = data.byte(1);
-    if(lower) vdp.bbram[address >> 1 & 0xffff].byte(0) = data.byte(0);
-    return;
-  }
+  if(address >= 0x0400'0000 && address <= 0x05ff'ffff) {
+    address &= 0x0403'ffff;
 
-  if(address >= 0x0402'0000 && address <= 0x0403'ffff) {
-    if (!vdp.framebufferAccess) return;
-    if(shm.active()) shm.internalStep(4); if(shs.active()) shs.internalStep(4);
-    if(upper && data.byte(1)) vdp.bbram[address >> 1 & 0xffff].byte(1) = data.byte(1);
-    if(lower && data.byte(0)) vdp.bbram[address >> 1 & 0xffff].byte(0) = data.byte(0);
-    return;
-  }
+    if(address >= 0x0400'0000 && address <= 0x0401'ffff) {
+      if (!vdp.framebufferAccess) return;
+      if(vdp.framebufferEngaged()) { debug(unusual, "[32X FB] SH2 write while FEN==1"); return; } // wait instead?
+      if(!data && (!upper || !lower)) return;  //8-bit 0x00 writes do not go through
+      if(shm.active()) shm.internalStep(4); if(shs.active()) shs.internalStep(4);
+      if(upper) vdp.bbram[address >> 1 & 0xffff].byte(1) = data.byte(1);
+      if(lower) vdp.bbram[address >> 1 & 0xffff].byte(0) = data.byte(0);
+      return;
+    }
 
-  if(address >= 0x0404'0000 && address <= 0x0405'ffff) {
-    if (!vdp.framebufferAccess) return;
-    if(!data && (!upper || !lower)) return;  //8-bit 0x00 writes do not go through
-    if(shm.active()) shm.internalStep(4); if(shs.active()) shs.internalStep(4);
-    if(upper) vdp.bbram[address >> 1 & 0xffff].byte(1) = data.byte(1);
-    if(lower) vdp.bbram[address >> 1 & 0xffff].byte(0) = data.byte(0);
-    return;
+    if(address >= 0x0402'0000 && address <= 0x0403'ffff) {
+      if (!vdp.framebufferAccess) return;
+      if(vdp.framebufferEngaged()) { debug(unusual, "[32X FB] SH2 overwrite while FEN==1"); return; } // wait instead?
+      if(shm.active()) shm.internalStep(4); if(shs.active()) shs.internalStep(4);
+      if(upper && data.byte(1)) vdp.bbram[address >> 1 & 0xffff].byte(1) = data.byte(1);
+      if(lower && data.byte(0)) vdp.bbram[address >> 1 & 0xffff].byte(0) = data.byte(0);
+      return;
+    }
   }
 
   if(address >= 0x0600'0000 && address <= 0x0603'ffff) {

--- a/ares/md/m32x/m32x.cpp
+++ b/ares/md/m32x/m32x.cpp
@@ -76,6 +76,13 @@ auto M32X::vblank(bool line) -> void {
 }
 
 auto M32X::hblank(bool line) -> void {
+  if(vdp.hblank > line) {
+    // TODO: VDP regs should be latched 192 MClks (~82 cycles) before end of hblank (according to official docs)
+    vdp.latch.mode = vdp.mode;
+    vdp.latch.lines = vdp.lines;
+    vdp.latch.priority = vdp.priority;
+    vdp.latch.dotshift = vdp.dotshift;
+  }
   vdp.hblank = line;
   shm.irq.hint.active = 0;
   shs.irq.hint.active = 0;

--- a/ares/md/m32x/m32x.hpp
+++ b/ares/md/m32x/m32x.hpp
@@ -103,6 +103,8 @@ struct M32X {
     auto plot(u32* output, u16 color) -> void;
     auto fill() -> void;
     auto selectFramebuffer(n1 active) -> void;
+    auto framebufferEngaged() -> bool;
+    auto paletteEngaged() -> bool;
 
     //serialization.cpp
     auto serialize(serializer&) -> void;
@@ -117,8 +119,16 @@ struct M32X {
     n1  framebufferAccess;
     n1  framebufferActive;
     n1  framebufferSelect;
+    int framebufferWait;
     n1  hblank;
     n1  vblank;
+
+    struct Latch {
+      n2 mode;
+      n1 lines;
+      n1 priority;
+      n1 dotshift;
+    } latch;
   };
 
   struct PWM : Thread {

--- a/ares/md/m32x/serialization.cpp
+++ b/ares/md/m32x/serialization.cpp
@@ -46,12 +46,17 @@ auto M32X::VDP::serialize(serializer& s) -> void {
   s(lines);
   s(priority);
   s(dotshift);
+  s(latch.mode);
+  s(latch.lines);
+  s(latch.priority);
+  s(latch.dotshift);
   s(autofillLength);
   s(autofillAddress);
   s(autofillData);
   s(framebufferAccess);
   s(framebufferActive);
   s(framebufferSelect);
+  s(framebufferWait);
   s(hblank);
   s(vblank);
   selectFramebuffer(framebufferSelect);

--- a/ares/md/m32x/sh7604.cpp
+++ b/ares/md/m32x/sh7604.cpp
@@ -66,6 +66,8 @@ auto M32X::SH7604::step(u32 clocks) -> void {
   cyclesUntilSh2Sync -= clocks;
   cyclesUntilM68kSync -= clocks;
 
+  m32x.vdp.framebufferWait -= min(clocks, m32x.vdp.framebufferWait);
+
   if(cyclesUntilSh2Sync <= 0) {
     cyclesUntilSh2Sync = minCyclesBetweenSh2Syncs;
     if (m32x.shm.active()) Thread::synchronize(m32x.shs);

--- a/ares/md/system/serialization.cpp
+++ b/ares/md/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v141.1";
+static const string SerializerVersion = "v142";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
- SH2 memory windows have been adjusted. The framebuffer areas must be mirrored up to 0x5ffffff -- fixes Toughman Contest backgrounds.
- VDP FEN & PEN flags are closer to accurate but still missing some finer timing details.
- FEN/PEN status may block vdp memory accesses. The docs seem to indicate that accesses may be held in wait until a status change, but thats not totally clear (nor validated?). For now, these accesses are blocked and logged in debug.
- FM setting (framebufferAccess) only allows vdp access by either 68k or SH2-side, so additional guards have been inserted for cram/framebuffer accesses. VDP reg accesses should be blocked as well according to docs, but this aspect needs to be reviewed.
- VDP reg latching has been implemented. The timing isnt completely accurate, but should be decent enough for now. Fixes Mars Check image test (corrupt lines from mode switching).
- Autofill timing has been implemented according to the docs. For now, this is just signaling via the FEN flag. Fixes MK II glitching et al.