### PR TITLE
Proper 32X region header processing for licensed games

### DIFF
--- a/mia/medium/mega-32x.cpp
+++ b/mia/medium/mega-32x.cpp
@@ -120,9 +120,12 @@ auto Mega32X::analyze(vector<u8>& rom) -> string {
 
   vector<string> regions;
   string region = slice((const char*)&rom[0x01f0], 0, 16).trimRight(" ");
-  if(!regions) {
-    if(region == "JAPAN" ) regions.append("NTSC-J");
-    if(region == "EUROPE") regions.append("PAL");
+
+  //Stellar Assault (U,E) is the one game using the single-byte region coding which
+  //uses an 'E' value for both PAL and NTSC-U region. (NTSC-J cartridge uses '1')  
+  //https://segaretro.org/ROM_header#Regional_compatiblity
+  if(region(0) == 'E' && hash == "2f9b6017258fbb1c37d81df07c68d5255495d3bf76d9c7b680ff66bccf665750") {
+    regions.append("NTSC-U", "PAL");
   }
   if(!regions) {
     if(region.find("J")) regions.append("NTSC-J");
@@ -139,19 +142,8 @@ auto Mega32X::analyze(vector<u8>& rom) -> string {
     if(bits && *bits & 4) regions.append("NTSC-U");  //overseas 60hz
     if(bits && *bits & 8) regions.append("PAL");     //overseas 50hz
   }
-  if(!regions) {
+  if(!regions) { 
     regions.append("NTSC-J", "NTSC-U", "PAL");
-  }
-
-  // FIFA Soccer 96 and Mortal Kombat II have an incorrect header, so force PAL based on name
-  if(location.ifind("(Europe)") || location.ifind("(PAL)")) {
-    regions.reset();
-    regions.append("PAL");
-  }
-
-  //Shadow Squadron - Stellar Assault is missing NTSC-U region in header
-  if(hash == "2f9b6017258fbb1c37d81df07c68d5255495d3bf76d9c7b680ff66bccf665750") {
-    regions.append("NTSC-U");
   }
 
   string domesticName;

--- a/mia/medium/mega-32x.cpp
+++ b/mia/medium/mega-32x.cpp
@@ -142,7 +142,7 @@ auto Mega32X::analyze(vector<u8>& rom) -> string {
     if(bits && *bits & 4) regions.append("NTSC-U");  //overseas 60hz
     if(bits && *bits & 8) regions.append("PAL");     //overseas 50hz
   }
-  if(!regions) { 
+  if(!regions) {
     regions.append("NTSC-J", "NTSC-U", "PAL");
   }
 


### PR DESCRIPTION
Final update for 32X region header processing. All headers should be identified correctly as they were initially defined. Note this was a time of transition and there were two methods of specifying regions. The simpler, older "JUE" option, or the more complicated single byte method (https://segaretro.org/ROM_header#Regional_compatiblity) where an 'E' could have a duel meaning as a result. After reviewing every header for every licensed game (summary at the end), there is a single 32X game where 'E' is used to represent both PAL regions as well as NTSC-U (using the single byte method). The Japanese release uses a '1', meaning the NTSC-J region only, so this was intentional. So this is the only game that needs to be special cased to properly handle this (quite frankly, silly) situation Sega allowed when introducing the newer region markings. 

All headers will be honored as they were defined when set by developers. No changes will be made based on names in the ROMs. Ares isn't going to attempt to correct or overwrite headers. For the older method, headers marked as 'JUE' were meant to mean region free - meaning they should work anywhere. For the newer header, 'F' means to allow for all regions. Some games were not released in all regions (they may have had plans to that didn't work out given the short lifespan of the system), just as FIFA which really only saw a European release, so if you want to play at 50Hz then you have to set region preference to Europe prior to loading the game. Otherwise the header is going to be honored and since J is first it will assume NTSC-J by default. 

25 games use the newer region markings:
`Amazing Spider-Man - Web of Fire (F)
BC Racers (F)
Blackthorne (4)
Brutal (4)
Knuckles Chaotix (5, A)
Cosmic Carnage (5, A)
Darkside (A)
Kolibri (F)
Metal Head (5, A)
Motherbase/Parasquad/Zaxxon (5, A)
NBA Jam (F)
NFL Quarterback Club (F)
Pitfall Mayan Adventure (4)
Primal Rage (F)
RBI Baseball 95 (4)
Sangokushi IV (1)
Star Trek - Starfleet Academy (4)
Tempo (5)
T-Mek (F)
Toughman Contest (F)
Virtua Fighter (5, A)
World Series Baseball (F)
WWF Raw (F)
WWF Wrestlemania (F)`

6 games use the older 'JUE' region headers:
`Doom Europe - (E),  Japan/USA uses (JU)
FIFA (JUE, need to use prefer Europe region for PAL)
Golf Magazine Presents - 36 Great Holes Starring Fred Couples - (E)  NTSC-J/U release - (JU)  
Mortal Kombat II (JUE used in both releases, need to use prefer Europe region for PAL version)
Motocross - Europe uses (E), USA uses (JU) 
Star Wars Arcade - Europe is (E), Japan is (J), USA is (UJ) `

2 games mixed them up:
`Space Harrier Europe is (A), Japan & USA is (JU)
Virtua Racing Deluxe - Japan (1), USA (U), PAL regions (A)`

And as already mentioned Stellar Assault used '1' for NTSC-J, and 'E' for NTSC-U and both PAL regions.

Fixes: https://github.com/ares-emulator/ares/issues/1066 