### PR TITLE
nall: Resolve all file paths passed on command line

### DIFF
--- a/nall/arguments.hpp
+++ b/nall/arguments.hpp
@@ -60,8 +60,14 @@ inline auto Arguments::construct() -> void {
 
   //normalize path and file arguments
   for(auto& argument : arguments) {
-    if(directory::exists(argument)) argument.transform("\\", "/").trimRight("/").append("/");
-    else if(file::exists(argument)) argument.transform("\\", "/").trimRight("/");
+    if(directory::exists(argument)) {
+      argument.transform("\\", "/").trimRight("/").append("/");
+      argument = Path::real(argument);
+    }
+    else if(file::exists(argument)) {
+      argument.transform("\\", "/").trimRight("/");
+      argument = {Path::real(argument), Location::file(argument)};
+    }
   }
 }
 


### PR DESCRIPTION
When loading a game from the command line with a relative path with a saves directory unspecified, `nall::Location` would fail to return a valid directory for the load location, because it expects an absolute path.