### PR TITLE
hiro/cocoa: Ensure trailing slash in directory picker result

### DIFF
--- a/hiro/cocoa/browser-window.cpp
+++ b/hiro/cocoa/browser-window.cpp
@@ -10,11 +10,14 @@ auto pBrowserWindow::directory(BrowserWindow::State& state) -> string {
     if(state.title) [panel setTitle:[NSString stringWithUTF8String:state.title]];
     panel.canChooseDirectories = YES;
     panel.canChooseFiles = NO;
+    panel.canCreateDirectories = YES;
     panel.directoryURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:state.path]];
     if([panel runModal] == NSModalResponseOK) {
-      NSArray* files = [panel URLs];
-      const char* path = [[[files objectAtIndex:0] path] UTF8String];
-      if(path) result = path;
+      NSString* path = panel.URLs.firstObject.path;
+      if(path) {
+        path = [path stringByAppendingString:@"/"];
+        result = path.UTF8String;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #1786.

The Cocoa directory picker returns paths as they are provided by the system, which is generally absent a trailing slash. This causes issues when serializing mia's paks to disk, as well as other emulator save routines, which assume that this path contains a trailing slash.

I don't think this solution is completely ideal; ideally ares would have more robust path abstractions that gracefully handle however the system wants to provide paths. For the moment however it seems fine. Note that this makes the directory picker match the behavior of the generalized file picker, which also appends trailing slashes to directory results.