### PR TITLE
build: More miscellaneous fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     - name: "macOS: Import Certificate"
       if: runner.os == 'macOS' && inputs.codesign
       uses: apple-actions/import-codesign-certs@v3
-      continue-on-error: ${{ !inputs.codesign }}
+      continue-on-error: ${{ secrets.MACOS_CERTIFICATE_NAME == '' }}
       with:
         p12-file-base64: ${{ secrets.MACOS_CERTIFICATE_DATA }}
         p12-password: ${{ secrets.MACOS_CERTIFICATE_PASSPHRASE }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,8 +1,6 @@
 name: Push
 on:
-  push:
-    branches: [ '*' ]
-    tags: [ 'v*' ]
+  push
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.head_ref || github.ref }}'
   cancel-in-progress: true

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ mia/resource/resource.cpp
 mia/resource/resource.hpp
 tests/arm7tdmi/tests
 tests/m68000/tests
+thirdparty/libchdr/deps/zlib-*/zconf.h
+thirdparty/libchdr/deps/zlib-*/zconf.h.included

--- a/ares/ares/ares.cpp.in
+++ b/ares/ares/ares.cpp.in
@@ -11,7 +11,7 @@ bool _runAhead = false;
 
 const string Name       = "@ARES_NAME@";
 const string Version    = "@ARES_VERSION@";
-const string Copyright  = "@ARES_LEGAL_COPYRIGHT@";
+const string Copyright  = "@ARES_LEGAL_COPYRIGHT_SHORT@";
 const string License    = "ISC";
 const string LicenseURI = "https://opensource.org/licenses/ISC";
 const string Website    = "@ARES_WEBSITE@";

--- a/cmake/common/bootstrap.cmake
+++ b/cmake/common/bootstrap.cmake
@@ -25,6 +25,7 @@ set(
 )
 string(TIMESTAMP CURRENT_YEAR "%Y")
 set(ARES_LEGAL_COPYRIGHT "Copyright (c) 2004-${CURRENT_YEAR} ares team, Near et. al.")
+set(ARES_LEGAL_COPYRIGHT_SHORT "2004-${CURRENT_YEAR} ares team, Near")
 
 # Add common module directories to default search path
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/common" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/finders")

--- a/cmake/windows/compilerconfig.cmake
+++ b/cmake/windows/compilerconfig.cmake
@@ -147,6 +147,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   add_link_options("$<$<CONFIG:Debug,RelWithDebInfo>:${_ares_mingw_gcc_debug_link_options}>")
 
   add_compile_options(${_ares_gcc_common_options})
+  add_link_options(-static-libstdc++)
 endif()
 
 # arch/machine-specific optimizations


### PR DESCRIPTION
* On Windows, statically link libc++ under GCC to match behavior under MSYS2/MinGW clang.
* Add the legacy removed zconf.h header to the .gitignore, so that it continues to not be tracked when/if we update libchdr
* Adjust CI workflows so that the push workflow will run on all branches (but the build will still proceed on codesign errors if the repository does not have codesigning configured)
* Add a shortened version of the copyright string to display in the About dialog so that it fits in the window