### PR TITLE
gba: DMA fixes

### DIFF
--- a/ares/gba/cartridge/cartridge.hpp
+++ b/ares/gba/cartridge/cartridge.hpp
@@ -17,8 +17,10 @@ struct Cartridge {
   auto save() -> void;
   auto power() -> void;
 
-  auto read(u32 mode, n32 address) -> n32;
-  auto write(u32 mode, n32 address, n32 word) -> void;
+  auto readRom(u32 mode, n32 address) -> n32;
+  auto readBackup(u32 mode, n32 address) -> n32;
+  auto writeRom(u32 mode, n32 address, n32 word) -> void;
+  auto writeBackup(u32 mode, n32 address, n32 word) -> void;
 
   auto serialize(serializer&) -> void;
 

--- a/ares/gba/cartridge/memory.hpp
+++ b/ares/gba/cartridge/memory.hpp
@@ -1,7 +1,6 @@
 struct MROM {
   //mrom.cpp
-  auto read(u32 mode, n32 address) -> n32;
-  auto readBus(u32 mode, n32 address) -> n16;
+  auto read(u32 mode, n32 address) -> n16;
   auto write(u32 mode, n32 address, n32 word) -> void;
 
   //serialization.cpp

--- a/ares/gba/cartridge/mrom.cpp
+++ b/ares/gba/cartridge/mrom.cpp
@@ -1,15 +1,4 @@
-auto Cartridge::MROM::read(u32 mode, n32 address) -> n32 {
-  if(mode & Word) {
-    n32 word = 0;
-    word |= readBus(mode & ~Word | Half, (address & ~3) + 0) <<  0;
-    word |= readBus(mode & ~Word | Half, (address & ~3) + 2) << 16;
-    return word;
-  }
-
-  return readBus(mode, address);
-}
-
-auto Cartridge::MROM::readBus(u32 mode, n32 address) -> n16 {
+auto Cartridge::MROM::read(u32 mode, n32 address) -> n16 {
   address &= 0x01ff'ffff;
 
   if(address >= size) {
@@ -20,8 +9,7 @@ auto Cartridge::MROM::readBus(u32 mode, n32 address) -> n16 {
   if(mode & Half) address &= ~1;
   auto p = data + address;
   if(mode & Half) return p[0] << 0 | p[1] << 8;
-  if(mode & Byte) return p[0] << 0;
-  return 0;  //should never occur
+  return p[0] << 0;
 }
 
 auto Cartridge::MROM::write(u32 mode, n32 address, n32 word) -> void {

--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -58,11 +58,18 @@ auto CPU::main() -> void {
 auto CPU::dmaRun() -> void {
   if(!context.dmaActive && !context.busLocked) {
     context.dmaActive = true;
-    while(dma[0].run() | dma[1].run() | dma[2].run() | dma[3].run());
+    while(true) {
+      if(dma[0].run()) continue;
+      if(dma[1].run()) continue;
+      if(dma[2].run()) continue;
+      if(dma[3].run()) continue;
+      break;
+    }
     if(context.dmaRan) {
       idle();
       context.dmaRan = false;
       context.dmaRomAccess = false;
+      context.dmaActiveChannel = 0;  //assign burst to a channel that cannot access ROM
     }
     context.dmaActive = false;
   }

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -263,6 +263,7 @@ struct CPU : ARM7TDMI, Thread, IO {
     n1  dmaRan;
     n1  dmaRomAccess;
     n1  dmaActive;
+    n2  dmaActiveChannel;
     n1  timerLatched;
     n1  busLocked;
   } context;

--- a/ares/gba/cpu/prefetch.cpp
+++ b/ares/gba/cpu/prefetch.cpp
@@ -11,7 +11,7 @@ auto CPU::prefetchSync(n32 address) -> void {
 
 auto CPU::prefetchStep(u32 clocks) -> void {
   step(clocks);
-  if(!wait.prefetch || context.dmaRomAccess || prefetch.stopped) return;
+  if(!wait.prefetch || prefetch.stopped) return;
 
   while(!prefetch.full() && clocks--) {
     if(--prefetch.wait) continue;

--- a/ares/gba/cpu/prefetch.cpp
+++ b/ares/gba/cpu/prefetch.cpp
@@ -15,7 +15,7 @@ auto CPU::prefetchStep(u32 clocks) -> void {
 
   while(!prefetch.full() && clocks--) {
     if(--prefetch.wait) continue;
-    prefetch.slot[prefetch.load >> 1 & 7] = cartridge.read(Half, prefetch.load);
+    prefetch.slot[prefetch.load >> 1 & 7] = cartridge.readRom(Half, prefetch.load);
     prefetch.load += 2;
     prefetch.wait = waitCartridge(Half | Sequential, prefetch.load);
   }

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -116,6 +116,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(context.dmaRan);
   s(context.dmaRomAccess);
   s(context.dmaActive);
+  s(context.dmaActiveChannel);
   s(context.timerLatched);
   s(context.busLocked);
 }

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v141.6";
+static const string SerializerVersion = "v142";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Improves timings when running multiple DMA channels at once, and fixes a timing bug when accessing the cartridge backup region.