### PR TITLE
m32x: fix pwm serialization

### DIFF
--- a/ares/md/m32x/serialization.cpp
+++ b/ares/md/m32x/serialization.cpp
@@ -81,4 +81,5 @@ auto M32X::PWM::serialize(serializer& s) -> void {
   s(lfifoLatch);
   s(rfifoLatch);
   s(mfifoLatch);
+  updateFrequency();
 }


### PR DESCRIPTION
Fixes the issue of distorted audio when reloading a 32X save state. While it has not yet been confirmed whether this is a complete fix for the issue as originally reported, it does correct the most apparent anomaly.