### PR TITLE
ws: First pass at "mono" model color emulation.

### DIFF
--- a/ares/ws/ppu/color.cpp
+++ b/ares/ws/ppu/color.cpp
@@ -8,12 +8,22 @@ auto PPU::color(n32 color) -> n64 {
   u64 B = image::normalize(b, 4, 16);
 
   if(colorEmulation->value()) {
-    R = (r * 26 + g *  4 + b *  2);
-    G = (         g * 24 + b *  8);
-    B = (r *  6 + g *  4 + b * 22);
-    R = image::normalize(min(480, R), 9, 16);
-    G = image::normalize(min(480, G), 9, 16);
-    B = image::normalize(min(480, B), 9, 16);
+    if(SoC::ASWAN()) {
+      auto gammaAdjustBetween = [=](u32 c, u32 min, u32 max) { return min + (u32) (pow(c / 15.0, 1 / 2.2) * (max - min)); };
+      // The WS's display has similar characteristics to the GBP.
+      R = gammaAdjustBetween(r, 0x2b2b, 0xe0e0);
+      G = gammaAdjustBetween(g, 0x2b2b, 0xdbdb);
+      B = gammaAdjustBetween(b, 0x2626, 0xcdcd);
+      return R << 32 | G << 16 | B << 0;
+    } else {
+      // The SC's display has similar characteristics to the GBC.
+      R = (r * 26 + g *  4 + b *  2);
+      G = (         g * 24 + b *  8);
+      B = (r *  6 + g *  4 + b * 22);
+      R = image::normalize(min(480, R), 9, 16);
+      G = image::normalize(min(480, G), 9, 16);
+      B = image::normalize(min(480, B), 9, 16);
+    }
   }
 
   return R << 32 | G << 16 | B << 0;


### PR DESCRIPTION
The "mono" WonderSwan has an FSTN display, same as the Game Boy Pocket and resulting in the same display hue. While there are [more accurate palettes](https://bgb.bircd.org/reality/index.html) for FSTN displays available these days, I've decided to use Near's GBP palette for consistency. It also has sixteen shades of grey with a contrast slider; according to lidnariq, with the optimal contrast wheel setting, they follow a linear gamma of 1.0.

This PR adds color emulation to the "mono" WonderSwan under these assumptions; I am a little concerned that not every game expects the same contrast wheel setting, but I'd say it's good enough for a first pass. A proper second pass would require photographic documentation to create a more precise palette, probably.