### PR TITLE
CI: Align MSYS2 git line ending settings with system git

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,10 @@ jobs:
       with:
         fetch-tags: true
         fetch-depth: 0
+    - name: Setup MSYS2 Git Environment
+      if: matrix.platform.shell == 'msys2 {0}'
+      run: |
+        git config core.autocrlf true
     - name: Install Linux Dependencies
       if: runner.os == 'Linux'
       run: |


### PR DESCRIPTION
CI checks out code with Windows system Git in `C:/Program Files`, which has line ending settings that conflict with MSYS2 git, which ends up being used to derive the version information in CMake. The checkout action's git seems to use `autocrlf = true`, while apparently MSYS2 does not, so MSYS2 git believes all line endings in the project have been changed.

This should resolve the issue of MSYS2 tagged releases having `-modified` in the version information.