### PR TITLE
md+m32x fixes, validated by testpico (notaz)

### DIFF
--- a/ares/component/audio/ym2612/io.cpp
+++ b/ares/component/audio/ym2612/io.cpp
@@ -36,18 +36,14 @@ auto YM2612::writeData(n8 data) -> void {
   //timer B period
   case 0x026: {
     timerB.period.bit(0,7) = data.bit(0,7);
+    // Not sure if this is the right place for it, but...
+    // handle a specific use case to reset the subticks on timer B
+    if(!timerB.enable) timerB.divider = 0;
     break;
   }
 
   //timer control
   case 0x027: {
-    //reload period on 0->1 transition
-    if(!timerA.enable && data.bit(0)) timerA.counter = timerA.period;
-    if(!timerB.enable && data.bit(1)) {
-      timerB.counter = timerB.period;
-      timerB.divider = 0;
-    }
-
     timerA.enable = data.bit(0);
     timerB.enable = data.bit(1);
     timerA.irq = data.bit(2);

--- a/ares/component/audio/ym2612/serialization.cpp
+++ b/ares/component/audio/ym2612/serialization.cpp
@@ -13,12 +13,14 @@ auto YM2612::serialize(serializer& s) -> void {
   s(envelope.divider);
 
   s(timerA.enable);
+  s(timerA.enableLatch);
   s(timerA.irq);
   s(timerA.line);
   s(timerA.period);
   s(timerA.counter);
 
   s(timerB.enable);
+  s(timerB.enableLatch);
   s(timerB.irq);
   s(timerB.line);
   s(timerB.period);

--- a/ares/component/audio/ym2612/timer.cpp
+++ b/ares/component/audio/ym2612/timer.cpp
@@ -1,16 +1,15 @@
 auto YM2612::TimerA::run() -> void {
-  if(!enable) return;
-  if(++counter) return;
-
-  counter = period;
-  line |= irq;
+  if(!++counter)
+    line |= irq & enableLatch;
+  if(enableLatch < enable || !counter)
+    counter = period;
+  enableLatch = enable;
 }
 
 auto YM2612::TimerB::run() -> void {
-  if(!enable) return;
-  if(++divider) return;
-  if(++counter) return;
-
-  counter = period;
-  line |= irq;
+  if(!++divider && !++counter)
+    line |= irq & enableLatch;
+  if(enableLatch < enable || !counter && !divider)
+    counter = period; // do not reset divider on reenable
+  enableLatch = enable;
 }

--- a/ares/component/audio/ym2612/ym2612.hpp
+++ b/ares/component/audio/ym2612/ym2612.hpp
@@ -45,6 +45,7 @@ protected:
     auto run() -> void;
 
     n1  enable = 0;
+    n1  enableLatch = 0;
     n1  irq = 0;
     n1  line = 0;
     n10 period = 0;
@@ -56,6 +57,7 @@ protected:
     auto run() -> void;
 
     n1 enable = 0;
+    n1 enableLatch = 0;
     n1 irq = 0;
     n1 line = 0;
     n8 period = 0;

--- a/ares/md/m32x/io-external.cpp
+++ b/ares/md/m32x/io-external.cpp
@@ -35,7 +35,9 @@ auto M32X::readExternalIO(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
     data.bit(0) = dreq.vram;
     data.bit(1) = dreq.dma;
     data.bit(2) = dreq.active;
+    data.bit(3,6) = 0;
     data.bit(7) = dreq.fifo.full();
+    data.bit(8,15) = 0;
   }
 
   //68K to SH2 DREQ source address
@@ -62,9 +64,18 @@ auto M32X::readExternalIO(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
     data.byte(0) = dreq.length.byte(0);
   }
 
+  if(address == 0xa15114 ||
+     address == 0xa15116 ||
+     address == 0xa15118 ||
+     address == 0xa1511c ||
+     address == 0xa1511e) {
+    data = 0;
+  }
+
   //TV register
   if(address == 0xa1511a) {
     data.bit(0) = io.cartridgeMode;
+    data.bit(1,15) = 0;
   }
 
   //communication

--- a/ares/md/m32x/m32x.cpp
+++ b/ares/md/m32x/m32x.cpp
@@ -51,14 +51,11 @@ auto M32X::power(bool reset) -> void {
   shs.power(reset);
   vdp.power(reset);
   pwm.power(reset);
+  n32 vec4 = io.vectorLevel4;
   io = {};
+  if(reset) io.vectorLevel4 = vec4;
   dreq = {};
   for(auto& word : communication) word = 0;
-
-  io.vectorLevel4.byte(3) = vectors[0x70 >> 1].byte(1);
-  io.vectorLevel4.byte(2) = vectors[0x70 >> 1].byte(0);
-  io.vectorLevel4.byte(1) = vectors[0x72 >> 1].byte(1);
-  io.vectorLevel4.byte(0) = vectors[0x72 >> 1].byte(0);
 
   //connect interfaces
   shm.sci.link = shs;

--- a/ares/md/m32x/m32x.hpp
+++ b/ares/md/m32x/m32x.hpp
@@ -218,7 +218,7 @@ struct M32X {
 
     //$a15000
     n1 adapterEnable;
-    n1 adapterReset;
+    n1 adapterReset = 1;
     n1 resetEnable = 1;
 
     //$a15004

--- a/ares/md/system/serialization.cpp
+++ b/ares/md/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v142";
+static const string SerializerVersion = "v142.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);

--- a/ares/md/vdp/io.cpp
+++ b/ares/md/vdp/io.cpp
@@ -171,12 +171,6 @@ auto VDP::readControlPort() -> n16 {
 auto VDP::writeControlPort(n16 data) -> void {
   //command write (lo)
 
-  // Note: A pending interrupt will be delayed when a register write
-  // is used to enable that interrupt. Further testing is required,
-  // but the current method should be sufficient to handle most cases.
-  // Required for Sesame Street Counting Cafe et al.
-  irq.delay = 2; // 4 pixel delay (4-6 M68k clocks) from this write
-
   if(command.latch) {
     command.latch = 0;
 
@@ -222,6 +216,7 @@ auto VDP::writeControlPort(n16 data) -> void {
     io.counterLatch          = data.bit(1);
     io.videoMode4            = data.bit(2);
     irq.hblank.enable        = data.bit(4);
+    irq.delay = h40() ? 3 : 2; // 4-6 pixel delay (~6 M68k cycles)
     io.leftColumnBlank       = data.bit(5);
 
     if(!io.videoMode4) debug(unimplemented, "[VDP] M4=0");
@@ -237,6 +232,7 @@ auto VDP::writeControlPort(n16 data) -> void {
     }
     dma.enable         = data.bit(4);
     irq.vblank.enable  = data.bit(5);
+    irq.delay = h40() ? 3 : 2; // 4-6 pixel delay (~6 M68k cycles)
     io.displayEnable   = data.bit(6);
     vram.mode          = data.bit(7);
 

--- a/ares/md/vdp/irq.cpp
+++ b/ares/md/vdp/irq.cpp
@@ -30,7 +30,7 @@ auto VDP::IRQ::acknowledge(u8 level) -> void {
     else
       hblank.pending = 0;
   }
-  if(level == 6) vblank.pending = 0;
+  if(level == 6 && vblank.enable) vblank.pending = 0;
 }
 
 auto VDP::IRQ::power(bool reset) -> void {

--- a/ares/md/vdp/main.cpp
+++ b/ares/md/vdp/main.cpp
@@ -110,6 +110,7 @@ auto VDP::vtick() -> void {
   } else if(irq.hblank.counter-- == 0) {
     irq.hblank.counter = irq.hblank.frequency;
     irq.hblank.pending = 1;
+    irq.delay = h40() ? 3 : 2; // 4-6 pixel delay (~6 M68k cycles)
     debugger.interrupt(CPU::Interrupt::HorizontalBlank);
   }
 
@@ -147,6 +148,7 @@ auto VDP::vedge() -> void {
     cartridge.vblank(1);
     apu.setINT(1);
     irq.vblank.pending = 1;
+    irq.delay = h40() ? 3 : 2; // 4-6 pixel delay (~6 M68k cycles)
     debugger.interrupt(CPU::Interrupt::VerticalBlank);
   }
 }


### PR DESCRIPTION
ref: https://github.com/notaz/megadrive/tree/3d80f9400569f545d9e651a68aa0382f7ca6db40/testpico
(note: results reported from out-of-date build; need to check against latest)

1. Revised the vdp irq delay implementation based on testpico _42: irq f flag h40_ & _43: irq f flag h32_. The delay that occurs on vdp reg writes apparently occurs on normal irq triggers as well. Co-validated via gen_test_int_delay rom by Mask of Destiny. Additionallly, per _39: irq ack v-h 2_, v-int ack can be missed if v-irq is disabled prior to action.
2. Per testpico _44: 32x init_ & _50: 32x disable_, various unused reg bits should read as clear. Per _47: 32x md rom_, h-int vector should not be preinitialized. The fix was borrowed from the mcd, but the soft reset case is unverified.
3. YM2612 timer has particular behaviors covered by _34: timer b stop_ & _35: timer ab sync_. This mostly applies to timer b which counts by subticks (represented by _divider_ in source). These subticks are only reset in the case where period is set, but not when the timer is enabled. Also, there is an apparent latch effect on timer enables which affect timing.

NOT FIXED:
* Per _24: time z80 vdp_, access to the vdp from Z80 apparently incurs an average delay of ~2.5 cycles, not 3 cycles like the Z80 bank access. There may be other factors that affect timing (like repeated access), so a fix is on hold pending investigation.
* Some tests fail only when testpico is run as a 32X rom. This is a sync issue. Lowering the cpu sync threshold would fix this.
* testpico will run off the rails and start freezing up ares ~30 seconds after the tests has completed. This may be due to not handling SH-2 sleep/standby mode correctly.
