### PR TITLE
Update sha256 for Wonder Boy in Monster World (USA, Europe) for proper eeprom assignment

### DIFF
--- a/mia/medium/mega-drive.cpp
+++ b/mia/medium/mega-drive.cpp
@@ -615,7 +615,8 @@ auto MegaDrive::analyzeStorage(vector<u8>& rom, string hash) -> void {
   }
 
   //Wonder Boy in Monster World (USA, Europe)
-  if(hash == "8d905c863b73a1522f6ea734d630beae1b824b9eecb63f899534c02efbde20fd") {
+  if(hash == "8d905c863b73a1522f6ea734d630beae1b824b9eecb63f899534c02efbde20fd" ||  
+     hash == "6b2ac36f624f914ad26e32baa87d1253aea9dcfc13d2a5842ecdd2bd4a7a43b9") {
     eeprom.mode = "X24C01";
     eeprom.size = 128;
     eeprom.rsda = 0;

--- a/mia/medium/mega-drive.cpp
+++ b/mia/medium/mega-drive.cpp
@@ -615,7 +615,7 @@ auto MegaDrive::analyzeStorage(vector<u8>& rom, string hash) -> void {
   }
 
   //Wonder Boy in Monster World (USA, Europe)
-  if(hash == "6b2ac36f624f914ad26e32baa87d1253aea9dcfc13d2a5842ecdd2bd4a7a43b9") {
+  if(hash == "8d905c863b73a1522f6ea734d630beae1b824b9eecb63f899534c02efbde20fd") {
     eeprom.mode = "X24C01";
     eeprom.size = 128;
     eeprom.rsda = 0;


### PR DESCRIPTION
Looks like the has value we had for Wonder Boy in Monster World was outdated from the GoodGen era and was not current with the currently agreed dump of this game in No-Intro's DB. This resulted in a hang after pressing start at the main menu as EEPROM values were not being found. 

This update the sha256 hash with the currently accepted dump of this game. EEPROM values are now being found and assigned correctly and the game is now playable.