### PR TITLE
gb: tick timer on falling edge

### DIFF
--- a/ares/gb/cpu/cpu.hpp
+++ b/ares/gb/cpu/cpu.hpp
@@ -66,11 +66,8 @@ struct CPU : SM83, Thread {
   //timing.cpp
   auto step() -> void;
   auto step(u32 clocks) -> void;
-  auto timer262144hz() -> void;
-  auto timer65536hz() -> void;
-  auto timer16384hz() -> void;
+  auto timerTick() -> void;
   auto timer8192hz() -> void;
-  auto timer4096hz() -> void;
   auto timer1024hz() -> void;
   auto hblank() -> void;
   auto hblankTrigger() -> void;
@@ -79,6 +76,7 @@ struct CPU : SM83, Thread {
     n22 clock;
     n8  interruptLatch;
     n1  hblankPending;
+    n1  timerLine;
 
     //$ff00  JOYP
     n4 joyp;

--- a/ares/gb/cpu/serialization.cpp
+++ b/ares/gb/cpu/serialization.cpp
@@ -8,6 +8,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(status.clock);
   s(status.interruptLatch);
   s(status.hblankPending);
+  s(status.timerLine);
 
   s(status.joyp);
   s(status.p14);

--- a/ares/gb/system/serialization.cpp
+++ b/ares/gb/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v131";
+static const string SerializerVersion = "v143";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);

--- a/ares/sfc/system/serialization.cpp
+++ b/ares/sfc/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v131";
+static const string SerializerVersion = "v143";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Implements a [quirk](https://gbdev.io/pandocs/Timer_Obscure_Behaviour.html#relation-between-timer-and-divider-register) of the Game Boy timer hardware, where actions such as resetting DIV, disabling the timer, or changing the timer frequency, can sometimes cause a timer tick to occur. Passes five more [timer tests](https://github.com/Gekkio/mooneye-test-suite/tree/main/acceptance/timer) in the Mooneye test suite.