### PR TITLE
nall: Retrieve executable path more reliably

### DIFF
--- a/nall/nall/path.cpp
+++ b/nall/nall/path.cpp
@@ -25,9 +25,16 @@ NALL_HEADER_INLINE auto program() -> string {
     return Path::real(path);
   }
   #endif
-  Dl_info info;
-  dladdr((void*)&program, &info);
-  return Path::real(info.dli_fname);
+  char exe[PATH_MAX];
+  ssize_t count = readlink("/proc/self/exe", exe, PATH_MAX - 1);
+  if(count >= 0) {
+    exe[count] = '\0';
+    return Path::real(exe);
+  } else {
+    Dl_info info;
+    dladdr((void*)&program, &info);
+    return Path::real(info.dli_fname);
+  }
   #endif
 }
 


### PR DESCRIPTION
In a sandboxed Flatpak environment on Linux, the current `dladdr` strategy for retrieving the binary path seems to provide the bare executable name `ares` for `dli_fname` rather than the binary's full location. There don't seem to be any guarantees about what sort of path (relative or absolute) will be provided for `dli_fname`, so we shouldn't rely on it.

On platforms where `/proc/self/exe` is available, we can use that in conjunction with `readlink` instead.

If `/proc/self/exe` is not available, we will fall back to the current dladdr strategy. `readlink`, meanwhile, should be available on any *nix platform supported by ares.

> [!NOTE]
> Verified that this strategy works for retrieving the sandboxed binary path inside a Flatpak (`/app/bin/ares`), as intended.
