### PR TITLE
ruby: Update to SDL3

### DIFF
--- a/cmake/finders/FindSDL.cmake
+++ b/cmake/finders/FindSDL.cmake
@@ -42,7 +42,7 @@ include(FindPackageHandleStandardArgs)
 
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
-  pkg_search_module(PC_SDL QUIET sdl2)
+  pkg_search_module(PC_SDL QUIET sdl3)
 endif()
 
 # SDL_set_soname: Set SONAME on imported library target
@@ -64,10 +64,18 @@ macro(SDL_set_soname)
   unset(_result)
 endmacro()
 
+find_library(
+  SDL_LIBRARY
+  NAMES SDL3 SDL3-3.0.0 SDL3-3.0
+  HINTS ${PC_SDL_LIBRARY_DIRS}
+  PATHS ${CMAKE_SOURCE_DIR}/.deps /usr/lib /usr/local/lib
+  DOC "SDL location"
+)
+
 find_path(
   SDL_INCLUDE_DIR
-  NAMES SDL.h SDL2/SDL.h
-  HINTS ${PC_SDL_INCLUDE_DIRS}
+  NAMES SDL.h SDL3/SDL.h
+  HINTS ${PC_SDL_INCLUDE_DIRS} ${SDL_LIBRARY}/..
   PATHS ${CMAKE_SOURCE_DIR}/.deps /usr/include /usr/local/include
   DOC "SDL include directory"
   # "$<$<PLATFORM_ID:Darwin>:NO_DEFAULT_PATH>"
@@ -81,15 +89,6 @@ else()
   endif()
   set(SDL_VERSION 0.0.0)
 endif()
-
-find_library(
-  SDL_LIBRARY
-  NAMES SDL2 SDL2-2.0.0 SDL2-2.0
-  HINTS ${PC_SDL_LIBRARY_DIRS}
-  PATHS ${CMAKE_SOURCE_DIR}/.deps /usr/lib /usr/local/lib
-  DOC "SDL location"
-  # "$<$<PLATFORM_ID:Darwin>:NO_DEFAULT_PATH>"
-)
 
 if(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin|Windows")
   set(SDL_ERROR_REASON "Ensure that ares-deps are provided as part of CMAKE_PREFIX_PATH.")

--- a/cmake/macos/defaults.cmake
+++ b/cmake/macos/defaults.cmake
@@ -2,9 +2,6 @@
 
 include_guard(GLOBAL)
 
-# Required to avoid us finding a system SDL2.framework before our provided SDL2.dylib
-set(CMAKE_FIND_FRAMEWORK LAST)
-
 # Set empty codesigning team if not specified as cache variable
 if(NOT ARES_CODESIGN_TEAM)
   set(ARES_CODESIGN_TEAM "" CACHE STRING "ares code signing team for macOS" FORCE)

--- a/cmake/macos/helpers.cmake
+++ b/cmake/macos/helpers.cmake
@@ -112,8 +112,6 @@ function(_bundle_dependencies target)
 
       if(is_system_framework OR is_xcode_framework)
         continue()
-      elseif(is_framework)
-        file(REAL_PATH "../../.." library_location BASE_DIRECTORY "${imported_location}")
       elseif(_required_macos VERSION_GREATER CMAKE_OSX_DEPLOYMENT_TARGET)
         continue()
       elseif(NOT library_type STREQUAL "STATIC_LIBRARY")

--- a/ruby/cmake/os-macos.cmake
+++ b/ruby/cmake/os-macos.cmake
@@ -43,8 +43,7 @@ target_link_libraries(
 if(SDL_FOUND)
   target_link_libraries(
     ruby
-    PRIVATE "$<LINK_LIBRARY:WEAK_LIBRARY,SDL::SDL>"
-    # "$<$<BOOL:${SDL_FOUND}>:SDL::SDL>"
+    PRIVATE "$<LINK_LIBRARY:WEAK_FRAMEWORK,SDL::SDL>"
   )
 endif()
 

--- a/ruby/input/sdl.cpp
+++ b/ruby/input/sdl.cpp
@@ -1,4 +1,4 @@
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 #if defined(PLATFORM_WINDOWS)
 #include "shared/rawinput.cpp"


### PR DESCRIPTION
Draft status pending ares-deps update and further testing.

In the input subsystem, changes are mostly cosmetic with renamed functions and joystick enumeration being slightly different.

In the audio subsystem, there are somewhat more significant changes. Audio queues are replaced by audio streams. The conversation between the API and the host to get a desired buffer size proceeds differently; the only way to request a specific buffer size is now via an SDL_HINT. It seems like the behavior here is quite platform-dependent. On macOS at least, it looks like we actually have more precise control over our buffer sizes with SDL3; buffer sizes no longer need be powers of 2. Performance seems to be fine; blocking behavior is somewhat different but not significantly.