### PR TITLE
ruby: SDL2 input fixups

### DIFF
--- a/ruby/input/joypad/sdl.cpp
+++ b/ruby/input/joypad/sdl.cpp
@@ -94,10 +94,20 @@ private:
       Joypad jp;
       jp.id = id;
       jp.handle = SDL_JoystickOpen(jp.id);
+      if(!jp.handle) {
+        const char *err = SDL_GetError();
+        print("Error opening SDL joystick id ", id, ": ", err);
+        continue;
+      }
 
-      u32 axes = SDL_JoystickNumAxes(jp.handle);
-      u32 hats = SDL_JoystickNumHats(jp.handle) * 2;
-      u32 buttons = SDL_JoystickNumButtons(jp.handle);
+      s32 axes = SDL_JoystickNumAxes(jp.handle);
+      s32 hats = SDL_JoystickNumHats(jp.handle) * 2;
+      s32 buttons = SDL_JoystickNumButtons(jp.handle);
+      if(axes < 0 || hats < 0 || buttons < 0) {
+        const char *err = SDL_GetError();
+        print("Error retrieving SDL joystick information for device ", jp.handle, " at index ", id, ": ", err);
+        continue;
+      }
 
       u16 vid = SDL_JoystickGetVendor(jp.handle);
       u16 pid = SDL_JoystickGetProduct(jp.handle);


### PR DESCRIPTION
This should deal with at least one catastrophic failure condition present in the SDL driver:

First, `SDL_JoystickOpen` can return `NULL` if an error occurred, which we were not checking for.

If `SDL_JoystickOpen` returned `NULL`, then enumerating the control surfaces of the joystick would fail by returning negative numbers. We were assigning these return values to a `u32`, not checking for any failure condition, then iterating over it with a range-based for loop, adding nonexistent device property entries on each iteration.

It seems like this is a likely culprit for various reports of ares consuming all available system memory on startup under the SDL input driver.

This PR adds appropriate error checking in both the `SDL_JoystickOpen` call as well as the enumeration of the device properties.