### PR TITLE
ps1: gpu: Ensure hi >= lo when calling std::clamp()

### DIFF
--- a/ares/ps1/gpu/renderer.cpp
+++ b/ares/ps1/gpu/renderer.cpp
@@ -1,3 +1,5 @@
+#define clip(X, LO, HI) std::clamp((X), (((LO) <= (HI)) ? (LO) : (HI)), (((HI) >= (LO)) ? (HI) : (LO)))
+
 auto GPU::generateTables() -> void {
   static constexpr s8 table[4][4] = {
     {-4, +0, -3, +1},
@@ -165,10 +167,10 @@ auto GPU::Render::line() -> void {
   v0.x += drawingAreaOffsetX, v0.y += drawingAreaOffsetY;
   v1.x += drawingAreaOffsetX, v1.y += drawingAreaOffsetY;
 
-  v0.x = std::clamp(v0.x, drawingAreaOriginX1, drawingAreaOriginX2);
-  v0.y = std::clamp(v0.y, drawingAreaOriginY1, drawingAreaOriginY2);
-  v1.x = std::clamp(v1.x, drawingAreaOriginX1, drawingAreaOriginX2);
-  v1.y = std::clamp(v1.y, drawingAreaOriginY1, drawingAreaOriginY2);
+  v0.x = clip(v0.x, drawingAreaOriginX1, drawingAreaOriginX2);
+  v0.y = clip(v0.y, drawingAreaOriginY1, drawingAreaOriginY2);
+  v1.x = clip(v1.x, drawingAreaOriginX1, drawingAreaOriginX2);
+  v1.y = clip(v1.y, drawingAreaOriginY1, drawingAreaOriginY2);
 
   Point d = {v1.x - v0.x, v1.y - v0.y};
   s32 steps = abs(d.x) > abs(d.y) ? abs(d.x) : abs(d.y);
@@ -215,10 +217,10 @@ auto GPU::Render::triangle() -> void {
   if(vmax.x - vmin.x > 1024 || vmax.y - vmin.y > 512) return;
 
   //clip rendering to drawing area
-  vmin.x = std::clamp(vmin.x, drawingAreaOriginX1, drawingAreaOriginX2);
-  vmin.y = std::clamp(vmin.y, drawingAreaOriginY1, drawingAreaOriginY2);
-  vmax.x = std::clamp(vmax.x, drawingAreaOriginX1, drawingAreaOriginX2);
-  vmax.y = std::clamp(vmax.y, drawingAreaOriginY1, drawingAreaOriginY2);
+  vmin.x = clip(vmin.x, drawingAreaOriginX1, drawingAreaOriginX2);
+  vmin.y = clip(vmin.y, drawingAreaOriginY1, drawingAreaOriginY2);
+  vmax.x = clip(vmax.x, drawingAreaOriginX1, drawingAreaOriginX2);
+  vmax.y = clip(vmax.y, drawingAreaOriginY1, drawingAreaOriginY2);
 
   s32 area = weight(v0, v1, v2);  //<0 = counter-clockwise; 0 = colinear, >0 = clockwise
   if(area == 0) return;  //do not render colinear triangles


### PR DESCRIPTION
On Lunar Disc 1, when entering Berg (about two minutes in,) going into Alex's house or the barn to the right of it, winds up causing an assertion failure in std::clamp() on the screen transition. Could be a bug in the game where it sends the 0xe3/0xe4 coords in the wrong order, or if it's off by one calculating them. Not sure if the real hardware ignores it or does anything in particular as a result.

Adding some print() calls in ``GPU::Render::triangle()`` before the clamp, I see:
```
v0=(320,216), v1=(336,216) v2=(320,232)
vmin.x=320, x1=160 x2=159
vmin.y=216, y1=112 y2=111
vmax.x=336, x1=160 x2=159
vmax.y=232, y1=112 y2=111

/usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/stl_algo.h:3626: constexpr const _Tp& std::clamp(const _Tp&, const _Tp&, const _Tp&) [with _Tp = int]: Assertion '!(__hi < __lo)' failed.
```

Thus, this patch ensures ``hi >= lo``.
