### PR TITLE
gba: latch lower ROM address lines during burst transfer

### DIFF
--- a/ares/component/processor/arm7tdmi/arm7tdmi.hpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.hpp
@@ -6,15 +6,13 @@ namespace ares {
 
 struct ARM7TDMI {
   enum : u32 {
-    Nonsequential = 1 << 0,  //N cycle
-    Sequential    = 1 << 1,  //S cycle
+    Load          = 1 << 0,  //load operation
+    Store         = 1 << 1,  //store operation
     Prefetch      = 1 << 2,  //instruction fetch
     Byte          = 1 << 3,  // 8-bit access
     Half          = 1 << 4,  //16-bit access
     Word          = 1 << 5,  //32-bit access
-    Load          = 1 << 6,  //load operation
-    Store         = 1 << 7,  //store operation
-    Signed        = 1 << 8,  //sign-extend
+    Signed        = 1 << 6,  //sign-extend
   };
 
   virtual auto step(u32 clocks) -> void = 0;
@@ -44,6 +42,7 @@ struct ARM7TDMI {
   auto load(u32 mode, n32 address) -> n32;
   auto write(u32 mode, n32 address, n32 word) -> void;
   auto store(u32 mode, n32 address, n32 word) -> void;
+  auto endBurst() -> void { nonsequential = true; return; }
 
   //algorithms.cpp
   auto ADD(n32, n32, bool) -> n32;
@@ -221,7 +220,6 @@ struct ARM7TDMI {
     };
 
     n1 reload = 1;
-    n1 nonsequential = 1;
     Instruction fetch;
     Instruction decode;
     Instruction execute;
@@ -230,6 +228,7 @@ struct ARM7TDMI {
   n32 opcode;
   b1  carry;
   b1  irq;
+  b1  nonsequential;
 
   function<void (n32 opcode)> armInstruction[4096];
   function<void ()> thumbInstruction[65536];

--- a/ares/component/processor/arm7tdmi/disassembler.cpp
+++ b/ares/component/processor/arm7tdmi/disassembler.cpp
@@ -17,12 +17,12 @@ auto ARM7TDMI::disassembleInstruction(maybe<n32> pc, maybe<boolean> thumb) -> st
 
   _pc = pc();
   if(!thumb()) {
-    n32 opcode = getDebugger(Word | Nonsequential, _pc & ~3);
+    n32 opcode = getDebugger(Word, _pc & ~3);
     n12 index = (opcode & 0x0ff00000) >> 16 | (opcode & 0x000000f0) >> 4;
     _c = _conditions[opcode >> 28];
     return pad(armDisassemble[index](opcode), -40);
   } else {
-    n16 opcode = getDebugger(Half | Nonsequential, _pc & ~1);
+    n16 opcode = getDebugger(Half, _pc & ~1);
     return pad(thumbDisassemble[opcode](), -40);
   }
 }
@@ -121,7 +121,7 @@ auto ARM7TDMI::armDisassembleDataRegisterShift
 auto ARM7TDMI::armDisassembleLoadImmediate
 (n8 immediate, n1 half, n4 d, n4 n, n1 writeback, n1 up, n1 pre) -> string {
   string data;
-  if(n == 15) data = {" =0x", hex(getDebugger((half ? Half : Byte) | Nonsequential,
+  if(n == 15) data = {" =0x", hex(getDebugger((half ? Half : Byte),
     _pc + 8 + (up ? +immediate : -immediate)), half ? 4L : 2L)};
 
   return {"ldr", _c, half ? "sh" : "sb", " ",
@@ -150,7 +150,7 @@ auto ARM7TDMI::armDisassembleMemorySwap
 auto ARM7TDMI::armDisassembleMoveHalfImmediate
 (n8 immediate, n4 d, n4 n, n1 mode, n1 writeback, n1 up, n1 pre) -> string {
   string data;
-  if(n == 15) data = {" =0x", hex(getDebugger(Half | Nonsequential, _pc + (up ? +immediate : -immediate)), 4L)};
+  if(n == 15) data = {" =0x", hex(getDebugger(Half, _pc + (up ? +immediate : -immediate)), 4L)};
 
   return {mode ? "ldr" : "str", _c, "h ",
     _r[d], ",[", _r[n],
@@ -173,7 +173,7 @@ auto ARM7TDMI::armDisassembleMoveHalfRegister
 auto ARM7TDMI::armDisassembleMoveImmediateOffset
 (n12 immediate, n4 d, n4 n, n1 mode, n1 writeback, n1 byte, n1 up, n1 pre) -> string {
   string data;
-  if(n == 15) data = {" =0x", hex(getDebugger((byte ? Byte : Word) | Nonsequential,
+  if(n == 15) data = {" =0x", hex(getDebugger((byte ? Byte : Word),
     _pc + 8 + (up ? +immediate : -immediate)), byte ? 2L : 4L)};
   return {mode ? "ldr" : "str", _c, byte ? "b" : "", " ", _r[d], ",[", _r[n],
     pre == 0 ? "]" : "",
@@ -308,7 +308,7 @@ auto ARM7TDMI::thumbDisassembleBranchExchange
 
 auto ARM7TDMI::thumbDisassembleBranchFarPrefix
 (i11 displacementHi) -> string {
-  n11 displacementLo = getDebugger(Half | Nonsequential, (_pc & ~1) + 2);
+  n11 displacementLo = getDebugger(Half, (_pc & ~1) + 2);
   i22 displacement = displacementHi << 11 | displacementLo << 0;
   n32 address = _pc + 4 + displacement * 2;
   return {"bl 0x", hex(address, 8L)};
@@ -340,7 +340,7 @@ auto ARM7TDMI::thumbDisassembleImmediate
 auto ARM7TDMI::thumbDisassembleLoadLiteral
 (n8 displacement, n3 d) -> string {
   n32 address = ((_pc + 4) & ~3) + (displacement << 2);
-  n32 data = getDebugger(Word | Nonsequential, address);
+  n32 data = getDebugger(Word, address);
   return {"ldr ", _r[d], ",[pc,#0x", hex(address, 8L), "] =0x", hex(data, 8L)};
 }
 

--- a/ares/component/processor/arm7tdmi/instruction.cpp
+++ b/ares/component/processor/arm7tdmi/instruction.cpp
@@ -3,9 +3,10 @@ auto ARM7TDMI::reload() -> void {
   u32 size = !cpsr().t ? Word : Half;
 
   pipeline.reload = false;
+  endBurst();
   r(15).data &= ~mask;
   pipeline.fetch.address = r(15) & ~mask;
-  pipeline.fetch.instruction = read(Prefetch | size | Nonsequential, pipeline.fetch.address);
+  pipeline.fetch.instruction = read(Prefetch | size, pipeline.fetch.address);
   fetch();
 }
 
@@ -16,18 +17,12 @@ auto ARM7TDMI::fetch() -> void {
   pipeline.decode.thumb = cpsr().t;
   pipeline.decode.irq = !cpsr().i;
 
-  u32 sequential = Sequential;
-  if(pipeline.nonsequential) {
-    pipeline.nonsequential = false;
-    sequential = Nonsequential;
-  }
-
   u32 mask = !cpsr().t ? 3 : 1;
   u32 size = !cpsr().t ? Word : Half;
 
   r(15).data += size >> 3;
   pipeline.fetch.address = r(15) & ~mask;
-  pipeline.fetch.instruction = read(Prefetch | size | sequential, pipeline.fetch.address);
+  pipeline.fetch.instruction = read(Prefetch | size, pipeline.fetch.address);
 }
 
 auto ARM7TDMI::instruction() -> void {

--- a/ares/component/processor/arm7tdmi/instructions-arm.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-arm.cpp
@@ -108,7 +108,7 @@ auto ARM7TDMI::armInstructionLoadImmediate
   n32 rd = r(d);
 
   if(pre == 1) rn = up ? rn + immediate : rn - immediate;
-  rd = load((half ? Half : Byte) | Nonsequential | Signed, rn);
+  rd = load((half ? Half : Byte) | Signed, rn);
   if(pre == 0) rn = up ? rn + immediate : rn - immediate;
 
   if(pre == 0 || writeback) r(n) = rn;
@@ -122,7 +122,7 @@ auto ARM7TDMI::armInstructionLoadRegister
   n32 rd = r(d);
 
   if(pre == 1) rn = up ? rn + rm : rn - rm;
-  rd = load((half ? Half : Byte) | Nonsequential | Signed, rn);
+  rd = load((half ? Half : Byte) | Signed, rn);
   if(pre == 0) rn = up ? rn + rm : rn - rm;
 
   if(pre == 0 || writeback) r(n) = rn;
@@ -132,8 +132,8 @@ auto ARM7TDMI::armInstructionLoadRegister
 auto ARM7TDMI::armInstructionMemorySwap
 (n4 m, n4 d, n4 n, n1 byte) -> void {
   lock();
-  n32 word = load((byte ? Byte : Word) | Nonsequential, r(n));
-  store((byte ? Byte : Word) | Nonsequential, r(n), r(m));
+  n32 word = load((byte ? Byte : Word), r(n));
+  store((byte ? Byte : Word), r(n), r(m));
   r(d) = word;
   unlock();
 }
@@ -144,8 +144,8 @@ auto ARM7TDMI::armInstructionMoveHalfImmediate
   n32 rd = r(d);
 
   if(pre == 1) rn = up ? rn + immediate : rn - immediate;
-  if(mode == 1) rd = load(Half | Nonsequential, rn);
-  if(mode == 0) store(Half | Nonsequential, rn, rd);
+  if(mode == 1) rd = load(Half, rn);
+  if(mode == 0) store(Half, rn, rd);
   if(pre == 0) rn = up ? rn + immediate : rn - immediate;
 
   if(pre == 0 || writeback) r(n) = rn;
@@ -159,8 +159,8 @@ auto ARM7TDMI::armInstructionMoveHalfRegister
   n32 rd = r(d);
 
   if(pre == 1) rn = up ? rn + rm : rn - rm;
-  if(mode == 1) rd = load(Half | Nonsequential, rn);
-  if(mode == 0) store(Half | Nonsequential, rn, rd);
+  if(mode == 1) rd = load(Half, rn);
+  if(mode == 0) store(Half, rn, rd);
   if(pre == 0) rn = up ? rn + rm : rn - rm;
 
   if(pre == 0 || writeback) r(n) = rn;
@@ -173,8 +173,8 @@ auto ARM7TDMI::armInstructionMoveImmediateOffset
   n32 rd = r(d) + (d == 15 ? 4 : 0);
 
   if(pre == 1) rn = up ? rn + immediate : rn - immediate;
-  if(mode == 1) rd = load((byte ? Byte : Word) | Nonsequential, rn);
-  if(mode == 0) store((byte ? Byte : Word) | Nonsequential, rn, rd);
+  if(mode == 1) rd = load((byte ? Byte : Word), rn);
+  if(mode == 0) store((byte ? Byte : Word), rn, rd);
   if(pre == 0) rn = up ? rn + immediate : rn - immediate;
 
   if(pre == 0 || writeback) r(n) = rn;
@@ -201,17 +201,16 @@ auto ARM7TDMI::armInstructionMoveMultiple
   if(type && mode == 0) usr = true;
   if(usr) cpsr().m = PSR::USR;
 
-  u32 sequential = Nonsequential;
+  endBurst();
   if(!list) {
-    if(mode == 1) r(15) = read(Word | sequential, rn);
-    if(mode == 0) write(Word | sequential, rn, r(15) + 4);
+    if(mode == 1) r(15) = read(Word, rn);
+    if(mode == 0) write(Word, rn, r(15) + 4);
   } else {
     for(u32 m : range(16)) {
       if(!list.bit(m)) continue;
-      if(mode == 1) r(m) = read(Word | sequential, rn);
-      if(mode == 0) write(Word | sequential, rn, r(m) + (m == 15 ? 4 : 0));
+      if(mode == 1) r(m) = read(Word, rn);
+      if(mode == 0) write(Word, rn, r(m) + (m == 15 ? 4 : 0));
       rn += 4;
-      sequential = Sequential;
     }
   }
 
@@ -223,7 +222,7 @@ auto ARM7TDMI::armInstructionMoveMultiple
       cpsr() = spsr();
     }
   } else {
-    pipeline.nonsequential = true;
+    endBurst();
   }
 
   if(writeback && mode == 0) {
@@ -247,8 +246,8 @@ auto ARM7TDMI::armInstructionMoveRegisterOffset
   }
 
   if(pre == 1) rn = up ? rn + rm : rn - rm;
-  if(mode == 1) rd = load((byte ? Byte : Word) | Nonsequential, rn);
-  if(mode == 0) store((byte ? Byte : Word) | Nonsequential, rn, rd);
+  if(mode == 1) rd = load((byte ? Byte : Word), rn);
+  if(mode == 0) store((byte ? Byte : Word), rn, rd);
   if(pre == 0) rn = up ? rn + rm : rn - rm;
 
   if(pre == 0 || writeback) r(n) = rn;

--- a/ares/component/processor/arm7tdmi/memory.cpp
+++ b/ares/component/processor/arm7tdmi/memory.cpp
@@ -1,14 +1,16 @@
 auto ARM7TDMI::idle() -> void {
-  pipeline.nonsequential = true;
+  endBurst();
   sleep();
 }
 
 auto ARM7TDMI::read(u32 mode, n32 address) -> n32 {
-  return get(mode, address);
+  n32 word = get(mode, address);
+  nonsequential = false;  //allows burst transfer to continue
+  return word;
 }
 
 auto ARM7TDMI::load(u32 mode, n32 address) -> n32 {
-  pipeline.nonsequential = true;
+  endBurst();
   auto word = get(Load | mode, address);
   if(mode & Half) {
     address &= 1;
@@ -28,12 +30,13 @@ auto ARM7TDMI::load(u32 mode, n32 address) -> n32 {
 }
 
 auto ARM7TDMI::write(u32 mode, n32 address, n32 word) -> void {
-  pipeline.nonsequential = true;
-  return set(mode, address, word);
+  set(mode, address, word);
+  nonsequential = false;  //allows burst transfer to continue
+  return;
 }
 
 auto ARM7TDMI::store(u32 mode, n32 address, n32 word) -> void {
-  pipeline.nonsequential = true;
+  endBurst();
   if(mode & Half) { word &= 0xffff; word |= word << 16; }
   if(mode & Byte) { word &= 0xff; word |= word << 8; word |= word << 16; }
   return set(Store | mode, address, word);

--- a/ares/component/processor/arm7tdmi/serialization.cpp
+++ b/ares/component/processor/arm7tdmi/serialization.cpp
@@ -3,6 +3,7 @@ auto ARM7TDMI::serialize(serializer& s) -> void {
   s(pipeline);
   s(carry);
   s(irq);
+  s(nonsequential);
 }
 
 auto ARM7TDMI::Processor::serialize(serializer& s) -> void {
@@ -58,7 +59,6 @@ auto ARM7TDMI::PSR::serialize(serializer& s) -> void {
 
 auto ARM7TDMI::Pipeline::serialize(serializer& s) -> void {
   s(reload);
-  s(nonsequential);
   s(fetch.address);
   s(fetch.instruction);
   s(fetch.thumb);

--- a/ares/gba/cartridge/cartridge.hpp
+++ b/ares/gba/cartridge/cartridge.hpp
@@ -17,10 +17,55 @@ struct Cartridge {
   auto save() -> void;
   auto power() -> void;
 
-  auto readRom(u32 mode, n32 address) -> n32;
-  auto readBackup(u32 mode, n32 address) -> n32;
-  auto writeRom(u32 mode, n32 address, n32 word) -> void;
-  auto writeBackup(u32 mode, n32 address, n32 word) -> void;
+  template<bool UseDebugger>
+  auto readRom(u32 mode, n32 address) -> n32 {
+    if(mode & Word) {
+      n32 word = 0;
+      word |= readRom<UseDebugger>(mode & ~Word | Half, (address & ~3) + 0) <<  0;
+      word |= readRom<UseDebugger>(Sequential | Half, (address & ~3) + 2) << 16;
+      return word;
+    }
+
+    if(has.eeprom && (address & eeprom.mask) == eeprom.test) return eeprom.read();
+
+    n32 romAddr;
+    if constexpr(!UseDebugger) romAddr = mrom.burstAddr(mode, address);
+    if constexpr( UseDebugger) romAddr = address & 0x1ff'fffe;
+    n16 half = mrom.read(mode, romAddr);
+    if constexpr(!UseDebugger) mrom.pageAddr++;
+
+    if(mode & Byte) return half.byte(address & 1);
+    return half;
+  }
+
+  auto readBackup(u32 mode, n32 address) -> n32 {
+    n32 word = 0xff;
+    if(has.sram) word = sram.read(address);
+    if(has.flash) word = flash.read(address);
+    word *= 0x01010101;
+    return word;
+  }
+
+  auto writeRom(u32 mode, n32 address, n32 word) -> void {
+    if(mode & Word) {
+      writeRom(mode & ~Word | Half, (address & ~3) + 0, word >> 0);
+      writeRom(Sequential | Half, (address & ~3) + 2, word >> 16);
+    }
+
+    if(has.eeprom && (address & eeprom.mask) == eeprom.test) return eeprom.write(word & 1);
+
+    n32 romAddr = mrom.burstAddr(mode, address);
+    mrom.write(mode, romAddr, word);
+    mrom.pageAddr++;
+    return;
+  }
+
+  auto writeBackup(u32 mode, n32 address, n32 word) -> void {
+    if(mode & Word) word = word >> (8 * (address & 3));
+    if(mode & Half) word = word >> (8 * (address & 1));
+    if(has.sram) return sram.write(address, word);
+    if(has.flash) return flash.write(address, word);
+  }
 
   auto serialize(serializer&) -> void;
 

--- a/ares/gba/cartridge/memory.hpp
+++ b/ares/gba/cartridge/memory.hpp
@@ -1,14 +1,17 @@
 struct MROM {
   //mrom.cpp
   auto read(u32 mode, n32 address) -> n16;
-  auto write(u32 mode, n32 address, n32 word) -> void;
+  auto write(u32 mode, n32 address, n16 half) -> void;
+  auto burstAddr(u32 mode, n32 address) -> n32;
 
   //serialization.cpp
   auto serialize(serializer&) -> void;
 
-  n8* data = nullptr;
+  Memory::Readable<n16> data;
   u32 size;
   u32 mask;
+  n16 pageAddr;
+  n1  burst;
   bool mirror;
 } mrom;
 

--- a/ares/gba/cartridge/mrom.cpp
+++ b/ares/gba/cartridge/mrom.cpp
@@ -1,16 +1,26 @@
 auto Cartridge::MROM::read(u32 mode, n32 address) -> n16 {
-  address &= 0x01ff'ffff;
-
+  //out-of-bounds accesses
   if(address >= size) {
-    if(!mirror) return (n16)(address >> 1);
-    address &= size - 1;
+    if(!mirror) return pageAddr;
+    address &= (size - 1);
   }
 
-  if(mode & Half) address &= ~1;
-  auto p = data + address;
-  if(mode & Half) return p[0] << 0 | p[1] << 8;
-  return p[0] << 0;
+  return data[address >> 1];
 }
 
-auto Cartridge::MROM::write(u32 mode, n32 address, n32 word) -> void {
+auto Cartridge::MROM::write(u32 mode, n32 address, n16 half) -> void {
+}
+
+auto Cartridge::MROM::burstAddr(u32 mode, n32 address) -> n32 {
+  //use latched lower 16 bits of address lines if sequential
+  n8 page = address >> 17;
+  if(mode & Nonsequential) {
+    pageAddr = address >> 1;
+    burst = true;
+  }
+
+  //end burst transfer if requesting last address on page
+  if((address & 0x1fffe) == 0x1fffe) burst = false;
+
+  return (page << 17) | (pageAddr << 1);
 }

--- a/ares/gba/cartridge/serialization.cpp
+++ b/ares/gba/cartridge/serialization.cpp
@@ -8,6 +8,8 @@ auto Cartridge::serialize(serializer& s) -> void {
 auto Cartridge::MROM::serialize(serializer& s) -> void {
   s(size);
   s(mask);
+  s(pageAddr);
+  s(burst);
 }
 
 auto Cartridge::SRAM::serialize(serializer& s) -> void {

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -68,6 +68,7 @@ struct CPU : ARM7TDMI, Thread, IO {
   auto unlock() -> void override;
   auto waitEWRAM(u32 mode) -> u32;
   auto waitCartridge(u32 mode, n32 address) -> u32;
+  auto cartMode(u32 mode, n32 address) -> u32;
 
   //io.cpp
   auto readIO(n32 address) -> n8 override;
@@ -260,8 +261,9 @@ struct CPU : ARM7TDMI, Thread, IO {
     n1  halted;
     n1  stopped;
     n1  booted;  //set to true by the GBA BIOS
-    n1  dmaRan;
+    n1  romAccess;
     n1  dmaRomAccess;
+    n1  dmaRan;
     n1  dmaActive;
     n2  dmaActiveChannel;
     n1  timerLatched;

--- a/ares/gba/cpu/dma.cpp
+++ b/ares/gba/cpu/dma.cpp
@@ -28,9 +28,7 @@ auto CPU::DMA::transfer() -> void {
     n32 addr = latch.source();
     if(mode & Word) addr &= ~3;
     if(mode & Half) addr &= ~1;
-    u32 sequential = Nonsequential;
-    if(cpu.context.dmaRomAccess) sequential = Sequential;
-    latch.data = cpu.get(mode | sequential, addr);
+    latch.data = cpu.get(mode, addr);
     if(mode & Half) latch.data |= latch.data << 16;
   }
 
@@ -40,9 +38,7 @@ auto CPU::DMA::transfer() -> void {
     n32 addr = latch.target();
     if(mode & Word) addr &= ~3;
     if(mode & Half) addr &= ~1;
-    u32 sequential = Nonsequential;
-    if(cpu.context.dmaRomAccess) sequential = Sequential;
-    cpu.set(mode | sequential, addr, latch.data >> (addr & 2) * 8);
+    cpu.set(mode, addr, latch.data >> (addr & 2) * 8);
   }
 
   switch(sourceMode) {

--- a/ares/gba/cpu/prefetch.cpp
+++ b/ares/gba/cpu/prefetch.cpp
@@ -15,7 +15,7 @@ auto CPU::prefetchStep(u32 clocks) -> void {
 
   while(!prefetch.full() && clocks--) {
     if(--prefetch.wait) continue;
-    prefetch.slot[prefetch.load >> 1 & 7] = cartridge.readRom(Half, prefetch.load);
+    prefetch.slot[prefetch.load >> 1 & 7] = cartridge.readRom<false>(Half | Nonsequential, prefetch.load);  //todo: make access sequentiality consistent with timing used
     prefetch.load += 2;
     prefetch.wait = waitCartridge(Half | Sequential, prefetch.load);
   }

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -113,8 +113,9 @@ auto CPU::serialize(serializer& s) -> void {
   s(context.halted);
   s(context.stopped);
   s(context.booted);
-  s(context.dmaRan);
+  s(context.romAccess);
   s(context.dmaRomAccess);
+  s(context.dmaRan);
   s(context.dmaActive);
   s(context.dmaActiveChannel);
   s(context.timerLatched);

--- a/ares/gba/gba.hpp
+++ b/ares/gba/gba.hpp
@@ -12,15 +12,15 @@ namespace ares::GameBoyAdvance {
   auto option(string name, string value) -> bool;
 
   enum : u32 {           //mode flags for bus read, write:
-    Nonsequential =   1,  //N cycle
-    Sequential    =   2,  //S cycle
+    Load          =   1,  //load operation
+    Store         =   2,  //store operation
     Prefetch      =   4,  //instruction fetch (eligible for prefetch)
     Byte          =   8,  //8-bit access
     Half          =  16,  //16-bit access
     Word          =  32,  //32-bit access
-    Load          =  64,  //load operation
-    Store         = 128,  //store operation
-    Signed        = 256,  //sign extended
+    Signed        =  64,  //sign extended
+    Nonsequential = 128,  //N cycle
+    Sequential    = 256,  //S cycle
   };
 
   struct Model {

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v142";
+static const string SerializerVersion = "v143";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);

--- a/tests/arm7tdmi/arm7tdmi.cpp
+++ b/tests/arm7tdmi/arm7tdmi.cpp
@@ -117,8 +117,8 @@ struct CPU : ares::ARM7TDMI {
       }
       if(result) {
         //don't check sequential unless we got a result, otherwise it's just noise
-        if(!(mode & Sequential) != !(t.access & Access::Sequential)) {
-          error("write: nonsequential ", !(mode & Sequential), " != ", !(t.access & Access::Sequential), "\n");
+        if(!(!nonsequential) != !(t.access & Access::Sequential)) {
+          error("write: nonsequential ", !(!nonsequential), " != ", !(t.access & Access::Sequential), "\n");
           result = nothing;
         }
       }
@@ -231,7 +231,7 @@ auto CPU::run(const TestCase& test, bool logErrors) -> TestResult {
   if(!thumb && (test.opcode & 0b00001111101111110000000011110000) == 0b0000'00010'0'001111'00000000'1001'0000) return skip;
 
   pipeline.reload = false;
-  pipeline.nonsequential = !(is.access & Access::Sequential);
+  nonsequential = !(is.access & Access::Sequential);
 
   pipeline.decode.address = test.base_addr;
   pipeline.decode.instruction = is.pipeline[0];
@@ -334,7 +334,7 @@ auto CPU::run(const TestCase& test, bool logErrors) -> TestResult {
   if(pipeline.fetch.instruction != fs.pipeline[1]) error("pipeline[1]: ", hex(u32(pipeline.decode.instruction), 8), " != ", hex(fs.pipeline[1], 8));
   //todo: fails some tests in arm_data_proc_register_shift, thumb_data_proc that operate on registers
   //should e.g. asr r4,r4 really change the state to nonsequential?
-  //if(pipeline.nonsequential != !(fs.access & Access::Sequential)) error("nonsequential: ", pipeline.nonsequential, " != ", !(fs.access & Access::Sequential));
+  //if(nonsequential != !(fs.access & Access::Sequential)) error("nonsequential: ", nonsequential, " != ", !(fs.access & Access::Sequential));
 
   if(tindex != test.transactions.size()) {
     error("transactions: ", tindex, " != ", test.transactions.size(), "\n");


### PR DESCRIPTION
Implements a hardware quirk that can cause DMA to read from incorrect addresses in ROM.