### PR TITLE
gba: fix oversight with Classic NES Series game code list

### DIFF
--- a/mia/medium/game-boy-advance.cpp
+++ b/mia/medium/game-boy-advance.cpp
@@ -87,6 +87,7 @@ auto GameBoyAdvance::analyze(vector<u8>& rom) -> string {
     "FP7E",  //Classic NES Series - Pac-Man (USA, Europe)
     "FXVE",  //Classic NES Series - Xevious (USA, Europe)
     "FLBE",  //Classic NES Series - Zelda II - The Adventure of Link (USA, Europe)
+    "FADP",  //NES Classics - Castlevania (Europe)
     "FSRJ",  //Famicom Mini - Dai-2-ji Super Robot Taisen (Japan) (Promo)
     "FGZJ",  //Famicom Mini - Kidou Senshi Z Gundam - Hot Scramble (Japan) (Promo)
     "FSMJ",  //Famicom Mini 01 - Super Mario Bros. (Japan) (En) (Rev 1)


### PR DESCRIPTION
When writing #1456, I wasn't aware that "NES Classics - Castlevania (Europe)" had a unique naming convention compared to all the other Classic NES Series and Famicom Mini titles, so it didn't show up when I searched the No-Intro website for game ID codes.

Closes #1868.