### PR TITLE
ws: APU accuracy fixes

### DIFF
--- a/ares/ws/apu/apu.hpp
+++ b/ares/ws/apu/apu.hpp
@@ -155,7 +155,6 @@ struct APU : Thread, IO {
       n4  volumeLeft;
       n4  volumeRight;
       n3  noiseMode;
-      n1  noiseReset;
       n1  noiseUpdate;
       n1  enable;
       n1  noise;

--- a/ares/ws/apu/channel1.cpp
+++ b/ares/ws/apu/channel1.cpp
@@ -1,7 +1,9 @@
 auto APU::Channel1::tick() -> void {
-  if(--state.period == io.pitch) {
-    state.period = 0;
-    state.sampleOffset++;
+  if(io.enable) {
+    if(--state.period == io.pitch) {
+      state.period = 0;
+      state.sampleOffset++;
+    }
   }
 }
 

--- a/ares/ws/apu/channel2.cpp
+++ b/ares/ws/apu/channel2.cpp
@@ -1,5 +1,5 @@
 auto APU::Channel2::tick() -> void {
-  if(!io.voice) {
+  if(io.enable) {
     if(--state.period == io.pitch) {
       state.period = 0;
       state.sampleOffset++;

--- a/ares/ws/apu/channel3.cpp
+++ b/ares/ws/apu/channel3.cpp
@@ -6,9 +6,11 @@ auto APU::Channel3::sweep() -> void {
 }
 
 auto APU::Channel3::tick() -> void {
-  if(--state.period == io.pitch) {
-    state.period = 0;
-    state.sampleOffset++;
+  if(io.enable) {
+    if(--state.period == io.pitch) {
+      state.period = 0;
+      state.sampleOffset++;
+    }
   }
 }
 

--- a/ares/ws/apu/channel4.cpp
+++ b/ares/ws/apu/channel4.cpp
@@ -3,22 +3,18 @@ auto APU::Channel4::noiseSample() -> n4 {
 }
 
 auto APU::Channel4::tick() -> void {
-  if(--state.period == io.pitch) {
-    state.period = 0;
-    state.sampleOffset++;
+  if(io.enable) {
+    if(--state.period == io.pitch) {
+      state.period = 0;
+      state.sampleOffset++;
 
-    if(io.noiseReset) {
-      io.noiseReset = 0;
-      state.noiseLFSR = 0;
-      state.noiseOutput = 0;
-    }
+      if(io.noise && io.noiseUpdate && !apu.io.seqDbgNoise) {
+        static constexpr s32 taps[8] = {14, 10, 13, 4, 8, 6, 9, 11};
+        auto tap = taps[io.noiseMode];
 
-    if(io.noiseUpdate && !apu.io.seqDbgNoise) {
-      static constexpr s32 taps[8] = {14, 10, 13, 4, 8, 6, 9, 11};
-      auto tap = taps[io.noiseMode];
-
-      state.noiseOutput = (1 ^ (state.noiseLFSR >> 7) ^ (state.noiseLFSR >> tap)) & 1;
-      state.noiseLFSR = state.noiseLFSR << 1 | state.noiseOutput;
+        state.noiseOutput = (1 ^ (state.noiseLFSR >> 7) ^ (state.noiseLFSR >> tap)) & 1;
+        state.noiseLFSR = state.noiseLFSR << 1 | state.noiseOutput;
+      }
     }
   }
 }

--- a/ares/ws/apu/io.cpp
+++ b/ares/ws/apu/io.cpp
@@ -255,8 +255,10 @@ auto APU::writeIO(n16 address, n8 data) -> void {
 
   case 0x008e:  //SND_NOISE
     channel4.io.noiseMode   = data.bit(0,2);
-    channel4.io.noiseReset  = data.bit(3);
     channel4.io.noiseUpdate = data.bit(4);
+    if (data.bit(3)) {
+      channel4.state.noiseLFSR = 0;
+    }
     break;
 
   case 0x008f:  //SND_WAVE_BASE

--- a/ares/ws/apu/serialization.cpp
+++ b/ares/ws/apu/serialization.cpp
@@ -84,7 +84,6 @@ auto APU::Channel4::serialize(serializer& s) -> void {
   s(io.volumeLeft);
   s(io.volumeRight);
   s(io.noiseMode);
-  s(io.noiseReset);
   s(io.noiseUpdate);
   s(io.enable);
   s(io.noise);

--- a/ares/ws/system/serialization.cpp
+++ b/ares/ws/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v144.1";
+static const string SerializerVersion = "v144.2";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
- the noise LFSR reset bit takes effect immediately
- channel period counters tick only when they're enabled, including if channel 2 is in voice mode or channel 4 is in noise mode
- the noise LFSR only ticks if channel 4 is enabled in noise mode

Spent this evening writing a test to cover all of this.