### PR TITLE
v30mz: make I/O access timing marginally more accurate

### DIFF
--- a/ares/component/processor/v30mz/instructions-misc.cpp
+++ b/ares/component/processor/v30mz/instructions-misc.cpp
@@ -43,21 +43,27 @@ auto V30MZ::instructionUndefined1() -> void {
 }
 
 template<u32 size> auto V30MZ::instructionIn() -> void {
-  wait(6);
+  // TODO: The exact cycle on which I/O access is performed remains unknown.
+  wait(5);
   setAccumulator<size>(in<size>(fetch<Byte>()));
+  wait(1);
 }
 
 template<u32 size> auto V30MZ::instructionOut() -> void {
+  // TODO: The exact cycle on which I/O access is performed remains unknown.
   wait(6);
   out<size>(fetch<Byte>(), getAccumulator<size>());
 }
 
 template<u32 size> auto V30MZ::instructionInDW() -> void {
-  wait(5);
+  // TODO: The exact cycle on which I/O access is performed remains unknown.
+  wait(4);
   setAccumulator<size>(in<size>(DW));
+  wait(1);
 }
 
 template<u32 size> auto V30MZ::instructionOutDW() -> void {
+  // TODO: The exact cycle on which I/O access is performed remains unknown.
   wait(5);
   out<size>(DW, getAccumulator<size>());
 }


### PR DESCRIPTION
Solely so people don't complain about the `gdma_timing` test not working. It's not 100% certain to be the right cycle, it's just marginally closer.