### PR TITLE
n64: add IPL2 checksum failure as accuracy flag

### DIFF
--- a/ares/n64/accuracy.hpp
+++ b/ares/n64/accuracy.hpp
@@ -26,5 +26,7 @@ struct Accuracy {
   struct PIF {
     // Emulate a region-locked console
     static constexpr bool RegionLock = false;
+    // Emulate the PIF's checksum security check
+    static constexpr bool IPL2Checksum = true;
   };
 };

--- a/ares/n64/pif/hle.cpp
+++ b/ares/n64/pif/hle.cpp
@@ -340,8 +340,11 @@ auto PIF::mainHLE() -> void {
           " != cpu:", 
           hex(intram.cpuChecksum[0], 2L), hex(intram.cpuChecksum[1], 2L), hex(intram.cpuChecksum[2], 2L),
           hex(intram.cpuChecksum[3], 2L), hex(intram.cpuChecksum[4], 2L), hex(intram.cpuChecksum[5], 2L));
-        state = Error;
-        return;
+        if constexpr(Accuracy::PIF::IPL2Checksum) {
+          state = Error;
+          return;
+        }
+        break;
       }
     }
     for (auto i: range(6)) intram.cpuChecksum[i] = 0;


### PR DESCRIPTION
As part of the boot security, IPL2 (run by CPU), PIF and CIC collaborate to verify that the IPL3 (stored at the beginning of the ROM) is valid and not tampered, by running a checksum. If the checksum is invalid, the console is halted immediately.

Ares emulates this behavior correctly. Sometimes, though, it might be useful for development purposes to let some ROM boot even with a failing checksum. Given that disabling the check was non-obvious, I'm adding an accuracy compile-time flag for now.