### PR TITLE
gba: improve VRAM access timings in linear background modes

### DIFF
--- a/ares/gba/ppu/background.cpp
+++ b/ares/gba/ppu/background.cpp
@@ -12,6 +12,7 @@ auto PPU::Background::setEnable(n1 status) -> void {
 auto PPU::Background::scanline(u32 y) -> void {
   mosaicOffset = 0;
   for(auto& pixel : output) pixel = {};
+  latch.active = false;
 }
 
 auto PPU::Background::outputPixel(u32 x, u32 y) -> void {
@@ -23,47 +24,68 @@ auto PPU::Background::outputPixel(u32 x, u32 y) -> void {
   mosaicOffset--;
 }
 
-auto PPU::Background::run(u32 x, u32 y) -> void {
+auto PPU::Background::run(s32 x, u32 y) -> void {
   switch(id) {
   case PPU::BG0:
-    if(io.mode <= 1) { linear(x, y); break; }
+    if(io.mode <= 1) { linearFetchTileMap(x, y); linearRender(x, y); break; }
     break;
 
   case PPU::BG1:
-    if(io.mode <= 1) { linear(x, y); break; }
+    if(io.mode <= 1) { linearFetchTileMap(x, y); linearRender(x, y); break; }
     break;
 
   case PPU::BG2:
-    if(io.mode == 0) { linear(x, y); break; }
+    if(io.mode == 0) { linearFetchTileMap(x, y); linearRender(x, y); break; }
     if(io.mode <= 2) { affineFetchTileMap(x, y); affineFetchTileData(x, y); break; }
     if(io.mode <= 5) { bitmap(x, y); break; }
     break;
 
   case PPU::BG3:
-    if(io.mode == 0) { linear(x, y); break; }
+    if(io.mode == 0) { linearFetchTileMap(x, y); linearRender(x, y); break; }
     if(io.mode == 2) { affineFetchTileMap(x, y); affineFetchTileData(x, y); break; }
     break;
   }
 }
 
-auto PPU::Background::linearFetchTileMap() -> void {
-  n6 tx = fx >> 3;
-  n6 ty = fy >> 3;
+auto PPU::Background::linearFetchTileMap(s32 x, u32 y) -> void {
+  if(ppu.blank() || !io.enable[0]) return;
 
-  u32 offset = (ty & 31) << 5 | (tx & 31);
-  if(io.screenSize.bit(0) && (tx & 32)) offset += 32 << 5;
-  if(io.screenSize.bit(1) && (ty & 32)) offset += 32 << 5 + io.screenSize.bit(0);
-  offset = (io.screenBase << 11) + (offset << 1);
+  //start scanline when first partially visible tile is reached
+  n3 subTileScroll = io.hoffset;
+  if(x + subTileScroll < 0) return;
+  if(x + subTileScroll == 0) {
+    if(!io.mosaic || (y % (1 + io.mosaicHeight)) == 0) {
+      vmosaic = y;
+    }
+    fx = io.hoffset & ~7;
+    fy = vmosaic + io.voffset;
+  }
 
-  n16 tilemap  = ppu.readVRAM_BG(Half, offset);
-  latch.character = tilemap.bit(0,9);
-  latch.hflip     = tilemap.bit(10);
-  latch.vflip     = tilemap.bit(11);
-  latch.palette   = tilemap.bit(12,15);
+  n3 px = fx;
+  if(px == 0) {
+    //fetch tilemap
+    n6 tx = fx >> 3;
+    n6 ty = fy >> 3;
+
+    u32 offset = (ty & 31) << 5 | (tx & 31);
+    if(io.screenSize.bit(0) && (tx & 32)) offset += 32 << 5;
+    if(io.screenSize.bit(1) && (ty & 32)) offset += 32 << 5 + io.screenSize.bit(0);
+    offset = (io.screenBase << 11) + (offset << 1);
+
+    n16 tilemap  = ppu.readVRAM_BG(Half, offset);
+    latch.character = tilemap.bit(0,9);
+    latch.hflip     = tilemap.bit(10);
+    latch.vflip     = tilemap.bit(11);
+    latch.palette   = tilemap.bit(12,15);
+    latch.active    = true;
+    latch.px        = 0;
+  }
+
+  fx++;
 }
 
 auto PPU::Background::linearFetchTileData() -> void {
-  n3 px = fx;
+  n3 px = latch.px;
   n3 py = fy;
   if(latch.hflip) px = ~px;
   if(latch.vflip) py = ~py;
@@ -75,29 +97,13 @@ auto PPU::Background::linearFetchTileData() -> void {
   latch.data = ppu.readVRAM_BG(Half, offset);
 }
 
-auto PPU::Background::linear(u32 x, u32 y) -> void {
-  if(x > 239) return;
+auto PPU::Background::linearRender(s32 x, u32 y) -> void {
   if(ppu.blank() || !io.enable[0]) return;
+  if(!latch.active) return;
 
-  if(x == 0) {
-    if(!io.mosaic || (y % (1 + io.mosaicHeight)) == 0) {
-      vmosaic = y;
-    }
-    fx = io.hoffset;
-    fy = vmosaic + io.voffset;
-  }
+  n3 px = latch.px;
 
-  n3 px = fx;
-  n3 py = fy;
-
-  if(x == 0 || px == 0) linearFetchTileMap();
-  if(x == 0) {
-    linearFetchTileData();
-  } else if(io.colorMode == 0 && (px & 3) == 0) {
-    linearFetchTileData();
-  } else if(io.colorMode == 1 && (px & 1) == 0) {
-    linearFetchTileData();
-  }
+  if(((px << io.colorMode) & 3) == 0) linearFetchTileData();
 
   if(latch.hflip) px = ~px;
 
@@ -111,13 +117,15 @@ auto PPU::Background::linear(u32 x, u32 y) -> void {
   }
 
   if(color) {
-    if(io.colorMode == 0) color |= latch.palette << 4;
-    output[x].enable = true;
-    output[x].priority = io.priority;
-    output[x].color = color;
+    if(x >= 0 && x < 240) {
+      if(io.colorMode == 0) color |= latch.palette << 4;
+      output[x].enable = true;
+      output[x].priority = io.priority;
+      output[x].color = color;
+    }
   }
 
-  fx++;
+  if(++latch.px == 0) latch.active = false;
 }
 
 auto PPU::Background::affineFetchTileMap(u32 x, u32 y) -> void {

--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -75,16 +75,25 @@ auto PPU::step(u32 clocks) -> void {
   Thread::synchronize(cpu, display);
 }
 
-template<u32 Cycle>
-auto PPU::cycleLinear(u32 x, u32 y) -> void {
+template<s32 Cycle>
+auto PPU::cycleLinearMap(s32 x, u32 y) -> void {
   n3 mode = PPU::Background::IO::mode;
-  if constexpr(Cycle == 0) if(mode <= 1) bg0.linear(x, y);
-  if constexpr(Cycle == 1) if(mode <= 1) bg1.linear(x, y);
-  if constexpr(Cycle == 2) if(mode == 0) bg2.linear(x, y);
-  if constexpr(Cycle == 3) if(mode == 0) bg3.linear(x, y);
+  if constexpr(Cycle == 0) if(mode <= 1) bg0.linearFetchTileMap(x, y);
+  if constexpr(Cycle == 1) if(mode <= 1) bg1.linearFetchTileMap(x, y);
+  if constexpr(Cycle == 2) if(mode == 0) bg2.linearFetchTileMap(x, y);
+  if constexpr(Cycle == 3) if(mode == 0) bg3.linearFetchTileMap(x, y);
 }
 
-template<u32 Cycle>
+template<s32 Cycle>
+auto PPU::cycleLinearRender(s32 x, u32 y) -> void {
+  n3 mode = PPU::Background::IO::mode;
+  if constexpr(Cycle == 0) if(mode <= 1) bg0.linearRender(x, y);
+  if constexpr(Cycle == 1) if(mode <= 1) bg1.linearRender(x, y);
+  if constexpr(Cycle == 2) if(mode == 0) bg2.linearRender(x, y);
+  if constexpr(Cycle == 3) if(mode == 0) bg3.linearRender(x, y);
+}
+
+template<s32 Cycle>
 auto PPU::cycleAffine(u32 x, u32 y) -> void {
   n3 mode = PPU::Background::IO::mode;
   if constexpr(Cycle == 0) if(             mode == 2) bg3.affineFetchTileMap(x, y);
@@ -111,11 +120,12 @@ auto PPU::cycleUpperLayer(u32 x, u32 y) -> void {
   dac.upperLayer(x, y);
 }
 
-template<u32 Cycle>
+template<s32 Cycle>
 auto PPU::cycle(u32 y) -> void {
-  if constexpr(Cycle >= 31 && Cycle <= 1005                         ) cycleLinear<(Cycle - 31) & 3>((Cycle - 31) / 4, y);
-  if constexpr(Cycle >= 31 && Cycle <= 1005                         ) cycleAffine<(Cycle - 31) & 3>((Cycle - 31) / 4, y);
-  if constexpr(Cycle >= 31 && Cycle <= 1005 && (Cycle - 31) % 4 == 3) cycleBitmap((Cycle - 31) / 4, y);
+  if constexpr(Cycle >=  7 && Cycle <= 1037                         ) cycleLinearRender<(Cycle -  7) & 3>((Cycle - 35) >> 2, y);
+  if constexpr(Cycle >=  3 && Cycle <= 1005                         ) cycleLinearMap<(Cycle -  3) & 3>((Cycle - 31) >> 2, y);
+  if constexpr(Cycle >= 31 && Cycle <= 1005                         ) cycleAffine<(Cycle - 31) & 3>((Cycle - 31) >> 2, y);
+  if constexpr(Cycle >= 31 && Cycle <= 1005 && (Cycle - 31) % 4 == 3) cycleBitmap((Cycle - 31) >> 2, y);
   if constexpr(Cycle >= 46 && Cycle <= 1005 && (Cycle - 46) % 4 == 0) cycleUpperLayer((Cycle - 46) / 4, y);
   if constexpr(Cycle >= 46 && Cycle <= 1005 && (Cycle - 46) % 4 == 2) dac.lowerLayer((Cycle - 46) / 4, y);
   step(1);
@@ -133,7 +143,7 @@ auto PPU::main() -> void {
     bg3.io.ly = bg3.io.y;
   }
 
-  step(31);
+  step(3);
 
   u32 y = display.io.vcounter;
   memory::move(io.forceBlank, io.forceBlank + 1, sizeof(io.forceBlank) - 1);
@@ -159,7 +169,13 @@ auto PPU::main() -> void {
       #define cycles32(index) cycles16(index); cycles16(index + 16)
       #define cycles64(index) cycles32(index); cycles32(index + 32)
 
-      //cycle 31 - start rendering backgrounds
+      //cycle 3 - earliest possible background render cycle
+      cycles04(  3);
+      cycles08(  7);
+      cycles08( 15);
+      cycles08( 23);
+
+      //cycle 31 - start rendering backgrounds unconditionally
       cycles01( 31);
       cycles02( 32);
       cycles04( 34);
@@ -182,6 +198,12 @@ auto PPU::main() -> void {
       cycles64(878);
       cycles64(942);
 
+      //cycle 1006 - finish rendering final background tiles
+      cycles08(1006);
+      cycles08(1014);
+      cycles08(1022);
+      cycles08(1030);
+
       #undef cycles02
       #undef cycles04
       #undef cycles08
@@ -189,22 +211,24 @@ auto PPU::main() -> void {
       #undef cycles32
       #undef cycles64
     } else {
+      for(s32 x : range(247)) {
+        bg0.run(x - 7, y);
+        bg1.run(x - 7, y);
+        bg2.run(x - 7, y);
+        bg3.run(x - 7, y);
+      }
       for(u32 x : range(240)) {
-        bg0.run(x, y);
-        bg1.run(x, y);
-        bg2.run(x, y);
-        bg3.run(x, y);
         cycleUpperLayer(x, y);
         dac.lowerLayer(x, y);
       }
       releaseBus();
-      step(975);
+      step(1035);
     }
   } else {
-    step(975);
+    step(1035);
   }
 
-  step(226);
+  step(194);
 }
 
 auto PPU::frame() -> void {

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -37,11 +37,12 @@ struct PPU : Thread, IO {
   auto blank() -> bool;
 
   auto step(u32 clocks) -> void;
-  template<u32> auto cycleLinear(u32 x, u32 y) -> void;
-  template<u32> auto cycleAffine(u32 x, u32 y) -> void;
+  template<s32> auto cycleLinearMap(s32 x, u32 y) -> void;
+  template<s32> auto cycleLinearRender(s32 x, u32 y) -> void;
+  template<s32> auto cycleAffine(u32 x, u32 y) -> void;
   auto cycleBitmap(u32 x, u32 y) -> void;
   auto cycleUpperLayer(u32 x, u32 y) -> void;
-  template<u32> auto cycle(u32 y) -> void;
+  template<s32> auto cycle(u32 y) -> void;
   auto main() -> void;
 
   auto frame() -> void;
@@ -106,10 +107,10 @@ private:
     auto setEnable(n1 status) -> void;
     auto scanline(u32 y) -> void;
     auto outputPixel(u32 x, u32 y) -> void;
-    auto run(u32 x, u32 y) -> void;
-    auto linearFetchTileMap() -> void;
+    auto run(s32 x, u32 y) -> void;
+    auto linearFetchTileMap(s32 x, u32 y) -> void;
     auto linearFetchTileData() -> void;
-    auto linear(u32 x, u32 y) -> void;
+    auto linearRender(s32 x, u32 y) -> void;
     auto affineFetchTileMap(u32 x, u32 y) -> void;
     auto affineFetchTileData(u32 x, u32 y) -> void;
     auto bitmap(u32 x, u32 y) -> void;
@@ -160,6 +161,9 @@ private:
       n4 palette;
 
       n16 data;
+
+      n1 active;
+      n3 px;
     } latch;
 
     struct Affine {


### PR DESCRIPTION
Offsets tilemap and tile data fetch timings from each other, and performs fetches for non-visible regions at the start and end of a scanline.