### PR TITLE
Fix check for pif rom when loading Aleck64 games

### DIFF
--- a/desktop-ui/emulator/emulator.cpp
+++ b/desktop-ui/emulator/emulator.cpp
@@ -64,11 +64,11 @@ auto Emulator::handleLoadResult(LoadResult result) -> void {
       return;
     case invalidROM:
       errorText = { "There was an error trying to parse the selected ROM. \n",
-                    "Your ROM may be corrupt or contain a bad dump." };
+                    "Your ROM may be corrupt or contain a bad dump. " };
       break;
     case couldNotParseManifest:
       errorText = { "An error occurred while parsing the database file. You \n",
-                    "may need to reinstall ares." };
+                    "may need to reinstall ares. " };
       break;
     case databaseNotFound:
       errorText = { "The database file for the system was not found. \n",
@@ -78,17 +78,17 @@ auto Emulator::handleLoadResult(LoadResult result) -> void {
     case noFirmware:
       errorText = { "Error: firmware is missing or invalid.\n",
                     result.firmwareSystemName, " - ", result.firmwareType, " (", result.firmwareRegion, ") is required to play this game.\n",
-                    "Would you like to configure firmware settings now?" };
+                    "Would you like to configure firmware settings now? " };
       break;
     case romNotFound:
-      errorText = "The selected ROM file was not found or could not be opened.";
+      errorText = "The selected ROM file was not found or could not be opened. ";
       break;
     case romNotFoundInDatabase:
       errorText = { "The required manifest for this ROM was not found in the database. \n",
-                    "This title may not be currently supported by ares." };
+                    "This title may not be currently supported by ares. " };
       break;
     case otherError:
-      errorText = "An internal error occurred when initializing the emulator core.";
+      errorText = "An internal error occurred when initializing the emulator core. ";
       break;
   }
   

--- a/mia/medium/arcade.cpp
+++ b/mia/medium/arcade.cpp
@@ -41,7 +41,7 @@ auto Arcade::load(string location) -> LoadResult {
     endianSwap(rom);
 
     vector<u8> pif = loadRoms(location, document, "user1");
-    if(!rom) return { invalidROM, "Ensure your ROM is in a MAME-compatible .zip format." };
+    if(!pif) return { invalidROM, "Ensure your ROM is in a MAME-compatible .zip format and that the Aleck64 pif ROM is available." };
 
     this->location = location;
 


### PR DESCRIPTION
Issue originally identified by SuperMikeMan100 and confirmed by Luke. I'm just submitting the fix. 

This corrects the check looking for the Aleck64 pif rom when loading an Aleck64 game.

Fixes issue: https://github.com/ares-emulator/ares/issues/1895