### PR TITLE
ws: fix regression in APU logic

### DIFF
--- a/ares/ws/apu/channel4.cpp
+++ b/ares/ws/apu/channel4.cpp
@@ -8,7 +8,7 @@ auto APU::Channel4::tick() -> void {
       state.period = 0;
       state.sampleOffset++;
 
-      if(io.noise && io.noiseUpdate && !apu.io.seqDbgNoise) {
+      if(io.noiseUpdate && !apu.io.seqDbgNoise) {
         static constexpr s32 taps[8] = {14, 10, 13, 4, 8, 6, 9, 11};
         auto tap = taps[io.noiseMode];
 


### PR DESCRIPTION
Apparently the test is wrong, that is it works on hardware for a different reason than this alleged observation. Manual testing confirms the `ch4 noise` bit (bit 7) has no bearing on whether the random counter updates...