### PR TITLE
[MS] Add DB entry for Back to the Future III which was PAL only

### DIFF
--- a/mia/medium/master-system.cpp
+++ b/mia/medium/master-system.cpp
@@ -65,6 +65,11 @@ auto MasterSystem::analyze(vector<u8>& rom) -> string {
     region = "NTSC-J";
   }
 
+  //Back to the Future III (Europe)
+  if(hash == "c39167c5dc187e7d4da8ead30b77f10d5b14596ebddf7aa081adf7285e1e8d8d") {
+    region = "PAL";
+  }
+
   //BMX Trial - Alex Kidd (Japan)
   if(hash == "0fdd18f1212072bfbc0cfeaf030436d746733029ef26a8a6470c7be101cfedfb") {
     paddle = true;


### PR DESCRIPTION
Add DB entry in mia for Back to the Future III for the Master System. Without a DB entry, we set the region field to all 3 regions by default. According to No-Intro ( https://datomatic.no-intro.org/index.php?page=show_record&s=26&n=0046 ), this game was only released in Europe, so it is appropriate to add a DB entry that indicates it is for the PAL region only by default.