### PR TITLE
gba: override save type in known problematic cases

### DIFF
--- a/mia/medium/game-boy-advance.cpp
+++ b/mia/medium/game-boy-advance.cpp
@@ -125,11 +125,17 @@ auto GameBoyAdvance::analyze(vector<u8>& rom) -> string {
     }
   }
 
-  vector<string> list;
+  vector<string> saveTypes;
+  if(gameCode == "A2YE") { saveTypes.append("NONE"      ); };  //Top Gun - Combat Zones (USA)
+  if(gameCode == "ALUE") { saveTypes.append("EEPROM_V"  ); };  //Super Monkey Ball Jr. (USA)
+  if(gameCode == "AR8E") { saveTypes.append("EEPROM_V"  ); };  //Rocky (USA)
+  if(gameCode == "AROP") { saveTypes.append("EEPROM_V"  ); };  //Rocky (Europe)
+  if(gameCode == "BR4J") { saveTypes.append("FLASH512_V"); };  //Rockman EXE 4.5 - Real Operation (Japan)
+
   for(auto& identifier : identifiers) {
     for(s32 n : range(rom.size() - 16)) {
       if(!memory::compare(&rom[n], identifier.data(), identifier.size())) {
-        if(!list.find(identifier.data())) list.append(identifier.data());
+        if(!saveTypes.find(identifier.data())) saveTypes.append(identifier.data());
       }
     }
   }
@@ -147,22 +153,22 @@ auto GameBoyAdvance::analyze(vector<u8>& rom) -> string {
   s += "      content: Program\n";
   s +={"      mirror: ", mirror, "\n"};
 
-  if(list) {
-    if(list.first().beginsWith("SRAM_V") || list.first().beginsWith("SRAM_F_V")) {
+  if(saveTypes) {
+    if(saveTypes.first().beginsWith("SRAM_V") || saveTypes.first().beginsWith("SRAM_F_V")) {
       s += "    memory\n";
       s += "      type: RAM\n";
       s += "      size: 0x8000\n";
       s += "      content: Save\n";
     }
 
-    if(list.first().beginsWith("EEPROM_V")) {
+    if(saveTypes.first().beginsWith("EEPROM_V")) {
       s += "    memory\n";
       s += "      type: EEPROM\n";
       s += "      size: 0x0\n";  //auto-detected
       s += "      content: Save\n";
     }
 
-    if(list.first().beginsWith("FLASH_V") || list.first().beginsWith("FLASH512_V")) {
+    if(saveTypes.first().beginsWith("FLASH_V") || saveTypes.first().beginsWith("FLASH512_V")) {
       s += "    memory\n";
       s += "      type: Flash\n";
       s += "      size: 0x10000\n";
@@ -170,7 +176,7 @@ auto GameBoyAdvance::analyze(vector<u8>& rom) -> string {
       s += "      manufacturer: Macronix\n";
     }
 
-    if(list.first().beginsWith("FLASH1M_V")) {
+    if(saveTypes.first().beginsWith("FLASH1M_V")) {
       s += "    memory\n";
       s += "      type: Flash\n";
       s += "      size: 0x20000\n";


### PR DESCRIPTION
Adds built-in overrides for games known to trip up our save type detection.

Closes #1889.