### PR TITLE
Build: A few fixes

### DIFF
--- a/desktop-ui/cmake/os-macos.cmake
+++ b/desktop-ui/cmake/os-macos.cmake
@@ -74,7 +74,6 @@ if(ARES_ENABLE_LIBRASHADER)
       add_custom_command(
         OUTPUT
           "${CMAKE_CURRENT_BINARY_DIR}/$<IF:$<BOOL:${XCODE}>,$<CONFIG>,>/ares.app/Contents/Resources/Shaders/bilinear.slangp"
-          POST_BUILD
         COMMAND ditto "${slang_shaders_LOCATION}" "$<TARGET_BUNDLE_CONTENT_DIR:desktop-ui>/Resources/Shaders/"
         WORKING_DIRECTORY "$<TARGET_BUNDLE_CONTENT_DIR:desktop-ui>"
         COMMENT "Copying slang shaders to app bundle"

--- a/desktop-ui/cmake/os-windows.cmake
+++ b/desktop-ui/cmake/os-windows.cmake
@@ -5,7 +5,7 @@ set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT desktop-u
 if(ARES_ENABLE_LIBRASHADER)
   if(TARGET libretro::slang_shaders)
     add_custom_command(
-      OUTPUT "${ARES_EXECUTABLE_DESTINATION}/desktop-ui/rundir/Shaders/bilinear.slangp" POST_BUILD
+      OUTPUT "${ARES_EXECUTABLE_DESTINATION}/desktop-ui/rundir/Shaders/bilinear.slangp"
       COMMAND "${CMAKE_COMMAND}" -E make_directory "${ARES_EXECUTABLE_DESTINATION}/desktop-ui/rundir/Shaders/"
       COMMAND
         "${CMAKE_COMMAND}" -E copy_directory "${slang_shaders_LOCATION}"

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -32,11 +32,13 @@ if(OS_WINDOWS)
   include(cmake/os-windows.cmake)
 elseif(OS_MACOS)
   include(cmake/os-macos.cmake)
-elseif(OS_LINUX OR OS_FREEBSD OR OS_OPENBSD)
+elseif(OS_LINUX)
   include(cmake/os-linux.cmake)
+elseif(OS_FREEBSD OR OS_OPENBSD)
+  include(cmake/os-freebsd.cmake)
 endif()
 
-target_sources(ruby PRIVATE cmake/os-macos.cmake cmake/os-windows.cmake cmake/os-linux.cmake)
+target_sources(ruby PRIVATE cmake/os-macos.cmake cmake/os-windows.cmake cmake/os-linux.cmake cmake/os-freebsd.cmake)
 
 target_link_libraries(ruby PUBLIC ares::nall)
 

--- a/ruby/cmake/os-freebsd.cmake
+++ b/ruby/cmake/os-freebsd.cmake
@@ -117,6 +117,16 @@ else()
   target_disable_feature(ruby "udev input driver")
 endif()
 
+option(ARES_ENABLE_USBHID "Enable the usbhid input driver" ON)
+if(ARES_ENABLE_USBHID)
+  find_package(usbhid)
+endif()
+if(usbhid_FOUND)
+  target_enable_feature(ruby "usbhid input driver" INPUT_UHID)
+else()
+  target_disable_feature(ruby "usbhid input driver")
+endif()
+
 target_link_libraries(
   ruby
   PRIVATE
@@ -129,4 +139,5 @@ target_link_libraries(
     $<$<BOOL:${PulseAudio_FOUND}>:PulseAudio::PulseAudioSimple>
     $<$<BOOL:${AO_FOUND}>:AO::AO>
     $<$<BOOL:${udev_FOUND}>:udev::udev>
+    $<$<BOOL:${usbhid_FOUND}>:usbhid::usbhid>
 )


### PR DESCRIPTION
* CMake 4.0.0 (in the release candidate phase) breaks macOS generation because it no longer defines `CMAKE_OSX_SYSROOT` by default. Instead get our SDK version information using `xcrun` (included in both the Command Line Tools and Xcode).
* No longer search for the usbhid driver unless we are specifically on BSD.
    * We choose to split ruby's build into separate `os-linux.cmake` and `os-freebsd.cmake` files here. While this is not strictly necessary, since the files are minimally different, I prefer this pattern so it's explicit which build code applies to which operating systems, where differences exist.
* Remove some invalid (and unused) arguments from some build commands that CMake was complaining about.