### PR TITLE
desktop-ui: Threading rework

### DIFF
--- a/ares/ares/node/video/screen.cpp
+++ b/ares/ares/node/video/screen.cpp
@@ -24,6 +24,7 @@ Screen::~Screen() {
 }
 
 auto Screen::main(uintptr_t) -> void {
+  thread::setName("dev.ares.screen");
   while(!_kill) {
     unique_lock<mutex> lock(_frameMutex);
 

--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -77,6 +77,10 @@ auto System::game() -> string {
 }
 
 auto System::run() -> void {
+  if(_vulkanNeedsLoad) {
+    vulkan.load(node);
+    _vulkanNeedsLoad = false;
+  }
   cpu.main();
 }
 
@@ -134,11 +138,9 @@ auto System::load(Node::System& root, string name) -> bool {
   rdp.load(node);
   if(_DD()) dd.load(node);
   if(model() == Model::Aleck64) aleck64.load(node);
-  #if defined(VULKAN)
-  vulkan.load(node);
-  #endif
 
   initDebugHooks();
+  _vulkanNeedsLoad = true;
 
   return true;
 }
@@ -308,6 +310,7 @@ auto System::unload() -> void {
   if(vi.screen) vi.screen->quit(); //stop video thread
   #if defined(VULKAN)
   vulkan.unload();
+  _vulkanNeedsLoad = false;
   #endif
   cartridgeSlot.unload();
   controllerPort1.unload();

--- a/ares/n64/system/system.hpp
+++ b/ares/n64/system/system.hpp
@@ -37,6 +37,8 @@ private:
     u32 videoFrequency = 48'681'818;
     bool dd = false;
   } information;
+  
+  atomic<bool> _vulkanNeedsLoad = false;
 
   auto initDebugHooks() -> void;
 

--- a/ares/n64/vi/vi.cpp
+++ b/ares/n64/vi/vi.cpp
@@ -111,13 +111,12 @@ auto VI::main() -> void {
         lineDuration = io.hsyncLeap[io.leapPattern.bit(io.leapCounter)];      
       step(io.quarterLineDuration);
     } else {
-      // arbitrarily call screen->frame() every once in a while to keep the UI responsive.
+      // Arbitrarily call screen->frame() every once in a while to keep the UI responsive.
       // We do that every 200 simulated lines of 0x800 quarter-clocks. This is just arbitrary,
       // the real VI is not clocking at all when inactive.
       io.vcounter = 0;
       if(++inactiveCounter >= 200) {
         inactiveCounter = 0;
-        screen->frame();
         refreshed = true;
       }
       step(0x800);

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -156,10 +156,10 @@ auto nall::main(Arguments arguments) -> void {
 
   Instances::presentation.construct();
   Instances::settingsWindow.construct();
-  Instances::toolsWindow.construct();
   Instances::gameBrowserWindow.construct();
 
   program.create();
+  Instances::toolsWindow.construct(&program.programMutex);
   Application::onMain({&Program::main, &program});
   Application::run();
 

--- a/desktop-ui/input/input.cpp
+++ b/desktop-ui/input/input.cpp
@@ -5,6 +5,7 @@ VirtualPort virtualPorts[5];
 InputManager inputManager;
 
 auto InputMapping::bind() -> void {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   for(auto& binding : bindings) binding = {};
 
   for(u32 index : range(BindingLimit)) {
@@ -32,22 +33,26 @@ auto InputMapping::bind() -> void {
 }
 
 auto InputMapping::bind(u32 binding, string assignment) -> void {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   if(binding >= BindingLimit) return;
   assignments[binding] = assignment;
   bind();
 }
 
 auto InputMapping::unbind() -> void {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   for(u32 binding : range(BindingLimit)) unbind(binding);
 }
 
 auto InputMapping::unbind(u32 binding) -> void {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   if(binding >= BindingLimit) return;
   bindings[binding] = {};
   assignments[binding] = {};
 }
 
 auto InputMapping::Binding::icon() -> multiFactorImage {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   if(!device && deviceID) return Icon::Device::Joypad;
   if(!device) return {};
   if(device->isKeyboard()) return Icon::Device::Keyboard;
@@ -57,6 +62,7 @@ auto InputMapping::Binding::icon() -> multiFactorImage {
 }
 
 auto InputMapping::Binding::text() -> string {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   if(!device && deviceID) return "(disconnected)";
   if(!device) return {};
   if(groupID >= device->size()) return {};
@@ -90,6 +96,7 @@ auto InputMapping::Binding::text() -> string {
 //
 
 auto InputDigital::bind(u32 binding, shared_pointer<HID::Device> device, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> bool {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   string assignment = {"0x", hex(device->id()), "/", groupID, "/", inputID};
 
   if(device->isNull()) {
@@ -128,6 +135,7 @@ auto InputDigital::bind(u32 binding, shared_pointer<HID::Device> device, u32 gro
 }
 
 auto InputDigital::value() -> s16 {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   s16 result = 0;
 
   for(auto& binding : bindings) {
@@ -165,11 +173,13 @@ auto InputDigital::value() -> s16 {
 }
 
 auto InputDigital::pressed() -> bool {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   return value() != 0;
 }
 
 
 auto InputHotkey::value() -> s16 {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   s16 result = 0;
 
   for(auto& binding : bindings) {
@@ -210,6 +220,7 @@ auto InputHotkey::value() -> s16 {
 //
 
 auto InputAnalog::bind(u32 binding, shared_pointer<HID::Device> device, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> bool {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   string assignment = {"0x", hex(device->id()), "/", groupID, "/", inputID};
 
   if(device->isNull()) {
@@ -244,6 +255,7 @@ auto InputAnalog::bind(u32 binding, shared_pointer<HID::Device> device, u32 grou
 }
 
 auto InputAnalog::value() -> s16 {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   s32 result = 0;
 
   for(auto& binding : bindings) {
@@ -274,12 +286,14 @@ auto InputAnalog::value() -> s16 {
 }
 
 auto InputAnalog::pressed() -> bool {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   return value() > 16384;
 }
 
 //
 
 auto InputAbsolute::bind(u32 binding, shared_pointer<HID::Device> device, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> bool {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   string assignment = {"0x", hex(device->id()), "/", groupID, "/", inputID};
 
   if(device->isNull()) {
@@ -310,6 +324,7 @@ auto InputAbsolute::bind(u32 binding, shared_pointer<HID::Device> device, u32 gr
 }
 
 auto InputAbsolute::value() -> s16 {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   s32 result = 0;
 
   for(auto& binding : bindings) {
@@ -337,6 +352,7 @@ auto InputAbsolute::value() -> s16 {
 //
 
 auto InputRelative::bind(u32 binding, shared_pointer<HID::Device> device, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> bool {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   string assignment = {"0x", hex(device->id()), "/", groupID, "/", inputID};
 
   if(device->isNull()) {
@@ -367,6 +383,7 @@ auto InputRelative::bind(u32 binding, shared_pointer<HID::Device> device, u32 gr
 }
 
 auto InputRelative::value() -> s16 {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   s32 result = 0;
 
   for(auto& binding : bindings) {
@@ -394,6 +411,7 @@ auto InputRelative::value() -> s16 {
 //
 
 auto InputRumble::bind(u32 binding, shared_pointer<HID::Device> device, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> bool {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   string assignment = {"0x", hex(device->id()), "/", groupID, "/", inputID};
 
   if(device->isNull()) {
@@ -468,10 +486,12 @@ VirtualMouse::VirtualMouse() {
 //
 
 auto InputManager::create() -> void {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   createHotkeys();
 }
 
 auto InputManager::bind() -> void {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   for(auto& port : virtualPorts) {
     for(auto& input : port.pad.inputs) input.mapping->bind();
     for(auto& input : port.mouse.inputs) input.mapping->bind();
@@ -485,6 +505,7 @@ auto InputManager::poll(bool force) -> void {
   if(thisPoll - lastPoll < pollFrequency && !force) return;
   lastPoll = thisPoll;
 
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   auto devices = ruby::input.poll();
   bool changed = devices.size() != this->devices.size();
   if(!changed) {
@@ -502,6 +523,7 @@ auto InputManager::poll(bool force) -> void {
 }
 
 auto InputManager::eventInput(shared_pointer<HID::Device> device, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> void {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
   inputSettings.eventInput(device, groupID, inputID, oldValue, newValue);
   hotkeySettings.eventInput(device, groupID, inputID, oldValue, newValue);
 }

--- a/desktop-ui/program/drivers.cpp
+++ b/desktop-ui/program/drivers.cpp
@@ -1,4 +1,5 @@
 auto Program::videoDriverUpdate() -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   ruby::video.create(settings.video.driver);
   ruby::video.setContext(presentation.viewport.handle());
   videoMonitorUpdate();
@@ -21,6 +22,7 @@ auto Program::videoDriverUpdate() -> void {
 }
 
 auto Program::videoMonitorUpdate() -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   if(!ruby::video.hasMonitor(settings.video.monitor)) {
     settings.video.monitor = ruby::video.monitor();
   }
@@ -28,6 +30,7 @@ auto Program::videoMonitorUpdate() -> void {
 }
 
 auto Program::videoFormatUpdate() -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   if(!ruby::video.hasFormat(settings.video.format)) {
     settings.video.format = ruby::video.format();
   }
@@ -35,6 +38,7 @@ auto Program::videoFormatUpdate() -> void {
 }
 
 auto Program::videoFullScreenToggle() -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   if(!ruby::video.hasFullScreen()) return;
 
   ruby::video.clear();
@@ -55,6 +59,7 @@ auto Program::videoFullScreenToggle() -> void {
 }
 
 auto Program::videoPseudoFullScreenToggle() -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   if(ruby::video.fullScreen()) return;
 
   if(!presentation.fullScreen()) {
@@ -69,6 +74,7 @@ auto Program::videoPseudoFullScreenToggle() -> void {
 }
 
 auto Program::audioDriverUpdate() -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   ruby::audio.create(settings.audio.driver);
   ruby::audio.setContext(presentation.viewport.handle());
   audioDeviceUpdate();
@@ -86,6 +92,7 @@ auto Program::audioDriverUpdate() -> void {
 }
 
 auto Program::audioDeviceUpdate() -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   if(!ruby::audio.hasDevice(settings.audio.device)) {
     settings.audio.device = ruby::audio.device();
   }
@@ -93,6 +100,7 @@ auto Program::audioDeviceUpdate() -> void {
 }
 
 auto Program::audioFrequencyUpdate() -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   if(!ruby::audio.hasFrequency(settings.audio.frequency)) {
     settings.audio.frequency = ruby::audio.frequency();
   }
@@ -104,6 +112,7 @@ auto Program::audioFrequencyUpdate() -> void {
 }
 
 auto Program::audioLatencyUpdate() -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   if(!ruby::audio.hasLatency(settings.audio.latency)) {
     settings.audio.latency = ruby::audio.latency();
   }
@@ -113,6 +122,7 @@ auto Program::audioLatencyUpdate() -> void {
 //
 
 auto Program::inputDriverUpdate() -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   ruby::input.create(settings.input.driver);
   ruby::input.setContext(presentation.viewport.handle());
   ruby::input.onChange({&InputManager::eventInput, &inputManager});

--- a/desktop-ui/program/program.cpp
+++ b/desktop-ui/program/program.cpp
@@ -8,6 +8,7 @@
 #include "drivers.cpp"
 
 Program program;
+thread worker;
 
 auto Program::create() -> void {
   ares::platform = this;
@@ -19,6 +20,8 @@ auto Program::create() -> void {
   driverSettings.videoRefresh();
   driverSettings.audioRefresh();
   driverSettings.inputRefresh();
+  
+  worker = thread::create({&Program::emulatorRunLoop, this});
 
   if(startGameLoad) {
     auto gameToLoad = startGameLoad.takeFirst();
@@ -41,71 +44,85 @@ auto Program::create() -> void {
   }
 }
 
+auto Program::emulatorRunLoop(uintptr_t) -> void {
+  thread::setName("dev.ares.worker");
+  while(!_quitting) {
+    // Allow other threads to access the program mutex
+    usleep(1);
+    
+    lock_guard<recursive_mutex> programLock(programMutex);
+    if(!emulator) {
+      usleep(20 * 1000);
+      continue;
+    }
+
+    if(emulator && nall::GDB::server.isHalted()) {
+      ruby::audio.clear();
+      nall::GDB::server.updateLoop(); // sleeps internally
+      continue;
+    }
+
+    bool defocused = driverSettings.inputDefocusPause.checked() && !ruby::video.fullScreen() && !presentation.focused();
+
+    if(!emulator || (paused && !program.requestFrameAdvance) || defocused) {
+      ruby::audio.clear();
+      nall::GDB::server.updateLoop();
+      usleep(20 * 1000);
+      continue;
+    }
+
+    rewindRun();
+
+    nall::GDB::server.updateLoop();
+
+    program.requestFrameAdvance = false;
+    if(!runAhead || fastForwarding || rewinding) {
+      emulator->root->run();
+    } else {
+      ares::setRunAhead(true);
+      emulator->root->run();
+      auto state = emulator->root->serialize(false);
+      ares::setRunAhead(false);
+      emulator->root->run();
+      state.setReading();
+      emulator->root->unserialize(state);
+    }
+
+    nall::GDB::server.updateLoop();
+
+    if(settings.general.autoSaveMemory) {
+      static u64 previousTime = chrono::timestamp();
+      u64 currentTime = chrono::timestamp();
+      if(currentTime - previousTime >= 30) {
+        previousTime = currentTime;
+        emulator->save();
+      }
+    }
+
+    if(emulator->latch.changed) {
+      emulator->latch.changed = false;
+      _needsResize = true;
+    }
+  }
+}
+
 auto Program::main() -> void {
   if(Application::modal()) {
     ruby::audio.clear();
     return;
   }
-
-  updateMessage();
+  
   inputManager.poll();
   inputManager.pollHotkeys();
 
-  bool defocused = driverSettings.inputDefocusPause.checked() && !ruby::video.fullScreen() && !presentation.focused();
-  if(emulator && defocused) message.text = "Paused";
+  updateMessage();
 
-  if(settings.debugServer.enabled) {
-    presentation.statusDebug.setText(
-      nall::GDB::server.getStatusText(settings.debugServer.port, settings.debugServer.useIPv4)
-    );
-  }
-
-  if(emulator && nall::GDB::server.isHalted()) {
-    ruby::audio.clear();
-    nall::GDB::server.updateLoop(); // sleeps internally
-    return;
-  }
-
-  if(!emulator || (paused && !program.requestFrameAdvance) || defocused) {
-    ruby::audio.clear();
-    nall::GDB::server.updateLoop();
-    usleep(20 * 1000);
-    return;
-  }
-
-  rewindRun();
-
-  nall::GDB::server.updateLoop();
-
-  program.requestFrameAdvance = false;
-  if(!runAhead || fastForwarding || rewinding) {
-    emulator->root->run();
-  } else {
-    ares::setRunAhead(true);
-    emulator->root->run();
-    auto state = emulator->root->serialize(false);
-    ares::setRunAhead(false);
-    emulator->root->run();
-    state.setReading();
-    emulator->root->unserialize(state);
-  }
-
-  nall::GDB::server.updateLoop();
-
-  if(settings.general.autoSaveMemory) {
-    static u64 previousTime = chrono::timestamp();
-    u64 currentTime = chrono::timestamp();
-    if(currentTime - previousTime >= 30) {
-      previousTime = currentTime;
-      emulator->save();
-    }
-  }
-
-  //if Platform::video() changed the screen resolution, resize the presentation window here.
-  //window operations must be performed from the main thread.
-  if(emulator->latch.changed) {
-    emulator->latch.changed = false;
+  //If Platform::video() changed the screen resolution, resize the presentation window here.
+  //Window operations must be performed from the main thread.
+  
+  if(_needsResize) {
     if(settings.video.adaptiveSizing) presentation.resizeWindow();
+    _needsResize = false;
   }
 
   memoryEditor.liveRefresh();
@@ -114,6 +131,8 @@ auto Program::main() -> void {
 }
 
 auto Program::quit() -> void {
+  _quitting = true;
+  worker.join();
   unload();
   Application::processEvents();
   Application::quit();

--- a/desktop-ui/program/rewind.cpp
+++ b/desktop-ui/program/rewind.cpp
@@ -1,9 +1,11 @@
 auto Program::rewindSetMode(Rewind::Mode mode) -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   rewind.mode = mode;
   rewind.counter = 0;
 }
 
 auto Program::rewindReset() -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   rewindSetMode(Rewind::Mode::Playing);
   rewind.history.reset();
   rewind.length = settings.rewind.length;
@@ -11,6 +13,7 @@ auto Program::rewindReset() -> void {
 }
 
 auto Program::rewindRun() -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   if(!settings.general.rewind) return;  //rewind disabled?
 
   if(rewind.mode == Rewind::Mode::Playing) {

--- a/desktop-ui/program/states.cpp
+++ b/desktop-ui/program/states.cpp
@@ -1,4 +1,5 @@
 auto Program::stateSave(u32 slot) -> bool {
+  lock_guard<recursive_mutex> programLock(programMutex);
   if(!emulator) return false;
 
   auto location = emulator->locate(emulator->game->location, {".bs", slot}, settings.paths.saves);
@@ -19,6 +20,7 @@ auto Program::stateSave(u32 slot) -> bool {
 }
 
 auto Program::stateLoad(u32 slot) -> bool {
+  lock_guard<recursive_mutex> programLock(programMutex);
   if(!emulator) return false;
 
   //Store current state for undo
@@ -41,6 +43,7 @@ auto Program::stateLoad(u32 slot) -> bool {
 }
 
 auto Program::undoStateSave() -> bool {
+  lock_guard<recursive_mutex> programLock(programMutex);
   if(!emulator) return false;
 
   auto undoLocation = emulator->locate(emulator->game->location, ".bsu", settings.paths.saves);
@@ -55,6 +58,7 @@ auto Program::undoStateSave() -> bool {
 }
 
 auto Program::undoStateLoad() -> bool {
+  lock_guard<recursive_mutex> programLock(programMutex);
   if(!emulator) return false;
 
   auto undoLocation = emulator->locate(emulator->game->location, ".blu", settings.paths.saves);
@@ -75,6 +79,7 @@ auto Program::undoStateLoad() -> bool {
 }
 
 auto Program::clearUndoStates() -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   if(!emulator) return;
 
   auto location = emulator->locate(emulator->game->location, ".blu", settings.paths.saves);

--- a/desktop-ui/program/status.cpp
+++ b/desktop-ui/program/status.cpp
@@ -1,16 +1,19 @@
 auto Program::updateMessage() -> void {
-  presentation.statusLeft.setText(message.text);
-
-  if(chrono::millisecond() - message.timestamp >= 2000) {
-    message = {};
-    if (messages.size()) {
+  {
+    // This function is called every iteration of the GUI run loop. Acquiring the emulator mutex would incur a severe
+    // responsiveness penalty, so use a dedicated mutex for message passing.
+    lock_guard<recursive_mutex> messageLock(messageMutex);
+    presentation.statusLeft.setText(message.text);
+    if(chrono::millisecond() - message.timestamp >= 2000) {
+      message = {};
+      if (messages.size()) {
         message = messages.takeFirst();
+      }
     }
   }
 
-  if(vblanksPerSecond) {
-    presentation.statusRight.setText({vblanksPerSecond(), " VPS"});
-    vblanksPerSecond.reset();
+  if(vblanksPerSecond > 0) {
+    presentation.statusRight.setText({vblanksPerSecond.load(), " VPS"});
   }
 
   if(!emulator) {
@@ -22,9 +25,19 @@ auto Program::updateMessage() -> void {
       presentation.statusLeft.setText("Keyboard capture is active");
     }
   }
+  
+  if(settings.debugServer.enabled) {
+    presentation.statusDebug.setText(
+      nall::GDB::server.getStatusText(settings.debugServer.port, settings.debugServer.useIPv4)
+    );
+  }
+  
+  bool defocused = driverSettings.inputDefocusPause.checked() && !ruby::video.fullScreen() && !presentation.focused();
+  if(emulator && defocused) message.text = "Paused";
 }
 
 auto Program::showMessage(const string& text) -> void {
+  lock_guard<recursive_mutex> messageLock(messageMutex);
   messages.append({chrono::millisecond(), text});
   printf("%s\n", (const char*)text);
 }

--- a/desktop-ui/program/utility.cpp
+++ b/desktop-ui/program/utility.cpp
@@ -1,4 +1,5 @@
 auto Program::pause(bool state) -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   if(paused == state) return;
   paused = state;
   presentation.pauseEmulation.setChecked(paused);
@@ -10,11 +11,13 @@ auto Program::pause(bool state) -> void {
 }
 
 auto Program::mute() -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   settings.audio.mute = !settings.audio.mute;
   presentation.muteAudioSetting.setChecked(settings.audio.mute);
 }
 
 auto Program::paletteUpdate() -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   if(!emulator) return;
   for(auto& screen : emulator->root->find<ares::Node::Video::Screen>()) {
     screen->setLuminance(settings.video.luminance);
@@ -24,6 +27,7 @@ auto Program::paletteUpdate() -> void {
 }
 
 auto Program::runAheadUpdate() -> void {
+  lock_guard<recursive_mutex> programLock(programMutex);
   runAhead = settings.general.runAhead;
   if(!emulator) return;
   if(emulator->name == "Game Boy Advance") runAhead = false;  //crashes immediately
@@ -42,6 +46,7 @@ auto Program::captureScreenshot(const u32* data, u32 pitch, u32 width, u32 heigh
 }
 
 auto Program::openFile(BrowserDialog& dialog) -> string {
+  lock_guard<recursive_mutex> programLock(programMutex);
   BrowserWindow window;
   window.setTitle(dialog.title());
   window.setPath(dialog.path());
@@ -53,6 +58,7 @@ auto Program::openFile(BrowserDialog& dialog) -> string {
 }
 
 auto Program::selectFolder(BrowserDialog& dialog) -> string {
+  lock_guard<recursive_mutex> programLock(programMutex);
   BrowserWindow window;
   window.setTitle(dialog.title());
   window.setPath(dialog.path());

--- a/desktop-ui/settings/drivers.cpp
+++ b/desktop-ui/settings/drivers.cpp
@@ -183,6 +183,7 @@ auto DriverSettings::videoDriverUpdate() -> bool {
     "Warning: incompatible drivers may cause this software to crash.\n"
     "Are you sure you want to change this driver while a game is loaded?"
   ).setAlignment(settingsWindow).question() != "Yes") return false;
+  lock_guard<recursive_mutex> programLock(program.programMutex);
   program.videoDriverUpdate();
   videoRefresh();
   return true;
@@ -228,6 +229,7 @@ auto DriverSettings::audioDriverUpdate() -> bool {
     "Warning: incompatible drivers may cause this software to crash.\n"
     "Are you sure you want to change this driver while a game is loaded?"
   ).setAlignment(settingsWindow).question() != "Yes") return false;
+  lock_guard<recursive_mutex> programLock(program.programMutex);
   program.audioDriverUpdate();
   audioRefresh();
   return true;
@@ -251,6 +253,7 @@ auto DriverSettings::inputDriverUpdate() -> bool {
     "Warning: incompatible drivers may cause this software to crash.\n"
     "Are you sure you want to change this driver while a game is loaded?"
   ).setAlignment(settingsWindow).question() != "Yes") return false;
+  lock_guard<recursive_mutex> programLock(program.programMutex);
   program.inputDriverUpdate();
   inputRefresh();
   return true;

--- a/desktop-ui/settings/hotkeys.cpp
+++ b/desktop-ui/settings/hotkeys.cpp
@@ -48,6 +48,7 @@ auto HotkeySettings::refresh() -> void {
 }
 
 auto HotkeySettings::eventChange() -> void {
+  lock_guard<recursive_mutex> programLock(program.programMutex);
   assignButton.setEnabled(inputList.batched().size() == 1);
   clearButton.setEnabled(inputList.batched().size() >= 1);
 }

--- a/desktop-ui/settings/input.cpp
+++ b/desktop-ui/settings/input.cpp
@@ -160,6 +160,7 @@ auto InputSettings::eventAssign(TableViewCell cell, string binding) -> void {
 }
 
 auto InputSettings::eventAssign(TableViewCell cell) -> void {
+  lock_guard<recursive_mutex> programLock(program.programMutex);
   inputManager.poll(true);  //clear any pending events first
 
   if(ruby::input.driver() == "None") return (void)MessageDialog().setText(

--- a/desktop-ui/tools/graphics.cpp
+++ b/desktop-ui/tools/graphics.cpp
@@ -1,4 +1,5 @@
-auto GraphicsViewer::construct() -> void {
+auto GraphicsViewer::construct(std::recursive_mutex *programMutexIn) -> void {
+  this->programMutex = programMutexIn;
   setCollapsible();
   setVisible(false);
 
@@ -6,6 +7,7 @@ auto GraphicsViewer::construct() -> void {
   graphicsList.onChange([&] { eventChange(); });
   graphicsView.setAlignment({0.0, 0.0});
   exportButton.setText("Export").onActivate([&] {
+    lock_guard<recursive_mutex> lock(*programMutex);
     eventExport();
   });
   liveOption.setText("Live");

--- a/desktop-ui/tools/tools.cpp
+++ b/desktop-ui/tools/tools.cpp
@@ -17,7 +17,7 @@ StreamManager& streamManager = toolsWindow.streamManager;
 PropertiesViewer& propertiesViewer = toolsWindow.propertiesViewer;
 TraceLogger& traceLogger = toolsWindow.traceLogger;
 
-ToolsWindow::ToolsWindow() {
+ToolsWindow::ToolsWindow(std::recursive_mutex *programMutex) {
 
   panelList.append(ListViewItem().setText("Manifest").setIcon(Icon::Emblem::Binary));
   panelList.append(ListViewItem().setText("Cheats").setIcon(Icon::Emblem::Text));
@@ -43,9 +43,9 @@ ToolsWindow::ToolsWindow() {
   panelContainer.append(homePanel, Size{~0, ~0});
 
   manifestViewer.construct();
-  cheatEditor.construct();
-  memoryEditor.construct();
-  graphicsViewer.construct();
+  cheatEditor.construct(programMutex);
+  memoryEditor.construct(programMutex);
+  graphicsViewer.construct(programMutex);
   streamManager.construct();
   propertiesViewer.construct();
   traceLogger.construct();

--- a/desktop-ui/tools/tools.hpp
+++ b/desktop-ui/tools/tools.hpp
@@ -12,13 +12,15 @@ struct ManifestViewer : VerticalLayout {
 };
 
 struct CheatEditor : VerticalLayout {
-  auto construct() -> void;
+  auto construct(std::recursive_mutex *programMutex) -> void;
   auto reload() -> void;
   auto unload() -> void;
   auto refresh() -> void;
   auto setVisible(bool visible = true) -> CheatEditor&;
 
   auto find(u32 address) -> maybe<u32>;
+  
+  std::recursive_mutex *programMutex;
 
   Label cheatsLabel{this, Size{~0, 0}, 5};
   HorizontalLayout editLayout{this, Size{~0, 0}};
@@ -47,7 +49,7 @@ struct CheatEditor : VerticalLayout {
 };
 
 struct MemoryEditor : VerticalLayout {
-  auto construct() -> void;
+  auto construct(std::recursive_mutex *programMutex) -> void;
   auto reload() -> void;
   auto unload() -> void;
   auto refresh() -> void;
@@ -55,6 +57,8 @@ struct MemoryEditor : VerticalLayout {
   auto eventChange() -> void;
   auto eventExport() -> void;
   auto setVisible(bool visible = true) -> MemoryEditor&;
+  
+  std::recursive_mutex *programMutex;
 
   Label memoryLabel{this, Size{~0, 0}, 5};
   ComboButton memoryList{this, Size{~0, 0}};
@@ -69,7 +73,7 @@ struct MemoryEditor : VerticalLayout {
 };
 
 struct GraphicsViewer : VerticalLayout {
-  auto construct() -> void;
+  auto construct(std::recursive_mutex *programMutex) -> void;
   auto reload() -> void;
   auto unload() -> void;
   auto refresh() -> void;
@@ -77,6 +81,8 @@ struct GraphicsViewer : VerticalLayout {
   auto eventChange() -> void;
   auto eventExport() -> void;
   auto setVisible(bool visible = true) -> GraphicsViewer&;
+  
+  std::recursive_mutex *programMutex;
 
   Label graphicsLabel{this, Size{~0, 0}, 5};
   ComboButton graphicsList{this, Size{~0, 0}};
@@ -128,7 +134,7 @@ struct TraceLogger : VerticalLayout {
 };
 
 struct ToolsWindow : Window {
-  ToolsWindow();
+  ToolsWindow(std::recursive_mutex *programMutex);
   auto show(const string& panel) -> void;
   auto eventChange() -> void;
 

--- a/hiro/cocoa/application.cpp
+++ b/hiro/cocoa/application.cpp
@@ -144,8 +144,7 @@ auto pApplication::run() -> void {
   if(Application::state().onMain) {
     applicationTimer = [NSTimer scheduledTimerWithTimeInterval:0.0 target:cocoaDelegate selector:@selector(run:) userInfo:nil repeats:YES];
 
-    //below line is needed to run application during window resize; however it has a large performance penalty on the resize smoothness
-    //[[NSRunLoop currentRunLoop] addTimer:applicationTimer forMode:NSEventTrackingRunLoopMode];
+    [[NSRunLoop currentRunLoop] addTimer:applicationTimer forMode:NSRunLoopCommonModes];
   }
   [[NSUserDefaults standardUserDefaults] registerDefaults:@{
     //@"NO" is not a mistake; the value really needs to be a string

--- a/hiro/core/core.hpp
+++ b/hiro/core/core.hpp
@@ -13,6 +13,7 @@
 #include <nall/shared-pointer.hpp>
 #include <nall/stdint.hpp>
 #include <nall/string.hpp>
+#include <nall/thread.hpp>
 #include <nall/traits.hpp>
 #include <nall/unique-pointer.hpp>
 #include <nall/utility.hpp>

--- a/hiro/windows/window.cpp
+++ b/hiro/windows/window.cpp
@@ -24,7 +24,6 @@ u32 pWindow::minimumStatusHeight = 0;
 
 auto pWindow::initialize() -> void {
   pApplication::state().modalTimer.setInterval(1);
-  pApplication::state().modalTimer.onActivate([] { Application::doMain(); });
 
   HWND hwnd = CreateWindow(L"hiroWindow", L"", ResizableStyle, 128, 128, 256, 256, 0, 0, GetModuleHandle(0), 0);
   HWND hstatus = CreateWindow(STATUSCLASSNAME, L"", WS_CHILD, 0, 0, 0, 0, hwnd, nullptr, GetModuleHandle(0), 0);

--- a/nall/nall/thread.cpp
+++ b/nall/nall/thread.cpp
@@ -29,11 +29,11 @@ NALL_HEADER_INLINE auto thread::join() -> void {
 
 NALL_HEADER_INLINE auto thread::create(const function<void (uintptr)>& callback, uintptr parameter, u32 stacksize) -> thread {
   thread instance;
-
+  
   auto context = new thread::context;
   context->callback = callback;
   context->parameter = parameter;
-
+  
   instance.handle = CreateThread(nullptr, stacksize, _threadCallback, (void*)context, 0, nullptr);
   return instance;
 }
@@ -46,6 +46,11 @@ NALL_HEADER_INLINE auto thread::detach() -> void {
 
 NALL_HEADER_INLINE auto thread::exit() -> void {
   ExitThread(0);
+}
+
+NALL_HEADER_INLINE auto thread::setName(string name) -> void {
+  HANDLE hThread = GetCurrentThread();
+  HRESULT hr = SetThreadDescription(hThread, (wchar_t*)utf16_t(name));
 }
 
 #endif

--- a/nall/nall/thread.cpp
+++ b/nall/nall/thread.cpp
@@ -29,11 +29,11 @@ NALL_HEADER_INLINE auto thread::join() -> void {
 
 NALL_HEADER_INLINE auto thread::create(const function<void (uintptr)>& callback, uintptr parameter, u32 stacksize) -> thread {
   thread instance;
-  
+
   auto context = new thread::context;
   context->callback = callback;
   context->parameter = parameter;
-  
+
   instance.handle = CreateThread(nullptr, stacksize, _threadCallback, (void*)context, 0, nullptr);
   return instance;
 }

--- a/nall/nall/thread.hpp
+++ b/nall/nall/thread.hpp
@@ -44,6 +44,7 @@ struct thread {
   static auto create(const function<void (uintptr)>& callback, uintptr parameter = 0, u32 stacksize = 0) -> thread;
   static auto detach() -> void;
   static auto exit() -> void;
+  static auto setName(string name) -> void;
 
   struct context {
     function<auto (uintptr) -> void> callback;
@@ -91,6 +92,14 @@ inline auto thread::exit() -> void {
   pthread_exit(nullptr);
 }
 
+inline auto thread::setName(string name) -> void {
+#if defined(__APPLE__)
+  pthread_setname_np(name);
+#else
+  pthread_setname_np(pthread_self(), name);
+#endif
+}
+
 }
 
 #elif defined(API_WINDOWS)
@@ -120,6 +129,7 @@ struct thread {
   static auto create(const function<void (uintptr)>& callback, uintptr parameter = 0, u32 stacksize = 0) -> thread;
   static auto detach() -> void;
   static auto exit() -> void;
+  static auto setName(string name) -> void;
 
   struct context {
     function<auto (uintptr) -> void> callback;


### PR DESCRIPTION
Rearranges ares's main run loop, putting emulation in its own dedicated thread that is separate from the main/GUI thread. This updates ares to somewhat more modern application practices. This rework should have an array of benefits, including increased UI responsiveness, improved energy efficiency/performance, and increased compatibility with various modern APIs and frameworks for rendering, input, and audio.

## Details

Generally, this PR implements a fairly simple approach to threading, using `nall::thread`'s pthread-like semantics and several basic recursive mutexes. For this initial implementation, we use very coarse locking on the emulation thread, combined with very limited access to the emulator state from the main and other ares threads, allowed to occur between emulator run loop iterations. Synchronization on the emulator state is managed via `programMutex`.

Since this mutex is held for the duration of the primary work loop, including while the thread is suspended, the GUI thread should try to never acquire the program mutex unless absolutely necessary. Doing so with regularity will incur a severe UI responsiveness penalty. For destructive updates like driver settings updates, memory writes, and game loads/unloads, we acquire it. For other cross-thread communication, we try to synchronize using other methods that do not incur a significant performance penalty.

Window resizes triggered via the emulation loop synchronize with the `_needsResize` atomic. Status messages are passed by acquiring the `messageMutex`. `vBlanksPerSecond` is also now an `atomic<u64>`.

Input continues to poll on the main thread for compatibility with existing code. Access to the input system is managed via `inputMutex`.

### Known Issues

Draft status as this is still a work in progress, but PRing now for visibility, feedback, and to consolidate any issue tracking. There are likely kinks left to work out; testing is appreciated.

~~- Cores are loaded on the main thread before being run on the emulator thread; this causes issues for paraLLEl-RDP, which expects that the thread to initialize Vulkan is also the thread that will make RDP calls.~~ Addressed.

~~- Memory editor currently does not have access to the program mutex; reads and writes are unsynchronized.~~ Addressed; memory editor synchronizes on writes but reads occur in a thread-unsafe fashion.

~~- The Clang thread sanitizer still reports a couple data races in Metal and OpenGL; further testing with other Ruby drivers is needed to make sure resource access is properly managed, particularly with respect to the output framebuffers.~~ A larger examination of locking in other parts of ares is probably necessary, but I think out of scope for the first iteration of this rework.

- The gdb server seems to still be working fine, but could probably use more testing.