### PR TITLE
gba: improve handling of mid-scanline writes to linear background scroll registers

### DIFF
--- a/ares/gba/ppu/background.cpp
+++ b/ares/gba/ppu/background.cpp
@@ -50,16 +50,14 @@ auto PPU::Background::run(s32 x, u32 y) -> void {
 auto PPU::Background::linearFetchTileMap(s32 x, u32 y) -> void {
   if(ppu.blank() || !io.enable[0]) return;
 
-  //start scanline when first partially visible tile is reached
-  n3 subTileScroll = io.hoffset;
-  if(x + subTileScroll < 0) return;
-  if(x + subTileScroll == 0) {
+  if(x == -7) {
     if(!io.mosaic || (y % (1 + io.mosaicHeight)) == 0) {
       vmosaic = y;
     }
-    fx = io.hoffset & ~7;
-    fy = vmosaic + io.voffset;
   }
+
+  fx = x + io.hoffset;
+  fy = vmosaic + io.voffset;
 
   n3 px = fx;
   if(px == 0) {
@@ -80,8 +78,6 @@ auto PPU::Background::linearFetchTileMap(s32 x, u32 y) -> void {
     latch.active    = true;
     latch.px        = 0;
   }
-
-  fx++;
 }
 
 auto PPU::Background::linearFetchTileData() -> void {

--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -211,6 +211,7 @@ auto PPU::main() -> void {
       #undef cycles32
       #undef cycles64
     } else {
+      step(renderingCycle);
       for(s32 x : range(247)) {
         bg0.run(x - 7, y);
         bg1.run(x - 7, y);
@@ -222,7 +223,7 @@ auto PPU::main() -> void {
         dac.lowerLayer(x, y);
       }
       releaseBus();
-      step(1035);
+      step(1035 - renderingCycle);
     }
   } else {
     step(1035);
@@ -261,6 +262,15 @@ auto PPU::power() -> void {
   window2.power(IN2);
   window3.power(OUT);
   dac.power();
+
+  renderingCycle = 43;  //by default, render at first cycle of pixel output
+  string gameID;
+  for(u32 index : range(4)) {
+    char byte = cartridge.readRom<true>(Byte, 0xac + index);
+    gameID.append(byte);
+  }
+  if(gameID == "AWRE") renderingCycle = 512;  //Advance Wars (USA)
+  if(gameID == "AWRP") renderingCycle = 512;  //Advance Wars (Europe) (En,Fr,De,Es)
 }
 
 }

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -307,6 +307,7 @@ private:
 
   bool pramAccessed;
   bool vramAccessedBG;
+  n32  renderingCycle;
 };
 
 extern PPU ppu;


### PR DESCRIPTION
Also added renderingCycle to scanline PPU, similarly to SFC and PCE cores.

Closes #716.