### PR TITLE
libco: Define `LIBCO_MPROTECT` by default on aarch64

### DIFF
--- a/libco/libco.c
+++ b/libco/libco.c
@@ -1,13 +1,3 @@
-#if defined(__clang__)
-  #pragma clang diagnostic ignored "-Wparentheses"
-
-  #if !defined(_MSC_VER)
-    /* placing code in section(text) does not mark it executable with Clang. */
-    #undef  LIBCO_MPROTECT
-    #define LIBCO_MPROTECT
-  #endif
-#endif
-
 #if defined(__clang__) || defined(__GNUC__)
   #if defined(__i386__)
     #include "x86.c"

--- a/libco/settings.h
+++ b/libco/settings.h
@@ -40,5 +40,23 @@
   #define section(name) __attribute__((section("." #name "#")))
 #endif
 
+#if defined(__clang__)
+  #pragma clang diagnostic ignored "-Wparentheses"
+
+  #if !defined(_MSC_VER)
+    /* placing code in section(text) does not mark it executable with Clang. */
+    #undef  LIBCO_MPROTECT
+    #define LIBCO_MPROTECT
+  #endif
+#endif
+
+#if defined(__aarch64__)
+  /* NX also seems to be consistently set under non-Windows arm64  */
+  #if !defined(_MSC_VER)
+    #undef  LIBCO_MPROTECT
+    #define LIBCO_MPROTECT
+  #endif
+#endif
+
 /* if defined(LIBCO_C) */
 #endif


### PR DESCRIPTION
Code on the stack on arm64 seems to generally be protected by the NX bit.

Fixes libco built with GCC on Apple Silicon.