### PR TITLE
gb: implement PCM12 and PCM34 registers

### DIFF
--- a/ares/gb/apu/apu.hpp
+++ b/ares/gb/apu/apu.hpp
@@ -44,6 +44,7 @@ struct APU : Thread {
     n11 frequency;
     bool counter;
 
+    n4 sample;
     i16 output;
     bool dutyOutput;
     n3 phase;
@@ -77,6 +78,7 @@ struct APU : Thread {
     n11 frequency;
     bool counter;
 
+    n4 sample;
     i16 output;
     bool dutyOutput;
     n3 phase;
@@ -105,6 +107,7 @@ struct APU : Thread {
     bool counter;
     n8 pattern[16];
 
+    n4 sample;
     i16 output;
     u32 length;
     u32 period;
@@ -135,6 +138,7 @@ struct APU : Thread {
     n3 divisor;
     bool counter;
 
+    n4 sample;
     i16 output;
     u32 length;
     n3 envelopePeriod;

--- a/ares/gb/apu/io.cpp
+++ b/ares/gb/apu/io.cpp
@@ -1,4 +1,20 @@
 auto APU::readIO(u32 cycle, n16 address, n8 data) -> n8 {
+  if(Model::GameBoyColor()) {
+    //PCM12
+    if(address == 0xff76 && cycle == 2) {
+      data.bit(0,3) = square1.sample;
+      data.bit(4,7) = square2.sample;
+      return data;
+    }
+
+    //PCM34
+    if(address == 0xff77 && cycle == 2) {
+      data.bit(0,3) = wave.sample;
+      data.bit(4,7) = noise.sample;
+      return data;
+    }
+  }
+
   if(address < 0xff10 || address > 0xff3f) return data;
 
   //NR10

--- a/ares/gb/apu/noise.cpp
+++ b/ares/gb/apu/noise.cpp
@@ -16,7 +16,7 @@ auto APU::Noise::run() -> void {
     }
   }
 
-  n4 sample = lfsr & 1 ? 0 : (u32)volume;
+  sample = lfsr & 1 ? 0 : (u32)volume;
   if(!enable) sample = 0;
 
   output = sample;
@@ -79,6 +79,7 @@ auto APU::Noise::serialize(serializer& s) -> void {
   s(divisor);
   s(counter);
 
+  s(sample);
   s(output);
   s(length);
   s(envelopePeriod);

--- a/ares/gb/apu/square1.cpp
+++ b/ares/gb/apu/square1.cpp
@@ -14,7 +14,7 @@ auto APU::Square1::run() -> void {
     }
   }
 
-  n4 sample = dutyOutput ? (u32)volume : 0;
+  sample = dutyOutput ? (u32)volume : 0;
   if(!enable) sample = 0;
 
   output = sample;
@@ -120,6 +120,7 @@ auto APU::Square1::serialize(serializer& s) -> void {
   s(frequency);
   s(counter);
 
+  s(sample);
   s(output);
   s(dutyOutput);
   s(phase);

--- a/ares/gb/apu/square2.cpp
+++ b/ares/gb/apu/square2.cpp
@@ -14,7 +14,7 @@ auto APU::Square2::run() -> void {
     }
   }
 
-  n4 sample = dutyOutput ? (u32)volume : 0;
+  sample = dutyOutput ? (u32)volume : 0;
   if(!enable) sample = 0;
 
   output = sample;
@@ -77,6 +77,7 @@ auto APU::Square2::serialize(serializer& s) -> void {
   s(frequency);
   s(counter);
 
+  s(sample);
   s(output);
   s(dutyOutput);
   s(phase);

--- a/ares/gb/apu/wave.cpp
+++ b/ares/gb/apu/wave.cpp
@@ -12,7 +12,7 @@ auto APU::Wave::run() -> void {
   }
 
   static const u32 shift[] = {4, 0, 1, 2};  //0%, 100%, 50%, 25%
-  n4 sample = patternSample >> shift[volume];
+  sample = patternSample >> shift[volume];
   if(!enable) sample = 0;
 
   output = sample;
@@ -95,6 +95,7 @@ auto APU::Wave::serialize(serializer& s) -> void {
   s(counter);
   s(pattern);
 
+  s(sample);
   s(output);
   s(length);
   s(period);

--- a/ares/gb/cpu/io.cpp
+++ b/ares/gb/cpu/io.cpp
@@ -139,16 +139,6 @@ auto CPU::readIO(u32 cycle, n16 address, n8 data) -> n8 {
     return data;
   }
 
-  if(Model::GameBoyColor())
-  if(address == 0xff76 && cycle == 2) {  //???
-    return 0xff;
-  }
-
-  if(Model::GameBoyColor())
-  if(address == 0xff77 && cycle == 2) {  //???
-    return 0xff;
-  }
-
   if(address == 0xffff && cycle == 2) {  //IE
     return status.interruptEnable;
   }

--- a/ares/gb/system/serialization.cpp
+++ b/ares/gb/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v143";
+static const string SerializerVersion = "v143.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);

--- a/ares/sfc/system/serialization.cpp
+++ b/ares/sfc/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v143";
+static const string SerializerVersion = "v143.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Reading these registers should return the digital output values of each APU channel, as described [here](https://gbdev.io/pandocs/Audio_details.html#pcm-registers).