### PR TITLE
build: Enable CHD support via build option

### DIFF
--- a/cmake/common/helpers_common.cmake
+++ b/cmake/common/helpers_common.cmake
@@ -235,6 +235,17 @@ function(_extract_target_from_link_expression)
         set(${arg_dt_TARGET_VAR} "${gen_library}")
       endif()
     endif()
+  elseif(arg_dt_LIBRARY MATCHES "\\$<LINK_ONLY:[^>]+>")
+    # Non-specific target link expression found. Since no other expressions matched, consider the parameter following
+    # LINK_ONLY to be a CMake target.
+    string(REGEX REPLACE "\\$<LINK_ONLY:([^>]+)>" "\\1" gen_library "${arg_dt_LIBRARY}")
+
+    message(DEBUG "gen_library is ${gen_library}")
+
+    if(TARGET ${gen_library})
+      message(DEBUG "setting arg_dt_TARGET_VAR to ${gen_library}")
+      set(${arg_dt_TARGET_VAR} ${gen_library})
+    endif()
   else()
     # Unknown or unimplemented generator expression found. Abort script run to either add to ignore list or implement
     # detection.

--- a/desktop-ui/CMakeLists.txt
+++ b/desktop-ui/CMakeLists.txt
@@ -47,8 +47,12 @@ endif()
 
 target_link_libraries(
   desktop-ui
-  PRIVATE ares::ruby ares::hiro ares::ares mia chdr-static sljit
+  PRIVATE ares::ruby ares::hiro ares::ares mia sljit
 )
+
+if(ARES_ENABLE_CHD)
+  target_link_libraries(desktop-ui PRIVATE chdr-static)
+endif()
 
 set_target_properties(desktop-ui PROPERTIES OUTPUT_NAME ares)
 

--- a/mia/CMakeLists.txt
+++ b/mia/CMakeLists.txt
@@ -3,6 +3,13 @@ add_library(ares::mia ALIAS mia)
 
 add_sourcery_command(mia resource)
 
+if(ARES_ENABLE_CHD)
+  target_compile_definitions(mia PUBLIC ARES_ENABLE_CHD)
+  target_enable_feature(mia "CHD format support via libchdr")
+else()
+  target_disable_feature(mia "CHD format support via libchdr")
+endif()
+
 target_sources(
   mia
   PRIVATE

--- a/mia/medium/medium.cpp
+++ b/mia/medium/medium.cpp
@@ -164,6 +164,19 @@ auto CompactDisc::manifestAudio(string location) -> string {
   return manifest;
 }
 
+auto CompactDisc::readDataSector(string pathname, u32 sectorID) -> vector<u8> {
+  if(pathname.iendsWith(".bcd")) {
+    return readDataSectorBCD(pathname, sectorID);
+  }
+  if(pathname.iendsWith(".cue")) {
+    return readDataSectorCUE(pathname, sectorID);
+  }
+  if(pathname.iendsWith(".chd")) {
+    return readDataSectorCHD(pathname, sectorID);
+  }
+  return {};
+}
+
 auto CompactDisc::readDataSectorBCD(string pathname, u32 sectorID) -> vector<u8> {
   auto fp = file::open({pathname, "cd.rom"}, file::mode::read);
   if(!fp) return {};

--- a/mia/medium/medium.cpp
+++ b/mia/medium/medium.cpp
@@ -171,9 +171,11 @@ auto CompactDisc::readDataSector(string pathname, u32 sectorID) -> vector<u8> {
   if(pathname.iendsWith(".cue")) {
     return readDataSectorCUE(pathname, sectorID);
   }
+#if defined(ARES_ENABLE_CHD)
   if(pathname.iendsWith(".chd")) {
     return readDataSectorCHD(pathname, sectorID);
   }
+#endif
   return {};
 }
 
@@ -250,6 +252,7 @@ auto CompactDisc::readDataSectorCUE(string filename, u32 sectorID) -> vector<u8>
   return {};
 }
 
+#if defined(ARES_ENABLE_CHD)
 auto CompactDisc::readDataSectorCHD(string filename, u32 sectorID) -> vector<u8> {
   Decode::CHD chd;
   if(!chd.load(filename)) return {};
@@ -277,3 +280,4 @@ auto CompactDisc::readDataSectorCHD(string filename, u32 sectorID) -> vector<u8>
 
   return {};
 }
+#endif

--- a/mia/medium/medium.hpp
+++ b/mia/medium/medium.hpp
@@ -21,6 +21,8 @@ struct CompactDisc : Medium {
   auto type() -> string override { return "Compact Disc"; }
   auto extensions() -> vector<string> override { return {"cue", "chd"}; }
   auto manifestAudio(string location) -> string;
+  auto readDataSector(string filename, u32 sectorID) -> vector<u8>;
+private:
   auto readDataSectorBCD(string filename, u32 sectorID) -> vector<u8>;
   auto readDataSectorCUE(string filename, u32 sectorID) -> vector<u8>;
   auto readDataSectorCHD(string filename, u32 sectorID) -> vector<u8>;

--- a/mia/medium/medium.hpp
+++ b/mia/medium/medium.hpp
@@ -19,13 +19,21 @@ struct Cartridge : Medium {
 
 struct CompactDisc : Medium {
   auto type() -> string override { return "Compact Disc"; }
-  auto extensions() -> vector<string> override { return {"cue", "chd"}; }
+  auto extensions() -> vector<string> override {
+#if defined(ARES_ENABLE_CHD)
+    return {"cue", "chd"};
+#else
+    return {"cue"};
+#endif
+  }
   auto manifestAudio(string location) -> string;
   auto readDataSector(string filename, u32 sectorID) -> vector<u8>;
 private:
   auto readDataSectorBCD(string filename, u32 sectorID) -> vector<u8>;
   auto readDataSectorCUE(string filename, u32 sectorID) -> vector<u8>;
+#if defined(ARES_ENABLE_CHD)
   auto readDataSectorCHD(string filename, u32 sectorID) -> vector<u8>;
+#endif
 };
 
 struct FloppyDisk : Medium {

--- a/mia/medium/mega-cd.cpp
+++ b/mia/medium/mega-cd.cpp
@@ -39,11 +39,7 @@ auto MegaCD::save(string location) -> bool {
 auto MegaCD::analyze(string location) -> string {
   vector<u8> sector;
 
-  if(location.iendsWith(".cue")) {
-      sector = readDataSectorCUE(location, 0);
-  } else if (location.iendsWith(".chd")) {
-      sector = readDataSectorCHD(location, 0);
-  }
+  sector = readDataSector(location, 0);
 
   if(!sector || memory::compare(sector.data(), "SEGA", 4))
     return CompactDisc::manifestAudio(location);

--- a/mia/medium/mega-cd.cpp
+++ b/mia/medium/mega-cd.cpp
@@ -1,6 +1,12 @@
 struct MegaCD : CompactDisc {
   auto name() -> string override { return "Mega CD"; }
-  auto extensions() -> vector<string> override { return {"cue", "chd"}; }
+  auto extensions() -> vector<string> override {
+#if defined(ARES_ENABLE_CHD)
+    return {"cue", "chd"};
+#else
+    return {"cue"};
+#endif
+  }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(string location) -> string;

--- a/mia/medium/pc-engine-cd.cpp
+++ b/mia/medium/pc-engine-cd.cpp
@@ -39,13 +39,8 @@ auto PCEngineCD::save(string location) -> bool {
 auto PCEngineCD::analyze(string location) -> string {
   vector<u8> sectors[2];
 
-  if(location.iendsWith(".cue")) {
-    sectors[0] = readDataSectorCUE(location, 0);  // NEC
-    sectors[1] = readDataSectorCUE(location, 16); // Games Express
-  } else if (location.iendsWith(".chd")) {
-    sectors[0] = readDataSectorCHD(location, 0);  // NEC
-    sectors[1] = readDataSectorCHD(location, 16); // Games Express
-  }
+  sectors[0] = readDataSector(location, 0);
+  sectors[1] = readDataSector(location, 16);
 
   if(!sectors[0] && !sectors[1]) return CompactDisc::manifestAudio(location);
 

--- a/mia/medium/pc-engine-cd.cpp
+++ b/mia/medium/pc-engine-cd.cpp
@@ -1,6 +1,12 @@
 struct PCEngineCD : CompactDisc {
   auto name() -> string override { return "PC Engine CD"; }
-  auto extensions() -> vector<string> override { return {"cue", "chd"}; }
+  auto extensions() -> vector<string> override {
+#if defined(ARES_ENABLE_CHD)
+    return {"cue", "chd"};
+#else
+    return {"cue"};
+#endif
+  }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(string location) -> string;

--- a/mia/medium/playstation.cpp
+++ b/mia/medium/playstation.cpp
@@ -1,6 +1,12 @@
 struct PlayStation : CompactDisc {
   auto name() -> string override { return "PlayStation"; }
-  auto extensions() -> vector<string> override { return {"cue", "chd", "exe"}; }
+  auto extensions() -> vector<string> override {
+#if defined(ARES_ENABLE_CHD)
+    return {"cue", "chd", "exe"};
+#else
+    return {"cue", "exe"};
+#endif
+  }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(string location) -> string;

--- a/mia/medium/playstation.cpp
+++ b/mia/medium/playstation.cpp
@@ -47,11 +47,7 @@ auto PlayStation::analyze(string location) -> string {
   if(location.iendsWith(".cue") || location.iendsWith(".chd")) {
     vector<u8> sector;
 
-    if(location.iendsWith(".cue")) {
-      sector = readDataSectorCUE(location, 4);
-    } else if (location.iendsWith(".chd")) {
-      sector = readDataSectorCHD(location, 4);
-    }
+    sector = readDataSector(location, 4);
 
     if(!sector) return CompactDisc::manifestAudio(location);
 

--- a/mia/mia.hpp
+++ b/mia/mia.hpp
@@ -4,7 +4,9 @@
 #include <nall/vfs.hpp>
 #include <nall/beat/single/apply.hpp>
 #include <nall/decode/cue.hpp>
+#if defined(ARES_ENABLE_CHD)
 #include <nall/decode/chd.hpp>
+#endif
 #include <nall/decode/wav.hpp>
 using namespace nall;
 

--- a/nall/nall/CMakeLists.txt
+++ b/nall/nall/CMakeLists.txt
@@ -3,7 +3,14 @@ add_library(ares::nall ALIAS nall)
 
 include(cmake/sources.cmake)
 
-target_link_libraries(nall PUBLIC sljit chdr-static)
+find_package(Threads REQUIRED)
+target_link_libraries(nall PRIVATE Threads::Threads)
+
+target_link_libraries(nall PUBLIC sljit)
+if(ARES_ENABLE_CHD)
+  target_link_libraries(nall PUBLIC chdr-static)
+  target_compile_definitions(nall PUBLIC ARES_ENABLE_CHD)
+endif()
 target_compile_definitions(nall PUBLIC CMAKE)
 target_compile_options(
   nall

--- a/nall/nall/cmake/headers.cpp
+++ b/nall/nall/cmake/headers.cpp
@@ -98,7 +98,9 @@
 #include <nall/cd.hpp>
 #include <nall/ips.hpp>
 #include <nall/decode/cue.hpp>
+#if defined(ARES_ENABLE_CHD)
 #include <nall/decode/chd.hpp>
+#endif
 #include <nall/decode/wav.hpp>
 #include <nall/dsp/iir/one-pole.hpp>
 #include <nall/dsp/iir/biquad.hpp>

--- a/nall/nall/vfs/cdrom.hpp
+++ b/nall/nall/vfs/cdrom.hpp
@@ -5,7 +5,9 @@
 #include <nall/file.hpp>
 #include <nall/string.hpp>
 #include <nall/decode/cue.hpp>
+#if defined(ARES_ENABLE_CHD)
 #include <nall/decode/chd.hpp>
+#endif
 #include <nall/decode/wav.hpp>
 
 namespace nall::vfs {
@@ -18,7 +20,9 @@ struct cdrom : file {
   static auto open(const string& location) -> shared_pointer<cdrom> {
     auto instance = shared_pointer<cdrom>{new cdrom};
     if(location.iendsWith(".cue") && instance->loadCue(location)) return instance;
+#if defined(ARES_ENABLE_CHD)
     if(location.iendsWith(".chd") && instance->loadChd(location)) return instance;
+#endif
     return {};
   }
 
@@ -184,7 +188,7 @@ private:
 
     return true;
   }
-
+#if defined(ARES_ENABLE_CHD)
   auto loadChd(const string& location) -> bool {
     auto chd = shared_pointer<Decode::CHD>::create();
     if(!chd->load(location)) return false;
@@ -265,6 +269,7 @@ private:
 
     return true;
   }
+#endif
 
 private:
   void loadSub(const string& location, const CD::Session& session) {

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -4,55 +4,59 @@ target_include_directories(sljit PUBLIC ../thirdparty)
 target_compile_definitions(sljit PUBLIC SLJIT_HAVE_CONFIG_PRE=1 SLJIT_HAVE_CONFIG_POST=1)
 target_compile_options(sljit PRIVATE $<$<COMPILE_LANG_AND_ID:C,AppleClang,Clang,GNU>:-Wno-conditional-uninitialized>)
 
-# lzma
-add_subdirectory(libchdr/deps/lzma-24.05 EXCLUDE_FROM_ALL)
-list(APPEND CHDR_LIBS lzma)
-list(APPEND CHDR_INCLUDES lzma)
+option(ARES_ENABLE_CHD "Enable CHD format support via libchdr" ON)
 
-if(OS_MACOS)
-  option(WITH_SYSTEM_ZLIB "Use system zlib" ON)
-endif()
-# zlib
-if(WITH_SYSTEM_ZLIB)
-  find_package(ZLIB REQUIRED)
-  list(APPEND PLATFORM_LIBS ZLIB::ZLIB)
-else()
-  option(ZLIB_BUILD_EXAMPLES "Enable Zlib Examples" OFF)
-  add_subdirectory(libchdr/deps/zlib-1.3.1 EXCLUDE_FROM_ALL)
-  set_target_properties(
-    zlibstatic
-    PROPERTIES POSITION_INDEPENDENT_CODE ON FOLDER thirdparty PREFIX ""
+if(ARES_ENABLE_CHD)
+  # lzma
+  add_subdirectory(libchdr/deps/lzma-24.05 EXCLUDE_FROM_ALL)
+  list(APPEND CHDR_LIBS lzma)
+  list(APPEND CHDR_INCLUDES lzma)
+
+  if(OS_MACOS)
+    option(WITH_SYSTEM_ZLIB "Use system zlib" ON)
+  endif()
+  # zlib
+  if(WITH_SYSTEM_ZLIB)
+    find_package(ZLIB REQUIRED)
+    list(APPEND PLATFORM_LIBS ZLIB::ZLIB)
+  else()
+    option(ZLIB_BUILD_EXAMPLES "Enable Zlib Examples" OFF)
+    add_subdirectory(libchdr/deps/zlib-1.3.1 EXCLUDE_FROM_ALL)
+    set_target_properties(
+      zlibstatic
+      PROPERTIES POSITION_INDEPENDENT_CODE ON FOLDER thirdparty PREFIX ""
+    )
+    list(APPEND CHDR_LIBS zlibstatic)
+  endif()
+
+  # zstd
+  option(ZSTD_BUILD_SHARED "BUILD SHARED LIBRARIES" OFF)
+  option(ZSTD_BUILD_PROGRAMS "BUILD PROGRAMS" OFF)
+  add_subdirectory(libchdr/deps/zstd-1.5.6/build/cmake EXCLUDE_FROM_ALL)
+  list(APPEND CHDR_LIBS libzstd_static)
+  #--------------------------------------------------
+  # chdr
+  #--------------------------------------------------
+
+  set(
+    CHDR_SOURCES
+    libchdr/src/libchdr_bitstream.c
+    libchdr/src/libchdr_cdrom.c
+    libchdr/src/libchdr_chd.c
+    libchdr/src/libchdr_flac.c
+    libchdr/src/libchdr_huffman.c
   )
-  list(APPEND CHDR_LIBS zlibstatic)
+
+  list(APPEND CHDR_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/libchdr/include)
+
+  add_library(chdr-static STATIC ${CHDR_SOURCES})
+  target_include_directories(chdr-static PUBLIC ${CHDR_INCLUDES} PUBLIC libchdr/include)
+  target_link_libraries(chdr-static PRIVATE ${CHDR_LIBS} ${PLATFORM_LIBS})
+  target_compile_options(
+    chdr-static
+    PRIVATE $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-unreachable-code -Wno-unused-function>
+  )
 endif()
-
-# zstd
-option(ZSTD_BUILD_SHARED "BUILD SHARED LIBRARIES" OFF)
-option(ZSTD_BUILD_PROGRAMS "BUILD PROGRAMS" OFF)
-add_subdirectory(libchdr/deps/zstd-1.5.6/build/cmake EXCLUDE_FROM_ALL)
-list(APPEND CHDR_LIBS libzstd_static)
-#--------------------------------------------------
-# chdr
-#--------------------------------------------------
-
-set(
-  CHDR_SOURCES
-  libchdr/src/libchdr_bitstream.c
-  libchdr/src/libchdr_cdrom.c
-  libchdr/src/libchdr_chd.c
-  libchdr/src/libchdr_flac.c
-  libchdr/src/libchdr_huffman.c
-)
-
-list(APPEND CHDR_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/libchdr/include)
-
-add_library(chdr-static STATIC ${CHDR_SOURCES})
-target_include_directories(chdr-static PUBLIC ${CHDR_INCLUDES} PUBLIC libchdr/include)
-target_link_libraries(chdr-static PRIVATE ${CHDR_LIBS} ${PLATFORM_LIBS})
-target_compile_options(
-  chdr-static
-  PRIVATE $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-unreachable-code -Wno-unused-function>
-)
 
 add_library(
   tzxfile
@@ -100,10 +104,12 @@ target_compile_options(ymfm PRIVATE $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-u
 
 set_target_properties(ymfm PROPERTIES FOLDER thirdparty PREFIX "")
 set_target_properties(tzxfile PROPERTIES FOLDER thirdparty PREFIX "")
-set_target_properties(chdr-static PROPERTIES FOLDER thirdparty PREFIX "")
 set_target_properties(sljit PROPERTIES FOLDER thirdparty PREFIX "")
-if(NOT WITH_SYSTEM_ZLIB)
-  set_target_properties(zlib PROPERTIES FOLDER thirdparty PREFIX "")
+if(ARES_ENABLE_CHD)
+  set_target_properties(chdr-static PROPERTIES FOLDER thirdparty PREFIX "")
+  if(NOT WITH_SYSTEM_ZLIB)
+    set_target_properties(zlib PROPERTIES FOLDER thirdparty PREFIX "")
+  endif()
+  set_target_properties(lzma PROPERTIES FOLDER thirdparty PREFIX "")
+  set_target_properties(libzstd_static PROPERTIES FOLDER thirdparty PREFIX "")
 endif()
-set_target_properties(lzma PROPERTIES FOLDER thirdparty PREFIX "")
-set_target_properties(libzstd_static PROPERTIES FOLDER thirdparty PREFIX "")


### PR DESCRIPTION
Changes support for MAME's "compressed hunks of data" format to be conditional in the build, controlled by the `ARES_ENABLE_CHD` CMake build option. The option is enabled by default.

Converting CHD support into an optional build flag has two benefits. Firstly, we can produce slimmer builds more quickly with fewer dependencies if we don't need CHD support, which is only relevant for a few cores and those users with ROMs stored in the CHD format.

Secondly, if we are eyeing a move to `chd-rs` over `libchdr`, we will want to maintain support for building ares without a Rust toolchain. If we migrate to `chd-rs`, CHD support would possibly be disabled by default on Linux, so that a Rust toolchain is not required there. On macOS and Windows, ares-deps would likely handle vendoring of `chd-rs`.