### PR TITLE
ws: improve RTC cartridge protocol emulation

### DIFF
--- a/ares/ws/cartridge/cartridge.hpp
+++ b/ares/ws/cartridge/cartridge.hpp
@@ -93,6 +93,7 @@ struct Cartridge : IO, Thread {
 
     n4 command;
     n1 active;
+    n1 ready;
     n4 index;
     n8 fetchedData;
     n15 counter;

--- a/ares/ws/cartridge/serialization.cpp
+++ b/ares/ws/cartridge/serialization.cpp
@@ -41,6 +41,7 @@ auto Cartridge::RTC::serialize(serializer& s) -> void {
 
   s(command);
   s(active);
+  s(ready);
   s(index);
   s(fetchedData);
   s(counter);

--- a/ares/ws/system/serialization.cpp
+++ b/ares/ws/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v144.2";
+static const string SerializerVersion = "v144.3";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Would you believe WS RTC emulation appears to have been just... broken?

- **Fixed writes not assuming that the first byte was already written.** This meant all RTC writes were broken in practice.
- Fixed the ready bit not being emulated; it still doesn't pass one test in my RTC test program, as that's timing-sensitive, and we don't emulate the RTC chip's communication timing.
- Fixed invalid commands not keeping the busy bit enabled.
- Stub implementation of starting new commands mid-command (on real hardware, this would cause a bug in S-3511A communication, but we'd need to separate S-3511A and mapper emulation for that to be implemented correctly).

Tested with lidnariq's rtctest, as well as my own RTC test program.