### PR TITLE
ym2612: fix LFO AM enabled bit not functioning

### DIFF
--- a/ares/component/audio/ym2612/channel.cpp
+++ b/ares/component/audio/ym2612/channel.cpp
@@ -125,7 +125,7 @@ auto YM2612::Channel::Operator::updatePhase() -> void {
 
 auto YM2612::Channel::Operator::updateLevel() -> void {
   u32 lfo = ym2612.lfo.clock & 0x40 ? ym2612.lfo.clock & 0x3f : ~ym2612.lfo.clock & 0x3f;
-  u32 depth = tremolos[channel.tremolo];
+  u32 depth = tremolos[tremoloEnable * channel.tremolo];
 
   bool invert = ssg.attack != ssg.invert && envelope.state != Release;
   n10 value = ssg.enable && invert ? 0x200 - envelope.value : 0 + envelope.value;
@@ -147,7 +147,7 @@ auto YM2612::Channel::power() -> void {
   for(auto& op : operators) {
     op.keyOn = 0;
     op.keyLine = 0;
-    op.lfoEnable = 0;
+    op.tremoloEnable = 0;
     op.keyScale = 0;
     op.detune = 0;
     op.multiple = 0;

--- a/ares/component/audio/ym2612/io.cpp
+++ b/ares/component/audio/ym2612/io.cpp
@@ -121,10 +121,10 @@ auto YM2612::writeData(n8 data) -> void {
     break;
   }
 
-  //LFO enable, decay rate
+  //LFO AM enable, decay rate
   case 0x060: {
     op.envelope.decayRate = data.bit(0,4);
-    op.lfoEnable = data.bit(7);
+    op.tremoloEnable = data.bit(7);
     channel[index].updateEnvelope();
     channel[index].updateLevel();
     break;

--- a/ares/component/audio/ym2612/serialization.cpp
+++ b/ares/component/audio/ym2612/serialization.cpp
@@ -45,7 +45,7 @@ auto YM2612::Channel::serialize(serializer& s) -> void {
 auto YM2612::Channel::Operator::serialize(serializer& s) -> void {
   s(keyOn);
   s(keyLine);
-  s(lfoEnable);
+  s(tremoloEnable);
   s(keyScale);
   s(detune);
   s(multiple);

--- a/ares/component/audio/ym2612/ym2612.hpp
+++ b/ares/component/audio/ym2612/ym2612.hpp
@@ -108,7 +108,7 @@ protected:
 
       n1 keyOn = 0;
       n1 keyLine = 0;
-      n1 lfoEnable = 0;
+      n1 tremoloEnable = 0;
       n5 keyScale = 0;
       n3 detune = 0;
       n4 multiple = 0;


### PR DESCRIPTION
This should fix #1910 (incorrect instrument sounds in Kid Chameleon).

This also renames the `lfoEnable` field to `tremoloEnable` to more accurately reflect what it does, since it has no effect on LFO FM / vibrato.