### PR TITLE
Update MD serialization.cpp

### DIFF
--- a/ares/md/system/serialization.cpp
+++ b/ares/md/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v142.1";
+static const string SerializerVersion = "v144";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Serialization for the MD, specific to the ym2612 audio implementation was changed in a recent PR, but there wasn't a version bump. This corrects this missing contribution. Otherwise it will attempt to load older save states files and fail.