### PR TITLE
Update ares-deps to 2025-04-09 release

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -1,14 +1,14 @@
 {
     "dependencies": {
         "prebuilt": {
-            "version": "2024-12-30",
+            "version": "2025-04-09",
             "baseUrl": "https://github.com/ares-emulator/ares-deps/releases/download",
             "label": "Pre-Built ares-deps",
             "hashes": {
-                "linux-universal": "d2a41db4569daf6fc9623d4933c7aa23fc176af13583a3eefbdbab832f0bc781",
-                "macos-universal": "1373844c53261684c19afc3ab8dec5942638ac21adb00654cbcc636420020a03",
-                "windows-arm64": "33425aac3151e51d9f1fa54e306ca1efba5af73be2b771890e1c2bc83af4c579",
-                "windows-x64": "7f1e1a2e7edb6f7344ff9c3913f530319ebb14c55e88da10ed9d4a1cf568daa8"
+                "linux-universal": "89e65e3fe217698cc04699efacf4479034bb4b5fd20ab1e054055ea61c9e1c18",
+                "macos-universal": "a949751272d359bb315bc18717703ae25a5f837a4c7f5008fe3a710b5c2eb22c",
+                "windows-arm64": "ed89ca335ced2194926e65ce99e82b5da3cced9f782f5f314786d301de3250dd",
+                "windows-x64": "22cb4ff5688fa3d133a39cbb9ee6f6dfdbf38be669940d3eab276736fbc3d977"
             }
         }
     },


### PR DESCRIPTION
Updates the dynamic dependencies used by ares.

Includes:

* Stop vendoring the librashader header on Linux
* deps.windows: Update librashader to 0.6.3
* deps.macos: Update librashader to 0.6.3
* Update slang-shaders to ref 25311dc
* Pin Rust nightly to version contemporary with librashader version
* Establish macOS deployment targets
* deps.macos: Update SDL to 3.2.10
* deps.windows: Update SDL to 3.2.10

> [!NOTE]
> This will cause ares on macOS and Windows to stop successfully locating SDL from ares-deps when configuring until the merger of #1845. This and #1845 should be merged together, but the order does not matter.