### PR TITLE
CI: Preserve symlinks in artifacts

### DIFF
--- a/.github/scripts/package_artifacts.sh
+++ b/.github/scripts/package_artifacts.sh
@@ -21,9 +21,8 @@ do
   mkdir ${outdir}-dSYMs
   cp -a ${bindir}/ares-${package}-dSYMs/*.dSYM ${outdir}-dSYMs
   cp -a ${bindir}/ares-${package}/*.app ${outdir}
-  zip -r ../ares-${package}.zip ${outdir}
-  zip -r ../ares-${package}-dSYMs.zip ${outdir}-dSYMs
-
+  zip -r -y ../ares-${package}.zip ${outdir}
+  zip -r -y ../ares-${package}-dSYMs.zip ${outdir}-dSYMs
   cd -
 done
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,18 +131,19 @@ jobs:
         TARGET_PRESET: ${{ matrix.platform.target-cmake-preset }}
         MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
         MACOS_NOTARIZATION_TEAMID: ${{ secrets.MACOS_NOTARIZATION_TEAMID }}
-    - name: Upload Build (Windows)
-      if: runner.os != 'macOS' && runner.os != 'Linux'
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ matrix.program }}-${{ matrix.platform.name }}
-        path: build/desktop-ui/rundir/*
-    - name: Upload Build (macOS)
+    - name: "Compress Build Artifact (macOS)"
       if: runner.os == 'macOS'
+      run: |
+        tar -cvJf ares-${{ matrix.platform.name }}.tar.xz -C build/desktop-ui/RelWithDebInfo/ .
+    - name: "Compress Build Artifacts (Windows)"
+      if: runner.os != 'macOS' && runner.os != 'Linux'
+      run: |
+        tar -cvJf ares-${{ matrix.platform.name }}.tar.xz -C build/desktop-ui/rundir/ .
+    - name: Upload Build
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.program }}-${{ matrix.platform.name }}
-        path: build/desktop-ui/RelWithDebInfo/
+        path: ares-${{ matrix.platform.name }}.tar.xz
     - name: Upload Debug Symbols (Windows)
       if: runner.os != 'macOS' && runner.os != 'Linux'
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,15 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         path: 'bin'
+    - name: "Decompress Build Artifacts"
+      if: runner.os == 'macOS'
+      run: |
+        for package in macos-universal windows-x64 windows-clang-cl-x64 windows-clang-cl-arm64; do
+          pushd bin/ares-${package}
+          tar -xJf ares-${package}.tar.xz
+          rm -f ares-${package}.tar.xz
+          popd
+        done
     - name: "macOS: notarize"
       if: inputs.notarize
       run: |


### PR DESCRIPTION
The new macOS SDL3 .framework bundle contains symlinks. These symlinks were not being preserved on artifact upload, leading to redundant copies of the SDL3 headers and binary. For some reason this also caused macOS notarization failure.

As noted offthread, our final release artifacts are still `zip`'d, which doesn't preserve file permissions. This doesn't seem to be an issue for us right now, and it's certainly more convenient than needing to decompress release artifacts twice, but is worth keeping in mind as a potential issue for the future.

Test release already done to validate this change here: https://github.com/jcm93/ares/releases/tag/v151