### PR TITLE
gba: approximate PRAM access stalls in scanline renderer

### DIFF
--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -88,6 +88,7 @@ inline auto CPU::stepIRQ() -> void {
 
 auto CPU::step(u32 clocks) -> void {
   if(!clocks) return;
+  context.hcounter = (context.hcounter + clocks) % 1232;
 
   dma[0].waiting = max(0, dma[0].waiting - (s32)clocks);
   dma[1].waiting = max(0, dma[1].waiting - (s32)clocks);

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -268,6 +268,7 @@ struct CPU : ARM7TDMI, Thread, IO {
     n2  dmaActiveChannel;
     n1  timerLatched;
     n1  busLocked;
+    n32 hcounter;
   } context;
 };
 

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -120,4 +120,5 @@ auto CPU::serialize(serializer& s) -> void {
   s(context.dmaActiveChannel);
   s(context.timerLatched);
   s(context.busLocked);
+  s(context.hcounter);
 }

--- a/ares/gba/ppu/memory.cpp
+++ b/ares/gba/ppu/memory.cpp
@@ -4,7 +4,16 @@ auto PPU::releaseBus() -> void {
 }
 
 auto PPU::pramContention() -> bool {
-  return pramAccessed;
+  if(accurate) return pramAccessed;
+
+  //approximate timings in scanline renderer, assuming no layer blending
+  n3 mode = PPU::Background::IO::mode;
+  if(display.io.vcounter < 160 && !ppu.blank() && mode != 3 && mode != 5) {
+    n32 hcounter = cpu.context.hcounter;
+    if(hcounter < 46 || hcounter > 1005) return false;
+    return (hcounter & 3) == 2;
+  }
+  return false;
 }
 
 auto PPU::vramContention(n32 address) -> bool {

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v143";
+static const string SerializerVersion = "v143.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
PRAM access stalls were previously only emulated in the pixel renderer, which could cause timing discrepancies when pixel accuracy was disabled. This PR adds an approximation for PRAM access stall timings in the scanline renderer. The approximation assumes no pixel blending and no I/O writes during HDRAW, which should cover the majority of cases.