### PR TITLE
[SNES] Fix loading of some games using firmware by removing unnecessary data definition/reference to rom

### DIFF
--- a/mia/medium/super-famicom.cpp
+++ b/mia/medium/super-famicom.cpp
@@ -560,8 +560,7 @@ auto SuperFamicom::board() const -> string {
   //Bishoujo Senshi Sailor Moon SuperS - Fuwafuwa Panic (Japan)
   //so we identify it with this embedded string
   string sufamiSignature = "BANDAI SFC-ADX";
-  vector<u8> romSignature; 
-  memory::copy(&romSignature[0], &rom[0], sufamiSignature.length());
+  auto romSignature = string_view(rom.data(), sufamiSignature.length());
   if(string(romSignature) == sufamiSignature) board.append("ST-", mode);
 
   //this game's title overwrite the map mode with '!' (0x21), but is a LOROM game

--- a/mia/medium/super-famicom.cpp
+++ b/mia/medium/super-famicom.cpp
@@ -560,7 +560,7 @@ auto SuperFamicom::board() const -> string {
   //Bishoujo Senshi Sailor Moon SuperS - Fuwafuwa Panic (Japan)
   //so we identify it with this embedded string
   string sufamiSignature = "BANDAI SFC-ADX";
-  auto romSignature = string_view(rom.data(), sufamiSignature.length());
+  auto romSignature = string_view((const char*)rom.data(), sufamiSignature.length());
   if(romSignature == sufamiSignature) board.append("ST-", mode);
 
   //this game's title overwrite the map mode with '!' (0x21), but is a LOROM game

--- a/mia/medium/super-famicom.cpp
+++ b/mia/medium/super-famicom.cpp
@@ -561,7 +561,7 @@ auto SuperFamicom::board() const -> string {
   //so we identify it with this embedded string
   string sufamiSignature = "BANDAI SFC-ADX";
   auto romSignature = string_view(rom.data(), sufamiSignature.length());
-  if(string(romSignature) == sufamiSignature) board.append("ST-", mode);
+  if(romSignature == sufamiSignature) board.append("ST-", mode);
 
   //this game's title overwrite the map mode with '!' (0x21), but is a LOROM game
   if(label() == "YUYU NO QUIZ DE GO!GO") mode = "LOROM-";


### PR DESCRIPTION
Note: Both yam (jcm93) & SuperMikeMan100 contributed to this investigation/resolution, so they are co-authors to this PR.

Maintaining a secondary reference to rom via the data array_view could lead to problems if rom was changed after the fact. Some refactoring done in v141 changed firmware loading and introduced a scenario where this was called twice and rom could be altered in between. At least two games were known to fail to load: Mega Man X3 & F1-ROC II - Race of Champions (USA).  Both of these now work, and games with other enhancements chips were checked, as well as games that don't have any. 

The refactoring introduced was a result of adding support for Powerfest 94 & Campus Challenge 92. These continue to work (assuming all 4 roms merged into a single ROM file without firmware appended to them, as it worked prior to this).

I also reverified this PR ( https://github.com/ares-emulator/ares/pull/1628 ) to make sure it still works as intended. It doesn't make a double request when loading the Sufami Turbo game: Bishoujo Senshi Sailor Moon SuperS - Fuwafuwa Panic (Japan).