### PR TITLE
Remove errant NALL_NOINLINE macro from SH2 instructions

### DIFF
--- a/ares/component/processor/sh2/instructions.cpp
+++ b/ares/component/processor/sh2/instructions.cpp
@@ -513,19 +513,19 @@ auto SH2::MOVI(u32 i, u32 n) -> void {
 }
 
 //MOV.W @(disp,PC),Rn
-NALL_NOINLINE auto SH2::MOVWI(u32 d, u32 n) -> void {
+auto SH2::MOVWI(u32 d, u32 n) -> void {
   u32 pc = inDelaySlot() ? PPC - 2 : PC;
   R[n] = (s16)readWord(pc + d * 2);
 }
 
 //MOV.L @(disp,PC),Rn
-NALL_NOINLINE auto SH2::MOVLI(u32 d, u32 n) -> void {
+auto SH2::MOVLI(u32 d, u32 n) -> void {
   u32 pc = inDelaySlot() ? PPC - 2 : PC;
   R[n] = readLong((pc & ~3) + d * 4);
 }
 
 //MOVA @(disp,PC),R0
-NALL_NOINLINE auto SH2::MOVA(u32 d) -> void {
+auto SH2::MOVA(u32 d) -> void {
   u32 pc = inDelaySlot() ? PPC - 2 : PC;
   R[0] = (pc & ~3) + d * 4;
 }


### PR DESCRIPTION
Minor code cleanup. All SH2 instructions are defined as inline in sh2.hpp, but for some reason reason 3 of them were marked with NALL_NOINLINE in instructions.cpp, even though they were marked inline in the header file. This triggers warnings in the build, although we have the specific warning disabled at the moment [-Wattributes]. 