### PR TITLE
gba: fix erroneous EEPROM zero-initialization

### DIFF
--- a/ares/gba/cartridge/cartridge.cpp
+++ b/ares/gba/cartridge/cartridge.cpp
@@ -56,7 +56,7 @@ auto Cartridge::connect() -> void {
     eeprom.mask = mrom.size > 16 * 1024 * 1024 ? 0x0fffff00 : 0x0f000000;
     eeprom.test = mrom.size > 16 * 1024 * 1024 ? 0x0dffff00 : 0x0d000000;
     for(auto n : range(eeprom.size)) eeprom.data[n] = 0xff;
-    fp->read({eeprom.data, eeprom.size});
+    if(!fp->end()) fp->read({eeprom.data, eeprom.size});  //only load save file if already present
   }
 
   if(auto fp = pak->read("save.flash")) {


### PR DESCRIPTION
EEPROM saves are supposed to be initialized with all bits set, and then data is read in from the save file. When no save file is present, eeprom.size is initialized to zero, resulting in no data being read. However, because eeprom.size is modified during load, ares unintentionally reads data from an empty file on first boot, zeroing out the EEPROM. This PR fixes the issue by checking EEPROM file size on load.

Partially fixes #1869.