### PR TITLE
build: Add arm64 runners to CI, fix msys2 clangarm64 build

### DIFF
--- a/.github/scripts/build_windows.sh
+++ b/.github/scripts/build_windows.sh
@@ -13,7 +13,7 @@ cmake --preset $TARGET_PRESET
 pushd build
 cmake --build . --config RelWithDebInfo
 
-if [ "$CROSS_COMPILE" = true ]; then
+if [ "$CROSS_COMPILE" = true ] || [ "$ARES_PLATFORM_NAME" = "windows-arm64" ]; then
   cp ../.deps/ares-deps-windows-arm64/lib/*.pdb desktop-ui/rundir/
 else
   cp ../.deps/ares-deps-windows-x64/lib/*.pdb desktop-ui/rundir/

--- a/.github/scripts/package_artifacts.sh
+++ b/.github/scripts/package_artifacts.sh
@@ -26,7 +26,7 @@ do
   cd -
 done
 
-for package in windows-x64 windows-clang-cl-x64 windows-clang-cl-arm64
+for package in windows-x64 windows-arm64
 do
   mkdir "${package}"
   cd "${package}"

--- a/.github/workflows/build-aux.yml
+++ b/.github/workflows/build-aux.yml
@@ -1,0 +1,111 @@
+name: Build (Auxiliary)
+on:
+  workflow_call
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        program:
+        - ares
+        config:
+        - RelWithDebInfo
+        platform:
+        - name: windows-x64-gcc
+          os: windows-latest
+          shell: 'msys2 {0}'
+          msystem: mingw64
+          install: mingw-w64-x86_64-toolchain
+          target-cmake-preset: windows-ci-mingw-native
+        - name: windows-clang-cl-x64
+          os: windows-latest
+          windres: rc
+          shell: bash
+          target-cmake-preset: windows-ci-cl-native
+        - name: windows-clang-cl-arm64
+          os: windows-latest
+          windres: rc
+          shell: bash
+          target-cmake-preset: windows-ci-cl-cross
+          native-cmake-preset: windows-ci-cl-native
+        - name: windows-msvc-x64
+          os: windows-latest
+          windres: rc
+          shell: bash
+          target-cmake-preset: windows-ci-msvc-native
+        - name: windows-msvc-arm64
+          os: windows-latest
+          windres: rc
+          shell: bash
+          target-cmake-preset: windows-ci-msvc-cross
+          native-cmake-preset: windows-ci-msvc-native
+        - name: ubuntu-gcc-x64
+          os: ubuntu-24.04
+          shell: bash
+          target-cmake-preset: ubuntu-ci
+        - name: ubuntu-gcc-arm64
+          os: ubuntu-24.04-arm
+          shell: bash
+          target-cmake-preset: ubuntu-ci
+        - name: ubuntu-clang-x64
+          os: ubuntu-24.04
+          shell: bash
+          target-cmake-preset: ubuntu-ci-clang
+        - name: ubuntu-clang-arm64
+          os: ubuntu-24.04-arm
+          shell: bash
+          target-cmake-preset: ubuntu-ci-clang
+    name: ${{ matrix.program }}-${{ matrix.platform.name }}
+    runs-on: ${{ matrix.platform.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.platform.shell }}
+    steps:
+    - name: Install MSYS2 Dependencies
+      if: matrix.platform.shell == 'msys2 {0}'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.platform.msystem }}
+        install: make git cmake ccache ninja ${{ matrix.platform.install }}
+    - name: Checkout source code
+      uses: actions/checkout@v4
+      with:
+        fetch-tags: true
+        fetch-depth: 0
+    - name: Setup MSYS2 Git Environment
+      if: matrix.platform.shell == 'msys2 {0}'
+      run: |
+        git config core.autocrlf true
+    - name: Install Linux Dependencies
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update -y -qq
+        sudo apt-get install cmake ccache ninja-build libsdl2-dev libgtk-3-dev libao-dev libopenal-dev
+    - name: "Build: Linux"
+      if: runner.os == 'Linux'
+      run: .github/scripts/build_ubuntu.sh
+      env:
+        TARGET_PRESET: ${{ matrix.platform.target-cmake-preset }}
+    - name: "Build: Windows"
+      if: runner.os != 'macOS' && runner.os != 'Linux'
+      run: .github/scripts/build_windows.sh
+      env:
+        ARES_PLATFORM_NAME: ${{ matrix.platform.name }}
+        CROSS_COMPILE: ${{ matrix.platform.native-cmake-preset != '' }}
+        NATIVE_PRESET: ${{ matrix.platform.native-cmake-preset }}
+        TARGET_PRESET: ${{ matrix.platform.target-cmake-preset }}
+    - name: "Compress Build Artifacts (Windows)"
+      if: runner.os != 'macOS' && runner.os != 'Linux'
+      run: |
+        tar -cvJf ares-${{ matrix.platform.name }}.tar.xz -C build/desktop-ui/rundir/ .
+    - name: Upload Build
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.program }}-${{ matrix.platform.name }}
+        path: ares-${{ matrix.platform.name }}.tar.xz
+    - name: Upload Debug Symbols (Windows)
+      if: runner.os != 'macOS' && runner.os != 'Linux'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.program }}-${{ matrix.platform.name }}-PDBs
+        path: build/PDBs/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build (Primary)
 on:
   workflow_call:
     inputs:
@@ -22,49 +22,21 @@ jobs:
           compiler: clang++
           shell: 'msys2 {0}'
           msystem: clang64
-          install: mingw-w64-clang-x86_64-clang
+          install: make git cmake ccache ninja mingw-w64-clang-x86_64-clang
           target-cmake-preset: windows-ci-mingw-native
-        - name: windows-x64-gcc
-          os: windows-latest
-          compiler: g++
+        - name: windows-arm64
+          os: windows-11-arm
+          compiler: clang++
           shell: 'msys2 {0}'
-          msystem: mingw64
-          install: mingw-w64-x86_64-toolchain
+          msystem: clangarm64
+          install: mingw-w64-clang-aarch64-make git mingw-w64-clang-aarch64-cmake mingw-w64-clang-aarch64-ccache mingw-w64-clang-aarch64-ninja  mingw-w64-clang-aarch64-clang
           target-cmake-preset: windows-ci-mingw-native
-        - name: windows-clang-cl-x64
-          os: windows-latest
-          windres: rc
-          shell: bash
-          target-cmake-preset: windows-ci-cl-native
-        - name: windows-clang-cl-arm64
-          os: windows-latest
-          windres: rc
-          shell: bash
-          target-cmake-preset: windows-ci-cl-cross
-          native-cmake-preset: windows-ci-cl-native
-        - name: windows-msvc-x64
-          os: windows-latest
-          windres: rc
-          shell: bash
-          target-cmake-preset: windows-ci-msvc-native
-        - name: windows-msvc-arm64
-          os: windows-latest
-          windres: rc
-          shell: bash
-          target-cmake-preset: windows-ci-msvc-cross
-          native-cmake-preset: windows-ci-msvc-native
         - name: macos-universal
           os: macos-15
           compiler: clang++
           shell: sh
           install: cmake ccache xcbeautify
           target-cmake-preset: macos-ci-universal
-        - name: ubuntu
-          os: ubuntu-latest
-          compiler: g++
-          shell: bash
-          install: cmake ccache ninja-build libsdl2-dev libgtk-3-dev libao-dev libopenal-dev
-          target-cmake-preset: ubuntu-ci
     name: ${{ matrix.program }}-${{ matrix.platform.name }}
     runs-on: ${{ matrix.platform.os }}
     defaults:
@@ -76,7 +48,7 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         msystem: ${{ matrix.platform.msystem }}
-        install: make git cmake ccache ninja ${{ matrix.platform.install }}
+        install: ${{ matrix.platform.install }}
     - name: "macOS: Import Certificate"
       if: runner.os == 'macOS' && inputs.codesign
       uses: apple-actions/import-codesign-certs@v3
@@ -102,15 +74,11 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew install ${{ matrix.platform.install }}
-    - name: "Build: Linux"
-      if: runner.os == 'Linux'
-      run: .github/scripts/build_ubuntu.sh
-      env:
-        TARGET_PRESET: ${{ matrix.platform.target-cmake-preset }}
     - name: "Build: Windows"
       if: runner.os != 'macOS' && runner.os != 'Linux'
       run: .github/scripts/build_windows.sh
       env:
+        ARES_PLATFORM_NAME: ${{ matrix.platform.name }}
         CROSS_COMPILE: ${{ matrix.platform.native-cmake-preset != '' }}
         NATIVE_PRESET: ${{ matrix.platform.native-cmake-preset }}
         TARGET_PRESET: ${{ matrix.platform.target-cmake-preset }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,11 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build-project:
-    name: Build
+    name: Build ares (primary)
     uses: ./.github/workflows/build.yml
     permissions:
       contents: read
+  build-aux:
+    name: Build ares (auxiliary)
+    uses: ./.github/workflows/build-aux.yml
+    secrets: inherit

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,11 +8,15 @@ permissions:
   contents: write
 jobs:
   build:
-    name: Build ares
+    name: Build ares (primary)
     uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
       codesign: true
+  build-aux:
+    name: Build ares (auxiliary)
+    uses: ./.github/workflows/build-aux.yml
+    secrets: inherit
   release:
     name: Release
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     - name: "Decompress Build Artifacts"
       if: runner.os == 'macOS'
       run: |
-        for package in macos-universal windows-x64 windows-clang-cl-x64 windows-clang-cl-arm64; do
+        for package in macos-universal windows-x64 windows-arm64; do
           pushd bin/ares-${package}
           tar -xJf ares-${package}.tar.xz
           rm -f ares-${package}.tar.xz
@@ -77,7 +77,5 @@ jobs:
           ${{ github.workspace }}/ares-macos-universal-dSYMs.zip
           ${{ github.workspace }}/ares-windows-x64.zip
           ${{ github.workspace }}/ares-windows-x64-PDBs.zip
-          ${{ github.workspace }}/ares-windows-clang-cl-x64.zip
-          ${{ github.workspace }}/ares-windows-clang-cl-x64-PDBs.zip
-          ${{ github.workspace }}/ares-windows-clang-cl-arm64.zip
-          ${{ github.workspace }}/ares-windows-clang-cl-arm64-PDBs.zip
+          ${{ github.workspace }}/ares-windows-arm64.zip
+          ${{ github.workspace }}/ares-windows-arm64-PDBs.zip

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -162,6 +162,16 @@
         "ARES_BUILD_OPTIONAL_TARGETS": true,
         "ARES_PRECOMPILE_HEADERS": false
       }
+    },
+    {
+      "name": "ubuntu-ci-clang",
+      "displayName": "Ubuntu CI (clang)",
+      "description": "Single-arch binary for building on Github Actions",
+      "inherits": ["ubuntu-ci"],
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++"
+      }
     }
   ],
   "buildPresets": [

--- a/ares/CMakeLists.txt
+++ b/ares/CMakeLists.txt
@@ -293,6 +293,13 @@ set_source_files_properties(
   n64/vulkan/parallel-rdp/vulkan/device.cpp
   n64/vulkan/parallel-rdp/vulkan/command_buffer.cpp
   n64/vulkan/parallel-rdp/vulkan/render_pass.cpp
+  n64/vulkan/parallel-rdp/vulkan/context.cpp
+  n64/vulkan/parallel-rdp/vulkan/memory_allocator.cpp
+  n64/vulkan/parallel-rdp/vulkan/semaphore.cpp
+  n64/vulkan/parallel-rdp/util/logging.cpp
+  n64/vulkan/parallel-rdp/util/environment.cpp
+  n64/vulkan/parallel-rdp/util/thread_name.cpp
+  n64/vulkan/parallel-rdp/util/timer.cpp
   PROPERTIES SKIP_PRECOMPILE_HEADERS ON
 )
 

--- a/ares/ares/ares.hpp
+++ b/ares/ares/ares.hpp
@@ -71,6 +71,18 @@ namespace ares {
   inline auto setRunAhead(bool runAhead) -> void { _runAhead = runAhead; }
 }
 
+/// ares elects to use the reserved C++ `register` identifier liberally in a few different areas so that it can more
+/// freely describe hardware registers within emulated system components. This macro exists to prevent compilers
+/// exploding at the sight of the reserved identifier.
+///
+/// Perhaps unsurprisingly, this macro will conflict with certain system headers. MSVC headers will emit an error
+/// forbidding macroizing `register` if the identifier is defined, while the `clangarm64` system headers in MSYS2
+/// appear to try to make use of the obsolete keyword meaning of the identifier.
+///
+/// Defining this macro after all platform headers are included avoids these conflicts... for now. Removing this
+/// macro along with all uses of this identifier may inevitably become necessary in the future.
+#define register $register
+
 #include <ares/types.hpp>
 #include <ares/random.hpp>
 #include <ares/debug/debug.hpp>

--- a/nall/nall/platform.hpp
+++ b/nall/nall/platform.hpp
@@ -187,7 +187,6 @@ namespace nall {
 #endif
 
 #define export $export
-#define register $register
 
 #if defined(NALL_HEADER_ONLY)
   #include <nall/platform.cpp>


### PR DESCRIPTION
Adds several ARM64 runners to CI, and makes clangarm64 the "primary" Windows arm64 build due to the performance benefits of GNU libc++ on Windows.

Also refactors the CI workflows to be neater; runs that are included in a GitHub release (macos-universal, windows-x64 and the new windows-arm64) will now run in their own dedicated workflow. 

Other build targets that we do not create releases with run now in an "auxiliary build" workflow. In addition to the old MSVC/clang-cl/gcc targets, this PR also adds the following runners to that workflow:

* Ubuntu compiling ares with GCC on arm64 using the `ubuntu-24.04-arm` runner
* Ubuntu compiling ares with clang on arm64 using the `ubuntu-24.04-arm` runner
* Ubuntu compiling ares with clang on x64.

Lastly, this PR fixes a build failure on the newest versions of `clangarm64` due to a macro conflict with our use of `register`. The failure and resolution are explained in a code comment next to the macro, because this probably isn't the last time we will need to take a look at it.