### PR TITLE
CI: clangarm64 Windows to aux, clang-cl-arm64 to primary

### DIFF
--- a/.github/scripts/package_artifacts.sh
+++ b/.github/scripts/package_artifacts.sh
@@ -26,7 +26,7 @@ do
   cd -
 done
 
-for package in windows-x64 windows-arm64
+for package in windows-x64 windows-clang-cl-arm64
 do
   mkdir "${package}"
   cd "${package}"

--- a/.github/workflows/build-aux.yml
+++ b/.github/workflows/build-aux.yml
@@ -15,19 +15,20 @@ jobs:
           os: windows-latest
           shell: 'msys2 {0}'
           msystem: mingw64
-          install: mingw-w64-x86_64-toolchain
+          install: make git cmake ccache ninja mingw-w64-x86_64-toolchain
           target-cmake-preset: windows-ci-mingw-native
         - name: windows-clang-cl-x64
           os: windows-latest
           windres: rc
           shell: bash
           target-cmake-preset: windows-ci-cl-native
-        - name: windows-clang-cl-arm64
-          os: windows-latest
-          windres: rc
-          shell: bash
-          target-cmake-preset: windows-ci-cl-cross
-          native-cmake-preset: windows-ci-cl-native
+        - name: windows-arm64
+          os: windows-11-arm
+          compiler: clang++
+          shell: 'msys2 {0}'
+          msystem: clangarm64
+          install: mingw-w64-clang-aarch64-make git mingw-w64-clang-aarch64-cmake mingw-w64-clang-aarch64-ccache mingw-w64-clang-aarch64-ninja  mingw-w64-clang-aarch64-clang
+          target-cmake-preset: windows-ci-mingw-native
         - name: windows-msvc-x64
           os: windows-latest
           windres: rc
@@ -66,7 +67,7 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         msystem: ${{ matrix.platform.msystem }}
-        install: make git cmake ccache ninja ${{ matrix.platform.install }}
+        install: ${{ matrix.platform.install }}
     - name: Checkout source code
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,13 +24,12 @@ jobs:
           msystem: clang64
           install: make git cmake ccache ninja mingw-w64-clang-x86_64-clang
           target-cmake-preset: windows-ci-mingw-native
-        - name: windows-arm64
-          os: windows-11-arm
-          compiler: clang++
-          shell: 'msys2 {0}'
-          msystem: clangarm64
-          install: mingw-w64-clang-aarch64-make git mingw-w64-clang-aarch64-cmake mingw-w64-clang-aarch64-ccache mingw-w64-clang-aarch64-ninja  mingw-w64-clang-aarch64-clang
-          target-cmake-preset: windows-ci-mingw-native
+        - name: windows-clang-cl-arm64
+          os: windows-latest
+          windres: rc
+          shell: bash
+          target-cmake-preset: windows-ci-cl-cross
+          native-cmake-preset: windows-ci-cl-native
         - name: macos-universal
           os: macos-15
           compiler: clang++

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     - name: "Decompress Build Artifacts"
       if: runner.os == 'macOS'
       run: |
-        for package in macos-universal windows-x64 windows-arm64; do
+        for package in macos-universal windows-x64 windows-clang-cl-arm64; do
           pushd bin/ares-${package}
           tar -xJf ares-${package}.tar.xz
           rm -f ares-${package}.tar.xz
@@ -77,5 +77,5 @@ jobs:
           ${{ github.workspace }}/ares-macos-universal-dSYMs.zip
           ${{ github.workspace }}/ares-windows-x64.zip
           ${{ github.workspace }}/ares-windows-x64-PDBs.zip
-          ${{ github.workspace }}/ares-windows-arm64.zip
-          ${{ github.workspace }}/ares-windows-arm64-PDBs.zip
+          ${{ github.workspace }}/ares-windows-clang-cl-arm64.zip
+          ${{ github.workspace }}/ares-windows-clang-cl-arm64-PDBs.zip


### PR DESCRIPTION
The [Windows signing action used by ares](https://github.com/Dana-Prajea/code-sign-action) fails under clangarm64 due to having the wrong path for `signtool.exe`.

This PR swaps the clang-cl arm64 Windows build back into the primary/nightly workflow until we have a fix for clangarm64 codesigning.