### PR TITLE
Edited insert to fix bug with "result" variable

### DIFF
--- a/nall/nall/set.hpp
+++ b/nall/nall/set.hpp
@@ -80,7 +80,7 @@ template<typename T> struct set {
 
   template<typename... P> auto insert(const T& value, P&&... p) -> bool {
     bool result = insert(value);
-    insert(std::forward<P>(p)...) | result;
+    result |= insert(std::forward<P>(p)...);
     return result;
   }
 


### PR DESCRIPTION
Fixed result such that insert(std::.....) actually updates result as it is supposed to.

The change is occured in ares/nall/nall/set.hpp, line 83