### PR TITLE
gba: reduce audio FIFO size from 32 to 28 bytes

### DIFF
--- a/ares/gba/apu/apu.hpp
+++ b/ares/gba/apu/apu.hpp
@@ -173,7 +173,7 @@ struct APU : Thread, IO {
     auto reset() -> void;
     auto power() -> void;
 
-    i8 samples[32];
+    i8 samples[28];
     i8 active;
     i8 output;
 

--- a/ares/gba/apu/fifo.cpp
+++ b/ares/gba/apu/fifo.cpp
@@ -5,13 +5,18 @@ auto APU::FIFO::sample() -> void {
 auto APU::FIFO::read() -> void {
   if(size == 0) return;
   size--;
-  active = samples[rdoffset++];
+  active = samples[rdoffset];
+  rdoffset = (rdoffset + 1) % 28;
 }
 
 auto APU::FIFO::write(i8 byte) -> void {
-  if(size == 32) rdoffset++;
-  else size++;
-  samples[wroffset++] = byte;
+  if(size == 28) {
+    rdoffset = (rdoffset + 1) % 28;
+  } else {
+    size++;
+  }
+  samples[wroffset] = byte;
+  wroffset = (wroffset + 1) % 28;
 }
 
 auto APU::FIFO::reset() -> void {

--- a/ares/gba/cpu/timer.cpp
+++ b/ares/gba/cpu/timer.cpp
@@ -57,7 +57,7 @@ auto CPU::Timer::step() -> void {
 auto CPU::runFIFO(u32 n) -> void {
   synchronize(apu);
   apu.fifo[n].read();
-  if(apu.fifo[n].size > 16) return;
+  if(apu.fifo[n].size > 12) return;
 
   auto& dma = this->dma[1 + n];
   if(dma.enable && dma.timingMode == 3) {

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v143.1";
+static const string SerializerVersion = "v144";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Closes #1869.