### PR TITLE
build: Improve version handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# When archiving, export a version file containing tag/commit information
+cmake/common/.archive-version export-subst

--- a/cmake/common/.archive-version
+++ b/cmake/common/.archive-version
@@ -1,0 +1,1 @@
+$Format:%(describe:tags,exclude=nightly)$

--- a/cmake/common/versionconfig.cmake
+++ b/cmake/common/versionconfig.cmake
@@ -1,25 +1,55 @@
 include_guard(GLOBAL)
 
-set(_ares_version 0)
+function(populate_ares_version_info)
+  if(DEFINED ARES_VERSION_OVERRIDE)
+    set(ARES_VERSION ${ARES_VERSION_OVERRIDE})
+  elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+    execute_process(
+      COMMAND git describe --always --tags --exclude=nightly --dirty=-modified
+      OUTPUT_VARIABLE ARES_VERSION
+      ERROR_VARIABLE git_describe_err
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+      RESULT_VARIABLE ares_version_result
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
 
-if(NOT DEFINED ARES_VERSION_OVERRIDE AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
-  execute_process(
-    COMMAND git describe --always --tags --exclude=nightly --dirty=-modified
-    OUTPUT_VARIABLE ARES_VERSION
-    ERROR_VARIABLE _git_describe_err
-    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-    RESULT_VARIABLE _ares_version_result
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-
-  if(_git_describe_err)
-    message(FATAL_ERROR "Could not fetch ares version tag from git.\n" ${_git_describe_err})
+    if(git_describe_err)
+      message(FATAL_ERROR "Could not fetch ares version tag from git.\n" ${git_describe_err})
+    endif()
+  else()
+    file(READ cmake/common/.archive-version ares_tarball_version)
+    string(STRIP "${ares_tarball_version}" ares_tarball_version)
+    set(ARES_VERSION "${ares_tarball_version}")
   endif()
-elseif(DEFINED ARES_VERSION_OVERRIDE)
-  set(ARES_VERSION ${ARES_VERSION_OVERRIDE})
+  
+  string(REGEX REPLACE "^v([0-9]+(\\.[0-9]+)*)-.*" "\\1" ares_version_stripped "${ARES_VERSION}")
+  string(REPLACE "." ";" ares_version_parts "${ares_version_stripped}")
+  list(LENGTH ares_version_parts ares_version_parts_length)
+  list(GET ares_version_parts 0 major)
+  if(ares_version_parts_length GREATER 1)
+    list(GET ares_version_parts 1 minor)
+  else()
+    set(minor 0)
+  endif()
+  if(ares_version_parts_length GREATER 2)
+    list(GET ares_version_parts 2 patch)
+  else()
+    set(patch 0)
+  endif()
+  set(ARES_VERSION_CANONICAL "${major}.${minor}.${patch}")
+  message(DEBUG "Canonical version set to ${ARES_VERSION_CANONICAL}")
+  return(PROPAGATE ARES_VERSION ARES_VERSION_CANONICAL)
+endfunction()
+
+populate_ares_version_info()
+
+if(NOT ARES_VERSION_CANONICAL MATCHES "^[0-9]+\\.[0-9]+\\.[0-9]+$")
+  message(
+    FATAL_ERROR
+    "Available ares version information ('${ARES_VERSION}') could not be converted to a valid CMake version string.\n"
+    "Make sure the repository you have cloned or archived from contains ares version tags ('git fetch --tags').\n"
+    "If tags are unavailable, you may specify a custom version with ARES_VERSION_OVERRIDE, using an ares-formatted "
+    "version string, e.g. 'v123'.\n"
+  )
 endif()
 
-string(REGEX REPLACE "^v([0-9]+)(.*)$" "\\1.0.0\\2" _ares_version "${ARES_VERSION}")
-string(REGEX REPLACE "(-[0-9]+-.*|-.+)" "" ARES_VERSION_CANONICAL "${_ares_version}")
-
-unset(_ares_version)


### PR DESCRIPTION
ares' build system tries to always have version information available for debuggability and build tracking. It depends upon the presence of Git to provide version information, since Git is the version control system used by the project.

When distributing tarballs of ares, however, no `.git` directory and no inherent version information is included in-tree, which causes the build to fail with a vague fatal error after failing to derive a version for itself.

Since we would like building a tarball to be at least possible with minimal fuss, we should provide some version information inside a tar archive served by GitHub. This PR uses Git's [export-subst](https://git-scm.com/docs/gitattributes#_export_subst) attribute to automatically bundle version information when `git-archive` is run against the repository, as is done when the GitHub API serves a tar archive of a given release, branch or commit. The build system will check for the presence of this file if it finds that there is no `.git` directory at the root of the repository.

This PR also improves the version handling in general to better support semantic version strings of the form `v123.x.y`, in case future releases of ares require hotfixes or minor versions.