### PR TITLE
Fix version number to not require tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.28...3.30)
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/common/bootstrap.cmake" NO_POLICY_SCOPE)
 
-project(ares VERSION ${ARES_VERSION_CANONICAL})
+project(ares)
 
 include(compilerconfig)
 include(defaults)

--- a/cmake/common/.archive-version
+++ b/cmake/common/.archive-version
@@ -1,1 +1,1 @@
-$Format:%(describe:tags,exclude=nightly)$
+$Format:%H$


### PR DESCRIPTION
The current version string is generated via git describe and requires tags to be available. If tags are not available, it will fail and require users to fetch tags via a custom error message. git does not fetch or update tags by default, so all forks won't have tags, or worse they'll be stale after the first time the user is instructed to fetch them.

With stale tags, the current code generates a wrong version number. For instance, it might generate something like:

   v139-234-c7cf2da81-modified

which means "234 commits after tag v139" (which is the last one it knows of), but maybe this is a commit after v142 was released. So the mention of v139 is wrong and confusing for the user, because the version is a "v143 + changes". While any "v143 + changes" is also technically a "v139 + changes" or even a "v1 + changes", that doesn't mean that showing that string as version number has any merit. In fact, it is better to just say the hash number at that point, rather than reporting a confusing previous version.

This PR changes the version string into something that doesn't require tags (but use them if available), and also shows an important piece of information which is the last commit date:

   master (abc1234-modified - 2025-05-05)

When building off a tag (to cut an official release), you get something like:

   v143 (c9285b528 - 2025-02-12)

so tags are indeed used, but only if available and relevant, without relying on possibly outdated tags.