### PR TITLE
gba: various APU improvements

### DIFF
--- a/ares/gba/apu/apu.hpp
+++ b/ares/gba/apu/apu.hpp
@@ -93,6 +93,7 @@ struct APU : Thread, IO {
     auto clockLength() -> void;
     auto read(u32 address) const -> n8;
     auto write(u32 address, n8 byte) -> void;
+    auto freeBank() const -> n1;
     auto readRAM(u32 address) const -> n8;
     auto writeRAM(u32 address, n8 byte) -> void;
     auto power() -> void;
@@ -169,17 +170,19 @@ struct APU : Thread, IO {
     //fifo.cpp
     auto sample() -> void;
     auto read() -> void;
-    auto write(i8 byte) -> void;
+    auto write(n2 address, n8 byte) -> void;
     auto reset() -> void;
     auto power() -> void;
+    auto size() -> n3 { return wroffset - rdoffset; }
 
-    i8 samples[28];
-    i8 active;
-    i8 output;
+    n32 buffer;
+    n32 samples[8];
+    i8  active;
+    i8  output;
 
-    n5 rdoffset;
-    n5 wroffset;
-    n6 size;
+    n3 rdoffset;
+    n3 wroffset;
+    n3 samplesRead;
 
     n1 volume;  //0 = 50%, 1 = 100%
     n1 lenable;

--- a/ares/gba/apu/fifo.cpp
+++ b/ares/gba/apu/fifo.cpp
@@ -3,30 +3,29 @@ auto APU::FIFO::sample() -> void {
 }
 
 auto APU::FIFO::read() -> void {
-  if(size == 0) return;
-  size--;
-  active = samples[rdoffset];
-  rdoffset = (rdoffset + 1) % 28;
+  if(samplesRead < 4) active = buffer.byte(samplesRead++);
+  if(size() > 0) {
+    if(samplesRead >= 4) {
+      samplesRead = 0;
+      buffer = samples[rdoffset++];
+    }
+  }
 }
 
-auto APU::FIFO::write(i8 byte) -> void {
-  if(size == 28) {
-    rdoffset = (rdoffset + 1) % 28;
-  } else {
-    size++;
-  }
-  samples[wroffset] = byte;
-  wroffset = (wroffset + 1) % 28;
+auto APU::FIFO::write(n2 address, n8 byte) -> void {
+  samples[wroffset].byte(address) = byte;
+  if(address == 3) wroffset++;
 }
 
 auto APU::FIFO::reset() -> void {
-  for(auto& byte : samples) byte = 0;
+  buffer = 0;
+  for(auto& word : samples) word = 0;
   active = 0;
   output = 0;
 
   rdoffset = 0;
   wroffset = 0;
-  size = 0;
+  samplesRead = 0;
 }
 
 auto APU::FIFO::power() -> void {

--- a/ares/gba/apu/io.cpp
+++ b/ares/gba/apu/io.cpp
@@ -146,6 +146,7 @@ auto APU::readIO(n32 address) -> n8 {
 }
 
 auto APU::writeIO(n32 address, n8 data) -> void {
+  if(!sequencer.masterenable && (address < 0x0400'0080 || address >= 0x0400'00a0)) return;
   cpu.synchronize(apu);
 
   switch(address) {
@@ -260,12 +261,12 @@ auto APU::writeIO(n32 address, n8 data) -> void {
   //FIFO_A_H
   case 0x0400'00a0: case 0x0400'00a1:
   case 0x0400'00a2: case 0x0400'00a3:
-    return fifo[0].write(data);
+    return fifo[0].write(address, data);
 
   //FIFO_B_L
   //FIFO_B_H
   case 0x0400'00a4: case 0x0400'00a5:
   case 0x0400'00a6: case 0x0400'00a7:
-    return fifo[1].write(data);
+    return fifo[1].write(address, data);
   }
 }

--- a/ares/gba/apu/serialization.cpp
+++ b/ares/gba/apu/serialization.cpp
@@ -96,12 +96,13 @@ auto APU::serialize(serializer& s) -> void {
   s(sequencer.routput);
 
   for(auto& f : fifo) {
+    s(f.buffer);
     s(f.samples);
     s(f.active);
     s(f.output);
     s(f.rdoffset);
     s(f.wroffset);
-    s(f.size);
+    s(f.samplesRead);
     s(f.volume);
     s(f.lenable);
     s(f.renable);

--- a/ares/gba/apu/wave.cpp
+++ b/ares/gba/apu/wave.cpp
@@ -65,16 +65,20 @@ auto APU::Wave::write(u32 address, n8 byte) -> void {
   }
 }
 
+auto APU::Wave::freeBank() const -> n1 {
+  return bank && apu.sequencer.masterenable;
+}
+
 auto APU::Wave::readRAM(u32 address) const -> n8 {
   n8 byte = 0;
-  byte |= pattern[!bank << 5 | address << 1 | 0] << 4;
-  byte |= pattern[!bank << 5 | address << 1 | 1] << 0;
+  byte |= pattern[freeBank() << 5 | address << 1 | 0] << 4;
+  byte |= pattern[freeBank() << 5 | address << 1 | 1] << 0;
   return byte;
 }
 
 auto APU::Wave::writeRAM(u32 address, n8 byte) -> void {
-  pattern[!bank << 5 | address << 1 | 0] = byte >> 4;
-  pattern[!bank << 5 | address << 1 | 1] = byte >> 0;
+  pattern[freeBank() << 5 | address << 1 | 0] = byte >> 4;
+  pattern[freeBank() << 5 | address << 1 | 1] = byte >> 0;
 }
 
 auto APU::Wave::power() -> void {

--- a/ares/gba/cpu/timer.cpp
+++ b/ares/gba/cpu/timer.cpp
@@ -57,7 +57,7 @@ auto CPU::Timer::step() -> void {
 auto CPU::runFIFO(u32 n) -> void {
   synchronize(apu);
   apu.fifo[n].read();
-  if(apu.fifo[n].size > 12) return;
+  if(apu.fifo[n].size() > 3) return;
 
   auto& dma = this->dma[1 + n];
   if(dma.enable && dma.timingMode == 3) {

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v144";
+static const string SerializerVersion = "v144.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
- Fixes an edge case involving overflowing audio FIFOs
- Slight FIFO channel timing improvements
- Prevents most APU registers from being written while audio is disabled
- Fixes writing to wave RAM while audio is disabled