### PR TITLE
arm7tdmi: branch instruction fixes

### DIFF
--- a/ares/component/processor/arm7tdmi/arm7tdmi.hpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.hpp
@@ -69,7 +69,7 @@ struct ARM7TDMI {
   auto armMoveToStatus(n4 field, n1 source, n32 data) -> void;
 
   auto armInstructionBranch(i24, n1) -> void;
-  auto armInstructionBranchExchangeRegister(n4) -> void;
+  auto armInstructionBranchExchangeRegister(n4, n4) -> void;
   auto armInstructionDataImmediate(n8, n4, n4, n4, n1, n4) -> void;
   auto armInstructionDataImmediateShift(n4, n2, n5, n4, n4, n1, n4) -> void;
   auto armInstructionDataRegisterShift(n4, n2, n4, n4, n4, n1, n4) -> void;
@@ -235,7 +235,7 @@ struct ARM7TDMI {
 
   //disassembler.cpp
   auto armDisassembleBranch(i24, n1) -> string;
-  auto armDisassembleBranchExchangeRegister(n4) -> string;
+  auto armDisassembleBranchExchangeRegister(n4, n4) -> string;
   auto armDisassembleDataImmediate(n8, n4, n4, n4, n1, n4) -> string;
   auto armDisassembleDataImmediateShift(n4, n2, n5, n4, n4, n1, n4) -> string;
   auto armDisassembleDataRegisterShift(n4, n2, n4, n4, n4, n1, n4) -> string;

--- a/ares/component/processor/arm7tdmi/disassembler.cpp
+++ b/ares/component/processor/arm7tdmi/disassembler.cpp
@@ -64,7 +64,7 @@ auto ARM7TDMI::armDisassembleBranch
 }
 
 auto ARM7TDMI::armDisassembleBranchExchangeRegister
-(n4 m) -> string {
+(n4 m, n4 d) -> string {
   return {"bx", _c, " ", _r[m]};
 }
 

--- a/ares/component/processor/arm7tdmi/instruction.cpp
+++ b/ares/component/processor/arm7tdmi/instruction.cpp
@@ -80,9 +80,12 @@ auto ARM7TDMI::armInitialize() -> void {
   #undef arguments
 
   #define arguments \
-    opcode.bit( 0, 3)   /* m */
-  {
-    auto opcode = pattern(".... 0001 0010 ---- ---- ---- 0001 ????");
+    opcode.bit( 0, 3),  /* m */ \
+    opcode.bit(12,15)   /* d */
+  for(n4 m : range(16))
+  for(n2 _ : range(4))
+  for(n4 d : range(16)) {
+    auto opcode = pattern(".... 0001 0010 ---- ???? ---- 0??1 ????") | d << 12 | _ << 5 | m << 0;
     bind(opcode, BranchExchangeRegister);
   }
   #undef arguments

--- a/ares/component/processor/arm7tdmi/instruction.cpp
+++ b/ares/component/processor/arm7tdmi/instruction.cpp
@@ -418,9 +418,9 @@ auto ARM7TDMI::thumbInitialize() -> void {
     bind(opcode, AdjustStack, immediate, mode);
   }
 
-  for(n4 d : range(16))
+  for(n4 _ : range(16))
   for(n4 m : range(16)) {
-    auto opcode = pattern("0100 0111 ???? ?---") | d.bit(0,2) << 0 | m << 3 | d.bit(3) << 7;
+    auto opcode = pattern("0100 0111 ???? ?---") | _.bit(0,2) << 0 | m << 3 | _.bit(3) << 7;
     bind(opcode, BranchExchange, m);
   }
 
@@ -441,6 +441,7 @@ auto ARM7TDMI::thumbInitialize() -> void {
 
   for(n8 displacement : range(256))
   for(n4 condition : range(16)) {
+    if(condition == 14) continue;  //BAL
     if(condition == 15) continue;  //BNV
     auto opcode = pattern("1101 ???? ???? ????") | displacement << 0 | condition << 8;
     bind(opcode, BranchTest, displacement, condition);

--- a/ares/component/processor/arm7tdmi/instructions-arm.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-arm.cpp
@@ -54,10 +54,10 @@ auto ARM7TDMI::armInstructionBranch
 }
 
 auto ARM7TDMI::armInstructionBranchExchangeRegister
-(n4 m) -> void {
+(n4 m, n4 d) -> void {
   n32 address = r(m);
   cpsr().t = address.bit(0);
-  r(15) = address;
+  r(d) = address;
 }
 
 auto ARM7TDMI::armInstructionDataImmediate

--- a/tests/arm7tdmi/arm7tdmi.cpp
+++ b/tests/arm7tdmi/arm7tdmi.cpp
@@ -332,9 +332,7 @@ auto CPU::run(const TestCase& test, bool logErrors) -> TestResult {
   if((processor.und.spsr & spsrMask) != (fs.SPSR[4] & spsrMask)) error("und.spsr: ", hex(u32(processor.und.spsr), 8), " != ", hex(fs.SPSR[4], 8));
   if(pipeline.decode.instruction != fs.pipeline[0]) error("pipeline[0]: ", hex(u32(pipeline.decode.instruction), 8), " != ", hex(fs.pipeline[0], 8));
   if(pipeline.fetch.instruction != fs.pipeline[1]) error("pipeline[1]: ", hex(u32(pipeline.decode.instruction), 8), " != ", hex(fs.pipeline[1], 8));
-  //todo: fails some tests in arm_data_proc_register_shift, thumb_data_proc that operate on registers
-  //should e.g. asr r4,r4 really change the state to nonsequential?
-  //if(nonsequential != !(fs.access & Access::Sequential)) error("nonsequential: ", nonsequential, " != ", !(fs.access & Access::Sequential));
+  if(nonsequential != !(fs.access & Access::Sequential)) error("nonsequential: ", nonsequential, " != ", !(fs.access & Access::Sequential));
 
   if(tindex != test.transactions.size()) {
     error("transactions: ", tindex, " != ", test.transactions.size(), "\n");

--- a/tests/arm7tdmi/arm7tdmi.cpp
+++ b/tests/arm7tdmi/arm7tdmi.cpp
@@ -230,6 +230,10 @@ auto CPU::run(const TestCase& test, bool logErrors) -> TestResult {
   //r15 as rn incorrectly reads from +4 offset in test data
   if(!thumb && (test.opcode & 0b00001111101111110000000011110000) == 0b0000'00010'0'001111'00000000'1001'0000) return skip;
 
+  //tests/v1/thumb_undefined_bcc.json
+  //condition code AL is invalid in Thumb mode
+  if(thumb && (test.opcode & 0b1111111100000000) == 0b1101'1110'00000000) return skip;
+
   pipeline.reload = false;
   nonsequential = !(is.access & Access::Sequential);
 
@@ -259,15 +263,8 @@ auto CPU::run(const TestCase& test, bool logErrors) -> TestResult {
 
   TestResult result = pass;
 
-  u32 cpsrMask = ~0u;
-
-  //arm MRS
-  if((test.opcode & 0b0000'1111'1011'0000'0000'0000'0000'0000) == 0b0000'0011'0010'0000'0000'0000'0000'0000
-  || (test.opcode & 0b0000'1111'1011'0000'0000'0000'1111'0000) == 0b0000'0001'0010'0000'0000'0000'0000'0000) {
-    //todo: are these bits settable on real hw?
-    cpsrMask &= ~0x0fffff00u;
-    result = skip;
-  }
+  //other PSR bits are not settable on real hardware
+  u32 cpsrMask = ~0x0fffff00u;
 
   //mul carry nyi (documented as "unpredictable")
   //thumb MUL


### PR DESCRIPTION
Fixed an issue where an undefined opcode was being treated as an unconditional branch in Thumb mode, and added a destination register field to ARM mode BX instructions.