### PR TITLE
arm7tdmi: implement more undocumented fields in BX and MSR instructions

### DIFF
--- a/ares/component/processor/arm7tdmi/arm7tdmi.hpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.hpp
@@ -83,7 +83,7 @@ struct ARM7TDMI {
   auto armInstructionMoveRegisterOffset(n4, n2, n5, n4, n4, n1, n1, n1, n1, n1) -> void;
   auto armInstructionMoveToRegisterFromStatus(n4, n1) -> void;
   auto armInstructionMoveToStatusFromImmediate(n8, n4, n4, n1) -> void;
-  auto armInstructionMoveToStatusFromRegister(n4, n4, n1) -> void;
+  auto armInstructionMoveToStatusFromRegister(n4, n2, n5, n4, n1) -> void;
   auto armInstructionMultiply(n4, n4, n4, n4, n1, n1) -> void;
   auto armInstructionMultiplyLong(n4, n4, n4, n4, n1, n1, n1) -> void;
   auto armInstructionSoftwareInterrupt(n24 immediate) -> void;
@@ -249,7 +249,7 @@ struct ARM7TDMI {
   auto armDisassembleMoveRegisterOffset(n4, n2, n5, n4, n4, n1, n1, n1, n1, n1) -> string;
   auto armDisassembleMoveToRegisterFromStatus(n4, n1) -> string;
   auto armDisassembleMoveToStatusFromImmediate(n8, n4, n4, n1) -> string;
-  auto armDisassembleMoveToStatusFromRegister(n4, n4, n1) -> string;
+  auto armDisassembleMoveToStatusFromRegister(n4, n2, n5, n4, n1) -> string;
   auto armDisassembleMultiply(n4, n4, n4, n4, n1, n1) -> string;
   auto armDisassembleMultiplyLong(n4, n4, n4, n4, n1, n1, n1) -> string;
   auto armDisassembleSoftwareInterrupt(n24) -> string;

--- a/ares/component/processor/arm7tdmi/arm7tdmi.hpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.hpp
@@ -69,7 +69,7 @@ struct ARM7TDMI {
   auto armMoveToStatus(n4 field, n1 source, n32 data) -> void;
 
   auto armInstructionBranch(i24, n1) -> void;
-  auto armInstructionBranchExchangeRegister(n4, n4) -> void;
+  auto armInstructionBranchExchangeRegister(n4, n4, n4) -> void;
   auto armInstructionDataImmediate(n8, n4, n4, n4, n1, n4) -> void;
   auto armInstructionDataImmediateShift(n4, n2, n5, n4, n4, n1, n4) -> void;
   auto armInstructionDataRegisterShift(n4, n2, n4, n4, n4, n1, n4) -> void;
@@ -235,7 +235,7 @@ struct ARM7TDMI {
 
   //disassembler.cpp
   auto armDisassembleBranch(i24, n1) -> string;
-  auto armDisassembleBranchExchangeRegister(n4, n4) -> string;
+  auto armDisassembleBranchExchangeRegister(n4, n4, n4) -> string;
   auto armDisassembleDataImmediate(n8, n4, n4, n4, n1, n4) -> string;
   auto armDisassembleDataImmediateShift(n4, n2, n5, n4, n4, n1, n4) -> string;
   auto armDisassembleDataRegisterShift(n4, n2, n4, n4, n4, n1, n4) -> string;

--- a/ares/component/processor/arm7tdmi/disassembler.cpp
+++ b/ares/component/processor/arm7tdmi/disassembler.cpp
@@ -229,13 +229,18 @@ auto ARM7TDMI::armDisassembleMoveToStatusFromImmediate
 }
 
 auto ARM7TDMI::armDisassembleMoveToStatusFromRegister
-(n4 m, n4 field, n1 mode) -> string {
+(n4 m, n2 type, n5 shift, n4 field, n1 mode) -> string {
   return {"msr", _c, " ", mode ? "spsr:" : "cpsr:",
     field.bit(0) ? "c" : "",
     field.bit(1) ? "x" : "",
     field.bit(2) ? "s" : "",
     field.bit(3) ? "f" : "",
-    ",", _r[m]};
+    ",", _r[m],
+    type == 0 && shift ? string{" lsl #", shift} : string{},
+    type == 1 ? string{" lsr #", shift ? (u32)shift : 32} : string{},
+    type == 2 ? string{" asr #", shift ? (u32)shift : 32} : string{},
+    type == 3 && shift ? string{" ror #", shift} : string{},
+    type == 3 && !shift ? " rrx" : ""};
 }
 
 auto ARM7TDMI::armDisassembleMultiply

--- a/ares/component/processor/arm7tdmi/disassembler.cpp
+++ b/ares/component/processor/arm7tdmi/disassembler.cpp
@@ -64,7 +64,7 @@ auto ARM7TDMI::armDisassembleBranch
 }
 
 auto ARM7TDMI::armDisassembleBranchExchangeRegister
-(n4 m, n4 d) -> string {
+(n4 m, n4 d, n4 field) -> string {
   return {"bx", _c, " ", _r[m]};
 }
 

--- a/ares/component/processor/arm7tdmi/instruction.cpp
+++ b/ares/component/processor/arm7tdmi/instruction.cpp
@@ -310,10 +310,14 @@ auto ARM7TDMI::armInitialize() -> void {
 
   #define arguments \
     opcode.bit( 0, 3),  /* m */ \
+    opcode.bit( 5, 6),  /* type */ \
+    opcode.bit( 7,11),  /* shift */ \
     opcode.bit(16,19),  /* field */ \
     opcode.bit(22)      /* mode */
+  for(n2 type : range(4))
+  for(n1 shiftLo : range(2))
   for(n1 mode : range(2)) {
-    auto opcode = pattern(".... 0001 0?10 ???? ---- ---- 0000 ????") | mode << 22;
+    auto opcode = pattern(".... 0001 0?10 ???? ---- ???? ???0 ????") | type << 5 | shiftLo << 7 | mode << 22;
     bind(opcode, MoveToStatusFromRegister);
   }
   #undef arguments

--- a/ares/component/processor/arm7tdmi/instruction.cpp
+++ b/ares/component/processor/arm7tdmi/instruction.cpp
@@ -81,11 +81,13 @@ auto ARM7TDMI::armInitialize() -> void {
 
   #define arguments \
     opcode.bit( 0, 3),  /* m */ \
-    opcode.bit(12,15)   /* d */
+    opcode.bit(12,15),  /* d */ \
+    opcode.bit(16,19)   /* field */
   for(n4 m : range(16))
   for(n2 _ : range(4))
-  for(n4 d : range(16)) {
-    auto opcode = pattern(".... 0001 0010 ---- ???? ---- 0??1 ????") | d << 12 | _ << 5 | m << 0;
+  for(n4 d : range(16))
+  for(n4 field : range(16)) {
+    auto opcode = pattern(".... 0001 0010 ???? ???? ---- 0??1 ????") | m << 0 | _ << 5 | d << 12 | field << 16;
     bind(opcode, BranchExchangeRegister);
   }
   #undef arguments

--- a/ares/component/processor/arm7tdmi/instructions-arm.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-arm.cpp
@@ -280,8 +280,18 @@ auto ARM7TDMI::armInstructionMoveToStatusFromImmediate
 }
 
 auto ARM7TDMI::armInstructionMoveToStatusFromRegister
-(n4 m, n4 field, n1 mode) -> void {
-  armMoveToStatus(field, mode, r(m));
+(n4 m, n2 type, n5 shift, n4 field, n1 mode) -> void {
+  n32 rm = r(m);
+  carry = cpsr().c;
+
+  switch(type) {
+  case 0: rm = LSL(rm, shift); break;
+  case 1: rm = LSR(rm, shift ? (u32)shift : 32); break;
+  case 2: rm = ASR(rm, shift ? (u32)shift : 32); break;
+  case 3: rm = shift ? ROR(rm, shift) : RRX(rm); break;
+  }
+
+  armMoveToStatus(field, mode, rm);
 }
 
 auto ARM7TDMI::armInstructionMultiply

--- a/ares/component/processor/arm7tdmi/instructions-arm.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-arm.cpp
@@ -98,10 +98,10 @@ auto ARM7TDMI::armInstructionDataRegisterShift
 
   idle();
   switch(type) {
-  case 0: rm = LSL(rm, rs < 33 ? rs : (n8)33); break;
-  case 1: rm = LSR(rm, rs < 33 ? rs : (n8)33); break;
-  case 2: rm = ASR(rm, rs < 32 ? rs : (n8)32); break;
-  case 3: if(rs) rm = ROR(rm, rs & 31 ? u32(rs & 31) : 32); break;
+  case 0: rm = LSL(rm, rs); break;
+  case 1: rm = LSR(rm, rs); break;
+  case 2: rm = ASR(rm, rs); break;
+  case 3: rm = ROR(rm, rs); break;
   }
 
   armALU(mode, d, rn, rm);

--- a/ares/component/processor/arm7tdmi/instructions-arm.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-arm.cpp
@@ -54,9 +54,13 @@ auto ARM7TDMI::armInstructionBranch
 }
 
 auto ARM7TDMI::armInstructionBranchExchangeRegister
-(n4 m, n4 d) -> void {
+(n4 m, n4 d, n4 field) -> void {
   n32 address = r(m);
-  cpsr().t = address.bit(0);
+  if((field & 0b1001) == 0b1001) {
+    cpsr().t = address.bit(0);
+  } else {
+    armMoveToStatus(field, 0, address);
+  }
   r(d) = address;
 }
 


### PR DESCRIPTION
Adds shifter fields to MSR, and a CPSR mask field to BX.