### PR TITLE
arm7tdmi: fix failed assertion in debug builds

### DIFF
--- a/ares/component/processor/arm7tdmi/instruction.cpp
+++ b/ares/component/processor/arm7tdmi/instruction.cpp
@@ -83,11 +83,8 @@ auto ARM7TDMI::armInitialize() -> void {
     opcode.bit( 0, 3),  /* m */ \
     opcode.bit(12,15),  /* d */ \
     opcode.bit(16,19)   /* field */
-  for(n4 m : range(16))
-  for(n2 _ : range(4))
-  for(n4 d : range(16))
-  for(n4 field : range(16)) {
-    auto opcode = pattern(".... 0001 0010 ???? ???? ---- 0??1 ????") | m << 0 | _ << 5 | d << 12 | field << 16;
+  for(n2 _ : range(4)) {
+    auto opcode = pattern(".... 0001 0010 ???? ???? ---- 0??1 ????") | _ << 5;
     bind(opcode, BranchExchangeRegister);
   }
   #undef arguments


### PR DESCRIPTION
Fixes an assertion that was failing because of an oversight in #2007 regarding ARM7TDMI BX instruction decode bits.