### PR TITLE
Update CMake policy version, add old Finder metadata to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@
 !CMakeLists.txt
 !CMakePresets.json
 
+# Exclude old macOS Finder metadata
+.DS_Store
+
+# Exclude generated sources that still reside in-tree
 ruby/video/metal/shaders.metallib
 ruby/video/metal/shaders.ir
 ares/ares/resource/resource.cpp
@@ -36,7 +40,11 @@ desktop-ui/resource/resource.cpp
 desktop-ui/resource/resource.hpp
 mia/resource/resource.cpp
 mia/resource/resource.hpp
+
+# Exclude fetched third-party processor test binaries
 tests/arm7tdmi/tests
 tests/m68000/tests
+
+# Exclude unused legacy zlib header that is renamed by CMake
 thirdparty/libchdr/deps/zlib-*/zconf.h
 thirdparty/libchdr/deps/zlib-*/zconf.h.included

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.28...3.30)
+cmake_minimum_required(VERSION 3.28...4.0)
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/common/bootstrap.cmake" NO_POLICY_SCOPE)
 

--- a/desktop-ui/cmake/os-linux.cmake
+++ b/desktop-ui/cmake/os-linux.cmake
@@ -6,7 +6,7 @@ if(ARES_ENABLE_LIBRASHADER)
   if(TARGET libretro::slang_shaders)
     if(ARES_BUNDLE_SHADERS)
       add_custom_command(
-        OUTPUT "${ARES_BUILD_OUTPUT_DIR}/${ARES_INSTALL_DATA_DESTINATION}/Shaders/bilinear.slangp" POST_BUILD
+        OUTPUT "${ARES_BUILD_OUTPUT_DIR}/${ARES_INSTALL_DATA_DESTINATION}/Shaders/bilinear.slangp"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${ARES_BUILD_OUTPUT_DIR}/${ARES_INSTALL_DATA_DESTINATION}/Shaders"
         COMMAND cp -R "${slang_shaders_LOCATION}/." "${ARES_BUILD_OUTPUT_DIR}/${ARES_INSTALL_DATA_DESTINATION}/Shaders"
         COMMENT "Copying slang shaders to staging directory"


### PR DESCRIPTION
Add explicit support for CMake 4.0 version policies; the only change required is to remove a superfluous/invalid POST_BUILD designation from Linux bundling code.

Also add .DS_Store to the .gitignore, since developers may possibly still be on systems old enough to litter these everywhere.