### PR TITLE
arm7tdmi, gba: initial ARM coprocessor interface

### DIFF
--- a/ares/component/processor/arm7tdmi/arm7tdmi.cpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.cpp
@@ -9,6 +9,7 @@ namespace ares {
 #include "instruction.cpp"
 #include "instructions-arm.cpp"
 #include "instructions-thumb.cpp"
+#include "coprocessor.cpp"
 #include "serialization.cpp"
 #include "disassembler.cpp"
 

--- a/ares/component/processor/arm7tdmi/arm7tdmi.hpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.hpp
@@ -7,7 +7,7 @@ namespace ares {
 struct Coprocessor {
   auto power(n4 cpID) -> void { id = cpID; }
 
-  virtual auto CDP(n32 opcode) -> void { return; }
+  virtual auto CDP(n4 cm, n3 op2, n4 cd, n4 cn, n4 op1) -> void { return; }
   virtual auto MCR(n32 data, n4 cm, n3 op2, n4 cn, n3 op1) -> void { return; }
   virtual auto MRC(n4 cm, n3 op2, n4 cn, n3 op1) -> n32 { return 0; }
 
@@ -80,6 +80,7 @@ struct ARM7TDMI {
 
   auto armInstructionBranch(i24, n1) -> void;
   auto armInstructionBranchExchangeRegister(n4, n4, n4) -> void;
+  auto armInstructionCoprocessorDataProcessing(n4, n3, n4, n4, n4, n4) -> void;
   auto armInstructionDataImmediate(n8, n4, n4, n4, n1, n4) -> void;
   auto armInstructionDataImmediateShift(n4, n2, n5, n4, n4, n1, n4) -> void;
   auto armInstructionDataRegisterShift(n4, n2, n4, n4, n4, n1, n4) -> void;
@@ -250,13 +251,14 @@ struct ARM7TDMI {
   auto bindMCR(Coprocessor& cp) -> void;
   auto bindMRC(Coprocessor& cp) -> void;
 
-  function<void (n32 opcode)> CDP[16];
+  function<void (n4 cm, n3 op2, n4 cd, n4 cn, n4 op1)> CDP[16];
   function<void (n32 data, n4 cm, n3 op2, n4 cn, n3 op1)> MCR[16];
   function<n32 (n4 cm, n3 op2, n4 cn, n3 op1)> MRC[16];
 
   //disassembler.cpp
   auto armDisassembleBranch(i24, n1) -> string;
   auto armDisassembleBranchExchangeRegister(n4, n4, n4) -> string;
+  auto armDisassembleCoprocessorDataProcessing(n4, n3, n4, n4, n4, n4) -> string;
   auto armDisassembleDataImmediate(n8, n4, n4, n4, n1, n4) -> string;
   auto armDisassembleDataImmediateShift(n4, n2, n5, n4, n4, n1, n4) -> string;
   auto armDisassembleDataRegisterShift(n4, n2, n4, n4, n4, n1, n4) -> string;

--- a/ares/component/processor/arm7tdmi/arm7tdmi.hpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.hpp
@@ -4,12 +4,6 @@
 
 namespace ares {
 
-struct Coprocessor {
-  virtual auto CDP(n4 cm, n3 op2, n4 cd, n4 cn, n4 op1) -> void { return; }
-  virtual auto MCR(n32 data, n4 cm, n3 op2, n4 cn, n3 op1) -> void { return; }
-  virtual auto MRC(n4 cm, n3 op2, n4 cn, n3 op1) -> n32 { return 0; }
-};
-
 struct ARM7TDMI {
   enum : u32 {
     Load          = 1 << 0,  //load operation
@@ -243,9 +237,9 @@ struct ARM7TDMI {
   function<void ()> thumbInstruction[65536];
 
   //coprocessor.cpp
-  auto bindCDP(n4 id, Coprocessor& cp) -> void;
-  auto bindMCR(n4 id, Coprocessor& cp) -> void;
-  auto bindMRC(n4 id, Coprocessor& cp) -> void;
+  auto bindCDP(n4 id, function<void (n4 cm, n3 op2, n4 cd, n4 cn, n4 op1)> handler) -> void;
+  auto bindMCR(n4 id, function<void (n32 data, n4 cm, n3 op2, n4 cn, n3 op1)> handler) -> void;
+  auto bindMRC(n4 id, function<n32 (n4 cm, n3 op2, n4 cn, n3 op1)> handler) -> void;
 
   function<void (n4 cm, n3 op2, n4 cd, n4 cn, n4 op1)> CDP[16];
   function<void (n32 data, n4 cm, n3 op2, n4 cn, n3 op1)> MCR[16];

--- a/ares/component/processor/arm7tdmi/arm7tdmi.hpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.hpp
@@ -5,13 +5,9 @@
 namespace ares {
 
 struct Coprocessor {
-  auto power(n4 cpID) -> void { id = cpID; }
-
   virtual auto CDP(n4 cm, n3 op2, n4 cd, n4 cn, n4 op1) -> void { return; }
   virtual auto MCR(n32 data, n4 cm, n3 op2, n4 cn, n3 op1) -> void { return; }
   virtual auto MRC(n4 cm, n3 op2, n4 cn, n3 op1) -> n32 { return 0; }
-
-  n4 id;
 };
 
 struct ARM7TDMI {
@@ -247,9 +243,9 @@ struct ARM7TDMI {
   function<void ()> thumbInstruction[65536];
 
   //coprocessor.cpp
-  auto bindCDP(Coprocessor& cp) -> void;
-  auto bindMCR(Coprocessor& cp) -> void;
-  auto bindMRC(Coprocessor& cp) -> void;
+  auto bindCDP(n4 id, Coprocessor& cp) -> void;
+  auto bindMCR(n4 id, Coprocessor& cp) -> void;
+  auto bindMRC(n4 id, Coprocessor& cp) -> void;
 
   function<void (n4 cm, n3 op2, n4 cd, n4 cn, n4 op1)> CDP[16];
   function<void (n32 data, n4 cm, n3 op2, n4 cn, n3 op1)> MCR[16];

--- a/ares/component/processor/arm7tdmi/arm7tdmi.hpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.hpp
@@ -4,6 +4,18 @@
 
 namespace ares {
 
+struct Coprocessor {
+  auto power(n4 cpID) -> void { id = cpID; }
+
+  virtual auto CDP(n32 opcode) -> void { return; }
+  virtual auto LDC(n32 opcode) -> void { return; }
+  virtual auto MCR(n32 opcode) -> void { return; }
+  virtual auto MRC(n4 cm, n3 op2, n4 cn, n3 op1) -> n32 { return 0; }
+  virtual auto STC(n32 opcode) -> void { return; }
+
+  n4 id;
+};
+
 struct ARM7TDMI {
   enum : u32 {
     Load          = 1 << 0,  //load operation
@@ -81,6 +93,7 @@ struct ARM7TDMI {
   auto armInstructionMoveImmediateOffset(n12, n4, n4, n1, n1, n1, n1, n1) -> void;
   auto armInstructionMoveMultiple(n16, n4, n1, n1, n1, n1, n1) -> void;
   auto armInstructionMoveRegisterOffset(n4, n2, n5, n4, n4, n1, n1, n1, n1, n1) -> void;
+  auto armInstructionMoveToRegisterFromCoprocessor(n4, n3, n4, n4, n4, n3) -> void;
   auto armInstructionMoveToRegisterFromStatus(n4, n1) -> void;
   auto armInstructionMoveToStatusFromImmediate(n8, n4, n4, n1) -> void;
   auto armInstructionMoveToStatusFromRegister(n4, n2, n5, n4, n1) -> void;
@@ -233,6 +246,19 @@ struct ARM7TDMI {
   function<void (n32 opcode)> armInstruction[4096];
   function<void ()> thumbInstruction[65536];
 
+  //coprocessor.cpp
+  auto bindCDP(Coprocessor& cp) -> void;
+  auto bindLDC(Coprocessor& cp) -> void;
+  auto bindMCR(Coprocessor& cp) -> void;
+  auto bindMRC(Coprocessor& cp) -> void;
+  auto bindSTC(Coprocessor& cp) -> void;
+
+  function<void (n32 opcode)> CDP[16];
+  function<void (n32 opcode)> LDC[16];
+  function<void (n32 opcode)> MCR[16];
+  function<n32 (n4 cm, n3 op2, n4 cn, n3 op1)> MRC[16];
+  function<void (n32 opcode)> STC[16];
+
   //disassembler.cpp
   auto armDisassembleBranch(i24, n1) -> string;
   auto armDisassembleBranchExchangeRegister(n4, n4, n4) -> string;
@@ -247,6 +273,7 @@ struct ARM7TDMI {
   auto armDisassembleMoveImmediateOffset(n12, n4, n4, n1, n1, n1, n1, n1) -> string;
   auto armDisassembleMoveMultiple(n16, n4, n1, n1, n1, n1, n1) -> string;
   auto armDisassembleMoveRegisterOffset(n4, n2, n5, n4, n4, n1, n1, n1, n1, n1) -> string;
+  auto armDisassembleMoveToRegisterFromCoprocessor(n4, n3, n4, n4, n4, n3) -> string;
   auto armDisassembleMoveToRegisterFromStatus(n4, n1) -> string;
   auto armDisassembleMoveToStatusFromImmediate(n8, n4, n4, n1) -> string;
   auto armDisassembleMoveToStatusFromRegister(n4, n2, n5, n4, n1) -> string;

--- a/ares/component/processor/arm7tdmi/arm7tdmi.hpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.hpp
@@ -8,10 +8,8 @@ struct Coprocessor {
   auto power(n4 cpID) -> void { id = cpID; }
 
   virtual auto CDP(n32 opcode) -> void { return; }
-  virtual auto LDC(n32 opcode) -> void { return; }
-  virtual auto MCR(n32 opcode) -> void { return; }
+  virtual auto MCR(n32 data, n4 cm, n3 op2, n4 cn, n3 op1) -> void { return; }
   virtual auto MRC(n4 cm, n3 op2, n4 cn, n3 op1) -> n32 { return 0; }
-  virtual auto STC(n32 opcode) -> void { return; }
 
   n4 id;
 };
@@ -93,6 +91,7 @@ struct ARM7TDMI {
   auto armInstructionMoveImmediateOffset(n12, n4, n4, n1, n1, n1, n1, n1) -> void;
   auto armInstructionMoveMultiple(n16, n4, n1, n1, n1, n1, n1) -> void;
   auto armInstructionMoveRegisterOffset(n4, n2, n5, n4, n4, n1, n1, n1, n1, n1) -> void;
+  auto armInstructionMoveToCoprocessorFromRegister(n4, n3, n4, n4, n4, n3) -> void;
   auto armInstructionMoveToRegisterFromCoprocessor(n4, n3, n4, n4, n4, n3) -> void;
   auto armInstructionMoveToRegisterFromStatus(n4, n1) -> void;
   auto armInstructionMoveToStatusFromImmediate(n8, n4, n4, n1) -> void;
@@ -248,16 +247,12 @@ struct ARM7TDMI {
 
   //coprocessor.cpp
   auto bindCDP(Coprocessor& cp) -> void;
-  auto bindLDC(Coprocessor& cp) -> void;
   auto bindMCR(Coprocessor& cp) -> void;
   auto bindMRC(Coprocessor& cp) -> void;
-  auto bindSTC(Coprocessor& cp) -> void;
 
   function<void (n32 opcode)> CDP[16];
-  function<void (n32 opcode)> LDC[16];
-  function<void (n32 opcode)> MCR[16];
+  function<void (n32 data, n4 cm, n3 op2, n4 cn, n3 op1)> MCR[16];
   function<n32 (n4 cm, n3 op2, n4 cn, n3 op1)> MRC[16];
-  function<void (n32 opcode)> STC[16];
 
   //disassembler.cpp
   auto armDisassembleBranch(i24, n1) -> string;
@@ -273,6 +268,7 @@ struct ARM7TDMI {
   auto armDisassembleMoveImmediateOffset(n12, n4, n4, n1, n1, n1, n1, n1) -> string;
   auto armDisassembleMoveMultiple(n16, n4, n1, n1, n1, n1, n1) -> string;
   auto armDisassembleMoveRegisterOffset(n4, n2, n5, n4, n4, n1, n1, n1, n1, n1) -> string;
+  auto armDisassembleMoveToCoprocessorFromRegister(n4, n3, n4, n4, n4, n3) -> string;
   auto armDisassembleMoveToRegisterFromCoprocessor(n4, n3, n4, n4, n4, n3) -> string;
   auto armDisassembleMoveToRegisterFromStatus(n4, n1) -> string;
   auto armDisassembleMoveToStatusFromImmediate(n8, n4, n4, n1) -> string;

--- a/ares/component/processor/arm7tdmi/coprocessor.cpp
+++ b/ares/component/processor/arm7tdmi/coprocessor.cpp
@@ -2,18 +2,10 @@ auto ARM7TDMI::bindCDP(Coprocessor& cp) -> void {
   CDP[cp.id] = [&](n32 opcode) { return cp.CDP(opcode); };
 }
 
-auto ARM7TDMI::bindLDC(Coprocessor& cp) -> void {
-  LDC[cp.id] = [&](n32 opcode) { return cp.LDC(opcode); };
-}
-
 auto ARM7TDMI::bindMCR(Coprocessor& cp) -> void {
-  MCR[cp.id] = [&](n32 opcode) { return cp.MCR(opcode); };
+  MCR[cp.id] = [&](n32 data, n4 cm, n3 op2, n4 cn, n3 op1) { return cp.MCR(data, cm, op2, cn, op1); };
 }
 
 auto ARM7TDMI::bindMRC(Coprocessor& cp) -> void {
   MRC[cp.id] = [&](n4 cm, n3 op2, n4 cn, n3 op1) { return cp.MRC(cm, op2, cn, op1); };
-}
-
-auto ARM7TDMI::bindSTC(Coprocessor& cp) -> void {
-  STC[cp.id] = [&](n32 opcode) { return cp.STC(opcode); };
 }

--- a/ares/component/processor/arm7tdmi/coprocessor.cpp
+++ b/ares/component/processor/arm7tdmi/coprocessor.cpp
@@ -1,0 +1,19 @@
+auto ARM7TDMI::bindCDP(Coprocessor& cp) -> void {
+  CDP[cp.id] = [&](n32 opcode) { return cp.CDP(opcode); };
+}
+
+auto ARM7TDMI::bindLDC(Coprocessor& cp) -> void {
+  LDC[cp.id] = [&](n32 opcode) { return cp.LDC(opcode); };
+}
+
+auto ARM7TDMI::bindMCR(Coprocessor& cp) -> void {
+  MCR[cp.id] = [&](n32 opcode) { return cp.MCR(opcode); };
+}
+
+auto ARM7TDMI::bindMRC(Coprocessor& cp) -> void {
+  MRC[cp.id] = [&](n4 cm, n3 op2, n4 cn, n3 op1) { return cp.MRC(cm, op2, cn, op1); };
+}
+
+auto ARM7TDMI::bindSTC(Coprocessor& cp) -> void {
+  STC[cp.id] = [&](n32 opcode) { return cp.STC(opcode); };
+}

--- a/ares/component/processor/arm7tdmi/coprocessor.cpp
+++ b/ares/component/processor/arm7tdmi/coprocessor.cpp
@@ -1,11 +1,11 @@
-auto ARM7TDMI::bindCDP(n4 id, Coprocessor& cp) -> void {
-  CDP[id] = [&](n4 cm, n3 op2, n4 cd, n4 cn, n4 op1) { return cp.CDP(cm, op2, cd, cn, op1); };
+auto ARM7TDMI::bindCDP(n4 id, function<void (n4 cm, n3 op2, n4 cd, n4 cn, n4 op1)> handler) -> void {
+  CDP[id] = handler;
 }
 
-auto ARM7TDMI::bindMCR(n4 id, Coprocessor& cp) -> void {
-  MCR[id] = [&](n32 data, n4 cm, n3 op2, n4 cn, n3 op1) { return cp.MCR(data, cm, op2, cn, op1); };
+auto ARM7TDMI::bindMCR(n4 id, function<void (n32 data, n4 cm, n3 op2, n4 cn, n3 op1)> handler) -> void {
+  MCR[id] = handler;
 }
 
-auto ARM7TDMI::bindMRC(n4 id, Coprocessor& cp) -> void {
-  MRC[id] = [&](n4 cm, n3 op2, n4 cn, n3 op1) { return cp.MRC(cm, op2, cn, op1); };
+auto ARM7TDMI::bindMRC(n4 id, function<n32 (n4 cm, n3 op2, n4 cn, n3 op1)> handler) -> void {
+  MRC[id] = handler;
 }

--- a/ares/component/processor/arm7tdmi/coprocessor.cpp
+++ b/ares/component/processor/arm7tdmi/coprocessor.cpp
@@ -1,11 +1,11 @@
-auto ARM7TDMI::bindCDP(Coprocessor& cp) -> void {
-  CDP[cp.id] = [&](n4 cm, n3 op2, n4 cd, n4 cn, n4 op1) { return cp.CDP(cm, op2, cd, cn, op1); };
+auto ARM7TDMI::bindCDP(n4 id, Coprocessor& cp) -> void {
+  CDP[id] = [&](n4 cm, n3 op2, n4 cd, n4 cn, n4 op1) { return cp.CDP(cm, op2, cd, cn, op1); };
 }
 
-auto ARM7TDMI::bindMCR(Coprocessor& cp) -> void {
-  MCR[cp.id] = [&](n32 data, n4 cm, n3 op2, n4 cn, n3 op1) { return cp.MCR(data, cm, op2, cn, op1); };
+auto ARM7TDMI::bindMCR(n4 id, Coprocessor& cp) -> void {
+  MCR[id] = [&](n32 data, n4 cm, n3 op2, n4 cn, n3 op1) { return cp.MCR(data, cm, op2, cn, op1); };
 }
 
-auto ARM7TDMI::bindMRC(Coprocessor& cp) -> void {
-  MRC[cp.id] = [&](n4 cm, n3 op2, n4 cn, n3 op1) { return cp.MRC(cm, op2, cn, op1); };
+auto ARM7TDMI::bindMRC(n4 id, Coprocessor& cp) -> void {
+  MRC[id] = [&](n4 cm, n3 op2, n4 cn, n3 op1) { return cp.MRC(cm, op2, cn, op1); };
 }

--- a/ares/component/processor/arm7tdmi/coprocessor.cpp
+++ b/ares/component/processor/arm7tdmi/coprocessor.cpp
@@ -1,5 +1,5 @@
 auto ARM7TDMI::bindCDP(Coprocessor& cp) -> void {
-  CDP[cp.id] = [&](n32 opcode) { return cp.CDP(opcode); };
+  CDP[cp.id] = [&](n4 cm, n3 op2, n4 cd, n4 cn, n4 op1) { return cp.CDP(cm, op2, cd, cn, op1); };
 }
 
 auto ARM7TDMI::bindMCR(Coprocessor& cp) -> void {

--- a/ares/component/processor/arm7tdmi/disassembler.cpp
+++ b/ares/component/processor/arm7tdmi/disassembler.cpp
@@ -68,6 +68,12 @@ auto ARM7TDMI::armDisassembleBranchExchangeRegister
   return {"bx", _c, " ", _r[m]};
 }
 
+auto ARM7TDMI::armDisassembleCoprocessorDataProcessing
+(n4 cm, n3 op2, n4 cpid, n4 cd, n4 cn, n4 op1) -> string {
+  return {"cdp", _c, " p", cpid, ", ", op1, ", cr", cd,
+    ", cr", cn, ", cr", cm, ", ", op2};
+}
+
 auto ARM7TDMI::armDisassembleDataImmediate
 (n8 immediate, n4 shift, n4 d, n4 n, n1 save, n4 mode) -> string {
   static const string opcode[] = {

--- a/ares/component/processor/arm7tdmi/disassembler.cpp
+++ b/ares/component/processor/arm7tdmi/disassembler.cpp
@@ -212,6 +212,12 @@ auto ARM7TDMI::armDisassembleMoveRegisterOffset
     pre == 0 || writeback ? "!" : ""};
 }
 
+auto ARM7TDMI::armDisassembleMoveToCoprocessorFromRegister
+(n4 cm, n3 op2, n4 cpid, n4 d, n4 cn, n3 op1) -> string {
+  return {"mcr", _c, " p", cpid, ", ", op1, ", ", _r[d],
+    ", cr", cn, ", cr", cm, ", ", op2};
+}
+
 auto ARM7TDMI::armDisassembleMoveToRegisterFromCoprocessor
 (n4 cm, n3 op2, n4 cpid, n4 d, n4 cn, n3 op1) -> string {
   return {"mrc", _c, " p", cpid, ", ", op1, ", ", _r[d],

--- a/ares/component/processor/arm7tdmi/disassembler.cpp
+++ b/ares/component/processor/arm7tdmi/disassembler.cpp
@@ -212,6 +212,12 @@ auto ARM7TDMI::armDisassembleMoveRegisterOffset
     pre == 0 || writeback ? "!" : ""};
 }
 
+auto ARM7TDMI::armDisassembleMoveToRegisterFromCoprocessor
+(n4 cm, n3 op2, n4 cpid, n4 d, n4 cn, n3 op1) -> string {
+  return {"mrc", _c, " p", cpid, ", ", op1, ", ", _r[d],
+    ", cr", cn, ", cr", cm, ", ", op2};
+}
+
 auto ARM7TDMI::armDisassembleMoveToRegisterFromStatus
 (n4 d, n1 mode) -> string {
   return {"mrs", _c, " ", _r[d], ",", mode ? "spsr" : "cpsr"};

--- a/ares/component/processor/arm7tdmi/instruction.cpp
+++ b/ares/component/processor/arm7tdmi/instruction.cpp
@@ -293,6 +293,20 @@ auto ARM7TDMI::armInitialize() -> void {
     opcode.bit(21,23)   /* op1 */
   for(n3 op2 : range(8))
   for(n3 op1 : range(8)) {
+    auto opcode = pattern(".... 1110 ???0 ???? ???? ???? ???1 ????") | op2 << 5 | op1 << 21;
+    bind(opcode, MoveToCoprocessorFromRegister);
+  }
+  #undef arguments
+
+  #define arguments \
+    opcode.bit( 0, 3),  /* cm */ \
+    opcode.bit( 5, 7),  /* op2 */ \
+    opcode.bit( 8,11),  /* cpid */ \
+    opcode.bit(12,15),  /* d */ \
+    opcode.bit(16,19),  /* cn */ \
+    opcode.bit(21,23)   /* op1 */
+  for(n3 op2 : range(8))
+  for(n3 op1 : range(8)) {
     auto opcode = pattern(".... 1110 ???1 ???? ???? ???? ???1 ????") | op2 << 5 | op1 << 21;
     bind(opcode, MoveToRegisterFromCoprocessor);
   }

--- a/ares/component/processor/arm7tdmi/instruction.cpp
+++ b/ares/component/processor/arm7tdmi/instruction.cpp
@@ -285,6 +285,20 @@ auto ARM7TDMI::armInitialize() -> void {
   #undef arguments
 
   #define arguments \
+    opcode.bit( 0, 3),  /* cm */ \
+    opcode.bit( 5, 7),  /* op2 */ \
+    opcode.bit( 8,11),  /* cpid */ \
+    opcode.bit(12,15),  /* d */ \
+    opcode.bit(16,19),  /* cn */ \
+    opcode.bit(21,23)   /* op1 */
+  for(n3 op2 : range(8))
+  for(n3 op1 : range(8)) {
+    auto opcode = pattern(".... 1110 ???1 ???? ???? ???? ???1 ????") | op2 << 5 | op1 << 21;
+    bind(opcode, MoveToRegisterFromCoprocessor);
+  }
+  #undef arguments
+
+  #define arguments \
     opcode.bit(12,15),  /* d */ \
     opcode.bit(22)      /* mode */
   for(n1 mode : range(2)) {

--- a/ares/component/processor/arm7tdmi/instruction.cpp
+++ b/ares/component/processor/arm7tdmi/instruction.cpp
@@ -90,6 +90,20 @@ auto ARM7TDMI::armInitialize() -> void {
   #undef arguments
 
   #define arguments \
+    opcode.bit( 0, 3),  /* cm */ \
+    opcode.bit( 5, 7),  /* op2 */ \
+    opcode.bit( 8,11),  /* cpid */ \
+    opcode.bit(12,15),  /* cd */ \
+    opcode.bit(16,19),  /* cn */ \
+    opcode.bit(20,23)   /* op1 */
+  for(n3 op2 : range(8))
+  for(n4 op1 : range(16)) {
+    auto opcode = pattern(".... 1110 ???? ???? ???? ???? ???0 ????") | op2 << 5 | op1 << 20;
+    bind(opcode, CoprocessorDataProcessing);
+  }
+  #undef arguments
+
+  #define arguments \
     opcode.bit( 0, 7),  /* immediate */ \
     opcode.bit( 8,11),  /* shift */ \
     opcode.bit(12,15),  /* d */ \

--- a/ares/component/processor/arm7tdmi/instructions-arm.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-arm.cpp
@@ -267,6 +267,12 @@ auto ARM7TDMI::armInstructionMoveRegisterOffset
   if(mode == 1) r(d) = rd;
 }
 
+auto ARM7TDMI::armInstructionMoveToRegisterFromCoprocessor
+(n4 cm, n3 op2, n4 cpid, n4 d, n4 cn, n3 op1) -> void {
+  if(!MRC[cpid]) return armInstructionUndefined();
+  r(d) = MRC[cpid](cm, op2, cn, op1);
+}
+
 auto ARM7TDMI::armInstructionMoveToRegisterFromStatus
 (n4 d, n1 mode) -> void {
   r(d) = (mode && cpsr().m != PSR::USR && cpsr().m != PSR::SYS) ? spsr() : cpsr();

--- a/ares/component/processor/arm7tdmi/instructions-arm.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-arm.cpp
@@ -64,6 +64,12 @@ auto ARM7TDMI::armInstructionBranchExchangeRegister
   r(d) = address;
 }
 
+auto ARM7TDMI::armInstructionCoprocessorDataProcessing
+(n4 cm, n3 op2, n4 cpid, n4 cd, n4 cn, n4 op1) -> void {
+  if(!CDP[cpid]) return armInstructionUndefined();
+  CDP[cpid](cm, op2, cd, cn, op1);
+}
+
 auto ARM7TDMI::armInstructionDataImmediate
 (n8 immediate, n4 shift, n4 d, n4 n, n1 save, n4 mode) -> void {
   n32 rn = r(n);

--- a/ares/component/processor/arm7tdmi/instructions-arm.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-arm.cpp
@@ -267,6 +267,12 @@ auto ARM7TDMI::armInstructionMoveRegisterOffset
   if(mode == 1) r(d) = rd;
 }
 
+auto ARM7TDMI::armInstructionMoveToCoprocessorFromRegister
+(n4 cm, n3 op2, n4 cpid, n4 d, n4 cn, n3 op1) -> void {
+  if(!MCR[cpid]) return armInstructionUndefined();
+  MCR[cpid](r(d), cm, op2, cn, op1);
+}
+
 auto ARM7TDMI::armInstructionMoveToRegisterFromCoprocessor
 (n4 cm, n3 op2, n4 cpid, n4 d, n4 cn, n3 op1) -> void {
   if(!MRC[cpid]) return armInstructionUndefined();

--- a/ares/gba/CMakeLists.txt
+++ b/ares/gba/CMakeLists.txt
@@ -60,6 +60,7 @@ ares_add_sources(
     gba
   INCLUDED #
     cpu/bus.cpp
+    cpu/coprocessor.cpp
     cpu/cpu.hpp
     cpu/debugger.cpp
     cpu/dma.cpp

--- a/ares/gba/cpu/coprocessor.cpp
+++ b/ares/gba/cpu/coprocessor.cpp
@@ -1,4 +1,4 @@
-auto CPU::CP0::CDP(n4 cm, n3 op2, n4 cd, n4 cn, n4 op1) -> void {
+auto CPU::Coprocessor::vcCDP() -> void {
   static bool warnVC = false;
   if(!warnVC) {
     warnVC = true;
@@ -7,10 +7,10 @@ auto CPU::CP0::CDP(n4 cm, n3 op2, n4 cd, n4 cn, n4 op1) -> void {
   cpu.armInstructionUndefined();
 }
 
-auto CPU::CP14::MCR(n32 data, n4 cm, n3 op2, n4 cn, n3 op1) -> void {
+auto CPU::Coprocessor::debugMCR() -> void {
   return;
 }
 
-auto CPU::CP14::MRC(n4 cm, n3 op2, n4 cn, n3 op1) -> n32 {
+auto CPU::Coprocessor::debugMRC() -> n32 {
   return cpu.openBus.get(Word, 0);
 }

--- a/ares/gba/cpu/coprocessor.cpp
+++ b/ares/gba/cpu/coprocessor.cpp
@@ -1,8 +1,8 @@
-auto CPU::CP0::CDP(n32 opcode) -> void {
+auto CPU::CP0::CDP(n4 cm, n3 op2, n4 cd, n4 cn, n4 op1) -> void {
   static bool warnVC = false;
   if(!warnVC) {
     warnVC = true;
-    print("Warning: CP0 instruction ", hex(opcode, 8L), " executed. This likely signifies a Virtual Console ROM which may not function correctly on real hardware.\n");
+    print("Warning: CP0 instruction executed. This likely signifies a Virtual Console ROM which may not function correctly on real hardware.\n");
   }
   cpu.armInstructionUndefined();
 }

--- a/ares/gba/cpu/coprocessor.cpp
+++ b/ares/gba/cpu/coprocessor.cpp
@@ -7,7 +7,7 @@ auto CPU::CP0::CDP(n32 opcode) -> void {
   cpu.armInstructionUndefined();
 }
 
-auto CPU::CP14::MCR(n32 opcode) -> void {
+auto CPU::CP14::MCR(n32 data, n4 cm, n3 op2, n4 cn, n3 op1) -> void {
   return;
 }
 

--- a/ares/gba/cpu/coprocessor.cpp
+++ b/ares/gba/cpu/coprocessor.cpp
@@ -1,0 +1,16 @@
+auto CPU::CP0::CDP(n32 opcode) -> void {
+  static bool warnVC = false;
+  if(!warnVC) {
+    warnVC = true;
+    print("Warning: CP0 instruction ", hex(opcode, 8L), " executed. This likely signifies a Virtual Console ROM which may not function correctly on real hardware.\n");
+  }
+  cpu.armInstructionUndefined();
+}
+
+auto CPU::CP14::MCR(n32 opcode) -> void {
+  return;
+}
+
+auto CPU::CP14::MRC(n4 cm, n3 op2, n4 cn, n3 op1) -> n32 {
+  return cpu.openBus.get(Word, 0);
+}

--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -132,11 +132,9 @@ auto CPU::power() -> void {
   ARM7TDMI::power();
   Thread::create(system.frequency(), {&CPU::main, this});
 
-  cp0.power(0);
-  cp14.power(14);
-  bindCDP(cp0);
-  bindMCR(cp14);
-  bindMRC(cp14);
+  bindCDP(0, cp0);
+  bindMCR(14, cp14);
+  bindMRC(14, cp14);
 
   for(auto& byte : iwram) byte = 0x00;
   for(auto& byte : ewram) byte = 0x00;

--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -10,6 +10,7 @@ CPU cpu;
 #include "dma.cpp"
 #include "timer.cpp"
 #include "keypad.cpp"
+#include "coprocessor.cpp"
 #include "debugger.cpp"
 #include "serialization.cpp"
 
@@ -130,6 +131,12 @@ auto CPU::step(u32 clocks) -> void {
 auto CPU::power() -> void {
   ARM7TDMI::power();
   Thread::create(system.frequency(), {&CPU::main, this});
+
+  cp0.power(0);
+  cp14.power(14);
+  bindCDP(cp0);
+  bindMCR(cp14);
+  bindMRC(cp14);
 
   for(auto& byte : iwram) byte = 0x00;
   for(auto& byte : ewram) byte = 0x00;

--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -132,9 +132,9 @@ auto CPU::power() -> void {
   ARM7TDMI::power();
   Thread::create(system.frequency(), {&CPU::main, this});
 
-  bindCDP(0, cp0);
-  bindMCR(14, cp14);
-  bindMRC(14, cp14);
+  bindCDP( 0, [&](n4 cm, n3 op2, n4 cd, n4 cn, n4 op1) { return coprocessor.vcCDP(); });
+  bindMCR(14, [&](n32 data, n4 cm, n3 op2, n4 cn, n3 op1) { return coprocessor.debugMCR(); });
+  bindMRC(14, [&](n4 cm, n3 op2, n4 cn, n3 op1) { return coprocessor.debugMRC(); });
 
   for(auto& byte : iwram) byte = 0x00;
   for(auto& byte : ewram) byte = 0x00;

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -264,7 +264,7 @@ struct CPU : ARM7TDMI, Thread, IO {
   struct CP14 : Coprocessor {
     //coprocessor.cpp
     auto MRC(n4 cm, n3 op2, n4 cn, n3 op1) -> n32 override;
-    auto MCR(n32 opcode) -> void override;
+    auto MCR(n32 data, n4 cm, n3 op2, n4 cn, n3 op1) -> void override;
   } cp14;
 
   struct Context {

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -256,16 +256,12 @@ struct CPU : ARM7TDMI, Thread, IO {
     n1  stopped = 1;
   } prefetch;
 
-  struct CP0 : Coprocessor {
+  struct Coprocessor {
     //coprocessor.cpp
-    auto CDP(n4 cm, n3 op2, n4 cd, n4 cn, n4 op1) -> void override;
-  } cp0;
-
-  struct CP14 : Coprocessor {
-    //coprocessor.cpp
-    auto MRC(n4 cm, n3 op2, n4 cn, n3 op1) -> n32 override;
-    auto MCR(n32 data, n4 cm, n3 op2, n4 cn, n3 op1) -> void override;
-  } cp14;
+    auto vcCDP() -> void;
+    auto debugMCR() -> void;
+    auto debugMRC() -> n32;
+  } coprocessor;
 
   struct Context {
     n32 clock;

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -256,6 +256,17 @@ struct CPU : ARM7TDMI, Thread, IO {
     n1  stopped = 1;
   } prefetch;
 
+  struct CP0 : Coprocessor {
+    //coprocessor.cpp
+    auto CDP(n32 opcode) -> void override;
+  } cp0;
+
+  struct CP14 : Coprocessor {
+    //coprocessor.cpp
+    auto MRC(n4 cm, n3 op2, n4 cn, n3 op1) -> n32 override;
+    auto MCR(n32 opcode) -> void override;
+  } cp14;
+
   struct Context {
     n32 clock;
     n1  halted;

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -258,7 +258,7 @@ struct CPU : ARM7TDMI, Thread, IO {
 
   struct CP0 : Coprocessor {
     //coprocessor.cpp
-    auto CDP(n32 opcode) -> void override;
+    auto CDP(n4 cm, n3 op2, n4 cd, n4 cn, n4 op1) -> void override;
   } cp0;
 
   struct CP14 : Coprocessor {


### PR DESCRIPTION
The GBA has a single coprocessor (CP14), which is a disconnected debug interface. Additionally, Virtual Console titles are sometimes modified to use CP0 instructions, which are undefined on real hardware. However, ARM coprocessor instructions are currently unsupported in ares.

This PR adds an interface for accessing ARM coprocessors. On the GBA side, a CP14 debug stub is added, as well as a CP0 stub that, when accessed, warns the user that they are running a Virtual Console title which may not function on real hardware.

The interface consists of three arrays of 16 functions. These arrays represent the CDP, MCR, and MRC operations for all 16 possible coprocessors, and can be bound using bindCDP, bindMCR, and bindMRC respectively. If no coprocessor function is bound, its corresponding instructions will be treated as undefined opcodes. This should allow future coprocessors to be implemented relatively easily with minimal restrictions.

Note that LDC and STC instructions remain unsupported, because these are undefined on the GBA and never used by Virtual Console, and attempting to support these instructions now would be a potential source of error when trying to support future coprocessors that require these instructions.