### PR TITLE
build: Fix build on macOS 10.15

### DIFF
--- a/ares/pce/psg/channel.cpp
+++ b/ares/pce/psg/channel.cpp
@@ -3,8 +3,8 @@ auto PSG::Channel::power(u32 id) -> void {
   io = {};
 }
 
-template<int index, int step> auto PSG::Channel::run() -> n5 {
-  for(u32 n : range(step)) {
+template<int index, int stepArg> auto PSG::Channel::run() -> n5 {
+  for(u32 n : range(stepArg)) {
     if(!io.direct && --io.wavePeriod == 0) {
       io.wavePeriod = io.waveFrequency;
       io.waveOffset++;

--- a/ares/pce/psg/psg.cpp
+++ b/ares/pce/psg/psg.cpp
@@ -46,7 +46,7 @@ auto PSG::main() -> void {
   #endif
 }
 
-template<int step> auto PSG::frame(i16& outputLeft, i16& outputRight) -> void {
+template<int stepArg> auto PSG::frame(i16& outputLeft, i16& outputRight) -> void {
   static const n5 volumeScale[16] = {
     0x00, 0x03, 0x05, 0x07, 0x09, 0x0b, 0x0d, 0x0f,
     0x10, 0x13, 0x15, 0x17, 0x19, 0x1b, 0x1d, 0x1f,
@@ -59,12 +59,12 @@ template<int step> auto PSG::frame(i16& outputLeft, i16& outputRight) -> void {
   n5 rmal = volumeScale[io.volumeRight];
 
   n5 output[6];
-  if(channel[0].io.enable) output[0] = channel[0].run<0, step>();
-  if(channel[1].io.enable) output[1] = channel[1].run<1, step>();
-  if(channel[2].io.enable) output[2] = channel[2].run<2, step>();
-  if(channel[3].io.enable) output[3] = channel[3].run<3, step>();
-  if(channel[4].io.enable) output[4] = channel[4].run<4, step>();
-  if(channel[5].io.enable) output[5] = channel[5].run<5, step>();
+  if(channel[0].io.enable) output[0] = channel[0].run<0, stepArg>();
+  if(channel[1].io.enable) output[1] = channel[1].run<1, stepArg>();
+  if(channel[2].io.enable) output[2] = channel[2].run<2, stepArg>();
+  if(channel[3].io.enable) output[3] = channel[3].run<3, stepArg>();
+  if(channel[4].io.enable) output[4] = channel[4].run<4, stepArg>();
+  if(channel[5].io.enable) output[5] = channel[5].run<5, stepArg>();
 
   for(u32 C : range(6)) {
     n5  al = channel[C].io.volume;

--- a/hiro/cocoa/widget/button.cpp
+++ b/hiro/cocoa/widget/button.cpp
@@ -8,7 +8,7 @@
     [self setTarget:self];
     [self setAction:@selector(activate:)];
     //NSRoundedBezelStyle has a fixed height; which breaks both icons and larger/smaller text
-    [self setBezelStyle:NSBezelStyleFlexiblePush];
+    [self setBezelStyle:NSBezelStyleRegularSquare];
   }
   return self;
 }

--- a/hiro/cocoa/widget/check-button.cpp
+++ b/hiro/cocoa/widget/check-button.cpp
@@ -8,7 +8,7 @@
 
     [self setTarget:self];
     [self setAction:@selector(activate:)];
-    [self setBezelStyle:NSBezelStyleFlexiblePush];
+    [self setBezelStyle:NSBezelStyleRegularSquare];
     [self setButtonType:NSButtonTypeOnOff];
   }
   return self;

--- a/hiro/cocoa/widget/radio-button.cpp
+++ b/hiro/cocoa/widget/radio-button.cpp
@@ -8,7 +8,7 @@
 
     [self setTarget:self];
     [self setAction:@selector(activate:)];
-    [self setBezelStyle:NSBezelStyleFlexiblePush];
+    [self setBezelStyle:NSBezelStyleRegularSquare];
     [self setButtonType:NSButtonTypeOnOff];
   }
   return self;

--- a/ruby/video/metal/metal.cpp
+++ b/ruby/video/metal/metal.cpp
@@ -127,13 +127,13 @@ struct VideoMetal : VideoDriver, Metal {
       NSTimeInterval minInterval = view.window.screen.minimumRefreshInterval;
       NSTimeInterval maxInterval = view.window.screen.maximumRefreshInterval;
       _vrrIsSupported = minInterval != maxInterval;
-#else
-      _vrrIsSupported = false;
-#endif
-      return _vrrIsSupported;
     } else {
-      return false;
+      _vrrIsSupported = false;
     }
+#else
+    _vrrIsSupported = false;
+#endif
+    return _vrrIsSupported;
   }
   
   auto updatePresentInterval() -> void {


### PR DESCRIPTION
[Build docs state](https://github.com/ares-emulator/ares/wiki/Build-Instructions-For-macOS) that we support building on macOS 10.15. A couple things broke since that was written:

https://github.com/ares-emulator/ares/commit/6cc9f5a416ec9b0077fc0f50912b1af96987cdf5 broke because AppleClang 12.0 thinks that `step` is referring to the function called `step` rather than the argument provided to the function.

https://github.com/ares-emulator/ares/commit/c287c1b22501152342746ada4c988049715a1934 broke because the availability macro was not written correctly.

https://github.com/ares-emulator/ares/commit/4fc09438d22b02ea23d70ff96661e24151165ef6 broke because we made an inappropriate replacement when replacing deprecations: `NSRegularSquareBezelStyle` should have become `NSBezelStyleRegularSquare`; `NSBezelStyleFlexiblePush` resolves to the same appearance, but is unavailable in the SDK included with Xcode 12.4.