### PR TITLE
build: Miscellaneous fixes

### DIFF
--- a/cmake/common/versionconfig.cmake
+++ b/cmake/common/versionconfig.cmake
@@ -30,7 +30,7 @@ function(ares_populate_version_info)
     string(STRIP "${ARES_VERSION}" ARES_VERSION)
   endif()
 
-  string(REGEX REPLACE "^v([0-9]+(\\.[0-9]+)*)-.*" "\\1" ares_version_stripped "${ARES_VERSION}")
+  string(REGEX REPLACE "^v([0-9]+(\\.[0-9]+)*)(-.*)?$" "\\1" ares_version_stripped "${ARES_VERSION}")
   string(REPLACE "." ";" ares_version_parts "${ares_version_stripped}")
   list(LENGTH ares_version_parts ares_version_parts_length)
   list(GET ares_version_parts 0 minor)

--- a/desktop-ui/resource/ares.rc.in
+++ b/desktop-ui/resource/ares.rc.in
@@ -20,5 +20,5 @@ END
 2 ICON DISCARDABLE "resource/ares.ico"
 
 #ifndef EXCLUDE_MANIFEST_FROM_RC
-3 24 "resource/ares.Manifest"
+1 24 "resource/ares.Manifest"
 #endif


### PR DESCRIPTION
* Fix a regression where the application manifest was not embedding properly on Windows, leading to various problems including incorrect UI styling and DPI settings
* Fix an issue where we would fail to parse a canonical version from a `git describe` string without a suffix 