### PR TITLE
ruby/metal: Zero-initialize librashader handles

### DIFF
--- a/ruby/video/metal/metal.hpp
+++ b/ruby/video/metal/metal.hpp
@@ -97,7 +97,7 @@ struct Metal {
   id<MTLTexture> _renderTargetTexture;
   
   libra_instance_t _libra;
-  libra_shader_preset_t _preset;
-  libra_mtl_filter_chain_t _filterChain;
+  libra_shader_preset_t _preset = nullptr;
+  libra_mtl_filter_chain_t _filterChain = nullptr;
   bool initialized = false;
 };


### PR DESCRIPTION
Metal checks whether librashader handles are non-null during deinitialization to determine whether to call librashader's `free` functions on them.

If the handles are initialized to contain junk data, they will be non-null but `free` will fail, causing a crash during the deinit that occurs prior to any initialization of the video driver.

On Apple Silicon, the system malloc implementation provides something of a guarantee that heap allocations are zero-initialized, but this proves to not always be the case in practice. There are also no (or fewer) such guarantees on x86_64.

On OpenGL, these pointers were already being zero-initialized.