### PR TITLE
desktop-ui: Initialize tools window before program

### DIFF
--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -157,9 +157,9 @@ auto nall::main(Arguments arguments) -> void {
   Instances::presentation.construct();
   Instances::settingsWindow.construct();
   Instances::gameBrowserWindow.construct();
+  Instances::toolsWindow.construct(&program.programMutex);
 
   program.create();
-  Instances::toolsWindow.construct(&program.programMutex);
   Application::onMain({&Program::main, &program});
   Application::run();
 


### PR DESCRIPTION
When loading a ROM via a startup argument, `Program` requires access to elements that are initialized as part of the Tools window. Thus, make sure the Tools window is fully loaded before creating `Program`.

This restores the load order prior to the threading rework. An earlier version of the threading rework created the program mutex differently, which is why the load order was modified in the first place (incidentally rather than intentionally).

Fixes #2043