### PR TITLE
desktop-ui: Threading fixes

### DIFF
--- a/desktop-ui/program/load.cpp
+++ b/desktop-ui/program/load.cpp
@@ -24,6 +24,10 @@ auto Program::load(shared_pointer<Emulator> emulator, string location) -> bool {
   // For arcade systems, show the game browser dialog as we're using MAME-compatible roms
   if(emulator->arcade() && !location) {
     gameBrowserWindow.show(emulator);
+    
+    // Temporarily pretend that the load failed to prevent crash
+    // The browser dialog will call load() again when necessary
+    ::emulator.reset();
     return false;
   }
 

--- a/desktop-ui/settings/drivers.cpp
+++ b/desktop-ui/settings/drivers.cpp
@@ -89,14 +89,17 @@ auto DriverSettings::construct() -> void {
     audioRefresh();
   });
   audioExclusiveToggle.setText("Exclusive mode").onToggle([&] {
+    lock_guard<recursive_mutex> programLock(program.programMutex);
     settings.audio.exclusive = audioExclusiveToggle.checked();
     ruby::audio.setExclusive(settings.audio.exclusive);
   });
   audioBlockingToggle.setText("Synchronize").onToggle([&] {
+    lock_guard<recursive_mutex> programLock(program.programMutex);
     settings.audio.blocking = audioBlockingToggle.checked();
     ruby::audio.setBlocking(settings.audio.blocking);
   });
   audioDynamicToggle.setText("Dynamic rate").onToggle([&] {
+    lock_guard<recursive_mutex> programLock(program.programMutex);
     settings.audio.dynamic = audioDynamicToggle.checked();
     ruby::audio.setDynamic(settings.audio.dynamic);
   });
@@ -179,11 +182,11 @@ auto DriverSettings::videoRefresh() -> void {
 }
 
 auto DriverSettings::videoDriverUpdate() -> bool {
+  lock_guard<recursive_mutex> programLock(program.programMutex);
   if(emulator && settings.video.driver != "None" && MessageDialog(
     "Warning: incompatible drivers may cause this software to crash.\n"
     "Are you sure you want to change this driver while a game is loaded?"
   ).setAlignment(settingsWindow).question() != "Yes") return false;
-  lock_guard<recursive_mutex> programLock(program.programMutex);
   program.videoDriverUpdate();
   videoRefresh();
   return true;
@@ -225,11 +228,11 @@ auto DriverSettings::audioRefresh() -> void {
 }
 
 auto DriverSettings::audioDriverUpdate() -> bool {
+  lock_guard<recursive_mutex> programLock(program.programMutex);
   if(emulator && settings.audio.driver != "None" && MessageDialog(
     "Warning: incompatible drivers may cause this software to crash.\n"
     "Are you sure you want to change this driver while a game is loaded?"
   ).setAlignment(settingsWindow).question() != "Yes") return false;
-  lock_guard<recursive_mutex> programLock(program.programMutex);
   program.audioDriverUpdate();
   audioRefresh();
   return true;
@@ -249,11 +252,11 @@ auto DriverSettings::inputRefresh() -> void {
 }
 
 auto DriverSettings::inputDriverUpdate() -> bool {
+  lock_guard<recursive_mutex> programLock(program.programMutex);
   if(emulator && settings.input.driver != "None" && MessageDialog(
     "Warning: incompatible drivers may cause this software to crash.\n"
     "Are you sure you want to change this driver while a game is loaded?"
   ).setAlignment(settingsWindow).question() != "Yes") return false;
-  lock_guard<recursive_mutex> programLock(program.programMutex);
   program.inputDriverUpdate();
   inputRefresh();
   return true;


### PR DESCRIPTION
* Acquire the program mutex when updating audio sync settings to prevent a possible crash in some audio drivers
* Pause emulation while showing driver confirmation modals to prevent interference from the UI thread calling `ruby::audio.clear()` during the modal state, and also because pausing the application for a modal is a normal pattern
* Restore a workaround when loading Arcade systems via the game browser window that prevented a crash