### PR TITLE
gba: prefetcher timing improvements

### DIFF
--- a/ares/gba/cpu/bus.cpp
+++ b/ares/gba/cpu/bus.cpp
@@ -48,6 +48,7 @@ inline auto CPU::getBus(u32 mode, n32 address) -> n32 {
     mode = cartMode(mode, address);
     context.romAccess = true;
     if(mode & Prefetch && wait.prefetch) {
+      if(mode & Nonsequential && prefetch.cycle == 0 && prefetch.empty()) prefetchReset();
       prefetchSync(address);
       prefetchStep(1);
       word = prefetchRead();

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -250,9 +250,10 @@ struct CPU : ARM7TDMI, Thread, IO {
     auto size() const { return (load - addr) >> 1; }
 
     n16 slot[8];
-    n32 addr;       //read location of slot buffer
-    n32 load;       //write location of slot buffer
-    i32 wait = 1;  //number of clocks before next slot load
+    n32 addr;      //read location of slot buffer
+    n32 load;      //write location of slot buffer
+    i32 wait = 1;  //wait states for current load
+    i32 cycle;     //number of clocks elapsed on current load
     n1  stopped = 1;
   } prefetch;
 

--- a/ares/gba/cpu/prefetch.cpp
+++ b/ares/gba/cpu/prefetch.cpp
@@ -1,12 +1,13 @@
 auto CPU::prefetchSync(n32 address) -> void {
   if(address == prefetch.addr) return;
 
-  if(prefetch.wait == 1) step(1);
+  if(prefetch.wait - prefetch.cycle == 1) step(1);
 
   prefetch.stopped = false;
   prefetch.addr = address;
   prefetch.load = address;
   prefetch.wait = waitCartridge(Half | Nonsequential, prefetch.load);
+  prefetch.cycle = 0;
 }
 
 auto CPU::prefetchStep(u32 clocks) -> void {
@@ -14,30 +15,34 @@ auto CPU::prefetchStep(u32 clocks) -> void {
   if(!wait.prefetch || prefetch.stopped) return;
 
   while(!prefetch.full() && clocks--) {
-    if(--prefetch.wait) continue;
+    prefetch.cycle++;
+    if(prefetch.wait > prefetch.cycle) continue;
     prefetch.slot[prefetch.load >> 1 & 7] = cartridge.readRom<false>(Half | Nonsequential, prefetch.load);  //todo: make access sequentiality consistent with timing used
     prefetch.load += 2;
     prefetch.wait = waitCartridge(Half | Sequential, prefetch.load);
+    prefetch.cycle = 0;
   }
 
   if(prefetch.full()) prefetch.stopped = true;
 }
 
 auto CPU::prefetchReset() -> void {
-  if(prefetch.wait == 1) step(1);
+  if(prefetch.wait - prefetch.cycle == 1) step(1);
 
   prefetch.stopped = true;
   prefetch.wait = 0;
   prefetch.addr = 0;
   prefetch.load = 0;
+  prefetch.cycle = 0;
 }
 
 auto CPU::prefetchRead() -> n16 {
   if(prefetch.stopped && prefetch.empty()) {
     prefetch.stopped = false;
     prefetch.wait = waitCartridge(Half | Nonsequential, prefetch.load);
+    prefetch.cycle = 0;
   }
-  if(prefetch.empty()) prefetchStep(prefetch.wait);
+  if(prefetch.empty()) prefetchStep(prefetch.wait - prefetch.cycle);
 
   n16 word = prefetch.slot[prefetch.addr >> 1 & 7];
   prefetch.addr += 2;

--- a/ares/gba/cpu/prefetch.cpp
+++ b/ares/gba/cpu/prefetch.cpp
@@ -33,15 +33,13 @@ auto CPU::prefetchReset() -> void {
 }
 
 auto CPU::prefetchRead() -> n16 {
-  if(prefetch.empty()) prefetchStep(prefetch.wait);
-
-  n16 word = prefetch.slot[prefetch.addr >> 1 & 7];
-  prefetch.addr += 2;
-
   if(prefetch.stopped && prefetch.empty()) {
     prefetch.stopped = false;
     prefetch.wait = waitCartridge(Half | Nonsequential, prefetch.load);
   }
+  if(prefetch.empty()) prefetchStep(prefetch.wait);
 
+  n16 word = prefetch.slot[prefetch.addr >> 1 & 7];
+  prefetch.addr += 2;
   return word;
 }

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -107,6 +107,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(prefetch.addr);
   s(prefetch.load);
   s(prefetch.wait);
+  s(prefetch.cycle);
   s(prefetch.stopped);
 
   s(context.clock);

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v144.2";
+static const string SerializerVersion = "v144.3";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Fixed a bug where the prefetcher was restarting too early upon being emptied, and implemented a timing edge case involving simultaneous accesses from the CPU and prefetcher.