### PR TITLE
ps1: represent spu noise as a signed 16-bit quantity

### DIFF
--- a/ares/ps1/spu/spu.hpp
+++ b/ares/ps1/spu/spu.hpp
@@ -67,7 +67,7 @@ struct SPU : Thread, Memory::Interface {
     n2  step;
     n4  shift;
   //internal:
-    n32 level;
+    i16 level;
     n32 count;
   } noise{*this};
 

--- a/ares/ps1/system/serialization.cpp
+++ b/ares/ps1/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v134";
+static const string SerializerVersion = "v144";
 
 auto System::serialize(bool synchronize) -> serializer {
   serializer s;


### PR DESCRIPTION
Fixes extra loud noise in Final Fantasy VII (and many, many other titles).