### PR TITLE
ps1: make save states robust across ares launches

### DIFF
--- a/ares/ps1/cpu/serialization.cpp
+++ b/ares/ps1/cpu/serialization.cpp
@@ -10,11 +10,12 @@ auto CPU::serialize(serializer& s) -> void {
   s(pipeline.address);
   s(pipeline.instruction);
 
-  //todo: serialize delay slot target pointers portably
-  s((u64&)delay.load[0].target);
-  s(delay.load[0].source);
-  s((u64&)delay.load[1].target);
-  s(delay.load[1].source);
+  for(auto& load : delay.load) {
+    u32 index = load.target ? load.target - ipu.r : ~0;
+    s(index);
+    load.target = index < 32 ? &ipu.r[index] : nullptr;
+    s(load.source);
+  }
   s(delay.branch[0].slot);
   s(delay.branch[0].take);
   s(delay.branch[0].address);

--- a/ares/ps1/system/serialization.cpp
+++ b/ares/ps1/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v144";
+static const string SerializerVersion = "v144.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   serializer s;


### PR DESCRIPTION
The CPU serialization logic would sometimes write pointers to save states. Needless to say, this was not very compatible with saving and loading states across separate runs of the ares process.