### PR TITLE
More threading fixes

### DIFF
--- a/ares/ares/ares.cpp.in
+++ b/ares/ares/ares.cpp.in
@@ -7,7 +7,7 @@
 namespace ares {
 
 Platform* platform = nullptr;
-bool _runAhead = false;
+atomic<bool> _runAhead = false;
 
 const string Name       = "@ARES_NAME@";
 const string Version    = "@ARES_VERSION@";

--- a/ares/ares/ares.hpp
+++ b/ares/ares/ares.hpp
@@ -66,7 +66,7 @@ namespace ares {
     }
   }
 
-  extern bool _runAhead;
+  extern atomic<bool> _runAhead;
   inline auto runAhead() -> bool { return _runAhead; }
   inline auto setRunAhead(bool runAhead) -> void { _runAhead = runAhead; }
 }

--- a/desktop-ui/program/load.cpp
+++ b/desktop-ui/program/load.cpp
@@ -94,6 +94,8 @@ auto Program::load(string location) -> bool {
   settings.recent.game[0] = {emulator->name, ";", location};
   presentation.loadEmulators();
 
+  configuration = emulator->root->attribute("configuration");
+
   return true;
 }
 
@@ -123,6 +125,7 @@ auto Program::unload() -> void {
   propertiesViewer.unload();
   traceLogger.unload();
   message.text = "";
+  configuration = "";
   ruby::video.clear();
   ruby::audio.clear();
 }

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -98,6 +98,7 @@ struct Program : ares::Platform {
   } message;
 
   vector<Message> messages;
+  string configuration;
   atomic<u64> vblanksPerSecond = 0;
   /// The emulator run loop mutex. The emulator thread will hold a lock on this mutex for the duration of its run loop, including while the thread is suspended. The UI thread should only acquire this mutex when absolutely necessary, as there will be a severe UI responsiveness penalty acquiring it.
   std::recursive_mutex programMutex;

--- a/desktop-ui/program/status.cpp
+++ b/desktop-ui/program/status.cpp
@@ -12,8 +12,8 @@ auto Program::updateMessage() -> void {
       presentation.statusLeft.setText(message.text);
     } else if(settings.debugServer.enabled) {
       presentation.statusLeft.setText(nall::GDB::server.getStatusText(settings.debugServer.port, settings.debugServer.useIPv4));
-    } else if(emulator && emulator->root) {
-      presentation.statusLeft.setText(emulator->root->attribute("configuration"));
+    } else if(configuration) {
+      presentation.statusLeft.setText(configuration);
     } else {
       presentation.statusLeft.setText();
     }


### PR DESCRIPTION
Resolves several TSan complaints.

When run-ahead is enabled, the screen thread will sometimes read the value, potentially while the emulator thread is modifying it; use an atomic to manage access to it.

Additionally, store the value of `emulator->root->attribute("configuration");` when a title is loaded or unloaded, rather than reading it repeatedly within the GUI loop.