### PR TITLE
build: #ifdef guard pragmas specific to gcc/clang

### DIFF
--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -23,8 +23,10 @@ auto CPU::Recompiler::block(u64 vaddr, u32 address, bool singleInstruction) -> B
 #define IpuReg(r)      sreg(1), offsetof(IPU, r) - IpuBase
 #define PipelineReg(x) mem(sreg(0), offsetof(CPU, pipeline) + offsetof(Pipeline, x))
 
+#if defined(COMPILER_CLANG) || defined(COMPILER_GCC)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Winvalid-offsetof"
+#endif
 auto CPU::Recompiler::emit(u64 vaddr, u32 address, bool singleInstruction) -> Block* {
   if(unlikely(allocator.available() < 1_MiB)) {
     print("CPU allocator flush\n");
@@ -96,7 +98,9 @@ auto CPU::Recompiler::emit(u64 vaddr, u32 address, bool singleInstruction) -> Bl
 //print(hex(PC, 8L), " ", instructions, " ", size(), "\n");
   return block;
 }
+#if defined(COMPILER_CLANG) || defined(COMPILER_GCC)
 #pragma GCC diagnostic pop
+#endif
 
 #define Sa  (instruction >>  6 & 31)
 #define Rdn (instruction >> 11 & 31)

--- a/ruby/video/opengl/main.hpp
+++ b/ruby/video/opengl/main.hpp
@@ -131,10 +131,10 @@ auto OpenGL::initialize(const string& shader) -> bool {
   return initialized = true;
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 auto OpenGL::resolveSymbol(const char* name) -> const void * {
 #if defined(PLATFORM_MACOS)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   NSSymbol symbol;
   char *symbolName;
   symbolName = (char*)malloc(strlen(name) + 2);
@@ -144,6 +144,7 @@ auto OpenGL::resolveSymbol(const char* name) -> const void * {
   if(NSIsSymbolNameDefined (symbolName)) symbol = NSLookupAndBindSymbol (symbolName);
   free(symbolName); // 5
   return (void*)(symbol ? NSAddressOfSymbol(symbol) : NULL);
+#pragma clang diagnostic pop
 #else
   void* symbol = (void*)glGetProcAddress(name);
   #if defined(PLATFORM_WINDOWS)
@@ -155,7 +156,6 @@ auto OpenGL::resolveSymbol(const char* name) -> const void * {
     }
   #endif
 #endif
-#pragma clang diagnostic pop
 
   return symbol;
 }


### PR DESCRIPTION
This eliminates some warnings compiling with MSVC.