### PR TITLE
Add "Await GDB Client" boot option

### DIFF
--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -77,6 +77,9 @@ Presentation::Presentation() {
   launchDebugger.setText("Launch Debugger").setChecked(settings.boot.debugger).onToggle([&] {
     settings.boot.debugger = launchDebugger.checked();
   });
+  waitGDB.setText("Wait GDB").setChecked(settings.boot.waitGDB).onToggle([&] {
+    settings.boot.waitGDB = waitGDB.checked();
+  });
 
   regionUJE.setText("NTSC-U -> NTSC-J -> PAL").onActivate([&] { settings.boot.prefer = "NTSC-U,NTSC-J,PAL"; });
   regionUEJ.setText("NTSC-U -> PAL -> NTSC-J").onActivate([&] { settings.boot.prefer = "NTSC-U,PAL,NTSC-J"; });

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -74,11 +74,11 @@ Presentation::Presentation() {
     settings.boot.fast = fastBoot.checked();
   });
   bootOptionsRegionMenu.setText("Region Preference").setIcon(Icon::Application::Browser);
-  launchDebugger.setText("Launch Debugger").setChecked(settings.boot.debugger).onToggle([&] {
+  launchDebugger.setText("Launch Tracer").setChecked(settings.boot.debugger).onToggle([&] {
     settings.boot.debugger = launchDebugger.checked();
   });
-  waitGDB.setText("Wait GDB").setChecked(settings.boot.waitGDB).onToggle([&] {
-    settings.boot.waitGDB = waitGDB.checked();
+  awaitGDBClient.setText("Await GDB Client").setChecked(settings.boot.awaitGDBClient).onToggle([&] {
+    settings.boot.awaitGDBClient = awaitGDBClient.checked();
   });
 
   regionUJE.setText("NTSC-U -> NTSC-J -> PAL").onActivate([&] { settings.boot.prefer = "NTSC-U,NTSC-J,PAL"; });

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -34,6 +34,7 @@ struct Presentation : Window {
       Menu bootOptionsMenu{&settingsMenu};
         MenuCheckItem fastBoot{&bootOptionsMenu};
         MenuCheckItem launchDebugger{&bootOptionsMenu};
+        MenuCheckItem waitGDB{&bootOptionsMenu};
         MenuSeparator bootOptionsSeparator{&bootOptionsMenu};
         Menu bootOptionsRegionMenu{&bootOptionsMenu};
           MenuRadioItem regionUJE{&bootOptionsRegionMenu};

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -34,7 +34,7 @@ struct Presentation : Window {
       Menu bootOptionsMenu{&settingsMenu};
         MenuCheckItem fastBoot{&bootOptionsMenu};
         MenuCheckItem launchDebugger{&bootOptionsMenu};
-        MenuCheckItem waitGDB{&bootOptionsMenu};
+        MenuCheckItem awaitGDBClient{&bootOptionsMenu};
         MenuSeparator bootOptionsSeparator{&bootOptionsMenu};
         Menu bootOptionsRegionMenu{&bootOptionsMenu};
           MenuRadioItem regionUJE{&bootOptionsRegionMenu};

--- a/desktop-ui/program/load.cpp
+++ b/desktop-ui/program/load.cpp
@@ -77,7 +77,7 @@ auto Program::load(string location) -> bool {
     pause(true);
     toolsWindow.show("Tracer");
     presentation.setFocused();
-  } else if (settings.boot.waitGDB) {
+  } else if (settings.boot.awaitGDBClient) {
     pause(true);
   } else {
     pause(false);
@@ -88,7 +88,7 @@ auto Program::load(string location) -> bool {
   if(settings.debugServer.enabled) {
     nall::GDB::server.open(settings.debugServer.port, settings.debugServer.useIPv4);
     nall::GDB::server.onClientConnectCallback = []() {
-      if (settings.boot.waitGDB)
+      if (settings.boot.awaitGDBClient)
         program.pause(false);
     };
   }

--- a/desktop-ui/program/load.cpp
+++ b/desktop-ui/program/load.cpp
@@ -77,6 +77,8 @@ auto Program::load(string location) -> bool {
     pause(true);
     toolsWindow.show("Tracer");
     presentation.setFocused();
+  } else if (settings.boot.waitGDB) {
+    pause(true);
   } else {
     pause(false);
   }
@@ -85,6 +87,10 @@ auto Program::load(string location) -> bool {
 
   if(settings.debugServer.enabled) {
     nall::GDB::server.open(settings.debugServer.port, settings.debugServer.useIPv4);
+    nall::GDB::server.onClientConnectCallback = []() {
+      if (settings.boot.waitGDB)
+        program.pause(false);
+    };
   }
 
   //update recent games list

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -96,6 +96,7 @@ auto Settings::process(bool load) -> void {
 
   bind(boolean, "Boot/Fast", boot.fast);
   bind(boolean, "Boot/Debugger", boot.debugger);
+  bind(boolean, "Boot/WaitGDB", boot.waitGDB);
   bind(string,  "Boot/Prefer", boot.prefer);
 
   bind(boolean, "General/ShowStatusBar", general.showStatusBar);

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -96,7 +96,7 @@ auto Settings::process(bool load) -> void {
 
   bind(boolean, "Boot/Fast", boot.fast);
   bind(boolean, "Boot/Debugger", boot.debugger);
-  bind(boolean, "Boot/WaitGDB", boot.waitGDB);
+  bind(boolean, "Boot/AwaitGDBClient", boot.awaitGDBClient);
   bind(string,  "Boot/Prefer", boot.prefer);
 
   bind(boolean, "General/ShowStatusBar", general.showStatusBar);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -60,6 +60,7 @@ struct Settings : Markup::Node {
   struct Boot {
     bool fast = false;
     bool debugger = false;
+    bool waitGDB = false;
     string prefer = "NTSC-U";
   } boot;
 

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -60,7 +60,7 @@ struct Settings : Markup::Node {
   struct Boot {
     bool fast = false;
     bool debugger = false;
-    bool waitGDB = false;
+    bool awaitGDBClient = false;
     string prefer = "NTSC-U";
   } boot;
 

--- a/nall/nall/gdb/server.cpp
+++ b/nall/nall/gdb/server.cpp
@@ -505,6 +505,8 @@ namespace nall::GDB {
 
   auto Server::onConnect() -> void {
     printf("GDB client connected\n");
+    if (onClientConnectCallback)
+      onClientConnectCallback();
     resetClientData();
     hasActiveClient = true;
   }

--- a/nall/nall/gdb/server.hpp
+++ b/nall/nall/gdb/server.hpp
@@ -83,6 +83,8 @@ class Server : public nall::TCPText::Server {
 
     } hooks{};
 
+    function<void()> onClientConnectCallback{};
+
     // Exception
     auto reportSignal(Signal sig, u64 originPC) -> bool;
 


### PR DESCRIPTION
This PR adds a "Await GDB Client" option located at `Settings > Boot Options > Await GDB Client`

When enabled, this option pauses the program on startup (like the "Launch Tracer" (renamed from "Launch Debugger" in this PR) boot option), then automatically unpauses when a gdb client connects

The purpose is to allow debugging a program "from the beginning" rather than gdb connecting after the program already started.

Feel free to let me know if this can be implemented better!

discussed on discord from https://discord.com/channels/976404869386747954/976463759935696977/1391268016959913994