### PR TITLE
desktop-ui: Threading behavior improvements

### DIFF
--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -157,7 +157,7 @@ auto nall::main(Arguments arguments) -> void {
   Instances::presentation.construct();
   Instances::settingsWindow.construct();
   Instances::gameBrowserWindow.construct();
-  Instances::toolsWindow.construct(&program.programMutex);
+  Instances::toolsWindow.construct();
 
   program.create();
   Application::onMain({&Program::main, &program});

--- a/desktop-ui/emulator/emulator.cpp
+++ b/desktop-ui/emulator/emulator.cpp
@@ -116,7 +116,7 @@ auto Emulator::handleLoadResult(LoadResult result) -> void {
 }
 
 auto Emulator::load(const string& location) -> bool {
-  lock_guard<recursive_mutex> programLock(program.programMutex);
+  Program::Guard guard;
   if(inode::exists(location)) locationQueue.append(location);
   
   LoadResult result = load();
@@ -136,7 +136,7 @@ auto Emulator::load(const string& location) -> bool {
 }
 
 auto Emulator::load(shared_pointer<mia::Pak> pak, string& path) -> string {
-  lock_guard<recursive_mutex> programLock(program.programMutex);
+  Program::Guard guard;
   string location;
   if(locationQueue) {
     location = locationQueue.takeFirst();  //pull from the game queue if an entry is available
@@ -167,7 +167,7 @@ auto Emulator::load(shared_pointer<mia::Pak> pak, string& path) -> string {
 }
 
 auto Emulator::loadFirmware(const Firmware& firmware) -> shared_pointer<vfs::file> {
-  lock_guard<recursive_mutex> programLock(program.programMutex);
+  Program::Guard guard;
   if(firmware.location.iendsWith(".zip")) {
     Decode::ZIP archive;
     if(archive.open(firmware.location) && archive.file) {
@@ -181,7 +181,7 @@ auto Emulator::loadFirmware(const Firmware& firmware) -> shared_pointer<vfs::fil
 }
 
 auto Emulator::unload() -> void {
-  lock_guard<recursive_mutex> programLock(program.programMutex);
+  Program::Guard guard;
   save();
   root->unload();
   game = {};
@@ -191,7 +191,7 @@ auto Emulator::unload() -> void {
 }
 
 auto Emulator::load(mia::Pak& node, string name) -> bool {
-  lock_guard<recursive_mutex> programLock(program.programMutex);
+  Program::Guard guard;
   if(auto fp = node.pak->read(name)) {
     if(auto memory = file::read({node.location, name})) {
       fp->read(memory);
@@ -202,7 +202,7 @@ auto Emulator::load(mia::Pak& node, string name) -> bool {
 }
 
 auto Emulator::save(mia::Pak& node, string name) -> bool {
-  lock_guard<recursive_mutex> programLock(program.programMutex);
+  Program::Guard guard;
   if(auto memory = node.pak->write(name)) {
     return file::write({node.location, name}, {memory->data(), memory->size()});
   }
@@ -210,14 +210,14 @@ auto Emulator::save(mia::Pak& node, string name) -> bool {
 }
 
 auto Emulator::refresh() -> void {
-  lock_guard<recursive_mutex> programLock(program.programMutex);
+  Program::Guard guard;
   if(auto screen = root->scan<ares::Node::Video::Screen>("Screen")) {
     screen->refresh();
   }
 }
 
 auto Emulator::setBoolean(const string& name, bool value) -> bool {
-  lock_guard<recursive_mutex> programLock(program.programMutex);
+  Program::Guard guard;
   if(auto node = root->scan<ares::Node::Setting::Boolean>(name)) {
     node->setValue(value);  //setValue() will not call modify() if value has not changed;
     node->modify(value);    //but that may prevent the initial setValue() from working
@@ -227,7 +227,7 @@ auto Emulator::setBoolean(const string& name, bool value) -> bool {
 }
 
 auto Emulator::setOverscan(bool value) -> bool {
-  lock_guard<recursive_mutex> programLock(program.programMutex);
+  Program::Guard guard;
   if(auto screen = root->scan<ares::Node::Video::Screen>("Screen")) {
     screen->setOverscan(value);
     return true;
@@ -236,7 +236,7 @@ auto Emulator::setOverscan(bool value) -> bool {
 }
 
 auto Emulator::setColorBleed(bool value) -> bool {
-  lock_guard<recursive_mutex> programLock(program.programMutex);
+  Program::Guard guard;
   if(auto screen = root->scan<ares::Node::Video::Screen>("Screen")) {
     screen->setColorBleed(screen->height() < 720 ? value : false);  //only apply to sub-HD content
     return true;

--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -12,7 +12,7 @@ auto InputManager::createHotkeys() -> void {
   }));
 
   hotkeys.append(InputHotkey("Toggle Mouse Capture").onPress([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     if(!emulator) return;
     if(!ruby::input.acquired()) {
       ruby::input.acquire();
@@ -22,14 +22,14 @@ auto InputManager::createHotkeys() -> void {
   }));
 
   hotkeys.append(InputHotkey("Toggle Keyboard Capture").onPress([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     if(!emulator) return;
     program.keyboardCaptured = !program.keyboardCaptured;
     print("Keyboard capture: ", program.keyboardCaptured, "\n");
   }));
 
   hotkeys.append(InputHotkey("Fast Forward").onPress([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     if(!emulator || program.rewinding) return;
     program.fastForwarding = true;
     fastForwardVideoBlocking = ruby::video.blocking();
@@ -39,7 +39,7 @@ auto InputManager::createHotkeys() -> void {
     ruby::audio.setBlocking(false);
     ruby::audio.setDynamic(false);
   }).onRelease([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     if(!emulator) return;
     program.fastForwarding = false;
     ruby::video.setBlocking(fastForwardVideoBlocking);
@@ -48,7 +48,7 @@ auto InputManager::createHotkeys() -> void {
   }));
 
   hotkeys.append(InputHotkey("Toggle Fast Forward").onPress([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     if(!emulator || program.rewinding) return;
     program.fastForwarding = !program.fastForwarding;
 
@@ -68,7 +68,7 @@ auto InputManager::createHotkeys() -> void {
   }));
 
   hotkeys.append(InputHotkey("Rewind").onPress([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     if(!emulator || program.fastForwarding) return;
     if(program.rewind.frequency == 0) {
       return program.showMessage("Please enable rewind support in the emulator settings first.");
@@ -82,26 +82,26 @@ auto InputManager::createHotkeys() -> void {
   }));
 
   hotkeys.append(InputHotkey("Frame Advance").onPress([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     if(!emulator) return;
     if(!program.paused) program.pause(true);
     program.requestFrameAdvance = true;
   }));
 
   hotkeys.append(InputHotkey("Capture Screenshot").onPress([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     if(!emulator) return;
     program.requestScreenshot = true;
   }));
 
   hotkeys.append(InputHotkey("Save State").onPress([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     if(!emulator) return;
     program.stateSave(program.state.slot);
   }));
 
   hotkeys.append(InputHotkey("Load State").onPress([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     if(!emulator) return;
     program.stateLoad(program.state.slot);
   }));
@@ -121,25 +121,25 @@ auto InputManager::createHotkeys() -> void {
   }));
 
   hotkeys.append(InputHotkey("Pause Emulation").onPress([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     if(!emulator) return;
     program.pause(!program.paused);
   }));
 
   hotkeys.append(InputHotkey("Reset System").onPress([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     if(!emulator) return;
     emulator->root->power(true);
   }));
 
   hotkeys.append(InputHotkey("Reload Current Game").onPress([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     if(!emulator) return;
     program.load(emulator, emulator->game->location);
   }));
 
   hotkeys.append(InputHotkey("Quit Emulator").onPress([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     program.quit();
   }));
 

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -146,7 +146,7 @@ Presentation::Presentation() {
   for(u32 slot : range(9)) {
     MenuItem item{&saveStateMenu};
     item.setText({"Slot ", 1 + slot}).onActivate([=] {
-      lock_guard<recursive_mutex> programLock(program.programMutex);
+      Program::Guard guard;
       if(program.stateSave(1 + slot)) {
         undoSaveStateMenu.setEnabled(true);
       }
@@ -156,7 +156,7 @@ Presentation::Presentation() {
   for(u32 slot : range(9)) {
     MenuItem item{&loadStateMenu};
     item.setText({"Slot ", 1 + slot}).onActivate([=] {
-      lock_guard<recursive_mutex> programLock(program.programMutex);
+      Program::Guard guard;
       if(program.stateLoad(1 + slot)) {
         undoLoadStateMenu.setEnabled(true);
       }
@@ -164,30 +164,30 @@ Presentation::Presentation() {
   }
   undoSaveStateMenu.setText("Undo Last Save State").setIcon(Icon::Edit::Undo).setEnabled(false);
   undoSaveStateMenu.onActivate([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     program.undoStateSave();
     undoSaveStateMenu.setEnabled(false);
   });
   undoLoadStateMenu.setText("Undo Last Load State").setIcon(Icon::Edit::Undo).setEnabled(false);
   undoLoadStateMenu.onActivate([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     program.undoStateLoad();
     undoLoadStateMenu.setEnabled(false);
   });
   captureScreenshot.setText("Capture Screenshot").setIcon(Icon::Emblem::Image).onActivate([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     program.requestScreenshot = true;
   });
   pauseEmulation.setText("Pause Emulation").onToggle([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     program.pause(!program.paused);
   });
   reloadGame.setText("Reload Game").setIcon(Icon::Action::Refresh).onActivate([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     program.load(emulator, emulator->game->location);
   });
   frameAdvance.setText("Frame Advance").setIcon(Icon::Media::Play).onActivate([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     if (!program.paused) program.pause(true);
     program.requestFrameAdvance = true;
   });
@@ -229,7 +229,7 @@ Presentation::Presentation() {
   });
 
   viewport.setDroppable().onDrop([&](auto filenames) {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     if(filenames.size() != 1) return;
     if(auto emulator = program.identify(filenames.first())) {
       program.load(emulator, filenames.first());
@@ -237,7 +237,7 @@ Presentation::Presentation() {
   });
     
   Application::onOpenFile([&](auto filename) {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     if(auto emulator = program.identify(filename)) {
       program.load(emulator, filename);
     }
@@ -373,7 +373,7 @@ auto Presentation::loadEmulators() -> void {
       item.setIconForFile(location);
       item.setText({Location::base(location).trimRight("/"), " (", system, ")"});
       item.onActivate([=] {
-        lock_guard<recursive_mutex> programLock(program.programMutex);
+        Program::Guard guard;
         if(!inode::exists(location)) {
           MessageDialog()
             .setTitle("Error")
@@ -595,7 +595,7 @@ auto Presentation::refreshSystemMenu() -> void {
 
   MenuItem reset{&systemMenu};
   reset.setText("Reset").setIcon(Icon::Action::Refresh).onActivate([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     emulator->root->power(true);
     program.showMessage("System reset");
   });
@@ -603,7 +603,7 @@ auto Presentation::refreshSystemMenu() -> void {
 
   MenuItem unload{&systemMenu};
   unload.setText("Unload").setIcon(Icon::Media::Eject).onActivate([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     program.unload();
     if(settings.video.adaptiveSizing) presentation.resizeWindow();
     presentation.showIcon(true);

--- a/desktop-ui/program/drivers.cpp
+++ b/desktop-ui/program/drivers.cpp
@@ -1,5 +1,5 @@
 auto Program::videoDriverUpdate() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   ruby::video.create(settings.video.driver);
   ruby::video.setContext(presentation.viewport.handle());
   videoMonitorUpdate();
@@ -22,7 +22,7 @@ auto Program::videoDriverUpdate() -> void {
 }
 
 auto Program::videoMonitorUpdate() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(!ruby::video.hasMonitor(settings.video.monitor)) {
     settings.video.monitor = ruby::video.monitor();
   }
@@ -30,7 +30,7 @@ auto Program::videoMonitorUpdate() -> void {
 }
 
 auto Program::videoFormatUpdate() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(!ruby::video.hasFormat(settings.video.format)) {
     settings.video.format = ruby::video.format();
   }
@@ -38,7 +38,7 @@ auto Program::videoFormatUpdate() -> void {
 }
 
 auto Program::videoFullScreenToggle() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(!ruby::video.hasFullScreen()) return;
 
   ruby::video.clear();
@@ -59,7 +59,7 @@ auto Program::videoFullScreenToggle() -> void {
 }
 
 auto Program::videoPseudoFullScreenToggle() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(ruby::video.fullScreen()) return;
 
   if(!presentation.fullScreen()) {
@@ -74,7 +74,7 @@ auto Program::videoPseudoFullScreenToggle() -> void {
 }
 
 auto Program::audioDriverUpdate() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   ruby::audio.create(settings.audio.driver);
   ruby::audio.setContext(presentation.viewport.handle());
   audioDeviceUpdate();
@@ -92,7 +92,7 @@ auto Program::audioDriverUpdate() -> void {
 }
 
 auto Program::audioDeviceUpdate() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(!ruby::audio.hasDevice(settings.audio.device)) {
     settings.audio.device = ruby::audio.device();
   }
@@ -100,7 +100,7 @@ auto Program::audioDeviceUpdate() -> void {
 }
 
 auto Program::audioFrequencyUpdate() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(!ruby::audio.hasFrequency(settings.audio.frequency)) {
     settings.audio.frequency = ruby::audio.frequency();
   }
@@ -112,7 +112,7 @@ auto Program::audioFrequencyUpdate() -> void {
 }
 
 auto Program::audioLatencyUpdate() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(!ruby::audio.hasLatency(settings.audio.latency)) {
     settings.audio.latency = ruby::audio.latency();
   }
@@ -122,7 +122,7 @@ auto Program::audioLatencyUpdate() -> void {
 //
 
 auto Program::inputDriverUpdate() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   ruby::input.create(settings.input.driver);
   ruby::input.setContext(presentation.viewport.handle());
   ruby::input.onChange({&InputManager::eventInput, &inputManager});

--- a/desktop-ui/program/load.cpp
+++ b/desktop-ui/program/load.cpp
@@ -1,5 +1,5 @@
 auto Program::identify(const string& filename) -> shared_pointer<Emulator> {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(auto system = mia::identify(filename)) {
     for(auto& emulator : emulators) {
       if(emulator->name == system) return emulator;
@@ -16,7 +16,7 @@ auto Program::identify(const string& filename) -> shared_pointer<Emulator> {
 
 /// Loads an emulator and, optionally, a ROM from the given location.
 auto Program::load(shared_pointer<Emulator> emulator, string location) -> bool {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   unload();
 
   ::emulator = emulator;
@@ -36,7 +36,7 @@ auto Program::load(shared_pointer<Emulator> emulator, string location) -> bool {
 
 /// Loads a ROM for an already-loaded emulator.
 auto Program::load(string location) -> bool {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(settings.debugServer.enabled) {
     nall::GDB::server.reset();
   }
@@ -100,7 +100,7 @@ auto Program::load(string location) -> bool {
 }
 
 auto Program::unload() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(!emulator) return;
 
   nall::GDB::server.close();

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -3,6 +3,7 @@ struct Program : ares::Platform {
   auto main() -> void;
   auto emulatorRunLoop(uintptr_t) -> void;
   auto quit() -> void;
+  auto waitForInterrupts() -> void;
 
   //platform.cpp
   auto attach(ares::Node::Object) -> void override;
@@ -97,21 +98,40 @@ struct Program : ares::Platform {
     string text;
   } message;
 
+  class Guard;
+
   vector<Message> messages;
   string configuration;
   atomic<u64> vblanksPerSecond = 0;
-  /// The emulator run loop mutex. The emulator thread will hold a lock on this mutex for the duration of its run loop, including while the thread is suspended. The UI thread should only acquire this mutex when absolutely necessary, as there will be a severe UI responsiveness penalty acquiring it.
-  std::recursive_mutex programMutex;
-  
-  /// Mutex used to manage access to the status message queue.
-  std::recursive_mutex messageMutex;
-  
+
+  bool _isRunning = false;
+
   /// Mutex used to manage access to the input system. Polling occurs on the main thread while the results are read by the emulation thread.
   std::recursive_mutex inputMutex;
   
 private:
   atomic<bool> _quitting = false;
   atomic<bool> _needsResize = false;
+  
+  /// Mutex used to manage access to the status message queue.
+  std::recursive_mutex _messageMutex;
+
+  /// Mutex used to manage interrupts to the emulator run loop. Acquired when setting either of the `_interruptWaiting` or `_interruptWorking` booleans.
+  std::mutex _programMutex;
+  /// The emulator run loop condition variable. This variable is signaled to indicate other threads may access the program mutex, as well as to indicate that the emulator run loop can continue.
+  std::condition_variable _programConditionVariable;
+  /// Boolean indicating whether another thread is waiting to modify the emulator program state.
+  std::atomic<bool> _interruptWaiting = false;
+  /// Boolean indicating whether a non-emulator worker thread is in the process of modifying the emulator program state.
+  bool _interruptWorking = false;
+  /// Counter used to allow for possible recursive creation of `Program::Guard` instances (which can happen in some UI paths).
+  u32 _interruptDepth = 0;
+  /// Thread-local variable used to allow the emulator worker thread to create `Program::Guard` instances without causing a deadlock.
+  static inline thread_local bool _programThread = false;
+  /// Debug accessor for `_programThread` since debuggers cannot read TLS values correctly.
+  NALL_USED auto getProgramThreadValue() -> bool {
+    return _programThread;
+  }
 };
 
 extern Program program;

--- a/desktop-ui/program/rewind.cpp
+++ b/desktop-ui/program/rewind.cpp
@@ -1,11 +1,11 @@
 auto Program::rewindSetMode(Rewind::Mode mode) -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   rewind.mode = mode;
   rewind.counter = 0;
 }
 
 auto Program::rewindReset() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   rewindSetMode(Rewind::Mode::Playing);
   rewind.history.reset();
   rewind.length = settings.rewind.length;
@@ -13,8 +13,8 @@ auto Program::rewindReset() -> void {
 }
 
 auto Program::rewindRun() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
   if(!settings.general.rewind) return;  //rewind disabled?
+  Program::Guard guard;
 
   if(rewind.mode == Rewind::Mode::Playing) {
     if(++rewind.counter < rewind.frequency) return;

--- a/desktop-ui/program/states.cpp
+++ b/desktop-ui/program/states.cpp
@@ -1,5 +1,5 @@
 auto Program::stateSave(u32 slot) -> bool {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(!emulator) return false;
 
   auto location = emulator->locate(emulator->game->location, {".bs", slot}, settings.paths.saves);
@@ -20,7 +20,7 @@ auto Program::stateSave(u32 slot) -> bool {
 }
 
 auto Program::stateLoad(u32 slot) -> bool {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(!emulator) return false;
 
   //Store current state for undo
@@ -43,7 +43,7 @@ auto Program::stateLoad(u32 slot) -> bool {
 }
 
 auto Program::undoStateSave() -> bool {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(!emulator) return false;
 
   auto undoLocation = emulator->locate(emulator->game->location, ".bsu", settings.paths.saves);
@@ -58,7 +58,7 @@ auto Program::undoStateSave() -> bool {
 }
 
 auto Program::undoStateLoad() -> bool {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(!emulator) return false;
 
   auto undoLocation = emulator->locate(emulator->game->location, ".blu", settings.paths.saves);
@@ -79,7 +79,7 @@ auto Program::undoStateLoad() -> bool {
 }
 
 auto Program::clearUndoStates() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(!emulator) return;
 
   auto location = emulator->locate(emulator->game->location, ".blu", settings.paths.saves);

--- a/desktop-ui/program/status.cpp
+++ b/desktop-ui/program/status.cpp
@@ -1,26 +1,24 @@
 auto Program::updateMessage() -> void {
-  {
-    // This function is called every iteration of the GUI run loop. Acquiring the emulator mutex would incur a severe
-    // responsiveness penalty, so use a dedicated mutex for message passing.
-    lock_guard<recursive_mutex> messageLock(messageMutex);
-    if(chrono::millisecond() - message.timestamp >= 2000) {
-      message = {};
-      if(messages.size()) message = messages.takeFirst();
-    }
+  // This function is called every iteration of the GUI run loop. Acquiring the emulator mutex would incur a severe
+  // responsiveness penalty, so use a dedicated mutex for message passing.
+  lock_guard<recursive_mutex> messageLock(_messageMutex);
+  if(chrono::millisecond() - message.timestamp >= 2000) {
+    message = {};
+    if(messages.size()) message = messages.takeFirst();
+  }
 
-    if(message.text.length() > 0) {
-      presentation.statusLeft.setText(message.text);
-    } else if(settings.debugServer.enabled) {
-      presentation.statusLeft.setText(nall::GDB::server.getStatusText(settings.debugServer.port, settings.debugServer.useIPv4));
-    } else if(configuration) {
-      presentation.statusLeft.setText(configuration);
-    } else {
-      presentation.statusLeft.setText();
-    }
+  if(message.text.length() > 0) {
+    presentation.statusLeft.setText(message.text);
+  } else if(settings.debugServer.enabled) {
+    presentation.statusLeft.setText(nall::GDB::server.getStatusText(settings.debugServer.port, settings.debugServer.useIPv4));
+  } else if(configuration) {
+    presentation.statusLeft.setText(configuration);
+  } else {
+    presentation.statusLeft.setText();
   }
 
   if(vblanksPerSecond > 0) {
-    presentation.statusRight.setText({vblanksPerSecond.load(), " VPS"});
+    presentation.statusRight.setText({ vblanksPerSecond.load(), " VPS" });
   }
 
   if(!emulator) {
@@ -39,7 +37,7 @@ auto Program::updateMessage() -> void {
 }
 
 auto Program::showMessage(const string& text) -> void {
-  lock_guard<recursive_mutex> messageLock(messageMutex);
+  lock_guard<recursive_mutex> messageLock(_messageMutex);
   messages.append({chrono::millisecond(), text});
   printf("%s\n", (const char*)text);
 }

--- a/desktop-ui/program/utility.cpp
+++ b/desktop-ui/program/utility.cpp
@@ -1,5 +1,5 @@
 auto Program::pause(bool state) -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(paused == state) return;
   paused = state;
   presentation.pauseEmulation.setChecked(paused);
@@ -11,13 +11,13 @@ auto Program::pause(bool state) -> void {
 }
 
 auto Program::mute() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   settings.audio.mute = !settings.audio.mute;
   presentation.muteAudioSetting.setChecked(settings.audio.mute);
 }
 
 auto Program::paletteUpdate() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   if(!emulator) return;
   for(auto& screen : emulator->root->find<ares::Node::Video::Screen>()) {
     screen->setLuminance(settings.video.luminance);
@@ -27,7 +27,7 @@ auto Program::paletteUpdate() -> void {
 }
 
 auto Program::runAheadUpdate() -> void {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   runAhead = settings.general.runAhead;
   if(!emulator) return;
   if(emulator->name == "Game Boy Advance") runAhead = false;  //crashes immediately
@@ -46,7 +46,7 @@ auto Program::captureScreenshot(const u32* data, u32 pitch, u32 width, u32 heigh
 }
 
 auto Program::openFile(BrowserDialog& dialog) -> string {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   BrowserWindow window;
   window.setTitle(dialog.title());
   window.setPath(dialog.path());
@@ -58,7 +58,7 @@ auto Program::openFile(BrowserDialog& dialog) -> string {
 }
 
 auto Program::selectFolder(BrowserDialog& dialog) -> string {
-  lock_guard<recursive_mutex> programLock(programMutex);
+  Program::Guard guard;
   BrowserWindow window;
   window.setTitle(dialog.title());
   window.setPath(dialog.path());

--- a/desktop-ui/settings/drivers.cpp
+++ b/desktop-ui/settings/drivers.cpp
@@ -89,17 +89,17 @@ auto DriverSettings::construct() -> void {
     audioRefresh();
   });
   audioExclusiveToggle.setText("Exclusive mode").onToggle([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     settings.audio.exclusive = audioExclusiveToggle.checked();
     ruby::audio.setExclusive(settings.audio.exclusive);
   });
   audioBlockingToggle.setText("Synchronize").onToggle([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     settings.audio.blocking = audioBlockingToggle.checked();
     ruby::audio.setBlocking(settings.audio.blocking);
   });
   audioDynamicToggle.setText("Dynamic rate").onToggle([&] {
-    lock_guard<recursive_mutex> programLock(program.programMutex);
+    Program::Guard guard;
     settings.audio.dynamic = audioDynamicToggle.checked();
     ruby::audio.setDynamic(settings.audio.dynamic);
   });
@@ -182,7 +182,7 @@ auto DriverSettings::videoRefresh() -> void {
 }
 
 auto DriverSettings::videoDriverUpdate() -> bool {
-  lock_guard<recursive_mutex> programLock(program.programMutex);
+  Program::Guard guard;
   if(emulator && settings.video.driver != "None" && MessageDialog(
     "Warning: incompatible drivers may cause this software to crash.\n"
     "Are you sure you want to change this driver while a game is loaded?"
@@ -228,7 +228,7 @@ auto DriverSettings::audioRefresh() -> void {
 }
 
 auto DriverSettings::audioDriverUpdate() -> bool {
-  lock_guard<recursive_mutex> programLock(program.programMutex);
+  Program::Guard guard;
   if(emulator && settings.audio.driver != "None" && MessageDialog(
     "Warning: incompatible drivers may cause this software to crash.\n"
     "Are you sure you want to change this driver while a game is loaded?"
@@ -252,7 +252,7 @@ auto DriverSettings::inputRefresh() -> void {
 }
 
 auto DriverSettings::inputDriverUpdate() -> bool {
-  lock_guard<recursive_mutex> programLock(program.programMutex);
+  Program::Guard guard;
   if(emulator && settings.input.driver != "None" && MessageDialog(
     "Warning: incompatible drivers may cause this software to crash.\n"
     "Are you sure you want to change this driver while a game is loaded?"

--- a/desktop-ui/settings/hotkeys.cpp
+++ b/desktop-ui/settings/hotkeys.cpp
@@ -48,7 +48,7 @@ auto HotkeySettings::refresh() -> void {
 }
 
 auto HotkeySettings::eventChange() -> void {
-  lock_guard<recursive_mutex> programLock(program.programMutex);
+  Program::Guard guard;
   assignButton.setEnabled(inputList.batched().size() == 1);
   clearButton.setEnabled(inputList.batched().size() >= 1);
 }

--- a/desktop-ui/settings/input.cpp
+++ b/desktop-ui/settings/input.cpp
@@ -160,7 +160,7 @@ auto InputSettings::eventAssign(TableViewCell cell, string binding) -> void {
 }
 
 auto InputSettings::eventAssign(TableViewCell cell) -> void {
-  lock_guard<recursive_mutex> programLock(program.programMutex);
+  Program::Guard guard;
   inputManager.poll(true);  //clear any pending events first
 
   if(ruby::input.driver() == "None") return (void)MessageDialog().setText(

--- a/desktop-ui/settings/video.cpp
+++ b/desktop-ui/settings/video.cpp
@@ -32,36 +32,42 @@ auto VideoSettings::construct() -> void {
 
   emulatorSettingsLabel.setText("Emulator Settings").setFont(Font().setBold());
   colorBleedOption.setText("Color Bleed").setChecked(settings.video.colorBleed).onToggle([&] {
+    Program::Guard guard;
     settings.video.colorBleed = colorBleedOption.checked();
     if(emulator) emulator->setColorBleed(settings.video.colorBleed);
   });
   colorBleedLayout.setAlignment(1).setPadding(12_sx, 0);
   colorBleedHint.setText("Blurs adjacent pixels for translucency effects").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
   colorEmulationOption.setText("Color Emulation").setChecked(settings.video.colorEmulation).onToggle([&] {
+    Program::Guard guard;
     settings.video.colorEmulation = colorEmulationOption.checked();
     if(emulator) emulator->setBoolean("Color Emulation", settings.video.colorEmulation);
   });
   colorEmulationLayout.setAlignment(1).setPadding(12_sx, 0);
   colorEmulationHint.setText("Matches colors to how they look on real hardware").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
   deepBlackBoostOption.setText("Deep Black Boost").setChecked(settings.video.deepBlackBoost).onToggle([&] {
+    Program::Guard guard;
     settings.video.deepBlackBoost = deepBlackBoostOption.checked();
     if(emulator) emulator->setBoolean("Deep Black Boost", settings.video.deepBlackBoost);
   });
   deepBlackBoostLayout.setAlignment(1).setPadding(12_sx, 0);
   deepBlackBoostHint.setText("Applies a gamma ramp to crush black levels (SNES/SFC)").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
   interframeBlendingOption.setText("Interframe Blending").setChecked(settings.video.interframeBlending).onToggle([&] {
+    Program::Guard guard;
     settings.video.interframeBlending = interframeBlendingOption.checked();
     if(emulator) emulator->setBoolean("Interframe Blending", settings.video.interframeBlending);
   });
   interframeBlendingLayout.setAlignment(1).setPadding(12_sx, 0);
   interframeBlendingHint.setText("Emulates LCD translucency effects, but increases motion blur").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
   overscanOption.setText("Overscan").setChecked(settings.video.overscan).onToggle([&] {
+    Program::Guard guard;
     settings.video.overscan = overscanOption.checked();
     if(emulator) emulator->setOverscan(settings.video.overscan);
   });
   overscanLayout.setAlignment(1).setPadding(12_sx, 0);
   overscanHint.setText("Displays the full frame without cropping 'undesirable' borders").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
   pixelAccuracyOption.setText("Pixel Accuracy Mode").setChecked(settings.video.pixelAccuracy).onToggle([&] {
+    Program::Guard guard;
     settings.video.pixelAccuracy = pixelAccuracyOption.checked();
     if(emulator) emulator->setBoolean("Pixel Accuracy", settings.video.pixelAccuracy);
   });
@@ -73,6 +79,7 @@ auto VideoSettings::construct() -> void {
   renderQualityLayout.setPadding(12_sx, 0);
 
   disableVideoInterfaceProcessingOption.setText("Disable Video Interface Processing").setChecked(settings.video.disableVideoInterfaceProcessing).onToggle([&] {
+    Program::Guard guard;
     settings.video.disableVideoInterfaceProcessing = disableVideoInterfaceProcessingOption.checked();
     if(emulator) emulator->setBoolean("Disable Video Interface Processing", settings.video.disableVideoInterfaceProcessing);
   });
@@ -81,6 +88,7 @@ auto VideoSettings::construct() -> void {
 
   weaveDeinterlacingOption.setText("Weave Deinterlacing").setChecked(settings.video.weaveDeinterlacing).onToggle([&] {
     settings.video.weaveDeinterlacing = weaveDeinterlacingOption.checked();
+    Program::Guard guard;
     if(emulator) emulator->setBoolean("(Experimental) Double the perceived vertical resolution; disabled when supersampling is used", settings.video.weaveDeinterlacing);
     if(weaveDeinterlacingOption.checked() == true) {
       renderSupersamplingOption.setChecked(false).setEnabled(false);

--- a/desktop-ui/tools/graphics.cpp
+++ b/desktop-ui/tools/graphics.cpp
@@ -1,5 +1,4 @@
-auto GraphicsViewer::construct(std::recursive_mutex *programMutexIn) -> void {
-  this->programMutex = programMutexIn;
+auto GraphicsViewer::construct() -> void {
   setCollapsible();
   setVisible(false);
 
@@ -7,7 +6,7 @@ auto GraphicsViewer::construct(std::recursive_mutex *programMutexIn) -> void {
   graphicsList.onChange([&] { eventChange(); });
   graphicsView.setAlignment({0.0, 0.0});
   exportButton.setText("Export").onActivate([&] {
-    lock_guard<recursive_mutex> lock(*programMutex);
+    Program::Guard guard;
     eventExport();
   });
   liveOption.setText("Live");

--- a/desktop-ui/tools/memory.cpp
+++ b/desktop-ui/tools/memory.cpp
@@ -1,5 +1,4 @@
-auto MemoryEditor::construct(std::recursive_mutex *programMutexIn) -> void {
-  this->programMutex = programMutexIn;
+auto MemoryEditor::construct() -> void {
   setCollapsible();
   setVisible(false);
 
@@ -9,13 +8,13 @@ auto MemoryEditor::construct(std::recursive_mutex *programMutexIn) -> void {
   memoryEditor.setRows(24);
 
   exportButton.setText("Export").onActivate([&] {
-    lock_guard<recursive_mutex> lock(*programMutex);
+    Program::Guard guard;
     eventExport();
   });
 
   gotoLabel.setText("Goto:");
   gotoAddress.setFont(Font().setFamily(Font::Mono)).onActivate([&] {
-    lock_guard<recursive_mutex> lock(*programMutex);
+    Program::Guard guard;
     auto address = gotoAddress.text().hex();
     memoryEditor.setAddress(address);
     gotoAddress.setText();
@@ -24,7 +23,7 @@ auto MemoryEditor::construct(std::recursive_mutex *programMutexIn) -> void {
   liveOption.setText("Live");
 
   refreshButton.setText("Refresh").onActivate([&] {
-    lock_guard<recursive_mutex> lock(*programMutex);
+    Program::Guard guard;
     memoryEditor.update();
   });
 }
@@ -62,7 +61,7 @@ auto MemoryEditor::eventChange() -> void {
         return memory->read(address);
       });
       memoryEditor.onWrite([=](u32 address, u8 data) -> void {
-        lock_guard<recursive_mutex> lock(*programMutex);
+        Program::Guard guard;
         return memory->write(address, data);
       });
     }
@@ -76,7 +75,7 @@ auto MemoryEditor::eventChange() -> void {
 }
 
 auto MemoryEditor::eventExport() -> void {
-  lock_guard<recursive_mutex> lock(*programMutex);
+  Program::Guard guard;
   if(auto item = memoryList.selected()) {
     if(auto memory = item.attribute<ares::Node::Debugger::Memory>("node")) {
       auto identifier = memory->name().downcase().replace(" ", "-");

--- a/desktop-ui/tools/tools.cpp
+++ b/desktop-ui/tools/tools.cpp
@@ -17,7 +17,7 @@ StreamManager& streamManager = toolsWindow.streamManager;
 PropertiesViewer& propertiesViewer = toolsWindow.propertiesViewer;
 TraceLogger& traceLogger = toolsWindow.traceLogger;
 
-ToolsWindow::ToolsWindow(std::recursive_mutex *programMutex) {
+ToolsWindow::ToolsWindow() {
 
   panelList.append(ListViewItem().setText("Manifest").setIcon(Icon::Emblem::Binary));
   panelList.append(ListViewItem().setText("Cheats").setIcon(Icon::Emblem::Text));
@@ -43,9 +43,9 @@ ToolsWindow::ToolsWindow(std::recursive_mutex *programMutex) {
   panelContainer.append(homePanel, Size{~0, ~0});
 
   manifestViewer.construct();
-  cheatEditor.construct(programMutex);
-  memoryEditor.construct(programMutex);
-  graphicsViewer.construct(programMutex);
+  cheatEditor.construct();
+  memoryEditor.construct();
+  graphicsViewer.construct();
   streamManager.construct();
   propertiesViewer.construct();
   traceLogger.construct();

--- a/desktop-ui/tools/tools.hpp
+++ b/desktop-ui/tools/tools.hpp
@@ -12,15 +12,13 @@ struct ManifestViewer : VerticalLayout {
 };
 
 struct CheatEditor : VerticalLayout {
-  auto construct(std::recursive_mutex *programMutex) -> void;
+  auto construct() -> void;
   auto reload() -> void;
   auto unload() -> void;
   auto refresh() -> void;
   auto setVisible(bool visible = true) -> CheatEditor&;
 
   auto find(u32 address) -> maybe<u32>;
-  
-  std::recursive_mutex *programMutex;
 
   Label cheatsLabel{this, Size{~0, 0}, 5};
   HorizontalLayout editLayout{this, Size{~0, 0}};
@@ -49,7 +47,7 @@ struct CheatEditor : VerticalLayout {
 };
 
 struct MemoryEditor : VerticalLayout {
-  auto construct(std::recursive_mutex *programMutex) -> void;
+  auto construct() -> void;
   auto reload() -> void;
   auto unload() -> void;
   auto refresh() -> void;
@@ -57,8 +55,6 @@ struct MemoryEditor : VerticalLayout {
   auto eventChange() -> void;
   auto eventExport() -> void;
   auto setVisible(bool visible = true) -> MemoryEditor&;
-  
-  std::recursive_mutex *programMutex;
 
   Label memoryLabel{this, Size{~0, 0}, 5};
   ComboButton memoryList{this, Size{~0, 0}};
@@ -73,7 +69,7 @@ struct MemoryEditor : VerticalLayout {
 };
 
 struct GraphicsViewer : VerticalLayout {
-  auto construct(std::recursive_mutex *programMutex) -> void;
+  auto construct() -> void;
   auto reload() -> void;
   auto unload() -> void;
   auto refresh() -> void;
@@ -81,8 +77,6 @@ struct GraphicsViewer : VerticalLayout {
   auto eventChange() -> void;
   auto eventExport() -> void;
   auto setVisible(bool visible = true) -> GraphicsViewer&;
-  
-  std::recursive_mutex *programMutex;
 
   Label graphicsLabel{this, Size{~0, 0}, 5};
   ComboButton graphicsList{this, Size{~0, 0}};
@@ -134,7 +128,7 @@ struct TraceLogger : VerticalLayout {
 };
 
 struct ToolsWindow : Window {
-  ToolsWindow(std::recursive_mutex *programMutex);
+  ToolsWindow();
   auto show(const string& panel) -> void;
   auto eventChange() -> void;
 

--- a/hiro/cocoa/application.cpp
+++ b/hiro/cocoa/application.cpp
@@ -142,7 +142,8 @@ auto pApplication::modal() -> bool {
 
 auto pApplication::run() -> void {
   if(Application::state().onMain) {
-    applicationTimer = [NSTimer scheduledTimerWithTimeInterval:0.0 target:cocoaDelegate selector:@selector(run:) userInfo:nil repeats:YES];
+    // Sleep for 8ms between main run loops
+    applicationTimer = [NSTimer scheduledTimerWithTimeInterval:0.008 target:cocoaDelegate selector:@selector(run:) userInfo:nil repeats:YES];
 
     [[NSRunLoop currentRunLoop] addTimer:applicationTimer forMode:NSRunLoopCommonModes];
   }

--- a/hiro/gtk/application.cpp
+++ b/hiro/gtk/application.cpp
@@ -27,10 +27,11 @@ auto pApplication::modal() -> bool {
 auto pApplication::run() -> void {
   while(!Application::state().quit) {
     Application::doMain();
+    // Sleep for 8ms between main run loops
+    usleep(8 * 1000);
     processEvents();
-    //avoid spinlooping the thread when there is no main loop ...
-    //when there is one, Application::onMain() is expected to sleep when possible instead
-    if(!Application::state().onMain) usleep(2000);
+    // If there is no main run loop, sleep for longer
+    if(!Application::state().onMain) usleep(20 * 1000);
   }
 }
 

--- a/hiro/windows/application.cpp
+++ b/hiro/windows/application.cpp
@@ -20,11 +20,12 @@ auto pApplication::modal() -> bool {
 auto pApplication::run() -> void {
   while(!Application::state().quit) {
     if(Application::state().onMain) {
-      //doMain() is responsible for sleeping the thread where practical
       Application::doMain();
+      // Sleep for 8ms between main run loops
+      usleep(8 * 1000);
       if(Application::state().quit) break;
     } else {
-      //avoid consuming 100% CPU thread usage
+      // If there is no main run loop, sleep for longer
       usleep(20 * 1000);
     }
     //called after doMain(), in case doMain() calls Application::quit()

--- a/nall/nall/platform.hpp
+++ b/nall/nall/platform.hpp
@@ -163,14 +163,17 @@ namespace nall {
   #define no_optimize __attribute__((optnone))
   #define NALL_NOINLINE __attribute__((noinline))
   #define alwaysinline inline __attribute__((always_inline))
+  #define NALL_USED __attribute__((used))
 #elif defined(COMPILER_MICROSOFT)
   #define no_optimize
   #define NALL_NOINLINE __declspec(noinline)
   #define alwaysinline inline __forceinline
+  #define NALL_USED
 #else
   #define no_optimize
   #define NALL_NOINLINE
   #define alwaysinline inline
+  #define NALL_USED
 #endif
 
 //P0627: [[unreachable]] -- impossible to simulate with identical syntax, must omit brackets ...


### PR DESCRIPTION
Generally improves performance and UI responsiveness on Windows, as well as efficiency on all platforms. Also fixes a possible data race when modifying some emulator color settings.

### Details

The first iteration of the threading rework used a synchronization strategy where a thread that wanted to modify the emulator state would simply try to acquire a lock on a single mutex owned by the emulator worker thread. The emulator worker thread would `usleep(1)` (`Sleep(0)` on Win32) at the beginning of each run loop to allow other threads an opportunity to grab the mutex and perform necessary work.

On Linux and macOS, this strategy was sufficient, if primitive; the UI thread generally did not have issues acquiring the mutex when it was ceded. On Windows, the story is different. `Sleep(0)` guarantees that a thread will give up its time to other threads on the system that are ready to run. It provides no guarantees about what threads those might be.

One of these threads would be the main thread waiting to acquire the program mutex. In practice, however, the main thread would not reliably acquire the mutex and be able to perform its work in a timely fashion. This would manifest as long delays when, for example, dragging and dropping a title onto the ares window; or assigning inputs, unloading titles, changing drivers, etc. A more complex/robust synchronization strategy was ultimately needed to provide more guarantees that threads that need to modify the program state would be able to perform work immediately when needed.

### `Program::Guard`

This PR introduces a new ares-specific synchronization object, designed around the use of a condition variable and other primitives inside `Program`, to manage "interrupts" to the emulator run loop that will affect its state.

Rather than non-program threads simply 'busy-waiting' to acquire the program mutex, the new sequence of events goes something like this:

1. A thread that wants to modify the emulator program state (Thread A) creates a `Program::Guard` object. Creating a guard sets the `interruptWaiting` atomic boolean to true, and uses the `programConditionVariable` condition variable to wait on the condition where another boolean, `interruptWorking`, is true.
2. At the beginning of its next run loop, the emulator thread will check if `interruptWaiting` is true, and if so, it will (safely) set `interruptWorking` to true. It will then signal the `programConditionVariable`, and initiate a new wait on the same condition variable, this time on the condition `interruptWorking == false`.
3. Thread A, with its condition variable now signaled via `interruptWorking = true`, performs its work.
4. Once the created `Program::Guard` goes out of scope, it is destroyed, which will set `interruptWaiting` and `interruptWorking` to false, and signal the `programConditionVariable`.
5. The emulator run loop thread, with the condition variable signaled, proceeds with the next run loop.

This paradigm allows threads to both wait more efficiently as well as perform their necessary work in a much more timely fashion.

Currently, these synchronization primitives are only exposed through this RAII object, but in the future they could also be exposed via separate methods, blocks, etc., if needed.

### `hiro` Improvements

While analyzing performance, it was noticed that the GUI run loop was running unthrottled on Windows and Linux. This  would perform a wholly unnecessary amount of work, potentially refreshing thousands of times per second, and performing expensive amounts of drawing of the status bar. On Linux, this was unlikely to affect emulator performance, but on Windows, this amount of drawing could have a significant effect on performance due to the locking behavior of `SendMessage`.

This PR sets a uniform 8ms between GUI run loops on all platforms, which should dramatically affect Windows CPU idle and general performance without impacting responsiveness. Future improvements can be made here to improve the performance of ares "idle" state, without any title loaded, as well as potential better synchronization between the GUI and emulator run loops, especially around the status bar, tools window and input polling.

The emulator run loop remains un-throttled, responsible for suspending itself as needed, either within drivers or within the run loop for idle scenarios.

