### PR TITLE
n64: Always re-init paraLLEl-RDP from worker thread

### DIFF
--- a/ares/n64/system/system.hpp
+++ b/ares/n64/system/system.hpp
@@ -39,8 +39,11 @@ private:
   } information;
   
   atomic<bool> _vulkanNeedsLoad = false;
+  atomic<bool> _needsPower = false;
+  bool _reset = false;
 
   auto initDebugHooks() -> void;
+  auto _power(bool reset) -> void;
 
   //serialization.cpp
   auto serialize(serializer&, bool synchronize) -> void;


### PR DESCRIPTION
Re-initializing paraLLEl-RDP from a thread that did not initialize it seems to occasionally cause a deadlock, for reasons that are still under investigation. As such, when we send a reset signal to the N64, delay it to be performed on the worker thread at the beginning of the next run loop.