### PR TITLE
gba: more prefetcher timing improvements

### DIFF
--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -54,6 +54,8 @@ struct CPU : ARM7TDMI, Thread, IO {
 
   //prefetch.cpp
   auto prefetchSync(n32 address) -> void;
+  auto prefetchAdvance(u32 mode) -> void;
+  auto prefetchStepInternal(u32 clocks) -> void;
   auto prefetchStep(u32 clocks) -> void;
   auto prefetchReset() -> void;
   auto prefetchRead() -> n16;
@@ -255,6 +257,7 @@ struct CPU : ARM7TDMI, Thread, IO {
     i32 wait = 1;  //wait states for current load
     i32 cycle;     //number of clocks elapsed on current load
     n1  stopped = 1;
+    n1  ahead;
   } prefetch;
 
   struct Coprocessor {

--- a/ares/gba/cpu/prefetch.cpp
+++ b/ares/gba/cpu/prefetch.cpp
@@ -4,13 +4,23 @@ auto CPU::prefetchSync(n32 address) -> void {
   if(prefetch.wait - prefetch.cycle == 1) step(1);
 
   prefetch.stopped = false;
+  prefetch.ahead = false;
   prefetch.addr = address;
   prefetch.load = address;
   prefetch.wait = waitCartridge(Half | Nonsequential, prefetch.load);
   prefetch.cycle = 0;
 }
 
-auto CPU::prefetchStep(u32 clocks) -> void {
+auto CPU::prefetchAdvance(u32 mode) -> void {
+  n32 size = (mode & Word) ? 4 : 2;
+  prefetch.addr += size;
+  prefetch.load += size;
+  prefetch.wait = waitCartridge(Half | Sequential, prefetch.load);
+  prefetch.cycle = 0;
+  prefetch.stopped = false;
+}
+
+auto CPU::prefetchStepInternal(u32 clocks) -> void {
   step(clocks);
   if(!wait.prefetch || prefetch.stopped) return;
 
@@ -23,13 +33,22 @@ auto CPU::prefetchStep(u32 clocks) -> void {
     prefetch.cycle = 0;
   }
 
-  if(prefetch.full()) prefetch.stopped = true;
+  if(prefetch.full()) {
+    prefetch.stopped = true;
+    prefetch.ahead = false;
+  }
+}
+
+auto CPU::prefetchStep(u32 clocks) -> void {
+  if(wait.prefetch && !prefetch.stopped && prefetch.empty()) prefetch.ahead = true;
+  prefetchStepInternal(clocks);
 }
 
 auto CPU::prefetchReset() -> void {
   if(prefetch.wait - prefetch.cycle == 1) step(1);
 
   prefetch.stopped = true;
+  prefetch.ahead = false;
   prefetch.wait = 0;
   prefetch.addr = 0;
   prefetch.load = 0;
@@ -42,7 +61,7 @@ auto CPU::prefetchRead() -> n16 {
     prefetch.wait = waitCartridge(Half | Nonsequential, prefetch.load);
     prefetch.cycle = 0;
   }
-  if(prefetch.empty()) prefetchStep(prefetch.wait - prefetch.cycle);
+  if(prefetch.empty()) prefetchStepInternal(prefetch.wait - prefetch.cycle);
 
   n16 word = prefetch.slot[prefetch.addr >> 1 & 7];
   prefetch.addr += 2;

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -109,6 +109,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(prefetch.wait);
   s(prefetch.cycle);
   s(prefetch.stopped);
+  s(prefetch.ahead);
 
   s(context.clock);
   s(context.halted);

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v144.3";
+static const string SerializerVersion = "v145";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Improves handling of a timing quirk involving branches to the head of an empty prefetch buffer. Previously this would always cause a nonsequential access, but it appears that this should only occur if the prefetcher has not run ahead of the CPU during the current burst transfer. Fixes two of Alyosha's prefetcher timing tests.