### PR TITLE
node, n64, ps1: Add ps1 virtual square and relocate common stick code to node

### DIFF
--- a/ares/ares/node/input/axis.hpp
+++ b/ares/ares/node/input/axis.hpp
@@ -5,6 +5,57 @@ struct Axis : Input {
   auto value() const -> s64 { return _value; }
   auto setValue(s64 value) -> void { _value = value; }
 
+    auto setOperatingRange(s16 position, double saturationRadius, double offset) -> double {
+    return position * saturationRadius / 32767.0 + offset;
+  }
+  
+  auto processDeadzoneAndResponseCurve(double position, double innerDeadzone, double cardinalMax, double offset) -> double {
+    auto lengthAbsolute = abs(position - offset);
+    if(lengthAbsolute <= innerDeadzone) {
+      position = offset;
+    } else {
+      lengthAbsolute = (lengthAbsolute - innerDeadzone) * (cardinalMax) / (cardinalMax - innerDeadzone) / lengthAbsolute;
+      position = (position - offset) * lengthAbsolute + offset;
+    }
+    return position;
+  }
+
+  auto revisePosition(double position, double length, double saturationRadius, double offset) -> double {
+    if(length > saturationRadius) {
+      length = saturationRadius / length;
+      position = (position - offset) * length + offset;
+    }
+    return position;
+  }
+
+  auto applyGateBoundaries(double innerDeadzone, double cardinalMax, double diagonalMax, double positionX, double positionY, double offset, double& boundedPositionX, double& boundedPositionY) -> void {
+    if(positionX != offset && positionY != offset) {
+      auto slope = (positionY - offset) / (positionX - offset);
+      auto edgex = copysign(cardinalMax / (abs(slope) + (cardinalMax - diagonalMax) / diagonalMax), positionX);
+      auto edgey = copysign(min(abs(edgex * slope), cardinalMax / (1.0 / abs(slope) + (cardinalMax - diagonalMax) / diagonalMax)), positionY);
+      edgex = edgey / slope;
+
+      auto distanceToEdge = hypot(edgex, edgey);
+
+      auto length = hypot(positionX - offset, positionY - offset);
+      if(length > distanceToEdge) {
+        positionX = edgex + offset;
+        positionY = edgey + offset;
+      }
+    }
+    boundedPositionX = positionX;
+    boundedPositionY = positionY;
+  }
+
+  auto clampAxisToNearestBoundary(double position, double offset, double cardinalMax) -> double {
+    if(abs(position - offset) > cardinalMax) position = copysign(cardinalMax, position - offset) + offset;
+    return position;
+  }
+
+  auto counteractPrecisionError(double position) -> double {
+    return copysign(abs(position) + 1e-09, position);
+  }
+  
 protected:
   s64 _value = 0;
   s64 _minimum = -32768;

--- a/ares/n64/controller/gamepad/gamepad.hpp
+++ b/ares/n64/controller/gamepad/gamepad.hpp
@@ -5,6 +5,7 @@ struct Gamepad : Controller {
   u8 bank;
   Memory::Writable ram;  //Toshiba TC55257DFL-85V
   Node::Input::Rumble motor;
+  Node::Input::Axis axis;
 
   Node::Input::Axis x;
   Node::Input::Axis y;

--- a/ares/ps1/peripheral/dualshock/dualshock.hpp
+++ b/ares/ps1/peripheral/dualshock/dualshock.hpp
@@ -1,4 +1,5 @@
 struct DualShock : PeripheralDevice {
+  Node::Input::Axis axis;
   Node::Input::Axis lx;
   Node::Input::Axis ly;
   Node::Input::Axis rx;


### PR DESCRIPTION
The PlayStation's DualShock controller can natively reach the entire 8-bit range. Before this PR, only keyboard input was able to do so as the limiting geometry and electromechanics of a modern controller were not taken into account. This PR addresses that by assuming an analog stick will follow a circular gate, sizing a circle with an offset center to PS1's range, and scaling from a deadzone of about 4.7% to the edge of the circle. Then, a square virtual gate is applied with boundaries defined by the offset-adjusted maximum values of the cardinals and the diagonals. Finally, excess cardinal input is clamped and an epsilon added to counteract floating point precision error.

Additionally, given the shared code with the N64 in making the PS1 virtual square, methods were created within node to reduce repeating elements.

Lastly, the linear response curve can take two approaches. One is to scale from the deadzone up to the cardinal's maximum value. The other is to scale from the deadzone up to the saturation radius of the sized circle. The N64 was following the former approach. While not necessarily incorrect, the decision was made to move to the saturation radius way since the sensitivity remains closer to linear over the former with an increasing deadzone.