### PR TITLE
n64: improve gdb memory hooks

### DIFF
--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -196,8 +196,8 @@ struct CPU : Thread {
     template<u32 Size> auto write(u64 vaddr, u32 paddr, u64 data) -> void;
     auto power(bool reset) -> void;
 
-    auto readDebug(u64 vaddr, u32 paddr) -> u8;
-    auto writeDebug(u64 vaddr, u32 paddr, u8 value) -> void;
+    template<u32 Size> auto readDebug(u64 vaddr, u32 paddr) -> u64;
+    template<u32 Size> auto writeDebug(u64 vaddr, u32 paddr, u64 value) -> void;
 
     //8KB
     struct Line {
@@ -318,7 +318,7 @@ struct CPU : Thread {
   template<u32 Size> auto vaddrAlignedError(u64 vaddr, bool write) -> bool;
   auto addressException(u64 vaddr) -> void;
 
-  auto readDebug(u64 vaddr) -> u8;
+  template <u32 Size> auto readDebug(u64 vaddr) -> u64;
   template <u32 Size> auto writeDebug(u64 vaddr, u64 data) -> bool;
 
   //serialization.cpp

--- a/ares/n64/cpu/dcache.cpp
+++ b/ares/n64/cpu/dcache.cpp
@@ -58,13 +58,16 @@ auto CPU::DataCache::read(u64 vaddr, u32 paddr) -> u64 {
   return line.read<Size>(paddr);
 }
 
-auto CPU::DataCache::readDebug(u64 vaddr, u32 paddr) -> u8 {
+template<u32 Size>
+auto CPU::DataCache::readDebug(u64 vaddr, u32 paddr) -> u64 {
+  // This is used by the debugger to read memory through the cache but without
+  // actually causing side effects that modify the cache state (eg: no line fill)
   auto& line = this->line(vaddr);
   if(!line.hit(paddr)) {
     Thread dummyThread{};
-    return bus.read<Byte>(paddr, dummyThread, "Ares Debugger");
+    return bus.read<Size>(paddr, dummyThread, "Ares Debugger");
   }
-  return line.read<Byte>(paddr);
+  return line.read<Size>(paddr);
 }
 
 template<u32 Size>
@@ -79,13 +82,16 @@ auto CPU::DataCache::write(u64 vaddr, u32 paddr, u64 data) -> void {
   line.write<Size>(paddr, data);
 }
 
-auto CPU::DataCache::writeDebug(u64 vaddr, u32 paddr, u8 data) -> void {
+template<u32 Size>
+auto CPU::DataCache::writeDebug(u64 vaddr, u32 paddr, u64 data) -> void {
+  // This is used by the debugger to write memory through the cache but without
+  // actually causing side effects that modify the cache state (eg: no line fill)
   auto& line = this->line(vaddr);
   if(!line.hit(paddr)) {
     Thread dummyThread{};
-    return bus.write<Byte>(paddr, data, dummyThread, "Ares Debugger");
+    return bus.write<Size>(paddr, data, dummyThread, "Ares Debugger");
   }
-  line.write<Byte>(paddr, data);
+  line.write<Size>(paddr, data);
 }
 
 auto CPU::DataCache::power(bool reset) -> void {
@@ -99,5 +105,6 @@ auto CPU::DataCache::power(bool reset) -> void {
   }
 }
 
-template
-auto CPU::DataCache::Line::write<Byte>(u32 paddr, u64 data) -> void;
+template auto CPU::DataCache::Line::write<Byte>(u32 paddr, u64 data) -> void;
+template auto CPU::DataCache::writeDebug<Byte>(u64 vaddr, u32 paddr, u64 data) -> void;
+template auto CPU::DataCache::readDebug<Byte>(u64 vaddr, u32 paddr) -> u64;

--- a/ares/n64/rdram/debugger.cpp
+++ b/ares/n64/rdram/debugger.cpp
@@ -17,7 +17,7 @@ auto RDRAM::Debugger::load(Node::Object parent) -> void {
   memory.dcache->setSize(4_MiB + 4_MiB);
   memory.dcache->setRead([&](u32 address) -> u8 {
     u32 vaddr = address | 0x8000'0000;
-    return cpu.dcache.readDebug(vaddr, address);
+    return cpu.dcache.readDebug<Byte>(vaddr, address);
   });
   memory.dcache->setWrite([&](u32 address, u8 data) -> void {
     u32 vaddr = address | 0x8000'0000;

--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -170,56 +170,126 @@ auto System::initDebugHooks() -> void {
     res.resize(byteCount * 2);
     char* resPtr = res.begin();
 
-    for(u32 i : range(byteCount)) {
-      auto val = cpu.readDebug(address++);
-      hexByte(resPtr, val);
-      resPtr += 2;
+    // For 8/16/32/64-bit reads, perform an actual read like the CPU would do.
+    // This makes sure we return the same value the CPU would get wrt to masking.
+    u64 value;
+    switch(byteCount) {
+      case Byte: 
+        value = cpu.readDebug<Byte>(address);
+        hexByte(resPtr, value);
+        return res;
+      case Half: 
+        value = cpu.readDebug<Half>(address);
+        hexByte(resPtr + 0, (value >> 8) & 0xff);
+        hexByte(resPtr + 2, value & 0xff);
+        return res;
+      case Word: 
+        value = cpu.readDebug<Word>(address);
+        hexByte(resPtr + 0, (value >> 24) & 0xff);
+        hexByte(resPtr + 2, (value >> 16) & 0xff);
+        hexByte(resPtr + 4, (value >> 8) & 0xff);
+        hexByte(resPtr + 6, value & 0xff);
+        return res;
+      case Dual:
+        value = cpu.readDebug<Dual>(address);
+        hexByte(resPtr + 0, (value >> 56) & 0xff);
+        hexByte(resPtr + 2, (value >> 48) & 0xff);
+        hexByte(resPtr + 4, (value >> 40) & 0xff);
+        hexByte(resPtr + 6, (value >> 32) & 0xff);
+        hexByte(resPtr + 8, (value >> 24) & 0xff);
+        hexByte(resPtr + 10, (value >> 16) & 0xff);
+        hexByte(resPtr + 12, (value >> 8) & 0xff);
+        hexByte(resPtr + 14, value & 0xff);
+        return res;
     }
 
-    return res;
+    // Handle reads of different/unaligned sizes only within the RDRAM area,
+    // where we are sure that the write size does not really matter
+    if(address >= 0xffff'ffff'8000'0000ull && address + byteCount <= 0xffff'ffff'83ef'ffffull) {
+      for(u32 i : range(byteCount)) {
+        auto val = cpu.readDebug<Byte>(address++);
+        hexByte(resPtr, val);
+        resPtr += 2;
+      }
+      return res;
+    } else if (address >= 0xffff'ffff'a000'0000ull && address + byteCount <= 0xffff'ffff'a3ef'ffffull) {
+      Thread dummyThread{};
+      for(u32 i : range(byteCount)) {
+        auto val = bus.read<Byte>(address & 0x1fff'ffff, dummyThread, "Ares Debugger");
+        hexByte(resPtr, val);
+        resPtr += 2;
+        address++;
+      }
+      return res;
+    } else if (address >= 0xffff'ffff'a400'0000ull && address + byteCount <= 0xffff'ffff'bfff'ffffull) {
+      // Otherwise, use 32-bit reads to read the data. This is the expected
+      // read for RCP, so it's the one that's most likely to return the data
+      // as the user would expect.
+      Thread dummyThread{};
+      for(u32 i : range(byteCount / 4)) {
+        u64 value = bus.read<Word>(address & 0x1fff'ffff, dummyThread, "Ares Debugger");
+        hexByte(resPtr + 0, (value >> 24) & 0xff);
+        hexByte(resPtr + 2, (value >> 16) & 0xff);
+        hexByte(resPtr + 4, (value >> 8) & 0xff);
+        hexByte(resPtr + 6, value & 0xff);
+        resPtr += 8;
+        address += 4;
+      }
+    }
+    return {};
   };
 
   GDB::server.hooks.write = [](u64 address, vector<u8> data) {
     address = (s32)address;
 
+    // For 8/16/32/64-bit writes, perform an actual write like the CPU would do.
+    // This makes sure we write the same value the CPU would write wrt to masking.
+    u64 value;
+    switch(data.size()) {
+      case Byte: 
+        value = (u64)data[0];
+        cpu.writeDebug<Byte>(address, value);
+        break;
+      case Half: 
+        value = ((u64)data[0]<<8) | ((u64)data[1]<<0);
+        cpu.writeDebug<Half>(address, value);
+        break;
+      case Word: 
+        value = ((u64)data[0]<<24) | ((u64)data[1]<<16) | ((u64)data[2]<<8) | ((u64)data[3]<<0);
+        cpu.writeDebug<Word>(address, value);
+        break;
+      case Dual:
+        value  = ((u64)data[0]<<56) | ((u64)data[1]<<48) | ((u64)data[2]<<40) | ((u64)data[3]<<32);
+        value |= ((u64)data[4]<<24) | ((u64)data[5]<<16) | ((u64)data[6]<< 8) | ((u64)data[7]<< 0);
+        cpu.writeDebug<Dual>(address, value);
+        break;
+    }
+
     // Handle writes of different/unaligned sizes only within the RDRAM area,
     // where we are sure that the write size does not really matter
-    if(address >= 0xffff'ffff'8000'0000ull && address <= 0xffff'ffff'83ef'ffffull) {
+    if(address >= 0xffff'ffff'8000'0000ull && address + data.size() <= 0xffff'ffff'83ef'ffffull) {
       for(auto b : data) {
-        cpu.dcache.writeDebug(address, address & 0x1fff'ffff, b);
+        cpu.dcache.writeDebug<Byte>(address, address & 0x1fff'ffff, b);
         address++;
       }
-    } else if (address >= 0xffff'ffff'a000'0000ull && address <= 0xffff'ffff'a3ef'ffffull) {
+    } else if (address >= 0xffff'ffff'a000'0000ull && address + data.size() <= 0xffff'ffff'a3ef'ffffull) {
       Thread dummyThread{};
       for(auto b : data) {
         bus.write<Byte>(address & 0x1fff'ffff, b, dummyThread, "Ares Debugger");
         address++;
       }
-    } else {
-      // Otherwise, the write is expected to be of a set size to an aligned address.
-      u64 value;
-      switch(data.size()) {
-        case Byte: 
-          value = (u64)data[0];
-          cpu.writeDebug<Byte>(address, value);
-          break;
-        case Half: 
-          value = ((u64)data[0]<<8) | ((u64)data[1]<<0);
-          cpu.writeDebug<Half>(address, value);
-          break;
-        case Word: 
-          value = ((u64)data[0]<<24) | ((u64)data[1]<<16) | ((u64)data[2]<<8) | ((u64)data[3]<<0);
-          cpu.writeDebug<Word>(address, value);
-          break;
-        case Dual:
-          value  = ((u64)data[0]<<56) | ((u64)data[1]<<48) | ((u64)data[2]<<40) | ((u64)data[3]<<32);
-          value |= ((u64)data[4]<<24) | ((u64)data[5]<<16) | ((u64)data[6]<< 8) | ((u64)data[7]<< 0);
-          cpu.writeDebug<Dual>(address, value);
-          break;
+    } else if (address >= 0xffff'ffff'a400'0000ull && address + data.size() <= 0xffff'ffff'bfff'ffffull) {
+      // Otherwise, use 32-bit writes to write the data. This is the expected
+      // write for RCP, so it's the one that's most likely to write the data
+      // as the user would expect.
+      Thread dummyThread{};
+      for(u32 i = 0; i < data.size() / 4; i++) {
+        u64 value = ((u64)data[i*4+0]<<24) | ((u64)data[i*4+1]<<16) | ((u64)data[i*4+2]<<8) | ((u64)data[i*4+3]<<0);
+        bus.write<Word>(address & 0x1fff'ffff, value, dummyThread, "Ares Debugger");
+        address += 4;
       }
     }
   };
-
 
   GDB::server.hooks.regRead = [](u32 regIdx) {
     if(regIdx < 32) {


### PR DESCRIPTION
Now support reads and writes of arbitrary lengths in both RDRAM and RCP ares (using respectively 8-bit and 32-bit accesses).