### PR TITLE
ms: fix erratic screen resizing

### DIFF
--- a/ares/ms/vdp/io.cpp
+++ b/ares/ms/vdp/io.cpp
@@ -119,7 +119,6 @@ auto VDP::registerWrite(n4 address, n8 data) -> void {
     background.io.vscrollLock = data.bit(7);
     irq.line.pending &= irq.line.enable;
     irq.poll();
-    updateScreenSize();
     return;
 
   case 0x1:  //mode control 2
@@ -131,7 +130,6 @@ auto VDP::registerWrite(n4 address, n8 data) -> void {
     io.displayEnable     = data.bit(6);
     irq.frame.pending &= irq.frame.enable;
     irq.poll();
-    updateScreenSize();
     return;
 
   case 0x2:  //name table base address

--- a/ares/ms/vdp/vdp.cpp
+++ b/ares/ms/vdp/vdp.cpp
@@ -149,15 +149,6 @@ auto VDP::step(u32 clocks) -> void {
   }
 }
 
-auto VDP::updateScreenSize() -> void {
-  if(Display::CRT()) {
-    screen->setSize(284, screenHeight());
-  }
-  //if(Display::LCD()) {
-  //  screen->setSize(160, 144);
-  //}
-}
-
 auto VDP::vlines() -> u32 {
   if(revision->value() == 1) return 192;
 

--- a/ares/ms/vdp/vdp.hpp
+++ b/ares/ms/vdp/vdp.hpp
@@ -38,7 +38,6 @@ struct VDP : Thread {
   auto main() -> void;
   auto step(u32 clocks) -> void;
 
-  auto updateScreenSize() -> void;
   auto screenHeight() const -> u32 { return Region::PAL() ? 288 : 243; }
 
   auto vlines() -> u32;


### PR DESCRIPTION
Per an issue reported in the Discord -- Aleste (J) flickering on title screen (frequent, erratic resizing)

This removes the old screen resizing code (obsoleted by https://github.com/ares-emulator/ares/commit/acaa1cabb53f3c62131189d9f5650b87298c3b4f) that was being triggered by vdp mode register updates. Screen size is currently updated on every frame.