### PR TITLE
build: remove extraneous msvc optimization flags

### DIFF
--- a/cmake/windows/compilerconfig.cmake
+++ b/cmake/windows/compilerconfig.cmake
@@ -55,11 +55,7 @@ set(
   /Zc:__cplusplus
   /utf-8
   /permissive-
-  $<$<NOT:$<CONFIG:Debug>>:/GL>
   $<$<NOT:$<CONFIG:Debug>>:/GS->
-  $<$<NOT:$<CONFIG:Debug>>:/Oi>
-  $<$<NOT:$<CONFIG:Debug>>:/Ob2>
-  $<$<NOT:$<CONFIG:Debug>>:/Ot>
 )
 
 set(


### PR DESCRIPTION
/Oi, /Ob2, and /Ot are implied by /O2, which CMake adds by default in Release and RelWithDebInfo builds. In RelWithDebInfo builds CMake also downgrades inlining by adding in /Ob1, but we already have a workaround for this. MinSizeRel builds may see a change in behavior, where CMake passes /O1 instead, but in any case that is the recommended flag for minimizing binary size.

The removal of /GL is especially important for MSVC builds. CMake will add it when IPO is enabled, and forcing it on for all non-debug builds was not simply redundant; it was overriding the user preference expressed with ENABLE_IPO. ClangCL requires other flags to enable the equivalent LTO feature, and this is already addressed elsewhere.