### PR TITLE
build: Statically link runtime library for Windows CI builds

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -102,7 +102,8 @@
         "ARES_BUILD_LOCAL": false,
         "ARES_BUILD_OPTIONAL_TARGETS": true,
         "ARES_UNITY_CORES": true,
-        "ARES_PRECOMPILE_HEADERS": true
+        "ARES_PRECOMPILE_HEADERS": true,
+        "CMAKE_MSVC_RUNTIME_LIBRARY": {"type": "STRING", "value": "MultiThreaded"}
       }
     },
     {


### PR DESCRIPTION
ares has not historically required the Microsoft C++ redistributable install to run releases; a dependence on it was inadvertently introduced by never specifying `/MT` in the new build system.

libc++ builds already link libc++ statically so they do not have the same issue.

Note that ares artifacts will still report `VCRUNTIME140.dll` as missing after this change if a redistributable is not present, pending a similar change with SDL3 in ares-deps (https://github.com/ares-emulator/ares-deps/pull/7).