### PR TITLE
build: Provide librashader header path hint on all OSs

### DIFF
--- a/cmake/finders/Findlibrashader.cmake
+++ b/cmake/finders/Findlibrashader.cmake
@@ -64,7 +64,7 @@ macro(librashader_set_soname)
   unset(_result)
 endmacro()
 
-if(OS_LINUX OR OS_FREEBSD OR OS_OPENBSD)
+if(OS_LINUX OR OS_FREEBSD OR OS_OPENBSD OR ARES_SKIP_DEPS OR (NOT ARES_ENABLE_LIBRASHADER))
   set(_librashader_path_hint "${CMAKE_SOURCE_DIR}/thirdparty/librashader/include")
 endif()
 


### PR DESCRIPTION
Tell the build system where our included librashader header is when we are skipping dependencies or disabling librashader, so that we can build without librashader properly on any OS.

The only reason we don't provide this hint totally unconditionally is so that under normal circumstances we can verify that ares-deps is vendoring the header properly. A path hint would always override that.

#### Context
Needed to produce a dependency-less build on Windows to debug another issue. providing ARES_SKIP_DEPS and ARES_ENABLE_LIBRASHADER=OFF on Windows resulted in failure to configure. This fixes that issue.