### PR TITLE
Fix mouse capture on Windows devices

### DIFF
--- a/ruby/input/mouse/rawinput.cpp
+++ b/ruby/input/mouse/rawinput.cpp
@@ -17,14 +17,7 @@ struct InputMouseRawInput {
   } ms;
 
   auto acquired() -> bool {
-    if(mouseAcquired) {
-      SetFocus((HWND)handle);
-      SetCapture((HWND)handle);
-      RECT rc;
-      GetWindowRect((HWND)handle, &rc);
-      ClipCursor(&rc);
-    }
-    return GetCapture() == (HWND)handle;
+    return mouseAcquired;
   }
 
   auto acquire() -> bool {
@@ -32,7 +25,13 @@ struct InputMouseRawInput {
       mouseAcquired = true;
       ShowCursor(false);
     }
-    return acquired();
+    
+    SetFocus((HWND)handle);
+    SetCapture((HWND)handle);
+    RECT rc;
+    GetWindowRect((HWND)handle, &rc);
+    ClipCursor(&rc);
+    return GetCapture() == (HWND)handle;
   }
 
   auto release() -> bool {


### PR DESCRIPTION
Mouse capture on Windows devices didn't work correctly with the release of v145. This fix is to address mouse capture.

Credits belong to SuperMikeMan100 for isolating the problem, and yam/jcm93 for creating the patch. I'm just the tester and person committing the change. 