### PR TITLE
n64: Reinitialize paraLLEl-RDP on system reset

### DIFF
--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -81,9 +81,6 @@ auto System::run() -> void {
     vulkan.load(node);
     _vulkanNeedsLoad = false;
   }
-  if(_needsPower) {
-    _power(_reset);
-  }
   cpu.main();
 }
 
@@ -422,13 +419,6 @@ auto System::save() -> void {
 }
 
 auto System::power(bool reset) -> void {
-  _reset = reset;
-  // Re-initializing ParaLLEl-RDP from a thread that did not initialize it seems to occasionally cause a deadlock.
-  // Delay reset until the next iteration of the system's run loop on the worker thread.
-  _needsPower = true;
-}
-
-auto System::_power(bool reset) -> void {
   for(auto& setting : node->find<Node::Setting::Setting>()) setting->setLatch();
 
   if constexpr(Accuracy::CPU::Recompiler || Accuracy::RSP::Recompiler) {
@@ -440,6 +430,10 @@ auto System::_power(bool reset) -> void {
   if(_DD()) dd.power(reset);
   mi.power(reset);
   vi.power(reset);
+  #if defined(VULKAN)
+  vulkan.unload();
+  _vulkanNeedsLoad = true;
+  #endif
   ai.power(reset);
   pi.power(reset);
   pif.power(reset);
@@ -450,7 +444,6 @@ auto System::_power(bool reset) -> void {
   rsp.power(reset);
   rdp.power(reset);
   if(model() == Model::Aleck64) aleck64.power(reset);
-  _needsPower = false;
 }
 
 }

--- a/ares/n64/system/system.hpp
+++ b/ares/n64/system/system.hpp
@@ -39,8 +39,6 @@ private:
   } information;
   
   atomic<bool> _vulkanNeedsLoad = false;
-  atomic<bool> _needsPower = false;
-  bool _reset = false;
 
   auto initDebugHooks() -> void;
   auto _power(bool reset) -> void;


### PR DESCRIPTION
The threading rework moved Vulkan initialization to a deferred routine inside the emulator run loop, because paraLLEl-RDP expects to be called into from the same thread that initialized it.

Meanwhile, 625df94 addressed a deadlock in paraLLEl-RDP that could occur if a reset or power on was sent from a thread that was not the thread that initialized it. It addressed the problem by deferring the `power` call until the next emulator run loop.

Unfortunately, that broke savestates in the N64 core. During unserialization, a power command is sent to the system directly before restoring the components' state. This combined with the new behavior would cause the system to reset immediately after loading a savestate.

This PR in effect reverts the previous fix and introduces a hopefully more robust solution: Unloading Vulkan whenever `power` is called on the system, and queueing it to be completely re-initialized on the next run loop.

> [!NOTE]
> This has been tested on macOS, but should undergo more testing on other platforms to verify it works fine.

Fixes #2100