### PR TITLE
desktop-ui: Fix undefined behavior in exit handler

### DIFF
--- a/desktop-ui/desktop-ui.hpp
+++ b/desktop-ui/desktop-ui.hpp
@@ -35,10 +35,10 @@ public:
     if(program._isRunning && !program._programThread) {
       program._interruptDepth += 1;
       if(program._interruptDepth == 1) {
-        lock.lock();
+        program.lock.lock();
         program._interruptWaiting = true;
         program._programConditionVariable.notify_one();
-        program._programConditionVariable.wait(lock, [] { return program._interruptWorking; });
+        program._programConditionVariable.wait(program.lock, [] { return program._interruptWorking; });
       }
     }
   }
@@ -49,14 +49,11 @@ public:
       if(program._interruptDepth == 0) {
         program._interruptWorking = false;
         program._interruptWaiting = false;
-        lock.unlock();
+        program.lock.unlock();
         program._programConditionVariable.notify_one();
       }
     }
   }
-  
-private:
-  std::unique_lock<std::mutex> lock{program._programMutex, std::defer_lock};
 };
 
 auto locate(const string& name) -> string;

--- a/desktop-ui/program/program.cpp
+++ b/desktop-ui/program/program.cpp
@@ -142,8 +142,9 @@ auto Program::main() -> void {
 }
 
 auto Program::quit() -> void {
+  Program::Guard guard;
   _quitting = true;
-  _programMutex.unlock();
+  lock.unlock();
   _programConditionVariable.notify_all();
   worker.join();
   program._isRunning = false;

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -132,6 +132,8 @@ private:
   NALL_USED auto getProgramThreadValue() -> bool {
     return _programThread;
   }
+  /// Unique lock used by `Program::Guard` instances to synchronize interrupts. Generally this should not be used directly, with synchronization happening via `Program::Guard` construction. However, it is still exposed for exceptions such as the exit handler in `Program::quit()`.
+  std::unique_lock<std::mutex> lock{_programMutex, std::defer_lock};
 };
 
 extern Program program;

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -1,9 +1,7 @@
 struct Program : ares::Platform {
   auto create() -> void;
   auto main() -> void;
-  auto emulatorRunLoop(uintptr_t) -> void;
   auto quit() -> void;
-  auto waitForInterrupts() -> void;
 
   //platform.cpp
   auto attach(ares::Node::Object) -> void override;
@@ -110,9 +108,14 @@ struct Program : ares::Platform {
   std::recursive_mutex inputMutex;
   
 private:
+  /// Routine used while the emulator thread is waiting for work to complete that modifies its state.
+  auto waitForInterrupts() -> void;
+  /// The main run loop for the emulator thread spawned on startup.
+  auto emulatorRunLoop(uintptr_t) -> void;
+
   atomic<bool> _quitting = false;
   atomic<bool> _needsResize = false;
-  
+
   /// Mutex used to manage access to the status message queue.
   std::recursive_mutex _messageMutex;
 


### PR DESCRIPTION
If an instance of our custom synchronization object for modifying the state of the emulator had not been created when we reached the exit handler, we would unlock a mutex that was not locked. This is undefined behavior. In testing, no platform made noise about this issue, but some (such as BSD) do, and others may as well.

Fixes https://github.com/ares-emulator/ares/issues/2115