### PR TITLE
gba: SIOMLT_SEND should be a 16-bit value

### DIFF
--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -176,7 +176,7 @@ struct CPU : ARM7TDMI, Thread, IO {
     n1  irqEnable;
 
     n16 data[4];
-    n8  data8;
+    n16 dataMulti;
   } serial;
 
   struct Keypad {

--- a/ares/gba/cpu/io.cpp
+++ b/ares/gba/cpu/io.cpp
@@ -61,8 +61,8 @@ auto CPU::readIO(n32 address) -> n8 {
   );
 
   //SIOMLT_SEND (SIODATA8)
-  case 0x0400'012a: return serial.data8;
-  case 0x0400'012b: return 0;
+  case 0x0400'012a: return serial.dataMulti.byte(0);
+  case 0x0400'012b: return serial.dataMulti.byte(1);
 
   //KEYINPUT
   case 0x04000130: {
@@ -346,8 +346,8 @@ auto CPU::writeIO(n32 address, n8 data) -> void {
     return;
 
   //SIOMLT_SEND (SIODATA8)
-  case 0x0400'012a: serial.data8 = data; return;
-  case 0x0400'012b: return;
+  case 0x0400'012a: serial.dataMulti.byte(0) = data; return;
+  case 0x0400'012b: serial.dataMulti.byte(1) = data; return;
 
   //KEYCNT
   case 0x0400'0132:

--- a/ares/gba/cpu/io.cpp
+++ b/ares/gba/cpu/io.cpp
@@ -62,7 +62,7 @@ auto CPU::readIO(n32 address) -> n8 {
 
   //SIOMLT_SEND (SIODATA8)
   case 0x0400'012a: return serial.dataMulti.byte(0);
-  case 0x0400'012b: return serial.dataMulti.byte(1);
+  case 0x0400'012b: return serial.dataMulti.byte(1);  //upper 8 bits are always readable, but only used in multiplayer mode
 
   //KEYINPUT
   case 0x04000130: {
@@ -347,7 +347,7 @@ auto CPU::writeIO(n32 address, n8 data) -> void {
 
   //SIOMLT_SEND (SIODATA8)
   case 0x0400'012a: serial.dataMulti.byte(0) = data; return;
-  case 0x0400'012b: serial.dataMulti.byte(1) = data; return;
+  case 0x0400'012b: serial.dataMulti.byte(1) = data; return;  //upper 8 bits are always writable, but only used in multiplayer mode
 
   //KEYCNT
   case 0x0400'0132:

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -56,7 +56,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(serial.mode);
   s(serial.irqEnable);
   for(auto& value : serial.data) s(value);
-  s(serial.data8);
+  s(serial.dataMulti);
 
   s(keypad.enable);
   s(keypad.condition);

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v145.1";
+static const string SerializerVersion = "v145.2";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
This I/O register is currently treated as 8-bit in ares, which is incorrect.