### PR TITLE
arm7tdmi: fix cycle order for SWP instruction

### DIFF
--- a/ares/component/processor/arm7tdmi/instructions-arm.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-arm.cpp
@@ -104,12 +104,12 @@ auto ARM7TDMI::armInstructionDataRegisterShift
 
 auto ARM7TDMI::armInstructionMemorySwap
 (n4 m, n4 d, n4 n, n1 byte) -> void {
-  n32 rm = r(m) + (m == 15 ? 4 : 0);
   lock();
   n32 word = load((byte ? Byte : Word), r(n));
-  store((byte ? Byte : Word), r(n), rm);
-  r(d) = word;
+  store((byte ? Byte : Word), r(n), r(m) + (m == 15 ? 4 : 0));
   unlock();
+  idle();
+  r(d) = word;
 }
 
 auto ARM7TDMI::armInstructionMoveHalfImmediate
@@ -123,7 +123,10 @@ auto ARM7TDMI::armInstructionMoveHalfImmediate
   if(pre == 0) rn = up ? rn + immediate : rn - immediate;
 
   if(pre == 0 || writeback) r(n) = rn + (n == 15 ? 4 : 0);
-  if(mode == 1) r(d) = rd;
+  if(mode == 1) {
+    idle();
+    r(d) = rd;
+  }
 }
 
 auto ARM7TDMI::armInstructionMoveHalfRegister
@@ -138,7 +141,10 @@ auto ARM7TDMI::armInstructionMoveHalfRegister
   if(pre == 0) rn = up ? rn + rm : rn - rm;
 
   if(pre == 0 || writeback) r(n) = rn + (n == 15 ? 4 : 0);
-  if(mode == 1) r(d) = rd;
+  if(mode == 1) {
+    idle();
+    r(d) = rd;
+  }
 }
 
 auto ARM7TDMI::armInstructionMoveImmediateOffset
@@ -152,7 +158,10 @@ auto ARM7TDMI::armInstructionMoveImmediateOffset
   if(pre == 0) rn = up ? rn + immediate : rn - immediate;
 
   if(pre == 0 || writeback) r(n) = rn;
-  if(mode == 1) r(d) = rd;
+  if(mode == 1) {
+    idle();
+    r(d) = rd;
+  }
 }
 
 auto ARM7TDMI::armInstructionMoveMultiple
@@ -219,7 +228,10 @@ auto ARM7TDMI::armInstructionMoveRegisterOffset
   if(pre == 0) rn = up ? rn + rm : rn - rm;
 
   if(pre == 0 || writeback) r(n) = rn;
-  if(mode == 1) r(d) = rd;
+  if(mode == 1) {
+    idle();
+    r(d) = rd;
+  }
 }
 
 auto ARM7TDMI::armInstructionMoveSignedImmediate
@@ -233,7 +245,10 @@ auto ARM7TDMI::armInstructionMoveSignedImmediate
   if(pre == 0) rn = up ? rn + immediate : rn - immediate;
 
   if(pre == 0 || writeback) r(n) = rn + (n == 15 ? 4 : 0);
-  if(mode == 1) r(d) = rd;
+  if(mode == 1) {
+    idle();
+    r(d) = rd;
+  }
 }
 
 auto ARM7TDMI::armInstructionMoveSignedRegister
@@ -248,7 +263,10 @@ auto ARM7TDMI::armInstructionMoveSignedRegister
   if(pre == 0) rn = up ? rn + rm : rn - rm;
 
   if(pre == 0 || writeback) r(n) = rn + (n == 15 ? 4 : 0);
-  if(mode == 1) r(d) = rd;
+  if(mode == 1) {
+    idle();
+    r(d) = rd;
+  }
 }
 
 auto ARM7TDMI::armInstructionMoveToCoprocessorFromRegister

--- a/ares/component/processor/arm7tdmi/instructions-thumb.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-thumb.cpp
@@ -106,13 +106,14 @@ auto ARM7TDMI::thumbInstructionLoadLiteral
 (n8 displacement, n3 d) -> void {
   n32 address = (r(15) & ~3) + (displacement << 2);
   r(d) = load(Word, address);
+  idle();
 }
 
 auto ARM7TDMI::thumbInstructionMoveByteImmediate
 (n3 d, n3 n, n5 offset, n1 mode) -> void {
   switch(mode) {
   case 0: store(Byte, r(n) + offset, r(d)); break;  //STRB
-  case 1: r(d) = load(Byte, r(n) + offset); break;  //LDRB
+  case 1: r(d) = load(Byte, r(n) + offset); idle(); break;  //LDRB
   }
 }
 
@@ -120,7 +121,7 @@ auto ARM7TDMI::thumbInstructionMoveHalfImmediate
 (n3 d, n3 n, n5 offset, n1 mode) -> void {
   switch(mode) {
   case 0: store(Half, r(n) + offset * 2, r(d)); break;  //STRH
-  case 1: r(d) = load(Half, r(n) + offset * 2); break;  //LDRH
+  case 1: r(d) = load(Half, r(n) + offset * 2); idle(); break;  //LDRH
   }
 }
 
@@ -158,11 +159,11 @@ auto ARM7TDMI::thumbInstructionMoveRegisterOffset
   case 0: store(Word, r(n) + r(m), r(d)); break;  //STR
   case 1: store(Half, r(n) + r(m), r(d)); break;  //STRH
   case 2: store(Byte, r(n) + r(m), r(d)); break;  //STRB
-  case 3: r(d) = load(Byte | Signed, r(n) + r(m)); break;  //LDSB
-  case 4: r(d) = load(Word, r(n) + r(m)); break;  //LDR
-  case 5: r(d) = load(Half, r(n) + r(m)); break;  //LDRH
-  case 6: r(d) = load(Byte, r(n) + r(m)); break;  //LDRB
-  case 7: r(d) = load(Half | Signed, r(n) + r(m)); break;  //LDSH
+  case 3: r(d) = load(Byte | Signed, r(n) + r(m)); idle(); break;  //LDSB
+  case 4: r(d) = load(Word, r(n) + r(m)); idle(); break;  //LDR
+  case 5: r(d) = load(Half, r(n) + r(m)); idle(); break;  //LDRH
+  case 6: r(d) = load(Byte, r(n) + r(m)); idle(); break;  //LDRB
+  case 7: r(d) = load(Half | Signed, r(n) + r(m)); idle(); break;  //LDSH
   }
 }
 
@@ -170,7 +171,7 @@ auto ARM7TDMI::thumbInstructionMoveStack
 (n8 immediate, n3 d, n1 mode) -> void {
   switch(mode) {
   case 0: store(Word, r(13) + immediate * 4, r(d)); break;  //STR
-  case 1: r(d) = load(Word, r(13) + immediate * 4); break;  //LDR
+  case 1: r(d) = load(Word, r(13) + immediate * 4); idle(); break;  //LDR
   }
 }
 
@@ -178,7 +179,7 @@ auto ARM7TDMI::thumbInstructionMoveWordImmediate
 (n3 d, n3 n, n5 offset, n1 mode) -> void {
   switch(mode) {
   case 0: store(Word, r(n) + offset * 4, r(d)); break;  //STR
-  case 1: r(d) = load(Word, r(n) + offset * 4); break;  //LDR
+  case 1: r(d) = load(Word, r(n) + offset * 4); idle(); break;  //LDR
   }
 }
 

--- a/ares/component/processor/arm7tdmi/memory.cpp
+++ b/ares/component/processor/arm7tdmi/memory.cpp
@@ -25,7 +25,6 @@ auto ARM7TDMI::load(u32 mode, n32 address) -> n32 {
   } else {
     word = ROR(word, address.bit(0,1) << 3);
   }
-  idle();
   return word;
 }
 


### PR DESCRIPTION
As described in ARM documentation and confirmed via hardware testing, the SWP instruction should consist of a read, then a write, then an idle cycle, in that order.