### PR TITLE
desktop-ui: Defer settings window initialization on startup

### DIFF
--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -162,7 +162,7 @@ auto InputManager::createHotkeys() -> void {
 auto InputManager::pollHotkeys() -> void {
   if(Application::modal()) return;
 
-  if(!driverSettings.inputDefocusAllow.checked()) {
+  if(settings.input.defocus == "Allow") {
     if (!presentation.focused() && !ruby::video.fullScreen()) return;
   }
 

--- a/desktop-ui/input/input.cpp
+++ b/desktop-ui/input/input.cpp
@@ -517,8 +517,10 @@ auto InputManager::poll(bool force) -> void {
   if(changed) {
     this->devices = devices;
     bind();
-    inputSettings.refresh();
-    hotkeySettings.refresh();
+    if(settingsWindow.initialized) {
+      inputSettings.refresh();
+      hotkeySettings.refresh();
+    }
   }
 }
 

--- a/desktop-ui/program/program.cpp
+++ b/desktop-ui/program/program.cpp
@@ -17,10 +17,6 @@ auto Program::create() -> void {
   audioDriverUpdate();
   inputDriverUpdate();
 
-  driverSettings.videoRefresh();
-  driverSettings.audioRefresh();
-  driverSettings.inputRefresh();
-
   _isRunning = true;
   worker = thread::create({&Program::emulatorRunLoop, this});
 

--- a/desktop-ui/program/status.cpp
+++ b/desktop-ui/program/status.cpp
@@ -32,7 +32,7 @@ auto Program::updateMessage() -> void {
   }
 
   
-  bool defocused = driverSettings.inputDefocusPause.checked() && !ruby::video.fullScreen() && !presentation.focused();
+  bool defocused = settings.input.defocus == "Pause" && !ruby::video.fullScreen() && !presentation.focused();
   if(emulator && defocused) message.text = "Paused";
 }
 

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -178,7 +178,7 @@ auto Settings::process(bool load) -> void {
 
 //
 
-SettingsWindow::SettingsWindow() {
+auto SettingsWindow::initialize() -> void {
   onClose([&] {
     settings.save();
     setVisible(false);
@@ -231,9 +231,15 @@ SettingsWindow::SettingsWindow() {
   setSize({700_sx, 425_sy});
   setAlignment({0.0, 1.0});
   setResizable(false);
+  
+  driverSettings.videoRefresh();
+  driverSettings.audioRefresh();
+  driverSettings.inputRefresh();
+  initialized = true;
 }
 
 auto SettingsWindow::show(const string& panel) -> void {
+  if(!initialized) initialize();
   for(auto item : panelList.items()) {
     if(item.text() == panel) {
       item.setSelected();

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -439,7 +439,6 @@ struct HomePanel : VerticalLayout {
 };
 
 struct SettingsWindow : Window {
-  SettingsWindow();
   auto show(const string& panel) -> void;
   auto eventChange() -> void;
 
@@ -457,6 +456,11 @@ struct SettingsWindow : Window {
       DriverSettings driverSettings;
       DebugSettings debugSettings;
       HomePanel homePanel;
+  
+  bool initialized = false;
+  
+private:
+  auto initialize() -> void;
 };
 
 extern Settings settings;


### PR DESCRIPTION
A fairly simple change that defers the initialization of the settings window to when it is actually shown, instead of on startup.

Initializing the settings window is a somewhat lengthy process, particularly on Windows; this PR should generally cut ares' startup times by around half.

Future work could include a similar deferred loading for the Tools window. However, this would be a less trivial change, because some aspects of program state are stored inside Tools UI classes, necessitating a bit more delicate and complex handling.