### PR TITLE
n64: correctly render full resolution on PAL

### DIFF
--- a/ares/n64/vi/vi.cpp
+++ b/ares/n64/vi/vi.cpp
@@ -44,18 +44,25 @@ auto VI::load(Node::Object parent) -> void {
     }
   });
   
+  int videoHeight = Region::PAL() ? 576 : 480;
+
   #if defined(VULKAN)
   if(vulkan.enable) {
-    screen->setSize(vulkan.outputUpscale * 640, vulkan.outputUpscale * 480);
+    screen->setSize(vulkan.outputUpscale * 640, vulkan.outputUpscale * videoHeight);
     if(!vulkan.supersampleScanout) {
       screen->setScale(1.0 / vulkan.outputUpscale, 1.0 / vulkan.outputUpscale);
     }
   } else {
-    screen->setSize(640, 480);
+    screen->setSize(640, videoHeight);
   }
   #else
-  screen->setSize(640, 480);
+  screen->setSize(640, videoHeight);
   #endif
+
+  // Pedantic N64 NTSC aspect ratio is 120:119, but let's keep 120:120 to avoid slight scaling.
+  // Pedantic N64 PAL aspect ratio is 5900000:4965653, but let's use 12:10 to achieve the
+  // same aspect ratio as NTSC.
+  Region::PAL() ? screen->setAspect(12, 10) : screen->setAspect(120, 120);
 
   debugger.load(node);
 }


### PR DESCRIPTION
Currently, we render PAL games as 640x480 which is wrong because PAL has more vertical resolution. This causes PAL graphics to be reduced in quality compared to a real output.

This commit renders PAL at 640x576 which is the commonly used active display area used by PAL games, and then configure the aspect ratio to make sure the output is correct.