### PR TITLE
Implement aspect correction mode

### DIFF
--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -57,14 +57,29 @@ Presentation::Presentation() {
   if(settings.video.output == "Scale"   ) videoOutputScale.setChecked();
   if(settings.video.output == "Stretch" ) videoOutputStretch.setChecked();
 
-  videoAspectCorrection.setText("Aspect Correction").setChecked(settings.video.aspectCorrection).onToggle([&] {
-    settings.video.aspectCorrection = videoAspectCorrection.checked();
+  videoAspectCorrectionNone.setText("Aspect: No correction").onActivate([&] {
+    settings.video.aspectCorrection = "None";
     if(settings.video.adaptiveSizing) resizeWindow();
   });
-  videoAdaptiveSizing.setText("Adaptive Sizing").setChecked(settings.video.adaptiveSizing).onToggle([&] {
+
+  videoAspectCorrectionStandard.setText("Aspect: Standard").onActivate([&] {
+    settings.video.aspectCorrection = "Standard";
+    if(settings.video.adaptiveSizing) resizeWindow();
+  });
+
+  videoAspectCorrectionAnamorphic.setText("Aspect: Anamorphic (16:9)").onActivate([&] {
+    settings.video.aspectCorrection = "Anamorphic";
+    if(settings.video.adaptiveSizing) resizeWindow();
+  });
+
+  if(settings.video.aspectCorrection == "None")       videoAspectCorrectionNone.setChecked();
+  if(settings.video.aspectCorrection == "Standard")   videoAspectCorrectionStandard.setChecked();
+  if(settings.video.aspectCorrection == "Anamorphic") videoAspectCorrectionAnamorphic.setChecked();
+
+  videoAdaptiveSizing.setText("Window: Auto resize").setChecked(settings.video.adaptiveSizing).onToggle([&] {
     if(settings.video.adaptiveSizing = videoAdaptiveSizing.checked()) resizeWindow();
   });
-  videoAutoCentering.setText("Auto Centering").setChecked(settings.video.autoCentering).onToggle([&] {
+  videoAutoCentering.setText("Window: Auto center").setChecked(settings.video.autoCentering).onToggle([&] {
     if(settings.video.autoCentering = videoAutoCentering.checked()) resizeWindow();
   });
   videoShaderMenu.setText("Shader").setIcon(Icon::Emblem::Image);
@@ -305,7 +320,8 @@ auto Presentation::resizeWindow() -> void {
     auto& node = program.screens.first();
     u32 videoWidth = node->width() * node->scaleX();
     u32 videoHeight = node->height() * node->scaleY();
-    if(settings.video.aspectCorrection) videoWidth = videoWidth * node->aspectX() / node->aspectY();
+    if(settings.video.aspectCorrection != "None")       videoWidth = videoWidth * node->aspectX() / node->aspectY();
+    if(settings.video.aspectCorrection == "Anamorphic") videoWidth = videoWidth * 4 / 3;
     if(node->rotation() == 90 || node->rotation() == 270) swap(videoWidth, videoHeight);
 
     viewportWidth = videoWidth * multiplier;

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -27,7 +27,12 @@ struct Presentation : Window {
         Group videoOutputGroup{&videoOutputPixelPerfect, &videoOutputFixedScale, &videoOutputIntegerScale,
                                &videoOutputScale, &videoOutputStretch};
         MenuSeparator videoOutputSeparator{&videoOutputMenu};
-        MenuCheckItem videoAspectCorrection{&videoOutputMenu};
+        MenuRadioItem videoAspectCorrectionNone{&videoOutputMenu};
+        MenuRadioItem videoAspectCorrectionStandard{&videoOutputMenu};
+        MenuRadioItem videoAspectCorrectionAnamorphic{&videoOutputMenu};
+        Group videoAspectCorrectionGroup{&videoAspectCorrectionNone, &videoAspectCorrectionStandard, 
+                                         &videoAspectCorrectionAnamorphic};
+        MenuSeparator videoOutputSeparator2{&videoOutputMenu};
         MenuCheckItem videoAdaptiveSizing{&videoOutputMenu};
         MenuCheckItem videoAutoCentering{&videoOutputMenu};
       Menu videoShaderMenu{&settingsMenu};

--- a/desktop-ui/program/platform.cpp
+++ b/desktop-ui/program/platform.cpp
@@ -74,7 +74,8 @@ auto Program::video(ares::Node::Video::Screen node, const u32* data, u32 pitch, 
 
   u32 videoWidth = node->width() * node->scaleX();
   u32 videoHeight = node->height() * node->scaleY();
-  if(settings.video.aspectCorrection) videoWidth = videoWidth * node->aspectX() / node->aspectY();
+  if(settings.video.aspectCorrection != "None")       videoWidth = videoWidth * node->aspectX() / node->aspectY();
+  if(settings.video.aspectCorrection == "Anamorphic") videoWidth = videoWidth * 4 / 3;
   if(node->rotation() == 90 || node->rotation() == 270) swap(videoWidth, videoHeight);
 
   ruby::video.lock();

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -63,7 +63,7 @@ auto Settings::process(bool load) -> void {
   bind(string,  "Video/Shader", video.shader);
   bind(natural, "Video/Multiplier", video.multiplier);
   bind(string,  "Video/Output", video.output);
-  bind(boolean, "Video/AspectCorrection", video.aspectCorrection);
+  bind(string,  "Video/AspectCorrectionMode", video.aspectCorrection);
   bind(boolean, "Video/AdaptiveSizing", video.adaptiveSizing);
   bind(boolean, "Video/AutoCentering", video.autoCentering);
   bind(real,    "Video/Luminance", video.luminance);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -18,7 +18,7 @@ struct Settings : Markup::Node {
     string shader = "None";
     u32 multiplier = 2;
     string output = "Scale";
-    bool aspectCorrection = true;
+    string aspectCorrection = "Standard";
     bool adaptiveSizing = true;
     bool autoCentering = false;
 


### PR DESCRIPTION
Currently, Ares has an "Aspect Correction" checkbox that allows to disable the PAR (pixel aspect ratio) configuration made by each core, to basically display the framebuffer without any additional scaling, with host PC aspect ratio.

In addition to this, it is common for people to request an "anamorphic 16:9" option, to correctly display games the way they would appear on a 16:9 TV when stretched. Sometimes, homebrew games are even designed to be viewed like this.

This PR changes the aspect mode from a boolean to a 3-value option. The standard option is now named "Standard (4:3 TV)", and a new option called "Anamorphic (16:9 TV)" is added.

<img width="382" height="249" alt="Screenshot 2025-07-28 alle 11 09 31" src="https://github.com/user-attachments/assets/2181c70f-e5ba-477d-9d44-ec3b31515c2b" />

