### PR TITLE
n64: improve PI DMA accuracy with stricter timings

### DIFF
--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -68,7 +68,7 @@ auto CPU::synchronize() -> void {
   queue.step(clocks, [](u32 event) {
     switch(event) {
     case Queue::PI_DMA_Read:   return pi.dmaFinished();
-    case Queue::PI_DMA_Write:  return pi.dmaFinished();
+    case Queue::PI_DMA_Write:  return pi.dmaWrite();
     case Queue::PI_BUS_Write:  return pi.writeFinished();
     case Queue::SI_DMA_Read:   return si.dmaRead();
     case Queue::SI_DMA_Write:  return si.dmaWrite();

--- a/ares/n64/pi/dma.cpp
+++ b/ares/n64/pi/dma.cpp
@@ -8,56 +8,124 @@ auto PI::dmaRead() -> void {
   }
 }
 
+auto PI::dmaWriteDuration() -> u32 {
+  BSD bsd;
+  switch (io.pbusAddress.bit(24,31)) {
+    case 0x05:               bsd = bsd2; break; 
+    case range8(0x08, 0x0F): bsd = bsd2; break;
+    default:                 bsd = bsd1; break;
+  }
+
+  int blockLen = (pi.runningDMA.blockLen() + 1) & ~1;
+  int rdramLen = blockLen - pi.runningDMA.misalign;
+  int pageShift = bsd.pageSize + 2;
+  int pageSize = 1 << pageShift;
+
+  int cyclesInitial = 0;
+  if(pi.runningDMA.firstBlock)
+    cyclesInitial = 4 * 3; // Initial setup time
+
+  // PI page selection time
+  int cyclePiSel = 0;
+  int firstPage = (io.pbusAddress >> pageShift);
+  int lastPage = (io.pbusAddress + blockLen - 1) >> pageShift;
+  if (pi.runningDMA.firstBlock || firstPage != lastPage)
+    cyclePiSel = (14 + bsd.latency + 1) * 3;
+
+  // PI transfer time for the block
+  int cyclesPiTx = ((bsd.pulseWidth + 1 + bsd.releaseDuration + 1) * blockLen/2) * 3;
+
+  // RDRAM row opening time
+  int cyclesRdramRow = 0;
+  int cyclesRdramMasking = 0;
+  int cyclesRdramSetup = 0;
+  int cyclesRdramTx = 0;
+
+  // RDRAM masking
+  if(pi.runningDMA.misalign || ((io.dramAddress + blockLen) & 7) != 0)
+    cyclesRdramMasking = 21 * 3;
+
+  if(rdramLen > 0) {
+    // RDRAM row opening
+    if((io.dramAddress & 0x7ff) == 0 && !pi.runningDMA.firstBlock)
+      cyclesRdramRow = 6 * 3; 
+
+    // RDRAM burst setup
+    cyclesRdramSetup = 6 * 3;
+
+    // RDRAM writeback time at 350 MiB/s
+    cyclesRdramTx = (i64)rdramLen * (62500000 * 3) / (350 * 1024 * 1024);
+  }
+
+  return cyclesInitial + cyclePiSel + cyclesPiTx + cyclesRdramRow + cyclesRdramMasking + cyclesRdramSetup + cyclesRdramTx;
+}
+
+
 auto PI::dmaWrite() -> void {
   u8 mem[128];
-  i32 length = io.writeLength+1;
-  i32 maxBlockSize = 128;
-  bool firstBlock = true;
+
+  if(!io.dmaBusy) {
+    io.dmaBusy = 1;
+    pi.runningDMA = {};
+    pi.runningDMA.firstBlock = 1;
+    pi.runningDMA.maxBlockSize = 128;
+    pi.runningDMA.length = io.writeLength+1;
+    pi.runningDMA.misalign = io.dramAddress & 7;
+    pi.runningDMA.distEndOfRow = 0x800-(io.dramAddress&0x7ff);
+    queue.insert(Queue::PI_DMA_Write, dmaWriteDuration());
+    return;
+  }
+
+  i32 curLen = pi.runningDMA.blockLen();
+
+  for (int i=0; i<curLen; i+=2) {
+    u16 data = busRead<Half>(io.pbusAddress);
+    mem[i+0] = data >> 8;
+    mem[i+1] = data >> 0;
+    io.pbusAddress += 2;
+    pi.runningDMA.length -= 2;
+  }
 
   if constexpr(Accuracy::CPU::Recompiler) {
-    cpu.recompiler.invalidateRange(io.dramAddress, (length + 1) & ~1);
+    cpu.recompiler.invalidateRange(io.dramAddress, curLen);
+  }
+  
+  if (pi.runningDMA.firstBlock && curLen < 127-pi.runningDMA.misalign) {
+    for (i32 i = 0; i < curLen-pi.runningDMA.misalign; i++) {
+      rdram.ram.write<Byte>(io.dramAddress++, mem[i], "PI DMA");
+    }
+  } else {
+    for (i32 i = 0; i < curLen-pi.runningDMA.misalign; i+=2) {
+      rdram.ram.write<Byte>(io.dramAddress++, mem[i+0], "PI DMA");
+      rdram.ram.write<Byte>(io.dramAddress++, mem[i+1], "PI DMA");
+    }
   }
 
-  while (length > 0) {
-    i32 misalign = io.dramAddress & 7;
-    i32 distEndOfRow = 0x800-(io.dramAddress&0x7ff);
-    i32 blockLen = min(maxBlockSize-misalign, distEndOfRow);
-    i32 curLen = min(length, blockLen);
+  io.dramAddress = (io.dramAddress + 7) & ~7;
+  io.writeLength = curLen <= 8 ? 127-pi.runningDMA.misalign : 127;
 
-    for (int i=0; i<curLen; i+=2) {
-      u16 data = busRead<Half>(io.pbusAddress);
-      mem[i+0] = data >> 8;
-      mem[i+1] = data >> 0;
-      io.pbusAddress += 2;
-      length -= 2;
-    }
-
-    if (firstBlock && curLen < 127-misalign) {
-      for (i32 i = 0; i < curLen-misalign; i++) {
-        rdram.ram.write<Byte>(io.dramAddress++, mem[i], "PI DMA");
-      }
-    } else {
-      for (i32 i = 0; i < curLen-misalign; i+=2) {
-        rdram.ram.write<Byte>(io.dramAddress++, mem[i+0], "PI DMA");
-        rdram.ram.write<Byte>(io.dramAddress++, mem[i+1], "PI DMA");
-      }
-    }
-
-    io.dramAddress = (io.dramAddress + 7) & ~7;
-    io.writeLength = curLen <= 8 ? 127-misalign : 127;
-    firstBlock = false;
-    maxBlockSize = distEndOfRow < 8 ? 128-misalign : 128;
+  if (pi.runningDMA.length <= 0) {
+    dmaFinished();
+    return;
   }
+
+  pi.runningDMA.firstBlock = 0;
+  pi.runningDMA.maxBlockSize = pi.runningDMA.distEndOfRow < 8 ? 128-pi.runningDMA.misalign : 128;
+  pi.runningDMA.misalign = io.dramAddress & 7;
+  pi.runningDMA.distEndOfRow = 0x800-(io.dramAddress&0x7ff);
+  queue.insert(Queue::PI_DMA_Write, dmaWriteDuration());
 }
 
 auto PI::dmaFinished() -> void {
+  pi.runningDMA = {};
   io.dmaBusy = 0;
   io.interrupt = 1;
   mi.raise(MI::IRQ::PI);
 }
 
-auto PI::dmaDuration(bool read) -> u32 {
-  auto len = read ? io.readLength : io.writeLength;
+auto PI::dmaReadDuration() -> u32 {
+  // FIXME: old algorithm, we keep it for one-shot DMA reads for now
+  auto len = io.readLength;
   len = (len | 1) + 1;
 
   BSD bsd;

--- a/ares/n64/pi/io.cpp
+++ b/ares/n64/pi/io.cpp
@@ -107,16 +107,14 @@ auto PI::ioWrite(u32 address, u32 data_) -> void {
     io.readLength = n24(data);
     io.dmaBusy = 1;
     io.originPc = cpu.ipu.pc;
-    queue.insert(Queue::PI_DMA_Read, dmaDuration(true));
+    queue.insert(Queue::PI_DMA_Read, dmaReadDuration());
     dmaRead();
   }
 
   if(address == 3) {
     //PI_WRITE_LENGTH
     io.writeLength = n24(data);
-    io.dmaBusy = 1;
     io.originPc = cpu.ipu.pc;
-    queue.insert(Queue::PI_DMA_Write, dmaDuration(false));
     dmaWrite();
   }
 

--- a/ares/n64/pi/pi.cpp
+++ b/ares/n64/pi/pi.cpp
@@ -23,6 +23,7 @@ auto PI::power(bool reset) -> void {
   io = {};
   bsd1 = {};
   bsd2 = {};
+  runningDMA = {};
 }
 
 }

--- a/ares/n64/pi/pi.hpp
+++ b/ares/n64/pi/pi.hpp
@@ -22,7 +22,8 @@ struct PI : Memory::RCP<PI> {
   auto dmaRead() -> void;
   auto dmaWrite() -> void;
   auto dmaFinished() -> void;
-  auto dmaDuration(bool read) -> u32;
+  auto dmaReadDuration() -> u32;
+  auto dmaWriteDuration() -> u32;
 
   //io.cpp
   auto ioRead(u32 address) -> u32;
@@ -53,6 +54,18 @@ struct PI : Memory::RCP<PI> {
     n32 busLatch;
     u64 originPc;
   } io;
+
+  struct RunningDMA {
+    n1 firstBlock;
+    i32 maxBlockSize;
+    i32 length;
+    i32 misalign;
+    i32 distEndOfRow;    
+
+    auto blockLen() -> i32 {
+      return min(length, min(maxBlockSize-misalign, distEndOfRow));
+    }    
+  } runningDMA;
 
   struct BSD {
     n8 latency;

--- a/ares/n64/pi/serialization.cpp
+++ b/ares/n64/pi/serialization.cpp
@@ -19,4 +19,10 @@ auto PI::serialize(serializer& s) -> void {
   s(bsd2.pulseWidth);
   s(bsd2.pageSize);
   s(bsd2.releaseDuration);
+
+  s(runningDMA.firstBlock);
+  s(runningDMA.maxBlockSize);
+  s(runningDMA.length);
+  s(runningDMA.misalign);
+  s(runningDMA.distEndOfRow);
 }

--- a/ares/n64/system/serialization.cpp
+++ b/ares/n64/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v144";
+static const string SerializerVersion = "v144.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   serializer s;

--- a/nall/nall/priority-queue.hpp
+++ b/nall/nall/priority-queue.hpp
@@ -26,10 +26,12 @@ struct priority_queue<T[Size]> {
 
   template<typename F>
   auto step(u32 clocks, const F& callback) -> void {
-    clock += clocks;
-    while(size && ge(clock, heap[0].clock)) {
+    u32 baseClock = clock;
+    while(size && ge(baseClock+clocks, heap[0].clock)) {
+      clock = heap[0].clock;
       if(auto event = remove()) callback(*event);
     }
+    clock = baseClock + clocks;
   }
 
   auto insert(const T& event, u32 clock) -> bool {


### PR DESCRIPTION
This commit splits the PI DMA-Write transfers (that is, loads from ROM)
in multiple blocks, following what happens on real hardware. Moreover,
it tries to more accurately reflect timing that each block takes. This
is easier to be done at the block granularity, otherwise the timing
algorithm would need to figure it out again the whole block splitting
logic.

From the point of view of the running application, now a ROM con see
the two hardware registers PI_CART_ADDR and PI_RDRAM_ADDR increment
one block at a time during the transfer, which more accurately reflect
what happens on real hardware.

This commit is validated with n64_pi_dma_test test ROM
(https://github.com/rasky/n64_pi_dma_test) which we now pass in full,
including timing tests with the default 10% tolerance.

<img width="752" height="644" alt="Screenshot 2025-08-07 alle 14 58 42" src="https://github.com/user-attachments/assets/7e271a84-fac1-414e-a0c3-2d883cd1fbed" />

