### PR TITLE
n64: support configuration of different paks via homebrew header

### DIFF
--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -140,7 +140,7 @@ auto Nintendo64::load() -> LoadResult {
       port->connect();
       bool transferPakConnected = false;
       if(auto port = peripheral->find<ares::Node::Port>("Pak")) {
-        if(id == 0 && game->pak->attribute("tpak").boolean()) {
+        if(game->pak->attribute({"port", id+1, "/tpak"}).boolean()) {
           #if defined(CORE_GB)
           auto transferPak = port->allocate("Transfer Pak");
           port->connect();
@@ -161,7 +161,7 @@ auto Nintendo64::load() -> LoadResult {
         }
 
         if(!transferPakConnected) {
-          if(id == 0 && game->pak->attribute("cpak").boolean()) {
+          if(game->pak->attribute({"port", id+1, "/cpak"}).boolean()) {
             gamepad = mia::Pak::create("Nintendo 64");
 
             //create maximum sized controller pak, file is resized later
@@ -169,7 +169,7 @@ auto Nintendo64::load() -> LoadResult {
             gamepad->load("save.pak", ".pak", game->location);
             port->allocate("Controller Pak");
             port->connect();
-          } else if(game->pak->attribute("rpak").boolean()) {
+          } else if(game->pak->attribute({"port", id+1, "/rpak"}).boolean()) {
             port->allocate("Rumble Pak");
             port->connect();
           }

--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -103,7 +103,11 @@ auto Nintendo64::load(string location) -> LoadResult {
   pak->setAttribute("id",     document["game/id"].string());
   pak->setAttribute("title",  document["game/title"].string());
   pak->setAttribute("region", document["game/region"].string());
-  pak->setAttribute("cpak",   (bool)document["game/controllerpak"]);
+  for (int i=0; i<4; i++) {
+    pak->setAttribute(string{"port", i + 1, "/cpak"}, (bool)document[{"game/controllers/port", i+1, "/cpak"}]);
+    pak->setAttribute(string{"port", i + 1, "/rpak"}, (bool)document[{"game/controllers/port", i+1, "/rpak"}]);
+    pak->setAttribute(string{"port", i + 1, "/tpak"}, (bool)document[{"game/controllers/port", i+1, "/tpak"}]);
+  }
   pak->setAttribute("rpak",   (bool)document["game/rumblepak"]);
   pak->setAttribute("tpak",   (bool)document["game/transferpak"]);
   pak->setAttribute("cic",    document["game/board/cic"].string());
@@ -276,9 +280,9 @@ auto Nintendo64::analyze(vector<u8>& data) -> string {
   u32 flash   = 0;      //128_KiB
 
   //supported peripherals
-  bool cpak = false;                 //Controller Pak
-  bool rpak = false;                 //Rumble Pak
-  bool tpak = false;                 //Transfer Pak
+  bool cpak = false;                 //Controller Pak (port 1)
+  bool rpak = false;                 //Rumble Pak (port 1)
+  bool tpak = false;                 //Transfer Pak (port 1)
   bool rtc  = false;                 //RTC
   bool dd   = id.beginsWith("C");    //64DD
 
@@ -739,6 +743,19 @@ auto Nintendo64::analyze(vector<u8>& data) -> string {
     else {cpak = true;}
   }
 
+  // Paks for the 4 ports
+  bool cpaks[4] = {false, false, false, false};
+  bool rpaks[4] = {false, false, false, false};
+  bool tpaks[4] = {false, false, false, false};
+  if(cpak && rpak) {
+    cpaks[0] = true; //default controller with Rumble Pak
+    rpaks[1] = true;
+  } else if(cpak) {
+    cpaks[0] = true; //default controller with Controller Pak
+  } else if(rpak) {
+    rpaks[0] = true; //default controller with Rumble Pak
+  }
+
   //Homebrew (libdragon / Everdrive special header flag)
   if(id(1) == 'E' && id(2) == 'D') {
     n8 config = data[0x3f];
@@ -749,29 +766,27 @@ auto Nintendo64::analyze(vector<u8>& data) -> string {
     if(config.bit(4,7) == 5) {flash = 128_KiB;}
     if(config.bit(4,7) == 6) {sram = 128_KiB;}
     if(config.bit(0) == 1)   {rtc = true;}
-    
+
     //Advanced Homebrew ROM Header
     //Controllers
     n8 controller_1 = data[0x34];
     n8 controller_2 = data[0x35];
     n8 controller_3 = data[0x36];
     n8 controller_4 = data[0x37];
-    
-    auto read_controller_config = [&](n8 controller_config) 
+
+    auto read_controller_config = [&](int idx, n8 controller_config) 
     { 
         switch(controller_config) {
             case 0x00: //default
-                rpak = true;
-                cpak = true; //TODO rumble does not work for homebrew because of that
                 break;
             case 0x01: //N64 controller with Rumble Pak
-                rpak = true;
+                rpaks[idx] = true;
                 break;
             case 0x02: //N64 controller with Controller Pak
-                cpak = true;
+                cpaks[idx] = true;
                 break;
             case 0x03: //N64 controller with Transfer Pak
-                tpak = true;
+                tpaks[idx] = true;
                 break;
             case 0x80: //N64 mouse
                 //not supported yet
@@ -794,11 +809,16 @@ auto Nintendo64::analyze(vector<u8>& data) -> string {
         }
     };
     
-    read_controller_config(controller_1);
-    //TODO ares does not differentiate for different controller setups yet in Nintendo64::load()
-    //read_controller_config(controller_2);
-    //read_controller_config(controller_3);
-    //read_controller_config(controller_4);
+    read_controller_config(0, controller_1);
+    read_controller_config(1, controller_2);
+    read_controller_config(2, controller_3);
+    read_controller_config(3, controller_4);
+
+    if (controller_1 == 0x00 && controller_2 == 0x00 && controller_3 == 0x00 && controller_4 == 0x00) {
+      // No controllers configured, set default used for years as backward compatibility
+      cpaks[0] = true;
+      rpaks[1] = true;
+    }
   }
 
   string s;
@@ -808,16 +828,17 @@ auto Nintendo64::analyze(vector<u8>& data) -> string {
   s +={"  sha256:   ", sha256, "\n"};
   s +={"  region:   ", region, "\n"};
   s +={"  id:       ", id, region_code, "\n"};
-  if(cpak)
-  s += "  controllerpak\n";
-  if(rpak)
-  s += "  rumblepak\n";
-  if(tpak)
-  s += "  transferpak\n";
   if(dd)
   s += "  dd\n";
   if(revision < 4) {
   s +={"  revision: 1.", revision, "\n"};
+  }
+  s += "  controllers\n";
+  for (int i=0; i<4; i++) {
+    s += {"    port", i+1, "\n"};
+    if(cpaks[i]) s += "      cpak\n";
+    if(rpaks[i]) s += "      rpak\n";
+    if(tpaks[i]) s += "      tpak\n";
   }
   s += "  board\n";
   s +={"    cic: ", cic, "\n"};


### PR DESCRIPTION
The homebrew header supports configuring a different controller and pak for each port, but mia couldn't represent that in the manifest. The required change is trivial though.

For backward compatibility, if the homebrew header doesn't declare anything (which is the same as asking for a standard controller in all four ports with no paks), we install a cpak in port 1 and a rpak in port 2, which is also what we have been doing forever with commercial games.