### PR TITLE
desktop-ui: Fix hotkey behavior when unfocused

### DIFF
--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -162,7 +162,7 @@ auto InputManager::createHotkeys() -> void {
 auto InputManager::pollHotkeys() -> void {
   if(Application::modal()) return;
 
-  if(settings.input.defocus == "Allow") {
+  if(settings.input.defocus != "Allow") {
     if (!presentation.focused() && !ruby::video.fullScreen()) return;
   }
 


### PR DESCRIPTION
Fix a logic error introduced with the threading rework that would lead to hotkeys being registered while the application was unfocused, against the user's preference.

Fixes #2144