### PR TITLE
ld: Fix memory issues with MegaLD games after merge. Some additional cleanup.

### DIFF
--- a/ares/md/mcd/mcd.hpp
+++ b/ares/md/mcd/mcd.hpp
@@ -437,6 +437,7 @@ struct MCD : M68000, Thread {
       n1 currentVideoFrameLeadOut;
       n1 currentVideoFrameFieldSelectionEnabled;
       n1 currentVideoFrameFieldSelectionEvenField;
+      n1 currentVideoFrameOnEvenField;
       qon_desc videoFileHeader;
       qoi2_desc videoFrameHeader;
       int drawIndex;

--- a/ares/md/mcd/serialization.cpp
+++ b/ares/md/mcd/serialization.cpp
@@ -199,6 +199,7 @@ auto MCD::LD::serialize(serializer& s) -> void {
   s(video.currentVideoFrameLeadOut);
   s(video.currentVideoFrameFieldSelectionEnabled);
   s(video.currentVideoFrameFieldSelectionEvenField);
+  s(video.currentVideoFrameOnEvenField);
 
   // Restore the current video frame into the display buffer
   if (MegaLD() && s.reading()) {

--- a/mia/medium/mega-ld.cpp
+++ b/mia/medium/mega-ld.cpp
@@ -63,7 +63,7 @@ auto MegaLD::analyze(string digitalTrack) -> string {
   }
   if(!regions) regions.append("NTSC-J","NTSC-U"); // unknown boot
 
-  string serialNumber = slice((const char*)(sector.data() + 0x180), 0, 14).trimRight(" ");
+  string serialNumber = slice((const char*)(sector.data() + 0x180), 0, 16).trimRight(" ");
 
   vector<string> devices;
   string device = slice((const char*)(sector.data() + 0x190), 0, 16).trimRight(" ");

--- a/nall/nall/decode/cue.hpp
+++ b/nall/nall/decode/cue.hpp
@@ -59,7 +59,12 @@ inline auto CUE::load(const string& location, const Decode::ZIP* archive, const 
       archiveFolder = compressedFile->name.slice(0, fileNameSeparatorPos.get() + 1);
     }
     auto rawDataBuffer = archive->extract(*compressedFile);
-    lines = string(string_view((const char*)rawDataBuffer.data(), rawDataBuffer.size())).replace("\r", "").split("\n");
+    // Currently (2025-08-14) there is no way to construct a nall::string from a fixed-length buffer using
+    // nall::string_view, as the variadic constructor overrides "string_view(const char* data, u32 size)",
+    // meaning we can't create a string_view from a fixed-length input. We use an array_view here as a
+    // workaround.
+    auto rawDataBufferAsArrayView = rawDataBuffer.view(0, rawDataBuffer.size());
+    lines = string(rawDataBufferAsArrayView).replace("\r", "").split("\n");
   } else {
     lines = string::read(location).replace("\r", "").split("\n");
   }

--- a/nall/nall/decode/mmi.hpp
+++ b/nall/nall/decode/mmi.hpp
@@ -75,10 +75,12 @@ struct MMI {
       return false;
     }
 
-    auto jsonString = string((const char*)jsonBuffer.data(), jsonBuffer.size());
-    //FIXME: Why is jsonString larger than the input data size when creating from the buffer?
-    //HACK: prevent JSON::unserialize from failing due to tailing data
-    if(jsonString.length() > jsonBuffer.size()) jsonString = jsonString.slice(0, jsonBuffer.size());
+    // Currently (2025-08-14) there is no way to construct a nall::string from a fixed-length buffer using
+    // nall::string_view, as the variadic constructor overrides "string_view(const char* data, u32 size)",
+    // meaning we can't create a string_view from a fixed-length input. We use an array_view here as a
+    // workaround.
+    auto jsonBufferAsArrayView = jsonBuffer.view(0, jsonBuffer.size());
+    auto jsonString = string(jsonBufferAsArrayView);
 
     _mediaInfo = JSON::unserialize(jsonString);
     if(!_mediaInfo) {

--- a/nall/nall/vector/specialization/u8.hpp
+++ b/nall/nall/vector/specialization/u8.hpp
@@ -29,7 +29,7 @@ template<> struct vector<u8> : vector_base<u8> {
   auto view(u32 offset, u32 length) -> array_view<u8> {
     #ifdef DEBUG
     struct out_of_bounds {};
-    if(offset + length >= size()) throw out_of_bounds{};
+    if(offset + length > size()) throw out_of_bounds{};
     #endif
     return {data() + offset, length};
   }

--- a/nall/nall/vfs/cdrom.hpp
+++ b/nall/nall/vfs/cdrom.hpp
@@ -157,8 +157,12 @@ private:
 
     //preload subchannel data
     if (compressedFile != nullptr) {
-      auto subFile = archive->findFile("Disc1Side1/DigitalAudio.sub");
-      loadSub(cueLocation, archive, &subFile.get(), session);
+      auto subFile = archive->findFile({ Location::notsuffix(compressedFile->name), ".sub" });
+      if (subFile) {
+        loadSub(cueLocation, archive, &subFile.get(), session);
+      } else {
+        loadSub(cueLocation, archive, nullptr, session);
+      }
     } else {
       loadSub({ Location::notsuffix(cueLocation), ".sub" }, archive, compressedFile, session);
     }


### PR DESCRIPTION
Fixed issues encountered with fixed string conversion post-merge, which was causing runtime failures. Discussion in dev-general discord channel. Also cleaned up some unwanted debug outputs left on, an issue affecting savestates, and some minor cleanup.