### PR TITLE
nall: clean up string conversions in cue/mmi decode

### DIFF
--- a/nall/nall/decode/cue.hpp
+++ b/nall/nall/decode/cue.hpp
@@ -59,12 +59,8 @@ inline auto CUE::load(const string& location, const Decode::ZIP* archive, const 
       archiveFolder = compressedFile->name.slice(0, fileNameSeparatorPos.get() + 1);
     }
     auto rawDataBuffer = archive->extract(*compressedFile);
-    // Currently (2025-08-14) there is no way to construct a nall::string from a fixed-length buffer using
-    // nall::string_view, as the variadic constructor overrides "string_view(const char* data, u32 size)",
-    // meaning we can't create a string_view from a fixed-length input. We use an array_view here as a
-    // workaround.
-    auto rawDataBufferAsArrayView = rawDataBuffer.view(0, rawDataBuffer.size());
-    lines = string(rawDataBufferAsArrayView).replace("\r", "").split("\n");
+    auto rawDataBufferView = string_view((const char*)rawDataBuffer.data(), rawDataBuffer.size());
+    lines = string(rawDataBufferView).replace("\r", "").split("\n");
   } else {
     lines = string::read(location).replace("\r", "").split("\n");
   }

--- a/nall/nall/decode/mmi.hpp
+++ b/nall/nall/decode/mmi.hpp
@@ -75,14 +75,8 @@ struct MMI {
       return false;
     }
 
-    // Currently (2025-08-14) there is no way to construct a nall::string from a fixed-length buffer using
-    // nall::string_view, as the variadic constructor overrides "string_view(const char* data, u32 size)",
-    // meaning we can't create a string_view from a fixed-length input. We use an array_view here as a
-    // workaround.
-    auto jsonBufferAsArrayView = jsonBuffer.view(0, jsonBuffer.size());
-    auto jsonString = string(jsonBufferAsArrayView);
-
-    _mediaInfo = JSON::unserialize(jsonString);
+    auto jsonBufferView = string_view((const char*)jsonBuffer.data(), jsonBuffer.size());
+    _mediaInfo = JSON::unserialize(jsonBufferView);
     if(!_mediaInfo) {
       close();
       return false;


### PR DESCRIPTION
Now that the usage issues with string_view have been resolved it can be safely used to wrap a vector<u8>. I'll note that passing a vector<u8> directly to the string constructor would work as well (thanks to a stringify overload) but I'm preserving the wishes of the author of the MegaLD code to keep the type conversions explicit.

I'll also note that we're still constructing a string from the string_view when we call JSON::unserialize(). Ideally, it would take a string_view instead of a const string& and we could avoid the copy. Unfortunately, all of the markup decoders currently require the input to be null-terminated, which is only guaranteed by the string class.