### PR TITLE
ld: Fixed a double buffering issue which caused single-frame errors

### DIFF
--- a/ares/md/mcd/mcd.hpp
+++ b/ares/md/mcd/mcd.hpp
@@ -437,8 +437,8 @@ struct MCD : M68000, Thread {
       s32 currentVideoFrameIndex;
       n1 currentVideoFrameLeadIn;
       n1 currentVideoFrameLeadOut;
-      n1 currentVideoFrameFieldSelectionEnabled;
-      n1 currentVideoFrameFieldSelectionEvenField;
+      n1 currentVideoFrameFieldSelectionEnabled[2];
+      n1 currentVideoFrameFieldSelectionEvenField[2];
       n1 currentVideoFrameOnEvenField;
       qon_desc videoFileHeader;
       qoi2_desc videoFrameHeader;


### PR DESCRIPTION
Saw a few single-frame transient glitches with Myst which were caused by an error in the recent video double buffering I added. This changes savestates, so I wanted to get it addressed before the new release drops.