### PR TITLE
screen: consistently refresh palette after `reset()`

### DIFF
--- a/ares/ares/node/video/screen.cpp
+++ b/ares/ares/node/video/screen.cpp
@@ -63,6 +63,7 @@ auto Screen::pixels(bool frame) -> array_span<u32> {
 auto Screen::resetPalette() -> void {
   lock_guard<recursive_mutex> lock(_mutex);
   _palette.reset();
+  refreshPalette();
 }
 
 auto Screen::resetSprites() -> void {
@@ -119,18 +120,21 @@ auto Screen::setSaturation(f64 saturation) -> void {
   lock_guard<recursive_mutex> lock(_mutex);
   _saturation = saturation;
   _palette.reset();
+  refreshPalette();
 }
 
 auto Screen::setGamma(f64 gamma) -> void {
   lock_guard<recursive_mutex> lock(_mutex);
   _gamma = gamma;
   _palette.reset();
+  refreshPalette();
 }
 
 auto Screen::setLuminance(f64 luminance) -> void {
   lock_guard<recursive_mutex> lock(_mutex);
   _luminance = luminance;
   _palette.reset();
+  refreshPalette();
 }
 
 auto Screen::setFillColor(u32 fillColor) -> void {
@@ -189,6 +193,7 @@ auto Screen::colors(u32 colors, function<n64 (n32)> color) -> void {
   _colors = colors;
   _color = color;
   _palette.reset();
+  refreshPalette();
 }
 
 auto Screen::frame() -> void {


### PR DESCRIPTION
Palette update operations would `reset()` the palette, but not recreate it until the next frame (at `refresh()`). If a system were to try to access the palette before the next `frame()` call, this would crash.

This PR modifies all such palette update operations to refresh the palette immediately afterward, to prevent the palette from being null when a system might access it.