### PR TITLE
Update controller pak menus for the N64

### DIFF
--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -308,10 +308,9 @@ auto Nintendo64::portMenu(Menu& portMenu, ares::Node::Port port) -> void {
     pakGroup.append(tpak);
 
     // set currently enabled pak
-    // Note: based on initialization routine in desktop-ui/emulator/nintendo-64.cpp & nintedo-64dd.cpp
-    if(emulator->game->pak->attribute("tpak").boolean() && portNum == "1") tpak.setChecked();
-    else if(emulator->game->pak->attribute("cpak").boolean() && portNum == "1") cpak.setChecked();
-    else if(emulator->game->pak->attribute("rpak").boolean()) rpak.setChecked();
+    if(emulator->game->pak->attribute({"port", portNum, "/tpak"}).boolean()) tpak.setChecked();
+    else if(emulator->game->pak->attribute({"port", portNum, "/cpak"}).boolean()) cpak.setChecked();
+    else if(emulator->game->pak->attribute({"port", portNum, "/rpak"}).boolean()) rpak.setChecked();
     else nothing.setChecked();
   }
 }

--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -747,7 +747,9 @@ auto Nintendo64::analyze(vector<u8>& data) -> string {
   bool cpaks[4] = {false, false, false, false};
   bool rpaks[4] = {false, false, false, false};
   bool tpaks[4] = {false, false, false, false};
-  if(cpak && rpak) {
+  if (tpak) {
+    tpaks[0] = true; //default controller with Transfer Pak
+  } else if(cpak && rpak) {
     cpaks[0] = true; //default controller with Rumble Pak
     rpaks[1] = true;
   } else if(cpak) {


### PR DESCRIPTION
The update to allow paks for homebrew headers was missing a few updates so that the manifest and menu properly represented transfer paks. This corrects this issue so that tpaks display in the manifest and the menu is properly set based off of these attributes.