### PR TITLE
hiro/cocoa: Don't autoenable menu items

### DIFF
--- a/hiro/cocoa/action/menu.cpp
+++ b/hiro/cocoa/action/menu.cpp
@@ -8,6 +8,7 @@
 
     cocoaMenu = [[NSMenu alloc] initWithTitle:@""];
     [self setSubmenu:cocoaMenu];
+    [cocoaMenu setAutoenablesItems:NO];
   }
   return self;
 }


### PR DESCRIPTION
Allows menu items on macOS to be disabled.