### PR TITLE
mos6502, fc: fix memory transactions in 6502 JSR instruction, and implement open bus bit of Famicom APU status register

### DIFF
--- a/ares/component/processor/mos6502/addresses.cpp
+++ b/ares/component/processor/mos6502/addresses.cpp
@@ -6,8 +6,8 @@ auto MOS6502::addressAbsolute() -> n16 {
 
 auto MOS6502::addressAbsoluteJMP() -> n16 {
   n16 absolute = operand();
-  // JMP Indirect last_cycle
-  L absolute |= operand() << 8;
+  // JMP Indirect last cycle
+L absolute |= operand() << 8;
   return absolute;
 }
 
@@ -39,10 +39,6 @@ auto MOS6502::addressAbsoluteYWrite() -> n16 {
   return absolute + Y;
 }
 
-auto MOS6502::addressAccumulator() -> n16 {
-  return PC;
-}
-
 auto MOS6502::addressImmediate() -> n16 {
   return PC++;
 }
@@ -56,8 +52,8 @@ auto MOS6502::addressIndirect() -> n16 {
   absolute |= operand() << 8;
   n16 indirect = read(absolute);
   absolute.byte(0)++;
-  // JMP Indirect last_cycle
-  L indirect |= read(absolute) << 8;
+  // JMP Indirect last cycle
+L indirect |= read(absolute) << 8;
   return indirect;
 }
 

--- a/ares/component/processor/mos6502/algorithms.cpp
+++ b/ares/component/processor/mos6502/algorithms.cpp
@@ -257,8 +257,8 @@ auto MOS6502::algorithmORA() -> void {
 }
 
 auto MOS6502::algorithmPHA() -> void {
-    read(MAR); // dummy implied read
-    L push(A);
+  read(MAR); // dummy implied read
+L push(A);
 }
 
 auto MOS6502::algorithmPHP() -> void {

--- a/ares/component/processor/mos6502/algorithms.cpp
+++ b/ares/component/processor/mos6502/algorithms.cpp
@@ -210,10 +210,12 @@ auto MOS6502::algorithmJMP() -> void {
 }
 
 auto MOS6502::algorithmJSR() -> void {
-  PC--;
+  n16 target = operand();
+  MDR = read(0x0100 | S); // dummy stack read
   push(PCH);
-L push(PCL);
-  PC = MAR;
+  push(PCL);
+L target |= operand() << 8;
+  PC = target;
 }
 
 auto MOS6502::algorithmLDA() -> void {

--- a/ares/component/processor/mos6502/instruction.cpp
+++ b/ares/component/processor/mos6502/instruction.cpp
@@ -64,7 +64,7 @@ auto MOS6502::instruction() -> void {
   op(0x1d, Load,   addr(AbsoluteXRead),  fp(ORA))
   op(0x1e, Modify, addr(AbsoluteXWrite), fp(ASLM))
   op(0x1f, Modify, addr(AbsoluteXWrite), fp(SLO))
-  op(0x20, Load,   addr(Absolute),       fp(JSR))
+  op(0x20, None,   addr(Implied),        fp(JSR))
   op(0x21, Load,   addr(IndirectX),      fp(AND))
   op(0x22, None,   addr(Implied),        fp(JAM))
   op(0x23, Modify, addr(IndirectX),      fp(RLA))

--- a/ares/component/processor/mos6502/instruction.cpp
+++ b/ares/component/processor/mos6502/instruction.cpp
@@ -24,7 +24,7 @@ auto MOS6502::reset() -> void {
   read(0x0100 | S--); // Dummy push (P)
   I = 1;
   PCL = read(vector++);
-  L PCH = read(vector++);
+L PCH = read(vector++);
   resetting = 0;
 }
 
@@ -42,7 +42,7 @@ auto MOS6502::instruction() -> void {
   op(0x07, Modify, addr(ZeroPage),       fp(SLO))
   op(0x08, None,   addr(Implied),        fp(PHP))
   op(0x09, Load,   addr(Immediate),      fp(ORA))
-  op(0x0a, Load,   addr(Accumulator),    fp(ASLA))
+  op(0x0a, Load,   addr(Implied),        fp(ASLA))
   op(0x0b, Load,   addr(Immediate),      fp(AAC))
   op(0x0c, Load,   addr(Absolute),       fp(NOP))
   op(0x0d, Load,   addr(Absolute),       fp(ORA))

--- a/ares/component/processor/mos6502/mos6502.hpp
+++ b/ares/component/processor/mos6502/mos6502.hpp
@@ -40,7 +40,6 @@ struct MOS6502 {
   auto addressAbsoluteXWrite() -> n16;
   auto addressAbsoluteYRead() -> n16;
   auto addressAbsoluteYWrite() -> n16;
-  auto addressAccumulator() -> n16;
   auto addressImmediate() -> n16;
   auto addressImplied() -> n16;
   auto addressIndirect() -> n16;

--- a/ares/fc/apu/apu.cpp
+++ b/ares/fc/apu/apu.cpp
@@ -100,7 +100,7 @@ auto APU::readIO(n16 address) -> n8 {
     data.bit(2) = (bool)triangle.length.counter;
     data.bit(3) = (bool)noise.length.counter;
     data.bit(4) = (bool)dmc.lengthCounter;
-    data.bit(5) = 0;
+    //bit 5 is open bus
     data.bit(6) = frame.irqPending;
     data.bit(7) = dmc.irqPending;
     frame.irqPending = false;


### PR DESCRIPTION
Fixes 5 test cases in the [AccuracyCoin.nes](https://github.com/100thCoin/AccuracyCoin/blob/main/AccuracyCoin.nes) test ROM.