### PR TITLE
build: Miscellaneous fixes and linking improvements

### DIFF
--- a/.gersemirc
+++ b/.gersemirc
@@ -1,11 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/BlankSpruce/gersemi/master/gersemi/configuration.schema.json
 
-color: false
 definitions: [ares/CMakeLists.txt]
 line_length: 120
 indent: 2
 list_expansion: favour-inlining
-quiet: false
 unsafe: false
 warn_about_unknown_commands: false
-workers: 10

--- a/.github/CMakeLists.txt
+++ b/.github/CMakeLists.txt
@@ -1,0 +1,31 @@
+# dummy GitHub target used to enable editing of GitHub files within generated IDE projects
+
+add_library(.github INTERFACE)
+
+set(.github_sources
+    ISSUE_TEMPLATE/bug_report.md
+    ISSUE_TEMPLATE/feature_request.md
+    ISSUE_TEMPLATE/game-issue-report.md
+    scripts/build_macos.sh
+    scripts/build_ubuntu.sh
+    scripts/build_windows.sh
+    scripts/package_artifacts.sh
+    workflows/build-aux.yml
+    workflows/build.yml
+    workflows/pr.yml
+    workflows/push.yml
+    workflows/release.yml
+)
+
+target_sources(
+  .github
+  PRIVATE
+  ${.github_sources}
+  ../.gitignore
+  ../.gitattributes
+  ../README.md
+  ../LICENSE
+)
+
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${.github_sources})
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ add_subdirectory(hiro)
 set(
   ARES_CORES
   a26 fc sfc sg ms md ps1 pce ng msx cv myvision gb gba ws ngp spec n64
-  CACHE STRING LIST
+  CACHE STRING "List of systems to be built by the project"
 )
 # gersemi: on
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,6 @@ include(compilerconfig)
 include(defaults)
 include(helpers)
 
-add_subdirectory(.github)
-add_subdirectory(cmake)
-
 add_subdirectory(thirdparty)
 
 add_subdirectory(nall/nall)
@@ -53,4 +50,7 @@ endif()
 add_subdirectory(tools/sourcery)
 
 message_configuration()
+
+add_subdirectory(.github)
+add_subdirectory(cmake)
 return()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.28...4.0)
+cmake_minimum_required(VERSION 3.28...4.1)
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/common/bootstrap.cmake" NO_POLICY_SCOPE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ include(compilerconfig)
 include(defaults)
 include(helpers)
 
+add_subdirectory(.github)
 add_subdirectory(cmake)
 
 add_subdirectory(thirdparty)

--- a/ares/CMakeLists.txt
+++ b/ares/CMakeLists.txt
@@ -21,7 +21,7 @@ if(ARES_PRECOMPILE_HEADERS)
   target_precompile_headers(ares PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:ares/ares.hpp>")
 endif()
 
-target_link_libraries(ares PUBLIC libco sljit nall)
+target_link_libraries(ares PRIVATE libco ares::nall::headers $<$<BOOL:${ARES_ENABLE_CHD}>:chdr-static> PUBLIC sljit)
 
 if(ARES_PROFILE_ACCURACY)
   target_compile_definitions(ares PUBLIC PROFILE_ACCURACY)

--- a/ares/component/CMakeLists.txt
+++ b/ares/component/CMakeLists.txt
@@ -1,6 +1,6 @@
 list(REMOVE_DUPLICATES ares.components)
 
-set(ARES_COMPONENTS_LIST "${ares.components}" CACHE LIST "Enabled shared hardware components" FORCE)
+set(ARES_COMPONENTS_LIST "${ares.components}" CACHE STRING "Enabled shared hardware components" FORCE)
 
 mark_as_advanced(ARES_COMPONENTS_LIST)
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -2,9 +2,7 @@
 
 add_library(cmake INTERFACE)
 
-target_sources(
-  cmake
-  PRIVATE
+set(cmake_sources
     common/bootstrap.cmake
     common/dependencies_common.cmake
     common/ccache.cmake
@@ -30,12 +28,20 @@ target_sources(
     windows/compilerconfig.cmake
     windows/defaults.cmake
     windows/dependencies.cmake
-    windows/helpers.cmake
+    windows/helpers.cmake 
     linux/compilerconfig.cmake
     linux/defaults.cmake
     linux/helpers.cmake
     linux/dependencies.cmake
 )
 
-get_target_property(cmake_SOURCES cmake SOURCES)
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${cmake_SOURCES})
+target_sources(
+  cmake
+  PRIVATE
+    ${cmake_sources}
+    ../CMakePresets.json
+    ../deps.json
+    ../.gersemirc
+)
+
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${cmake_sources})

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -2,47 +2,41 @@
 
 add_library(cmake INTERFACE)
 
-set(cmake_sources
-    common/bootstrap.cmake
-    common/dependencies_common.cmake
-    common/ccache.cmake
-    common/compiler_common.cmake
-    common/helpers_common.cmake
-    common/osconfig.cmake
-    common/versionconfig.cmake
-    finders/Findlibrashader.cmake
-    finders/Findslang_shaders.cmake
-    finders/FindMoltenVK.cmake
-    finders/FindSDL.cmake
-    finders/FindGTK.cmake
-    finders/FindAO.cmake
-    finders/FindOSS.cmake
-    finders/FindPulseAudio.cmake
-    finders/Findudev.cmake
-    finders/Findusbhid.cmake
-    macos/dependencies.cmake
-    macos/compilerconfig.cmake
-    macos/defaults.cmake
-    macos/helpers.cmake
-    macos/xcode.cmake
-    windows/compilerconfig.cmake
-    windows/defaults.cmake
-    windows/dependencies.cmake
-    windows/helpers.cmake 
-    linux/compilerconfig.cmake
-    linux/defaults.cmake
-    linux/helpers.cmake
-    linux/dependencies.cmake
+set(
+  cmake_sources
+  common/bootstrap.cmake
+  common/dependencies_common.cmake
+  common/ccache.cmake
+  common/compiler_common.cmake
+  common/helpers_common.cmake
+  common/osconfig.cmake
+  common/versionconfig.cmake
+  finders/Findlibrashader.cmake
+  finders/Findslang_shaders.cmake
+  finders/FindMoltenVK.cmake
+  finders/FindSDL.cmake
+  finders/FindGTK.cmake
+  finders/FindAO.cmake
+  finders/FindOSS.cmake
+  finders/FindPulseAudio.cmake
+  finders/Findudev.cmake
+  finders/Findusbhid.cmake
+  macos/dependencies.cmake
+  macos/compilerconfig.cmake
+  macos/defaults.cmake
+  macos/helpers.cmake
+  macos/xcode.cmake
+  windows/compilerconfig.cmake
+  windows/defaults.cmake
+  windows/dependencies.cmake
+  windows/helpers.cmake
+  linux/compilerconfig.cmake
+  linux/defaults.cmake
+  linux/helpers.cmake
+  linux/dependencies.cmake
 )
 
-target_sources(
-  cmake
-  PRIVATE
-    ${cmake_sources}
-    ../CMakePresets.json
-    ../deps.json
-    ../.gersemirc
-)
+target_sources(cmake PRIVATE ${cmake_sources} ../CMakePresets.json ../deps.json ../.gersemirc)
 
 if(TARGET clean-all)
   set_target_properties(clean-all PROPERTIES FOLDER cmake/unused PREFIX "")

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -44,4 +44,12 @@ target_sources(
     ../.gersemirc
 )
 
+if(TARGET clean-all)
+  set_target_properties(clean-all PROPERTIES FOLDER cmake/unused PREFIX "")
+endif()
+
+if(TARGET uninstall)
+  set_target_properties(uninstall PROPERTIES FOLDER cmake/unused PREFIX "")
+endif()
+
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${cmake_sources})

--- a/cmake/common/helpers_common.cmake
+++ b/cmake/common/helpers_common.cmake
@@ -15,7 +15,7 @@ function(add_sourcery_command target subdir)
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${subdir}/resource.cpp ${CMAKE_CURRENT_SOURCE_DIR}/${subdir}/resource.hpp
   )
   add_dependencies(${target} ${target}-resource)
-  set_target_properties(${target}-resource PROPERTIES FOLDER resources PREFIX "")
+  set_target_properties(${target}-resource PROPERTIES FOLDER ${target} PREFIX "")
 endfunction()
 
 # message_configuration: Function to print configuration outcome

--- a/cmake/macos/xcode.cmake
+++ b/cmake/macos/xcode.cmake
@@ -142,7 +142,7 @@ set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_UNGUARDED_AVAILABILITY YES)
 
 # set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS YES)
 
-# Add other warnings, downgrade errors to warnings where necessary 
+# Add other warnings, downgrade errors to warnings where necessary
 set(
   CMAKE_XCODE_ATTRIBUTE_WARNING_CFLAGS
   "-Wvla

--- a/cmake/windows/compilerconfig.cmake
+++ b/cmake/windows/compilerconfig.cmake
@@ -116,7 +116,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     # work around https://gitlab.kitware.com/cmake/cmake/-/issues/26559
     add_compile_options($<$<AND:$<BOOL:${ENABLE_IPO}>,$<NOT:$<CONFIG:Debug>>>:-flto=thin>)
     add_link_options(
-      $<$<AND:$<BOOL:${ENABLE_IPO}>,$<NOT:$<CONFIG:Debug>>>:-flto=thin>
       $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>
       /Debug
       $<$<NOT:$<CONFIG:Debug>>:/OPT:REF>

--- a/cmake/windows/helpers.cmake
+++ b/cmake/windows/helpers.cmake
@@ -18,9 +18,7 @@ function(ares_configure_executable target)
         "$<$<CONFIG:Debug,RelWithDebInfo,Release,MinSizeRel>:${ARES_EXECUTABLE_DESTINATION}/${target}/rundir>"
   )
   _bundle_dependencies(${target})
-  install(
-    TARGETS ${target} DESTINATION "${ARES_EXECUTABLE_DESTINATION}/${target}/rundir" COMPONENT Application
-  )
+  install(TARGETS ${target} DESTINATION "${ARES_EXECUTABLE_DESTINATION}/${target}/rundir" COMPONENT Application)
   add_custom_command(
     TARGET ${target}
     POST_BUILD

--- a/desktop-ui/CMakeLists.txt
+++ b/desktop-ui/CMakeLists.txt
@@ -45,9 +45,10 @@ elseif(OS_LINUX OR OS_FREEBSD OR OS_OPENBSD)
   include(cmake/os-linux.cmake)
 endif()
 
+target_include_directories(desktop-ui PRIVATE ${CMAKE_SOURCE_DIR})
 target_link_libraries(
   desktop-ui
-  PRIVATE ares::ruby ares::hiro ares::ares mia sljit
+  PRIVATE ares::ruby ares::hiro ares::ares ares::mia ares::nall
 )
 
 if(ARES_ENABLE_CHD)

--- a/desktop-ui/cmake/os-linux.cmake
+++ b/desktop-ui/cmake/os-linux.cmake
@@ -16,6 +16,7 @@ if(ARES_ENABLE_LIBRASHADER)
         DEPENDS "${ARES_BUILD_OUTPUT_DIR}/${ARES_INSTALL_DATA_DESTINATION}/Shaders/bilinear.slangp"
       )
       add_dependencies(desktop-ui bundled_shaders)
+      set_target_properties(bundled_shaders PROPERTIES FOLDER desktop-ui PREFIX "")
       install(
         DIRECTORY "${slang_shaders_LOCATION}"
         DESTINATION "${ARES_INSTALL_DATA_DESTINATION}/Shaders"

--- a/desktop-ui/cmake/os-macos.cmake
+++ b/desktop-ui/cmake/os-macos.cmake
@@ -83,6 +83,7 @@ if(ARES_ENABLE_LIBRASHADER)
           "${CMAKE_CURRENT_BINARY_DIR}/$<IF:$<BOOL:${XCODE}>,$<CONFIG>,>/ares.app/Contents/Resources/Shaders/bilinear.slangp"
       )
       add_dependencies(desktop-ui bundled_shaders)
+      set_target_properties(bundled_shaders PROPERTIES FOLDER desktop-ui PREFIX "")
     endif()
     unset(_required_macos)
   endif()

--- a/desktop-ui/cmake/os-windows.cmake
+++ b/desktop-ui/cmake/os-windows.cmake
@@ -20,6 +20,7 @@ if(ARES_ENABLE_LIBRASHADER)
       DEPENDS "${ARES_EXECUTABLE_DESTINATION}/desktop-ui/rundir/Shaders/bilinear.slangp"
     )
     add_dependencies(desktop-ui bundled_shaders)
+    set_target_properties(bundled_shaders PROPERTIES FOLDER desktop-ui PREFIX "")
   endif()
 endif()
 

--- a/hiro/CMakeLists.txt
+++ b/hiro/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(hiro STATIC)
 add_library(ares::hiro ALIAS hiro)
 
-target_link_libraries(hiro PUBLIC ares::nall)
+target_link_libraries(hiro PRIVATE ares::nall::headers)
 
 include(cmake/sources.cmake)
 

--- a/hiro/cmake/os-linux.cmake
+++ b/hiro/cmake/os-linux.cmake
@@ -8,7 +8,8 @@ if(NOT USE_QT5)
 
   target_link_libraries(hiro PRIVATE GTK::GTK X11::X11)
 
-  target_enable_feature(hiro "GTK3 UI backend" HIRO_GTK=3)
+  target_enable_feature(hiro "GTK3 UI backend")
+  target_compile_definitions(hiro PUBLIC HIRO_GTK=3)
 else()
   # Note that Qt6 is more-or-less a drop-in replacement here, but changing these targets to use Qt6 is deferred until
   # Qt support is properly addressed.
@@ -26,7 +27,8 @@ else()
     PRIVATE X11::X11 Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Xcb
   )
 
-  target_enable_feature(hiro "Qt5 UI backend" HIRO_QT=5)
+  target_enable_feature(hiro "Qt5 UI backend")
+  target_compile_definitions(hiro PUBLIC HIRO_QT=5)
 endif()
 
 get_target_property(hiro_SOURCES hiro SOURCES)

--- a/hiro/cmake/os-macos.cmake
+++ b/hiro/cmake/os-macos.cmake
@@ -1,6 +1,7 @@
 target_sources(hiro PRIVATE cmake/os-macos.cmake hiro.mm hiro.cpp)
 
-target_enable_feature(hiro "Cocoa UI backend" HIRO_COCOA)
+target_enable_feature(hiro "Cocoa UI backend")
+target_compile_definitions(hiro PUBLIC HIRO_COCOA)
 
 target_link_libraries(
   hiro

--- a/hiro/cmake/os-windows.cmake
+++ b/hiro/cmake/os-windows.cmake
@@ -1,4 +1,5 @@
-target_enable_feature(hiro "Win32 UI" HIRO_WINDOWS)
+target_enable_feature(hiro "Win32 UI")
+target_compile_definitions(hiro PUBLIC HIRO_WINDOWS)
 target_link_libraries(
   hiro
   PRIVATE kernel32 user32 gdi32 advapi32 ole32 comctl32 comdlg32 uxtheme msimg32 dwmapi

--- a/libco/CMakeLists.txt
+++ b/libco/CMakeLists.txt
@@ -32,4 +32,6 @@ target_compile_options(libco PRIVATE $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-
 
 set_source_files_properties(libco ${libco_SOURCES} PROPERTIES HEADER_FILE_ONLY TRUE)
 
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${libco_SOURCES})
+
 set_source_files_properties(libco libco.c PROPERTIES HEADER_FILE_ONLY FALSE)

--- a/mia/CMakeLists.txt
+++ b/mia/CMakeLists.txt
@@ -121,14 +121,7 @@ target_compile_definitions(mia PRIVATE MIA_LIBRARY)
 
 target_include_directories(mia PRIVATE ${CMAKE_SOURCE_DIR})
 target_include_directories(mia PRIVATE ${CMAKE_SOURCE_DIR}/thirdparty)
-target_link_libraries(
-  mia
-  PRIVATE
-    ares::ares
-    ares::nall::headers
-    tzxfile
-    $<$<BOOL:${ARES_ENABLE_CHD}>:chdr-static>
-)
+target_link_libraries(mia PRIVATE ares::ares ares::nall::headers tzxfile $<$<BOOL:${ARES_ENABLE_CHD}>:chdr-static>)
 
 if(ARES_BUILD_OPTIONAL_TARGETS)
   add_executable(mia-ui mia.cpp resource/resource.cpp)

--- a/mia/CMakeLists.txt
+++ b/mia/CMakeLists.txt
@@ -119,15 +119,27 @@ target_sources(
 
 target_compile_definitions(mia PRIVATE MIA_LIBRARY)
 
-target_link_libraries(mia PUBLIC ares::nall ares::ares ares::hiro PRIVATE tzxfile)
+target_include_directories(mia PRIVATE ${CMAKE_SOURCE_DIR})
+target_include_directories(mia PRIVATE ${CMAKE_SOURCE_DIR}/thirdparty)
+target_link_libraries(
+  mia
+  PRIVATE
+    ares::ares
+    ares::nall::headers
+    tzxfile
+    $<$<BOOL:${ARES_ENABLE_CHD}>:chdr-static>
+)
 
 if(ARES_BUILD_OPTIONAL_TARGETS)
   add_executable(mia-ui mia.cpp resource/resource.cpp)
 
+  target_include_directories(mia-ui PRIVATE ${CMAKE_SOURCE_DIR})
   target_link_libraries(
     mia-ui
-    PUBLIC ares::hiro ares::ares
     PRIVATE
+      ares::hiro
+      ares::ares
+      ares::nall
       tzxfile
       "$<$<PLATFORM_ID:Darwin>:$<LINK_LIBRARY:FRAMEWORK,Carbon.framework>>"
       "$<$<PLATFORM_ID:Darwin>:$<LINK_LIBRARY:FRAMEWORK,IOKit.framework>>"
@@ -137,12 +149,6 @@ if(ARES_BUILD_OPTIONAL_TARGETS)
 
   if(WIN32)
     target_sources(mia-ui PRIVATE resource/mia.rc resource/mia.Manifest)
-  endif()
-
-  if(OS_WINDOWS)
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      target_link_libraries(mia-ui PRIVATE nall)
-    endif()
   endif()
 
   set_target_properties(

--- a/nall/nall/CMakeLists.txt
+++ b/nall/nall/CMakeLists.txt
@@ -11,7 +11,6 @@ if(ARES_ENABLE_CHD)
   target_link_libraries(nall PUBLIC chdr-static)
   target_compile_definitions(nall PUBLIC ARES_ENABLE_CHD)
 endif()
-target_compile_definitions(nall PUBLIC CMAKE)
 target_compile_options(
   nall
   PRIVATE
@@ -53,13 +52,6 @@ if(ARES_TREAT_NALL_AS_SYSTEM)
 else()
   target_include_directories(nall PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/..")
 endif()
-
-# global compiler flags
-target_compile_features(nall PUBLIC c_std_11)
-set_target_properties(nall PROPERTIES C_EXTENSIONS OFF)
-
-target_compile_features(nall PUBLIC cxx_std_17)
-set_target_properties(nall PROPERTIES CXX_EXTENSIONS OFF)
 
 target_compile_definitions(
   nall

--- a/nall/nall/CMakeLists.txt
+++ b/nall/nall/CMakeLists.txt
@@ -1,6 +1,21 @@
 add_library(nall OBJECT main.cpp nall.cpp sljitAllocator.cpp)
 add_library(ares::nall ALIAS nall)
 
+add_library(nall-headers INTERFACE)
+add_library(ares::nall::headers ALIAS nall-headers)
+target_link_libraries(nall PUBLIC ares::nall::headers)
+if(ARES_ENABLE_CHD)
+  target_compile_definitions(nall-headers INTERFACE ARES_ENABLE_CHD)
+endif()
+target_compile_definitions(
+  nall-headers
+  INTERFACE
+    $<$<CONFIG:Debug>:BUILD_DEBUG>
+    $<$<CONFIG:Release>:BUILD_RELEASE>
+    $<$<CONFIG:RelWithDebInfo>:BUILD_RELEASE>
+    $<$<CONFIG:MinSizeRel>:BUILD_MINIFIED>
+)
+
 include(cmake/sources.cmake)
 
 find_package(Threads REQUIRED)
@@ -9,7 +24,6 @@ target_link_libraries(nall PRIVATE Threads::Threads)
 target_link_libraries(nall PUBLIC sljit)
 if(ARES_ENABLE_CHD)
   target_link_libraries(nall PUBLIC chdr-static)
-  target_compile_definitions(nall PUBLIC ARES_ENABLE_CHD)
 endif()
 target_compile_options(
   nall
@@ -37,7 +51,9 @@ option(ARES_TREAT_NALL_AS_SYSTEM "Enable system library semantics for nall in ot
 mark_as_advanced(ARES_TREAT_NALL_AS_SYSTEM)
 
 if(ARES_TREAT_NALL_AS_SYSTEM)
-  target_sources(nall PRIVATE cmake/headers.cpp)
+  add_library(nall-static-compile-test STATIC cmake/headers.cpp)
+  set_target_properties(nall-static-compile-test PROPERTIES FOLDER nall PREFIX "")
+  target_include_directories(nall-static-compile-test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/..")
 endif()
 
 get_target_property(nall_SOURCES nall SOURCES)
@@ -46,22 +62,11 @@ set_source_files_properties(${nall_SOURCES} PROPERTIES HEADER_FILE_ONLY TRUE)
 set_source_files_properties(nall nall.cpp main.cpp sljitAllocator.cpp PROPERTIES HEADER_FILE_ONLY FALSE)
 
 if(ARES_TREAT_NALL_AS_SYSTEM)
-  target_include_directories(nall SYSTEM INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/..")
-  target_include_directories(nall PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/..")
-  set_source_files_properties(nall cmake/headers.cpp PROPERTIES HEADER_FILE_ONLY FALSE)
+  target_include_directories(nall-headers SYSTEM INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/..")
 else()
-  target_include_directories(nall PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/..")
+  target_include_directories(nall-headers PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/..")
 endif()
 
-target_compile_definitions(
-  nall
-  PUBLIC
-    $<$<CONFIG:Debug>:BUILD_DEBUG>
-    $<$<CONFIG:Release>:BUILD_RELEASE>
-    $<$<CONFIG:RelWithDebInfo>:BUILD_RELEASE>
-    $<$<CONFIG:MinSizeRel>:BUILD_MINIFIED>
-)
-
 if(ARES_BUILD_LOCAL)
-  target_compile_definitions(nall PUBLIC BUILD_LOCAL)
+  target_compile_definitions(nall-headers INTERFACE BUILD_LOCAL)
 endif()

--- a/nall/nall/cmake/os-freebsd.cmake
+++ b/nall/nall/cmake/os-freebsd.cmake
@@ -1,7 +1,1 @@
-target_sources(
-  nall
-  PRIVATE
-    xorg/clipboard.hpp
-    xorg/guard.hpp
-    xorg/xorg.hpp
-)
+target_sources(nall PRIVATE xorg/clipboard.hpp xorg/guard.hpp xorg/xorg.hpp)

--- a/nall/nall/cmake/os-freebsd.cmake
+++ b/nall/nall/cmake/os-freebsd.cmake
@@ -1,6 +1,6 @@
 target_sources(
   nall
-  PRIVATE # cmake-format: sortable
+  PRIVATE
     xorg/clipboard.hpp
     xorg/guard.hpp
     xorg/xorg.hpp

--- a/nall/nall/cmake/os-linux.cmake
+++ b/nall/nall/cmake/os-linux.cmake
@@ -1,7 +1,1 @@
-target_sources(
-  nall
-  PRIVATE
-    xorg/clipboard.hpp
-    xorg/guard.hpp
-    xorg/xorg.hpp
-)
+target_sources(nall PRIVATE xorg/clipboard.hpp xorg/guard.hpp xorg/xorg.hpp)

--- a/nall/nall/cmake/os-linux.cmake
+++ b/nall/nall/cmake/os-linux.cmake
@@ -1,6 +1,6 @@
 target_sources(
   nall
-  PRIVATE # cmake-format: sortable
+  PRIVATE
     xorg/clipboard.hpp
     xorg/guard.hpp
     xorg/xorg.hpp

--- a/nall/nall/cmake/os-windows.cmake
+++ b/nall/nall/cmake/os-windows.cmake
@@ -16,15 +16,10 @@ target_sources(
     windows/windows.hpp
 )
 
-if(MSVC)
-  target_compile_options(nall PRIVATE /W2)
-endif()
-
 target_link_libraries(nall PUBLIC ws2_32 ole32 shell32 shlwapi)
 if(MINGW)
   target_link_options(nall PUBLIC -mthreads -static)
 endif()
-target_link_libraries(nall PUBLIC ws2_32 ole32 shell32 shlwapi)
 
 set_source_files_properties(
   nall

--- a/nall/nall/decode/chd.hpp
+++ b/nall/nall/decode/chd.hpp
@@ -3,7 +3,9 @@
 #include <nall/file.hpp>
 #include <nall/maybe.hpp>
 #include <nall/string.hpp>
+#if defined(ARES_ENABLE_CHD)
 #include <libchdr/chd.h>
+#endif
 
 namespace nall::Decode {
 

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -15,6 +15,8 @@ target_sources(ruby PRIVATE audio/audio.cpp audio/audio.hpp audio/sdl.cpp)
 
 target_sources(ruby PRIVATE input/input.cpp input/input.hpp input/sdl.cpp)
 
+target_include_directories(ruby PRIVATE ${CMAKE_SOURCE_DIR}/thirdparty)
+
 target_sources(
   ruby
   PRIVATE
@@ -40,7 +42,7 @@ endif()
 
 target_sources(ruby PRIVATE cmake/os-macos.cmake cmake/os-windows.cmake cmake/os-linux.cmake cmake/os-freebsd.cmake)
 
-target_link_libraries(ruby PUBLIC ares::nall)
+target_link_libraries(ruby PRIVATE ares::nall::headers)
 
 target_include_directories(ruby PRIVATE ${CMAKE_SOURCE_DIR})
 

--- a/ruby/cmake/os-windows.cmake
+++ b/ruby/cmake/os-windows.cmake
@@ -1,13 +1,13 @@
 target_sources(
   ruby
-  PRIVATE # cmake-format: sortable
+  PRIVATE #
     video/direct3d9.cpp
     video/wgl.cpp
 )
 
 target_sources(
   ruby
-  PRIVATE # cmake-format: sortable
+  PRIVATE
     audio/wasapi.cpp
     audio/xaudio2.cpp
     audio/xaudio2.hpp
@@ -18,7 +18,7 @@ target_sources(
 
 target_sources(
   ruby
-  PRIVATE # cmake-format: sortable
+  PRIVATE
     input/sdl.cpp
     input/shared/rawinput.cpp
     input/windows.cpp

--- a/ruby/cmake/os-windows.cmake
+++ b/ruby/cmake/os-windows.cmake
@@ -7,13 +7,7 @@ target_sources(
 
 target_sources(
   ruby
-  PRIVATE
-    audio/wasapi.cpp
-    audio/xaudio2.cpp
-    audio/xaudio2.hpp
-    audio/directsound.cpp
-    audio/waveout.cpp
-    audio/sdl.cpp
+  PRIVATE audio/wasapi.cpp audio/xaudio2.cpp audio/xaudio2.hpp audio/directsound.cpp audio/waveout.cpp audio/sdl.cpp
 )
 
 target_sources(

--- a/tests/arm7tdmi/CMakeLists.txt
+++ b/tests/arm7tdmi/CMakeLists.txt
@@ -30,7 +30,7 @@ if(arm7tdmi IN_LIST ARES_COMPONENTS_LIST)
 
   target_enable_subproject(arm7tdmi "arm7tdmi processor test harness")
 
-  target_link_libraries(arm7tdmi PRIVATE ares::ares)
+  target_link_libraries(arm7tdmi PRIVATE ares::ares ares::nall)
   set(CONSOLE TRUE)
   ares_configure_executable(arm7tdmi)
 

--- a/tests/i8080/CMakeLists.txt
+++ b/tests/i8080/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories(i8080 PRIVATE ${CMAKE_SOURCE_DIR})
 set_target_properties(i8080 PROPERTIES FOLDER tests PREFIX "")
 target_enable_subproject(i8080 "i8080 processor test harness")
 
-target_link_libraries(i8080 PRIVATE ares::ares)
+target_link_libraries(i8080 PRIVATE ares::ares ares::nall)
 set(CONSOLE TRUE)
 ares_configure_executable(i8080)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES i8080.cpp)

--- a/tests/m68000/CMakeLists.txt
+++ b/tests/m68000/CMakeLists.txt
@@ -30,7 +30,7 @@ if(m68000 IN_LIST ARES_COMPONENTS_LIST)
 
   target_enable_subproject(m68000 "m68000 processor test harness")
 
-  target_link_libraries(m68000 PRIVATE ares::ares)
+  target_link_libraries(m68000 PRIVATE ares::ares ares::nall)
   set(CONSOLE TRUE)
   ares_configure_executable(m68000)
 

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -102,11 +102,7 @@ target_include_directories(ymfm PUBLIC ../thirdparty/ymfm/src)
 
 target_compile_options(ymfm PRIVATE $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-unreachable-code>)
 
-add_library(
-  qon
-  STATIC
-  qon/qon.cpp
-)
+add_library(qon STATIC qon/qon.cpp)
 
 set_target_properties(ymfm PROPERTIES FOLDER thirdparty PREFIX "")
 set_target_properties(tzxfile PROPERTIES FOLDER thirdparty PREFIX "")

--- a/tools/genius/CMakeLists.txt
+++ b/tools/genius/CMakeLists.txt
@@ -14,7 +14,7 @@ elseif(OS_LINUX OR OS_FREEBSD OR OS_OPENBSD)
   include(cmake/os-linux.cmake)
 endif()
 
-target_link_libraries(genius PRIVATE nall ares::hiro)
+target_link_libraries(genius PRIVATE ares::nall ares::nall::headers ares::hiro)
 
 ares_configure_executable(genius)
 set_target_properties(genius PROPERTIES FOLDER tools PREFIX "")

--- a/tools/mame2bml/CMakeLists.txt
+++ b/tools/mame2bml/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(mame2bml mame2bml.cpp)
 
 target_include_directories(mame2bml PRIVATE ${CMAKE_SOURCE_DIR})
 
-target_link_libraries(mame2bml PRIVATE nall)
+target_link_libraries(mame2bml PRIVATE ares::nall)
 set_target_properties(mame2bml PROPERTIES FOLDER tools PREFIX "")
 target_enable_subproject(mame2bml "mame2bml (MAME manifest converter)")
 set(CONSOLE TRUE)

--- a/tools/sourcery/CMakeLists.txt
+++ b/tools/sourcery/CMakeLists.txt
@@ -4,7 +4,12 @@ if(NOT (CMAKE_CROSSCOMPILING OR ARES_CROSSCOMPILING))
 
   target_include_directories(sourcery PRIVATE ${CMAKE_SOURCE_DIR})
 
-  target_link_libraries(sourcery PRIVATE nall "$<$<PLATFORM_ID:Darwin>:$<LINK_LIBRARY:FRAMEWORK,Cocoa.framework>>")
+  target_link_libraries(
+    sourcery
+    PRIVATE
+      ares::nall
+      "$<$<PLATFORM_ID:Darwin>:$<LINK_LIBRARY:FRAMEWORK,Cocoa.framework>>"
+  )
 
   set(CONSOLE TRUE)
   ares_configure_executable(sourcery)


### PR DESCRIPTION
A bit of a chonkier housekeeping PR than usual, apologies. Nevertheless, no intended functional changes.

* Adds an interface target for the Markdown, CI code, and other non-code project files so they can be more easily edited in IDEs along with other project code
* Makes the hiro platform definition public (so for example `desktop-ui` can check if different hiro UI elements exist)
* Makes libco sources organized in IDEs the same way other targets are
* Update the maximum supported CMake version to 4.1
* Clean up various pieces of unused or extraneous build code; old `cmake-format` definitions, extraneous `-flto=thin` link option under Clang-CL, redundant compiler options that are already defined elsewhere, etc.
* Fix an extraneous argument for the ARES_CORES definition that should be a documentation string
* Move unused build targets created by dependencies into a dedicated folder so IDE organization is less cluttered
* Fix a warning about an implicit list->string conversion in build code
* Run a formatting pass on the CMake code

Lastly, this PR also reorganizes a few link relationships. The nall target is split into `nall` and `nall-headers`. This better reflects the fact that some targets want symbols from compiled nall sources, while others strictly require include directories so that header definitions are available. Various link relationships are changed from `PUBLIC` to `PRIVATE` to better avoid overlinking. This change was intended to make it easier to establish link relationships without worrying about possible duplicate symbols, given the variety of compilers/linkers we support, as well as to improve link performance. Unfortunately no notable performance benefit was observed, but the improved logical clarity should be a win for future build work.