### PR TITLE
build: Disable C++20 module scanning

### DIFF
--- a/cmake/common/compiler_common.cmake
+++ b/cmake/common/compiler_common.cmake
@@ -36,6 +36,9 @@ set(CMAKE_C_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
+# Disable C++20 module scanning (CMP0155)
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
+
 # Set symbols to be hidden by default for C and C++
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)


### PR DESCRIPTION
Enabling C++20 enabled scanning for imports in all targets, per [CMP0155](https://cmake.org/cmake/help/latest/policy/CMP0155.html). In numerous environments this will cause build failures because C++ module support is still quite sparse.