### PR TITLE
gba: handle cartridge access sizes via CPU bus

### DIFF
--- a/ares/gba/cartridge/memory.hpp
+++ b/ares/gba/cartridge/memory.hpp
@@ -18,7 +18,7 @@ struct MROM {
 struct SRAM {
   //sram.cpp
   auto read(n32 address) -> n8;
-  auto write(n32 address, n32 word) -> void;
+  auto write(n32 address, n8 byte) -> void;
 
   //serialization.cpp
   auto serialize(serializer&) -> void;

--- a/ares/gba/cartridge/sram.cpp
+++ b/ares/gba/cartridge/sram.cpp
@@ -2,6 +2,6 @@ auto Cartridge::SRAM::read(n32 address) -> n8 {
   return data[address & mask];
 }
 
-auto Cartridge::SRAM::write(n32 address, n32 word) -> void {
-  data[address & mask] = word;
+auto Cartridge::SRAM::write(n32 address, n8 byte) -> void {
+  data[address & mask] = byte;
 }

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -86,6 +86,9 @@ struct CPU : ARM7TDMI, Thread, IO {
   template<bool UseDebugger> auto readVRAM(u32 mode, n32 address) -> n32;
   auto writeVRAM(u32 mode, n32 address, n32 word) -> void;
 
+  template<bool UseDebugger> auto readROM(u32 mode, n32 address) -> n32;
+  auto writeROM(u32 mode, n32 address, n32 word) -> void;
+
   //dma.cpp
   auto dmaVblank() -> void;
   auto dmaHblank() -> void;

--- a/ares/gba/cpu/prefetch.cpp
+++ b/ares/gba/cpu/prefetch.cpp
@@ -6,7 +6,7 @@ auto CPU::prefetchSync(u32 mode, n32 address) -> void {
   prefetch.ahead = false;
   prefetch.addr = address + size;
   prefetch.load = address + size;
-  prefetch.wait = waitCartridge(Half | Sequential, prefetch.load);
+  prefetch.wait = waitCartridge(Sequential, prefetch.load);
 }
 
 auto CPU::prefetchStepInternal(u32 clocks) -> void {
@@ -20,9 +20,9 @@ auto CPU::prefetchStepInternal(u32 clocks) -> void {
       break;
     }
     if(--prefetch.wait) continue;
-    prefetch.slot[prefetch.load >> 1 & 7] = cartridge.readRom<false>(Half | Nonsequential, prefetch.load);  //todo: make access sequentiality consistent with timing used
+    prefetch.slot[prefetch.load >> 1 & 7] = cartridge.readRom<false>(Nonsequential, prefetch.load);  //todo: make access sequentiality consistent with timing used
     prefetch.load += 2;
-    prefetch.wait = waitCartridge(Half | Sequential, prefetch.load);
+    prefetch.wait = waitCartridge(Sequential, prefetch.load);
   }
 }
 
@@ -44,7 +44,7 @@ auto CPU::prefetchReset() -> void {
 auto CPU::prefetchRead() -> n16 {
   if(prefetch.stopped && prefetch.empty()) {
     prefetch.stopped = false;
-    prefetch.wait = waitCartridge(Half | Nonsequential, prefetch.load);
+    prefetch.wait = waitCartridge(Nonsequential, prefetch.load);
   }
   if(prefetch.empty()) prefetchStepInternal(prefetch.wait);
 

--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -267,7 +267,8 @@ auto PPU::power() -> void {
   renderingCycle = 43;  //by default, render at first cycle of pixel output
   string gameID;
   for(u32 index : range(4)) {
-    char byte = cartridge.readRom<true>(Byte, 0xac + index);
+    n32 address = 0xac + index;
+    char byte = cartridge.readRom<true>(0, address).byte(address & 1);
     gameID.append(byte);
   }
   if(gameID == "AWRE") renderingCycle = 512;  //Advance Wars (USA)


### PR DESCRIPTION
Fixes some bugs involving 32-bit writes to devices in cartridge ROM region.