### PR TITLE
Use QScreen for `Desktop::{size,workspace}`

### DIFF
--- a/hiro/qt/desktop.cpp
+++ b/hiro/qt/desktop.cpp
@@ -3,57 +3,19 @@
 namespace hiro {
 
 auto pDesktop::size() -> Size {
-  #if defined(DISPLAY_WINDOWS)
-  return {GetSystemMetrics(SM_CXVIRTUALSCREEN), GetSystemMetrics(SM_CYVIRTUALSCREEN)};
-  #elif defined(DISPLAY_XORG)
-  auto display = XOpenDisplay(nullptr);
-  s32 screen = DefaultScreen(display);
-  XWindowAttributes attributes;
-  XGetWindowAttributes(display, RootWindow(display, screen), &attributes);
-  XCloseDisplay(display);
-  return {attributes.width, attributes.height};
-  #else
-  //this only returns the geometry of the primary monitor rather than the entire desktop
-  QRect rect = QApplication::desktop()->screenGeometry();
+  QRect rect;
+  for(QScreen* screen : QApplication::screens()) {
+    rect = rect.united(screen->geometry());
+  }
   return {rect.width(), rect.height()};
-  #endif
 }
 
 auto pDesktop::workspace() -> Geometry {
-  #if defined(DISPLAY_WINDOWS)
-  RECT rc;
-  SystemParametersInfo(SPI_GETWORKAREA, 0, &rc, 0);
-  return {rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top};
-  #elif defined(DISPLAY_XORG)
-  auto display = XOpenDisplay(nullptr);
-  s32 screen = DefaultScreen(display);
-
-  s32 format;
-  unsigned char* data = nullptr;
-  unsigned long items, after;
-  XlibAtom returnAtom;
-
-  XlibAtom netWorkarea = XInternAtom(display, "_NET_WORKAREA", XlibTrue);
-  s32 result = XGetWindowProperty(
-    display, RootWindow(display, screen), netWorkarea, 0, 4, XlibFalse,
-    XInternAtom(display, "CARDINAL", XlibTrue), &returnAtom, &format, &items, &after, &data
-  );
-
-  XlibAtom cardinal = XInternAtom(display, "CARDINAL", XlibTrue);
-  if(result == Success && returnAtom == cardinal && format == 32 && items == 4) {
-    unsigned long* workarea = (unsigned long*)data;
-    XCloseDisplay(display);
-    return {(s32)workarea[0], (s32)workarea[1], (s32)workarea[2], (s32)workarea[3]};
+  QRect rect;
+  for(QScreen* screen : QApplication::screens()) {
+    rect = rect.united(screen->geometry());
   }
-
-  XCloseDisplay(display);
-  auto size = Desktop::size();
-  return {0, 0, size.width(), size.height()};
-  #else
-  //this only returns the workspace of the primary monitor rather than the entire desktop
-  QRect rect = QApplication::desktop()->availableGeometry();
   return {rect.x(), rect.y(), rect.width(), rect.height()};
-  #endif
 }
 
 }


### PR DESCRIPTION
Qt 5.0 adds the QScreen API, which exposes enough information that `Desktop::{size,workspace}` no longer needs to fall back to Win32/Xlib. I manually tested that this seems to give the same exact answers as the Xlib path (though it technically goes a different route for `Desktop::size`.)

Since this API doesn't exist until Qt 5.0, this would break the Qt 4 build. However, Qt 4 is long dead now, and ares no longer has any official way to build Hiro with Qt 4 support. Therefore, I propose we finally clean up all of the old Qt 4 codepaths and avoid bifurcating the code any further: #2187

Mirrored in:
- bsnes: https://github.com/bsnes-emu/bsnes/pull/362
- higan: https://github.com/higan-emu/higan/pull/217