### PR TITLE
CI: overwrite built-in pinned CMake installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'
       run: |
+        brew uninstall --ignore-dependencies cmake
         brew install ${{ matrix.platform.install }}
     - name: "Build: Windows"
       if: runner.os != 'macOS' && runner.os != 'Linux'


### PR DESCRIPTION
GitHub actions pins CMake version 3.31.6 because lots of older projects are incompatible with CMake 4.

We are compatible with the latest version of CMake, so we generally prefer to use the newest version available on Homebrew.

Hence uninstall the built-in CMake and install the newer one.

(Previously, we directed brew to install the new version without uninstalling the pinned one, which spit out a warning about a conflict, but did not error out. Recently this became an error for some reason).