### PR TITLE
gba: fix some warnings from C++20 deprecating bitwise operations between different enums

### DIFF
--- a/ares/gba/cartridge/cartridge.hpp
+++ b/ares/gba/cartridge/cartridge.hpp
@@ -17,20 +17,26 @@ struct Cartridge {
   auto save() -> void;
   auto power() -> void;
 
+  auto startBurst(n32 address) -> void {
+    //lower 16 address bits are latched on burst transfer start
+    mrom.pageAddr = address >> 1;
+    mrom.burst = true;
+  }
+
   template<bool UseDebugger>
-  auto readRom(u32 mode, n32 address) -> n16 {
+  auto readRom(n32 address) -> n16 {
+    n32 romAddr;
+    if constexpr(!UseDebugger) romAddr = mrom.burstAddr(address);
+    if constexpr( UseDebugger) romAddr = address & 0x1ff'fffe;
+    n16 half = mrom.read(romAddr);
+    if constexpr(!UseDebugger) mrom.pageAddr++;
+
     if(has.eeprom && (address & eeprom.mask) == eeprom.test) return eeprom.read();
     if(has.rtc) {
       if((address & 0x1fffffe) == 0xc4) return gpio.readData();
       if((address & 0x1fffffe) == 0xc6) return gpio.readDirection();
       if((address & 0x1fffffe) == 0xc8) return gpio.readControl();
     }
-
-    n32 romAddr;
-    if constexpr(!UseDebugger) romAddr = mrom.burstAddr(mode, address);
-    if constexpr( UseDebugger) romAddr = address & 0x1ff'fffe;
-    n16 half = mrom.read(mode, romAddr);
-    if constexpr(!UseDebugger) mrom.pageAddr++;
     return half;
   }
 
@@ -41,18 +47,17 @@ struct Cartridge {
     return byte;
   }
 
-  auto writeRom(u32 mode, n32 address, n16 half) -> void {
-    if(has.eeprom && (address & eeprom.mask) == eeprom.test) return eeprom.write(half & 1);
+  auto writeRom(n32 address, n16 half) -> void {
+    n32 romAddr = mrom.burstAddr(address);
+    mrom.write(romAddr, half);
+    mrom.pageAddr++;
 
+    if(has.eeprom && (address & eeprom.mask) == eeprom.test) return eeprom.write(half & 1);
     if(has.rtc) {
       if((address & 0x1fffffe) == 0xc4) return gpio.writeData(half);
       if((address & 0x1fffffe) == 0xc6) return gpio.writeDirection(half);
       if((address & 0x1fffffe) == 0xc8) return gpio.writeControl(half);
     }
-
-    n32 romAddr = mrom.burstAddr(mode, address);
-    mrom.write(mode, romAddr, half);
-    mrom.pageAddr++;
     return;
   }
 

--- a/ares/gba/cartridge/memory.hpp
+++ b/ares/gba/cartridge/memory.hpp
@@ -1,8 +1,8 @@
 struct MROM {
   //mrom.cpp
-  auto read(u32 mode, n32 address) -> n16;
-  auto write(u32 mode, n32 address, n16 half) -> void;
-  auto burstAddr(u32 mode, n32 address) -> n32;
+  auto read(n32 address) -> n16;
+  auto write(n32 address, n16 half) -> void;
+  auto burstAddr(n32 address) -> n32;
 
   //serialization.cpp
   auto serialize(serializer&) -> void;

--- a/ares/gba/cartridge/mrom.cpp
+++ b/ares/gba/cartridge/mrom.cpp
@@ -1,4 +1,4 @@
-auto Cartridge::MROM::read(u32 mode, n32 address) -> n16 {
+auto Cartridge::MROM::read(n32 address) -> n16 {
   //out-of-bounds accesses
   if(address >= size) {
     if(!mirror) return pageAddr;
@@ -8,19 +8,14 @@ auto Cartridge::MROM::read(u32 mode, n32 address) -> n16 {
   return data[address >> 1];
 }
 
-auto Cartridge::MROM::write(u32 mode, n32 address, n16 half) -> void {
+auto Cartridge::MROM::write(n32 address, n16 half) -> void {
 }
 
-auto Cartridge::MROM::burstAddr(u32 mode, n32 address) -> n32 {
-  //use latched lower 16 bits of address lines if sequential
-  n8 page = address >> 17;
-  if(mode & Nonsequential) {
-    pageAddr = address >> 1;
-    burst = true;
-  }
-
+auto Cartridge::MROM::burstAddr(n32 address) -> n32 {
   //end burst transfer if requesting last address on page
   if((address & 0x1fffe) == 0x1fffe) burst = false;
 
+  //use latched lower 16 bits of address lines
+  n8 page = address >> 17;
   return (page << 17) | (pageAddr << 1);
 }

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -67,8 +67,8 @@ struct CPU : ARM7TDMI, Thread, IO {
   auto lock() -> void override;
   auto unlock() -> void override;
   auto waitEWRAM(u32 mode) -> u32;
-  auto waitCartridge(u32 mode, n32 address) -> u32;
-  auto cartMode(u32 mode, n32 address) -> u32;
+  auto waitCartridge(n32 address, bool sequential) -> u32;
+  auto checkBurst(u32 mode) -> bool;
 
   //io.cpp
   auto readIO(n32 address) -> n8 override;
@@ -287,6 +287,7 @@ struct CPU : ARM7TDMI, Thread, IO {
     n1  romAccess;
     n1  timerLatched;
     n1  busLocked;
+    n1  burstActive;
     n32 hcounter;
   } context;
 };

--- a/ares/gba/cpu/prefetch.cpp
+++ b/ares/gba/cpu/prefetch.cpp
@@ -6,7 +6,7 @@ auto CPU::prefetchSync(u32 mode, n32 address) -> void {
   prefetch.ahead = false;
   prefetch.addr = address + size;
   prefetch.load = address + size;
-  prefetch.wait = waitCartridge(Sequential, prefetch.load);
+  prefetch.wait = waitCartridge(prefetch.load, true);
 }
 
 auto CPU::prefetchStepInternal(u32 clocks) -> void {
@@ -20,9 +20,10 @@ auto CPU::prefetchStepInternal(u32 clocks) -> void {
       break;
     }
     if(--prefetch.wait) continue;
-    prefetch.slot[prefetch.load >> 1 & 7] = cartridge.readRom<false>(Nonsequential, prefetch.load);  //todo: make access sequentiality consistent with timing used
+    cartridge.startBurst(prefetch.load);  //todo: only start burst when necessary
+    prefetch.slot[prefetch.load >> 1 & 7] = cartridge.readRom<false>(prefetch.load);
     prefetch.load += 2;
-    prefetch.wait = waitCartridge(Sequential, prefetch.load);
+    prefetch.wait = waitCartridge(prefetch.load, true);
   }
 }
 
@@ -44,7 +45,7 @@ auto CPU::prefetchReset() -> void {
 auto CPU::prefetchRead() -> n16 {
   if(prefetch.stopped && prefetch.empty()) {
     prefetch.stopped = false;
-    prefetch.wait = waitCartridge(Nonsequential, prefetch.load);
+    prefetch.wait = waitCartridge(prefetch.load, false);
   }
   if(prefetch.empty()) prefetchStepInternal(prefetch.wait);
 

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -122,5 +122,6 @@ auto CPU::serialize(serializer& s) -> void {
   s(context.romAccess);
   s(context.timerLatched);
   s(context.busLocked);
+  s(context.burstActive);
   s(context.hcounter);
 }

--- a/ares/gba/gba.hpp
+++ b/ares/gba/gba.hpp
@@ -20,9 +20,7 @@ namespace ares::GameBoyAdvance {
     Half          =  16,  //16-bit access
     Word          =  32,  //32-bit access
     Signed        =  64,  //sign extended
-    Nonsequential = 128,  //N cycle
-    Sequential    = 256,  //S cycle
-    DMA           = 512,  //DMA transaction
+    DMA           = 128,  //DMA transaction
   };
 
   struct Model {

--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -268,7 +268,7 @@ auto PPU::power() -> void {
   string gameID;
   for(u32 index : range(4)) {
     n32 address = 0xac + index;
-    char byte = cartridge.readRom<true>(0, address).byte(address & 1);
+    char byte = cartridge.readRom<true>(address).byte(address & 1);
     gameID.append(byte);
   }
   if(gameID == "AWRE") renderingCycle = 512;  //Advance Wars (USA)

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v145.3";
+static const string SerializerVersion = "v146";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Fixes some of the C++20 deprecation warnings in the GBA core.