### PR TITLE
hiro/qt: Add Qt 6 support

### DIFF
--- a/hiro/cmake/os-linux.cmake
+++ b/hiro/cmake/os-linux.cmake
@@ -1,9 +1,9 @@
 find_package(X11)
 
-option(USE_QT5 "Use Qt5 UI backend" OFF)
-mark_as_advanced(USE_QT5)
+option(USE_QT6 "Use Qt6 UI backend" OFF)
+mark_as_advanced(USE_QT6)
 
-if(NOT USE_QT5)
+if(NOT USE_QT6)
   find_package(GTK REQUIRED)
 
   target_link_libraries(hiro PRIVATE GTK::GTK X11::X11)
@@ -11,24 +11,24 @@ if(NOT USE_QT5)
   target_enable_feature(hiro "GTK3 UI backend")
   target_compile_definitions(hiro PUBLIC HIRO_GTK=3)
 else()
-  # Note that Qt6 is more-or-less a drop-in replacement here, but changing these targets to use Qt6 is deferred until
-  # Qt support is properly addressed.
+  find_package(Qt6 COMPONENTS Widgets REQUIRED)
 
-  find_package(Qt5 COMPONENTS Widgets Xcb REQUIRED)
-
-  find_program(qt_moc moc-qt5 moc)
+  get_target_property(QT_MOC_EXECUTABLE Qt6::moc LOCATION)
+  if(NOT QT_MOC_EXECUTABLE)
+    message(FATAL_ERROR "Qt6 moc is not found: QT_MOC_EXECUTABLE is not set.")
+  endif()
 
   execute_process(
-    COMMAND qt_moc -i -o ${CMAKE_CURRENT_SOURCE_DIR}/qt/qt.moc ${CMAKE_CURRENT_SOURCE_DIR}/qt/qt.hpp
+    COMMAND ${QT_MOC_EXECUTABLE} -i -o ${CMAKE_CURRENT_SOURCE_DIR}/qt/qt.moc ${CMAKE_CURRENT_SOURCE_DIR}/qt/qt.hpp
   )
 
   target_link_libraries(
     hiro
-    PRIVATE X11::X11 Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Xcb
+    PRIVATE X11::X11 Qt6::Core Qt6::Gui Qt6::Widgets
   )
 
-  target_enable_feature(hiro "Qt5 UI backend")
-  target_compile_definitions(hiro PUBLIC HIRO_QT=5)
+  target_enable_feature(hiro "Qt6 UI backend")
+  target_compile_definitions(hiro PUBLIC HIRO_QT=6)
 endif()
 
 get_target_property(hiro_SOURCES hiro SOURCES)

--- a/hiro/core/application.cpp
+++ b/hiro/core/application.cpp
@@ -46,10 +46,6 @@ auto Application::run() -> void {
   return pApplication::run();
 }
 
-auto Application::pendingEvents() -> bool {
-  return pApplication::pendingEvents();
-}
-
 auto Application::processEvents() -> void {
   return pApplication::processEvents();
 }

--- a/hiro/core/application.hpp
+++ b/hiro/core/application.hpp
@@ -15,7 +15,6 @@ struct Application {
   static auto run() -> void;
   static auto scale() -> f32;
   static auto scale(f32 value) -> f32;
-  static auto pendingEvents() -> bool;
   static auto processEvents() -> void;
   static auto quit() -> void;
   static auto screenSaver() -> bool;

--- a/hiro/qt/application.cpp
+++ b/hiro/qt/application.cpp
@@ -22,12 +22,12 @@ auto pApplication::run() -> void {
   }
 }
 
-auto pApplication::pendingEvents() -> bool {
-  return QApplication::hasPendingEvents();
-}
-
 auto pApplication::processEvents() -> void {
-  while(pendingEvents()) QApplication::processEvents();
+  //qt6 has no means to spin the event loop indefinitely
+  //this is likely to prevent bugs where events produced during the loop spin forever
+  //lets match hiro gtk and spin for a max of 50ms
+  //note that this overload of processEvents *will* spin, but it does exit if the queue is empty
+  QApplication::processEvents(QEventLoop::AllEvents, 50);
 }
 
 auto pApplication::quit() -> void {

--- a/hiro/qt/application.hpp
+++ b/hiro/qt/application.hpp
@@ -6,7 +6,6 @@ struct pApplication {
   static auto exit() -> void;
   static auto modal() -> bool;
   static auto run() -> void;
-  static auto pendingEvents() -> bool;
   static auto processEvents() -> void;
   static auto quit() -> void;
   static auto setScreenSaver(bool screenSaver) -> void;

--- a/hiro/qt/monitor.cpp
+++ b/hiro/qt/monitor.cpp
@@ -7,10 +7,9 @@ auto pMonitor::count() -> u32 {
 }
 
 auto pMonitor::dpi(u32 monitor) -> Position {
-  //Qt does not support per-monitor DPI retrieval
   return {
-    QApplication::desktop()->logicalDpiX(),
-    QApplication::desktop()->logicalDpiY()
+    QApplication::screens().at(monitor)->logicalDotsPerInchX(),
+    QApplication::screens().at(monitor)->logicalDotsPerInchY()
   };
 }
 

--- a/hiro/qt/widget/hex-edit.cpp
+++ b/hiro/qt/widget/hex-edit.cpp
@@ -11,7 +11,7 @@ auto pHexEdit::construct() -> void {
 
   qtLayout = new QHBoxLayout;
   qtLayout->setAlignment(Qt::AlignRight);
-  qtLayout->setMargin(0);
+  qtLayout->setContentsMargins(0, 0, 0, 0);
   qtLayout->setSpacing(0);
   qtHexEdit->setLayout(qtLayout);
 

--- a/hiro/qt/window.cpp
+++ b/hiro/qt/window.cpp
@@ -18,7 +18,7 @@ auto pWindow::construct() -> void {
   }
 
   qtLayout = new QVBoxLayout(qtWindow);
-  qtLayout->setMargin(0);
+  qtLayout->setContentsMargins(0, 0, 0, 0);
   qtLayout->setSpacing(0);
   qtWindow->setLayout(qtLayout);
 

--- a/hiro/qt/window.cpp
+++ b/hiro/qt/window.cpp
@@ -83,9 +83,9 @@ auto pWindow::handle() const -> uintptr_t {
 }
 
 auto pWindow::monitor() const -> u32 {
-  s32 monitor = QDesktopWidget().screenNumber(qtWindow);
-  if(monitor < 0) monitor = Monitor::primary();
-  return monitor;
+  auto screen = qtWindow->window()->windowHandle()->screen();
+  if(screen == nullptr) return Monitor::primary();
+  return max(QApplication::screens().indexOf(screen), 0);
 }
 
 auto pWindow::remove(sMenuBar menuBar) -> void {


### PR DESCRIPTION
This is mostly forward-porting from:

https://github.com/bsnes-emu/bsnes/pull/365
https://github.com/bsnes-emu/bsnes/pull/366
https://github.com/bsnes-emu/bsnes/pull/368

I just replaced the old Qt 5 build with a new Qt 6 build since Qt 5 has been completely EOL for a while now anyways. Qt 6 seems to have been in Debian since at least bookworm so I think it's unlikely to be a problem.

I should've checked beforehand but I can also see some places where the fixes here are better than mine (the QFontMetrics fix already applied makes a lot more sense for example; `boundingRect().width()` is probably what was desired in the first place.) So maybe I should backport some of the ares changes into bsnes/higan, too.