### PR TITLE
gba: fix remaining C++20 deprecation warnings

### DIFF
--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -60,15 +60,18 @@ struct CPU : ARM7TDMI, Thread, IO {
 
   //bus.cpp
   auto sleep() -> void override;
-  template<bool UseDebugger> auto getBus(u32 mode, n32 address) -> n32;
+  template<bool isDMA, bool UseDebugger> auto getBus(u32 mode, n32 address) -> n32;
   auto get(u32 mode, n32 address) -> n32 override;
+  auto getDMA(u32 mode, n32 address) -> n32;
   auto getDebugger(u32 mode, n32 address) -> n32 override;
+  template<bool IsDMA> auto setBus(u32 mode, n32 address, n32 word) -> void;
   auto set(u32 mode, n32 address, n32 word) -> void override;
+  auto setDMA(u32 mode, n32 address, n32 word) -> void;
   auto lock() -> void override;
   auto unlock() -> void override;
   auto waitEWRAM(u32 mode) -> u32;
   auto waitCartridge(n32 address, bool sequential) -> u32;
-  auto checkBurst(u32 mode) -> bool;
+  template<bool IsDMA> auto checkBurst(u32 mode) -> bool;
 
   //io.cpp
   auto readIO(n32 address) -> n8 override;

--- a/ares/gba/cpu/dma.cpp
+++ b/ares/gba/cpu/dma.cpp
@@ -44,7 +44,7 @@ inline auto CPU::DMAC::Channel::ready() -> bool {
 
 auto CPU::DMAC::Channel::read() -> void {
   u32 seek = size ? 4 : 2;
-  u32 mode = DMA | (size ? Word : Half );
+  u32 mode = size ? Word : Half;
 
   if(cpu.dmac.activeChannel != id) {
     //channel has switched - new burst transfer must be started
@@ -58,7 +58,7 @@ auto CPU::DMAC::Channel::read() -> void {
     n32 addr = latch.source();
     if(mode & Word) addr &= ~3;
     if(mode & Half) addr &= ~1;
-    latch.data = cpu.get(mode, addr);
+    latch.data = cpu.getDMA(mode, addr);
     if(mode & Half) latch.data |= latch.data << 16;
   }
 
@@ -72,7 +72,7 @@ auto CPU::DMAC::Channel::read() -> void {
 
 auto CPU::DMAC::Channel::write() -> void {
   u32 seek = size ? 4 : 2;
-  u32 mode = DMA | (size ? Word : Half );
+  u32 mode = size ? Word : Half;
 
   if(latch.target() < 0x0200'0000) {
     cpu.prefetchStep(1);  //cannot access BIOS
@@ -80,7 +80,7 @@ auto CPU::DMAC::Channel::write() -> void {
     n32 addr = latch.target();
     if(mode & Word) addr &= ~3;
     if(mode & Half) addr &= ~1;
-    cpu.set(mode, addr, latch.data >> (addr & 2) * 8);
+    cpu.setDMA(mode, addr, latch.data >> (addr & 2) * 8);
   }
 
   switch(targetMode) {

--- a/ares/gba/gba.hpp
+++ b/ares/gba/gba.hpp
@@ -12,15 +12,14 @@ namespace ares::GameBoyAdvance {
   auto load(Node::System& node, string name) -> bool;
   auto option(string name, string value) -> bool;
 
-  enum : u32 {           //mode flags for bus read, write:
-    Load          =   1,  //load operation
-    Store         =   2,  //store operation
-    Prefetch      =   4,  //instruction fetch (eligible for prefetch)
-    Byte          =   8,  //8-bit access
-    Half          =  16,  //16-bit access
-    Word          =  32,  //32-bit access
-    Signed        =  64,  //sign extended
-    DMA           = 128,  //DMA transaction
+  enum : u32 {
+    Load          = 1 << 0,  //load operation
+    Store         = 1 << 1,  //store operation
+    Prefetch      = 1 << 2,  //instruction fetch
+    Byte          = 1 << 3,  // 8-bit access
+    Half          = 1 << 4,  //16-bit access
+    Word          = 1 << 5,  //32-bit access
+    Signed        = 1 << 6,  //sign-extend
   };
 
   struct Model {


### PR DESCRIPTION
Followup to #2192 - fixes the remaining deprecation warnings in the GBA core.