### PR TITLE
n64: Implement basic MI repeat mode

### DIFF
--- a/ares/n64/mi/io.cpp
+++ b/ares/n64/mi/io.cpp
@@ -57,7 +57,6 @@ auto MI::writeWord(u32 address, u32 data_, Thread& thread) -> void {
     if(data.bit(12)) io.rdramRegisterSelect = 0;
     if(data.bit(13)) io.rdramRegisterSelect = 1;
 
-    if(io.initializeMode) debug(unimplemented, "[MI::writeWord] initializeMode=1");
     if(io.ebusTestMode  ) debug(unimplemented, "[MI::writeWord] ebusTestMode=1");
   }
 

--- a/ares/n64/mi/mi.hpp
+++ b/ares/n64/mi/mi.hpp
@@ -29,6 +29,8 @@ struct MI : Memory::RCP<MI> {
   //io.cpp
   auto readWord(u32 address, Thread& thread) -> u32;
   auto writeWord(u32 address, u32 data, Thread& thread) -> void;
+  auto initializeMode() -> bool { bool m = io.initializeMode; io.initializeMode = 0; return m; }
+  auto initializeLength() -> n7 { return io.initializeLength; }
 
   //serialization.cpp
   auto serialize(serializer&) -> void;


### PR DESCRIPTION
Implement the MI "repeat mode" described here: https://n64brew.dev/wiki/MIPS_Interface#0x0430_0000_-_MI_MODE

Matching n64-systemtest PR to verify the implementation is here: https://github.com/lemmy-64/n64-systemtest/pull/84

This implementation only works correctly for single writes on a 4-byte boundary. Fully accurate support of using repeat mode with SB/SH/SWL/SWR/SDL/SDR to any address will require more changes to how the memory bus is implemented.