### PR TITLE
stdc++: migrate desktop-ui and mia, add nall::merge/split and migrate some of the uses to them

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -181,7 +181,8 @@
       "description": "Single-arch binary for building on Github Actions",
       "inherits": ["ubuntu-ci"],
       "cacheVariables": {
-        "USE_QT6": true
+        "USE_QT6": true,
+        "ARES_BUILD_OPTIONAL_TARGETS": false
       }
     }
   ],

--- a/ares/ares/node/object.hpp
+++ b/ares/ares/node/object.hpp
@@ -109,11 +109,13 @@ struct Object : shared_pointer_this<Object> {
   template<typename T = Node::Object>
   auto find(string name) -> T {
     using Type = typename T::type;
-    auto path = name.split("/");
-    name = path.takeFirst();
+    auto path = ::nall::split(name, "/");
+    if(path.empty()) return {};
+    name = path.front();
+    path.erase(path.begin());
     for(auto& node : _nodes) {
       if(node->_name != name) continue;
-      if(path) return node->find<T>(path.merge("/"));
+      if(!path.empty()) return node->find<T>(::nall::merge(path, "/"));
       if(node->identity() == Type::identifier()) return node;
     }
     return {};

--- a/ares/ares/node/object.hpp
+++ b/ares/ares/node/object.hpp
@@ -109,13 +109,13 @@ struct Object : shared_pointer_this<Object> {
   template<typename T = Node::Object>
   auto find(string name) -> T {
     using Type = typename T::type;
-    auto path = ::nall::split(name, "/");
+    auto path = nall::split(name, "/");
     if(path.empty()) return {};
     name = path.front();
     path.erase(path.begin());
     for(auto& node : _nodes) {
       if(node->_name != name) continue;
-      if(!path.empty()) return node->find<T>(::nall::merge(path, "/"));
+      if(!path.empty()) return node->find<T>(nall::merge(path, "/"));
       if(node->identity() == Type::identifier()) return node;
     }
     return {};

--- a/ares/component/processor/huc6280/disassembler.cpp
+++ b/ares/component/processor/huc6280/disassembler.cpp
@@ -163,7 +163,7 @@ auto HuC6280::disassembleInstruction() -> string {
 
   n8 opcode = readByte();
 
-  #define op(id, name, ...) case id: o = {name, " ", nall::merge({__VA_ARGS__}, ",")}; break;
+  #define op(id, name, ...) case id: o = {name, " ", ::nall::merge({__VA_ARGS__}, ",")}; break;
   string o;
 
   #define U

--- a/ares/component/processor/huc6280/disassembler.cpp
+++ b/ares/component/processor/huc6280/disassembler.cpp
@@ -163,7 +163,7 @@ auto HuC6280::disassembleInstruction() -> string {
 
   n8 opcode = readByte();
 
-  #define op(id, name, ...) case id: o = {name, " ", ::nall::merge({__VA_ARGS__}, ",")}; break;
+  #define op(id, name, ...) case id: o = {name, " ", nall::merge({__VA_ARGS__}, ",")}; break;
   string o;
 
   #define U

--- a/ares/component/processor/i8080/disassembler.cpp
+++ b/ares/component/processor/i8080/disassembler.cpp
@@ -41,7 +41,7 @@ auto I8080::disassembleContext() -> string {
   return s;
 }
 
-#define op(id, name, ...) case id: return {name, " ", nall::merge({__VA_ARGS__}, ",")};
+#define op(id, name, ...) case id: return {name, " ", ::nall::merge({__VA_ARGS__}, ",")};
 
 #define N   string{"$", hex(byte(), 2L)}
 #define IN  string{"(", N, ")"}

--- a/ares/component/processor/i8080/disassembler.cpp
+++ b/ares/component/processor/i8080/disassembler.cpp
@@ -41,7 +41,7 @@ auto I8080::disassembleContext() -> string {
   return s;
 }
 
-#define op(id, name, ...) case id: return {name, " ", ::nall::merge({__VA_ARGS__}, ",")};
+#define op(id, name, ...) case id: return {name, " ", nall::merge({__VA_ARGS__}, ",")};
 
 #define N   string{"$", hex(byte(), 2L)}
 #define IN  string{"(", N, ")"}

--- a/ares/component/processor/sh2/disassembler.cpp
+++ b/ares/component/processor/sh2/disassembler.cpp
@@ -515,7 +515,7 @@ auto SH2::disassembleInstruction(u16 opcode) -> string {
   if(s.empty()) s = {"illegal", {"0x", hex(opcode, 4L)}};
   auto name = s.front(); s.erase(s.begin());
   while(name.size() < 8) name.append(" ");
-  string r = {name, nall::merge(s, ",")};
+  string r = {name, ::nall::merge(s, ",")};
   while(r.size() < 30) r.append(" ");
   return r;
 }

--- a/ares/component/processor/sh2/disassembler.cpp
+++ b/ares/component/processor/sh2/disassembler.cpp
@@ -515,7 +515,7 @@ auto SH2::disassembleInstruction(u16 opcode) -> string {
   if(s.empty()) s = {"illegal", {"0x", hex(opcode, 4L)}};
   auto name = s.front(); s.erase(s.begin());
   while(name.size() < 8) name.append(" ");
-  string r = {name, ::nall::merge(s, ",")};
+  string r = {name, nall::merge(s, ",")};
   while(r.size() < 30) r.append(" ");
   return r;
 }

--- a/ares/component/processor/v30mz/disassembler.cpp
+++ b/ares/component/processor/v30mz/disassembler.cpp
@@ -150,7 +150,7 @@ auto V30MZ::disassembleInstruction(u16 ps, u16 pc) -> string {
   };
 
   #define op(id, name, ...) case id: \
-    output.append(instruction(name), ::nall::merge({__VA_ARGS__}, ",")); \
+    output.append(instruction(name), nall::merge({__VA_ARGS__}, ",")); \
     break
 
   auto opcode = read(0);

--- a/ares/component/processor/v30mz/disassembler.cpp
+++ b/ares/component/processor/v30mz/disassembler.cpp
@@ -150,7 +150,7 @@ auto V30MZ::disassembleInstruction(u16 ps, u16 pc) -> string {
   };
 
   #define op(id, name, ...) case id: \
-    output.append(instruction(name), nall::merge({__VA_ARGS__}, ",")); \
+    output.append(instruction(name), ::nall::merge({__VA_ARGS__}, ",")); \
     break
 
   auto opcode = read(0);

--- a/ares/component/processor/z80/disassembler.cpp
+++ b/ares/component/processor/z80/disassembler.cpp
@@ -56,7 +56,7 @@ auto Z80::disassembleContext() -> string {
   return s;
 }
 
-#define op(id, name, ...) case id: return {name, " ", ::nall::merge({__VA_ARGS__}, ",")};
+#define op(id, name, ...) case id: return {name, " ", nall::merge({__VA_ARGS__}, ",")};
 
 #define N   string{"$", hex(byte(), 2L)}
 #define IN  string{"(", N, ")"}

--- a/ares/component/processor/z80/disassembler.cpp
+++ b/ares/component/processor/z80/disassembler.cpp
@@ -56,7 +56,7 @@ auto Z80::disassembleContext() -> string {
   return s;
 }
 
-#define op(id, name, ...) case id: return {name, " ", nall::merge({__VA_ARGS__}, ",")};
+#define op(id, name, ...) case id: return {name, " ", ::nall::merge({__VA_ARGS__}, ",")};
 
 #define N   string{"$", hex(byte(), 2L)}
 #define IN  string{"(", N, ")"}

--- a/ares/md/cartridge/cartridge.cpp
+++ b/ares/md/cartridge/cartridge.cpp
@@ -16,12 +16,8 @@ auto Cartridge::connect() -> void {
 
   information = {};
   information.title    = pak->attribute("title");
-  //FIXME(stdc++): make sure we fix this later
-  auto temp_regions = pak->attribute("region").split(",").strip();
-  information.regions.clear();
-  for(auto& region : temp_regions) {
-    information.regions.push_back(region);
-  }
+  auto region = pak->attribute("region");
+  information.regions  = ::nall::split_and_strip(region, ",");
   information.bootable = pak->attribute("bootable").boolean();
 
   if(pak->attribute("mega32x").boolean()) {

--- a/ares/md/cartridge/cartridge.cpp
+++ b/ares/md/cartridge/cartridge.cpp
@@ -17,7 +17,7 @@ auto Cartridge::connect() -> void {
   information = {};
   information.title    = pak->attribute("title");
   auto region = pak->attribute("region");
-  information.regions  = ::nall::split_and_strip(region, ",");
+  information.regions  = nall::split_and_strip(region, ",");
   information.bootable = pak->attribute("bootable").boolean();
 
   if(pak->attribute("mega32x").boolean()) {

--- a/ares/md/m32x/m32x.hpp
+++ b/ares/md/m32x/m32x.hpp
@@ -1,5 +1,4 @@
 //Mega 32X
-#include "nall/dsp/iir/dc-removal.hpp"
 
 struct M32X {
   Node::Object node;

--- a/ares/md/md.hpp
+++ b/ares/md/md.hpp
@@ -3,6 +3,7 @@
 
 #include <ares/ares.hpp>
 #include <nall/decode/mmi.hpp>
+#include <nall/dsp/iir/dc-removal.hpp>
 #include <vector>
 #include <cmath>
 

--- a/ares/n64/ai/debugger.cpp
+++ b/ares/n64/ai/debugger.cpp
@@ -16,10 +16,10 @@ auto AI::Debugger::io(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("AI_UNKNOWN"));
     if(mode == Read) {
-      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
+      message = {nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
+      message = {nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/ai/debugger.cpp
+++ b/ares/n64/ai/debugger.cpp
@@ -16,10 +16,10 @@ auto AI::Debugger::io(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("AI_UNKNOWN"));
     if(mode == Read) {
-      message = {name.split("|").first(), " => ", hex(data, 8L)};
+      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {name.split("|").last(), " <= ", hex(data, 8L)};
+      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/cpu/debugger.cpp
+++ b/ares/n64/cpu/debugger.cpp
@@ -69,7 +69,7 @@ auto CPU::Debugger::interrupt(u8 mask) -> void {
     if(mask & 0x20) sources.push_back("read RDB");
     if(mask & 0x40) sources.push_back("write RDB");
     if(mask & 0x80) sources.push_back("timer");
-    tracer.interrupt->notify(::nall::merge(sources, ","));
+    tracer.interrupt->notify(nall::merge(sources, ","));
   }
 }
 

--- a/ares/n64/cpu/debugger.cpp
+++ b/ares/n64/cpu/debugger.cpp
@@ -69,7 +69,7 @@ auto CPU::Debugger::interrupt(u8 mask) -> void {
     if(mask & 0x20) sources.push_back("read RDB");
     if(mask & 0x40) sources.push_back("write RDB");
     if(mask & 0x80) sources.push_back("timer");
-    tracer.interrupt->notify(nall::merge(sources, ","));
+    tracer.interrupt->notify(::nall::merge(sources, ","));
   }
 }
 

--- a/ares/n64/cpu/disassembler.cpp
+++ b/ares/n64/cpu/disassembler.cpp
@@ -7,7 +7,7 @@ auto CPU::Disassembler::disassemble(u32 address, u32 instruction) -> string {
   if(!instruction) v = {"nop"};
   auto s = pad(v.front(), -8L);
   v.erase(v.begin());
-  return {s, ::nall::merge(v, ",")};
+  return {s, nall::merge(v, ",")};
 }
 
 auto CPU::Disassembler::EXECUTE() -> std::vector<string> {

--- a/ares/n64/cpu/disassembler.cpp
+++ b/ares/n64/cpu/disassembler.cpp
@@ -7,7 +7,7 @@ auto CPU::Disassembler::disassemble(u32 address, u32 instruction) -> string {
   if(!instruction) v = {"nop"};
   auto s = pad(v.front(), -8L);
   v.erase(v.begin());
-  return {s, nall::merge(v, ",")};
+  return {s, ::nall::merge(v, ",")};
 }
 
 auto CPU::Disassembler::EXECUTE() -> std::vector<string> {

--- a/ares/n64/dd/debugger.cpp
+++ b/ares/n64/dd/debugger.cpp
@@ -39,10 +39,10 @@ auto DD::Debugger::io(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("ASIC_UNKNOWN"));
     if(mode == Read) {
-      message = {name.split("|").first(), " => ", hex(data, 8L)};
+      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {name.split("|").last(), " <= ", hex(data, 8L)};
+      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/dd/debugger.cpp
+++ b/ares/n64/dd/debugger.cpp
@@ -39,10 +39,10 @@ auto DD::Debugger::io(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("ASIC_UNKNOWN"));
     if(mode == Read) {
-      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
+      message = {nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
+      message = {nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/mi/debugger.cpp
+++ b/ares/n64/mi/debugger.cpp
@@ -28,10 +28,10 @@ auto MI::Debugger::io(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("MI_UNKNOWN"));
     if(mode == Read) {
-      message = {name.split("|").first(), " => ", hex(data, 8L)};
+      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {name.split("|").last(), " <= ", hex(data, 8L)};
+      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/mi/debugger.cpp
+++ b/ares/n64/mi/debugger.cpp
@@ -28,10 +28,10 @@ auto MI::Debugger::io(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("MI_UNKNOWN"));
     if(mode == Read) {
-      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
+      message = {nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
+      message = {nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/pi/debugger.cpp
+++ b/ares/n64/pi/debugger.cpp
@@ -23,10 +23,10 @@ auto PI::Debugger::io(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("PI_UNKNOWN"));
     if(mode == Read) {
-      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
+      message = {nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
+      message = {nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/pi/debugger.cpp
+++ b/ares/n64/pi/debugger.cpp
@@ -23,10 +23,10 @@ auto PI::Debugger::io(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("PI_UNKNOWN"));
     if(mode == Read) {
-      message = {name.split("|").first(), " => ", hex(data, 8L)};
+      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {name.split("|").last(), " <= ", hex(data, 8L)};
+      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/rdp/debugger.cpp
+++ b/ares/n64/rdp/debugger.cpp
@@ -25,10 +25,10 @@ auto RDP::Debugger::ioDPC(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("DPC_UNKNOWN"));
     if(mode == Read) {
-      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
+      message = {nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
+      message = {nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }
@@ -46,10 +46,10 @@ auto RDP::Debugger::ioDPS(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("DPS_UNKNOWN"));
     if(mode == Read) {
-      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
+      message = {nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
+      message = {nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/rdp/debugger.cpp
+++ b/ares/n64/rdp/debugger.cpp
@@ -25,10 +25,10 @@ auto RDP::Debugger::ioDPC(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("DPC_UNKNOWN"));
     if(mode == Read) {
-      message = {name.split("|").first(), " => ", hex(data, 8L)};
+      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {name.split("|").last(), " <= ", hex(data, 8L)};
+      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }
@@ -46,10 +46,10 @@ auto RDP::Debugger::ioDPS(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("DPS_UNKNOWN"));
     if(mode == Read) {
-      message = {name.split("|").first(), " => ", hex(data, 8L)};
+      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {name.split("|").last(), " <= ", hex(data, 8L)};
+      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/rdram/debugger.cpp
+++ b/ares/n64/rdram/debugger.cpp
@@ -51,10 +51,10 @@ auto RDRAM::Debugger::io(bool mode, u32 chipID, u32 address, u32 data) -> void {
     string name = (address < registerNames.size() ? registerNames[address] : string("RDRAM_UNKNOWN"));
     name.append("[", chipID, "]");
     if(mode == Read) {
-      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
+      message = {nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
+      message = {nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/rdram/debugger.cpp
+++ b/ares/n64/rdram/debugger.cpp
@@ -51,10 +51,10 @@ auto RDRAM::Debugger::io(bool mode, u32 chipID, u32 address, u32 data) -> void {
     string name = (address < registerNames.size() ? registerNames[address] : string("RDRAM_UNKNOWN"));
     name.append("[", chipID, "]");
     if(mode == Read) {
-      message = {name.split("|").first(), " => ", hex(data, 8L)};
+      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {name.split("|").last(), " <= ", hex(data, 8L)};
+      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/ri/debugger.cpp
+++ b/ares/n64/ri/debugger.cpp
@@ -18,10 +18,10 @@ auto RI::Debugger::io(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("RI_UNKNOWN"));
     if(mode == Read) {
-      message = {name.split("|").first(), " => ", hex(data, 8L)};
+      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {name.split("|").last(), " <= ", hex(data, 8L)};
+      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/ri/debugger.cpp
+++ b/ares/n64/ri/debugger.cpp
@@ -18,10 +18,10 @@ auto RI::Debugger::io(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("RI_UNKNOWN"));
     if(mode == Read) {
-      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
+      message = {nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
+      message = {nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/rsp/debugger.cpp
+++ b/ares/n64/rsp/debugger.cpp
@@ -76,10 +76,10 @@ auto RSP::Debugger::ioSCC(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("SP_UNKNOWN"));
     if(mode == Read) {
-      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
+      message = {nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
+      message = {nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }
@@ -95,10 +95,10 @@ auto RSP::Debugger::ioStatus(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("SP_UNKNOWN"));
     if(mode == Read) {
-      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
+      message = {nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
+      message = {nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/rsp/debugger.cpp
+++ b/ares/n64/rsp/debugger.cpp
@@ -76,10 +76,10 @@ auto RSP::Debugger::ioSCC(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("SP_UNKNOWN"));
     if(mode == Read) {
-      message = {name.split("|").first(), " => ", hex(data, 8L)};
+      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {name.split("|").last(), " <= ", hex(data, 8L)};
+      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }
@@ -95,10 +95,10 @@ auto RSP::Debugger::ioStatus(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("SP_UNKNOWN"));
     if(mode == Read) {
-      message = {name.split("|").first(), " => ", hex(data, 8L)};
+      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {name.split("|").last(), " <= ", hex(data, 8L)};
+      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/rsp/disassembler.cpp
+++ b/ares/n64/rsp/disassembler.cpp
@@ -7,7 +7,7 @@ auto RSP::Disassembler::disassemble(u32 address, u32 instruction) -> string {
   if(!instruction) v = {"nop"};
   auto s = pad(v.front(), -8L);
   v.erase(v.begin());
-  return {s, nall::merge(v, ",")};
+  return {s, ::nall::merge(v, ",")};
 }
 
 auto RSP::Disassembler::EXECUTE() -> std::vector<string> {
@@ -509,7 +509,7 @@ auto RSP::Disassembler::vpuRegisterValue(u32 index, u32 element) const -> string
     std::vector<string> elements;
     elements.reserve(8);
     for(u32 e : range(8)) elements.push_back(hex(self.vpu.r[index].element(e), 4L));
-    return {vpuRegisterName(index, element), hint("{$", nall::merge(elements, "|"), "}")};
+    return {vpuRegisterName(index, element), hint("{$", ::nall::merge(elements, "|"), "}")};
   }
   return vpuRegisterName(index, element);
 }

--- a/ares/n64/rsp/disassembler.cpp
+++ b/ares/n64/rsp/disassembler.cpp
@@ -7,7 +7,7 @@ auto RSP::Disassembler::disassemble(u32 address, u32 instruction) -> string {
   if(!instruction) v = {"nop"};
   auto s = pad(v.front(), -8L);
   v.erase(v.begin());
-  return {s, ::nall::merge(v, ",")};
+  return {s, nall::merge(v, ",")};
 }
 
 auto RSP::Disassembler::EXECUTE() -> std::vector<string> {
@@ -509,7 +509,7 @@ auto RSP::Disassembler::vpuRegisterValue(u32 index, u32 element) const -> string
     std::vector<string> elements;
     elements.reserve(8);
     for(u32 e : range(8)) elements.push_back(hex(self.vpu.r[index].element(e), 4L));
-    return {vpuRegisterName(index, element), hint("{$", ::nall::merge(elements, "|"), "}")};
+    return {vpuRegisterName(index, element), hint("{$", nall::merge(elements, "|"), "}")};
   }
   return vpuRegisterName(index, element);
 }

--- a/ares/n64/si/debugger.cpp
+++ b/ares/n64/si/debugger.cpp
@@ -17,10 +17,10 @@ auto SI::Debugger::io(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("SI_UNKNOWN"));
     if(mode == Read) {
-      message = {name.split("|").first(), " => ", hex(data, 8L)};
+      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {name.split("|").last(), " <= ", hex(data, 8L)};
+      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/si/debugger.cpp
+++ b/ares/n64/si/debugger.cpp
@@ -17,10 +17,10 @@ auto SI::Debugger::io(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("SI_UNKNOWN"));
     if(mode == Read) {
-      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
+      message = {nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
+      message = {nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/vi/debugger.cpp
+++ b/ares/n64/vi/debugger.cpp
@@ -24,10 +24,10 @@ auto VI::Debugger::io(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("VI_UNKNOWN"));
     if(mode == Read) {
-      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
+      message = {nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
+      message = {nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/n64/vi/debugger.cpp
+++ b/ares/n64/vi/debugger.cpp
@@ -24,10 +24,10 @@ auto VI::Debugger::io(bool mode, u32 address, u32 data) -> void {
     string message;
     string name = (address < registerNames.size() ? registerNames[address] : string("VI_UNKNOWN"));
     if(mode == Read) {
-      message = {name.split("|").first(), " => ", hex(data, 8L)};
+      message = {::nall::split(name, "|").front(), " => ", hex(data, 8L)};
     }
     if(mode == Write) {
-      message = {name.split("|").last(), " <= ", hex(data, 8L)};
+      message = {::nall::split(name, "|").back(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
   }

--- a/ares/ngp/cpu/debugger.cpp
+++ b/ares/ngp/cpu/debugger.cpp
@@ -43,7 +43,7 @@ auto CPU::Debugger::instruction() -> void {
   if(unlikely(tracer.systemCall->enabled())) {
     auto PC = self.TLCS900H::load(TLCS900H::PC);
     if(!PC) return;
-    if(auto vectorID = nall::index_of(vectors, n24(PC))) {
+    if(auto vectorID = ::nall::index_of(vectors, n24(PC))) {
       auto RA3  = self.TLCS900H::load(TLCS900H::RA3);
       auto RC3  = self.TLCS900H::load(TLCS900H::RC3);
       auto RB3  = self.TLCS900H::load(TLCS900H::RB3);
@@ -162,7 +162,7 @@ auto CPU::Debugger::instruction() -> void {
         name = {"VECT_UNKNOWN[$", hex(*vectorID, 2L), "]"};
         break;
       }
-      tracer.systemCall->notify(string{name, "(", nall::merge(args, ", "), ")"});
+      tracer.systemCall->notify(string{name, "(", ::nall::merge(args, ", "), ")"});
     }
   }
 

--- a/ares/ngp/cpu/debugger.cpp
+++ b/ares/ngp/cpu/debugger.cpp
@@ -43,7 +43,7 @@ auto CPU::Debugger::instruction() -> void {
   if(unlikely(tracer.systemCall->enabled())) {
     auto PC = self.TLCS900H::load(TLCS900H::PC);
     if(!PC) return;
-    if(auto vectorID = ::nall::index_of(vectors, n24(PC))) {
+    if(auto vectorID = nall::index_of(vectors, n24(PC))) {
       auto RA3  = self.TLCS900H::load(TLCS900H::RA3);
       auto RC3  = self.TLCS900H::load(TLCS900H::RC3);
       auto RB3  = self.TLCS900H::load(TLCS900H::RB3);
@@ -162,7 +162,7 @@ auto CPU::Debugger::instruction() -> void {
         name = {"VECT_UNKNOWN[$", hex(*vectorID, 2L), "]"};
         break;
       }
-      tracer.systemCall->notify(string{name, "(", ::nall::merge(args, ", "), ")"});
+      tracer.systemCall->notify(string{name, "(", nall::merge(args, ", "), ")"});
     }
   }
 

--- a/ares/ps1/peripheral/dualshock/dualshock.cpp
+++ b/ares/ps1/peripheral/dualshock/dualshock.cpp
@@ -103,7 +103,8 @@ auto DualShock::bus(u8 data) -> u8 {
 
   //if there is data in the output queue, return that
   if(outputData.size() > 0) {
-    output = outputData.front(); outputData.erase(outputData.begin());
+    output = outputData.front();
+    outputData.erase(outputData.begin());
     commandStep++;
     if(outputData.size() == 0) {
       commandStep = 0;
@@ -136,11 +137,16 @@ auto DualShock::bus(u8 data) -> u8 {
 
     //Global commands: these work during any operation mode
     switch(input) {
-      case 0x42: { auto v = readPad(); outputData.insert(outputData.end(), v.begin(), v.end()); } break;
+      case 0x42: { 
+        auto v = readPad();
+        outputData.insert(outputData.end(), v.begin(), v.end()); 
+      } break;
       case 0x43: {
         if(configMode) { outputData.insert(outputData.end(), {0x00,0x00,0x00,0x00,0x00,0x00}); }
-        else { auto v = readPad(); outputData.insert(outputData.end(), v.begin(), v.end()); }
-        break;
+        else {
+          auto v = readPad();
+          outputData.insert(outputData.end(), v.begin(), v.end());
+        } break;
       default:
         if(configMode) {
           switch(input) {

--- a/ares/sfc/cartridge/load.cpp
+++ b/ares/sfc/cartridge/load.cpp
@@ -13,9 +13,9 @@ auto Cartridge::loadBoard(string board) -> Markup::Node {
       auto id = leaf.text();
       bool matched = id == board;
       if(!matched && id.match("*(*)*")) {
-        auto part = ::nall::split(id.transform("()", "||"), "|");
+        auto part = nall::split(id.transform("()", "||"), "|");
         part.resize(3);
-        for(auto& revision : ::nall::split(part[1], ",")) {
+        for(auto& revision : nall::split(part[1], ",")) {
           if(string{part[0], revision, part[2]} == board) matched = true;
         }
       }

--- a/ares/sfc/cartridge/load.cpp
+++ b/ares/sfc/cartridge/load.cpp
@@ -13,9 +13,10 @@ auto Cartridge::loadBoard(string board) -> Markup::Node {
       auto id = leaf.text();
       bool matched = id == board;
       if(!matched && id.match("*(*)*")) {
-        auto part = id.transform("()", "||").split("|");
-        for(auto& revision : part(1).split(",")) {
-          if(string{part(0), revision, part(2)} == board) matched = true;
+        auto part = ::nall::split(id.transform("()", "||"), "|");
+        part.resize(3);
+        for(auto& revision : ::nall::split(part[1], ",")) {
+          if(string{part[0], revision, part[2]} == board) matched = true;
         }
       }
       if(matched) return leaf;

--- a/ares/sfc/memory/memory.cpp
+++ b/ares/sfc/memory/memory.cpp
@@ -42,14 +42,14 @@ auto Bus::map(
   reader[id] = read;
   writer[id] = write;
 
-  auto p = ::nall::split(addr, ":", 1L);
+  auto p = nall::split(addr, ":", 1L);
   p.resize(2);
-  auto banks = ::nall::split(p[0], ",");
-  auto addrs = ::nall::split(p[1], ",");
+  auto banks = nall::split(p[0], ",");
+  auto addrs = nall::split(p[1], ",");
   for(auto& bank : banks) {
     for(auto& addr : addrs) {
-      auto bankRange = ::nall::split(bank, "-", 1L);
-      auto addrRange = ::nall::split(addr, "-", 1L);
+      auto bankRange = nall::split(bank, "-", 1L);
+      auto addrRange = nall::split(addr, "-", 1L);
       u32 bankLo = bankRange[0].hex();
       u32 bankHi = bankRange.size() > 1 ? bankRange[1].hex() : bankRange[0].hex();
       u32 addrLo = addrRange[0].hex();
@@ -78,14 +78,14 @@ auto Bus::map(
 }
 
 auto Bus::unmap(const string& addr) -> void {
-  auto p = ::nall::split(addr, ":", 1L);
+  auto p = nall::split(addr, ":", 1L);
   p.resize(2);
-  auto banks = ::nall::split(p[0], ",");
-  auto addrs = ::nall::split(p[1], ",");
+  auto banks = nall::split(p[0], ",");
+  auto addrs = nall::split(p[1], ",");
   for(auto& bank : banks) {
     for(auto& addr : addrs) {
-      auto bankRange = ::nall::split(bank, "-", 1L);
-      auto addrRange = ::nall::split(addr, "-", 1L);
+      auto bankRange = nall::split(bank, "-", 1L);
+      auto addrRange = nall::split(addr, "-", 1L);
       u32 bankLo = bankRange[0].hex();
       u32 bankHi = bankRange.size() > 1 ? bankRange[1].hex() : bankRange[0].hex();
       u32 addrLo = addrRange[0].hex();

--- a/ares/sfc/memory/memory.cpp
+++ b/ares/sfc/memory/memory.cpp
@@ -42,17 +42,18 @@ auto Bus::map(
   reader[id] = read;
   writer[id] = write;
 
-  auto p = addr.split(":", 1L);
-  auto banks = p(0).split(",");
-  auto addrs = p(1).split(",");
+  auto p = ::nall::split(addr, ":", 1L);
+  p.resize(2);
+  auto banks = ::nall::split(p[0], ",");
+  auto addrs = ::nall::split(p[1], ",");
   for(auto& bank : banks) {
     for(auto& addr : addrs) {
-      auto bankRange = bank.split("-", 1L);
-      auto addrRange = addr.split("-", 1L);
-      u32 bankLo = bankRange(0).hex();
-      u32 bankHi = bankRange(1, bankRange(0)).hex();
-      u32 addrLo = addrRange(0).hex();
-      u32 addrHi = addrRange(1, addrRange(0)).hex();
+      auto bankRange = ::nall::split(bank, "-", 1L);
+      auto addrRange = ::nall::split(addr, "-", 1L);
+      u32 bankLo = bankRange[0].hex();
+      u32 bankHi = bankRange.size() > 1 ? bankRange[1].hex() : bankRange[0].hex();
+      u32 addrLo = addrRange[0].hex();
+      u32 addrHi = addrRange.size() > 1 ? addrRange[1].hex() : addrRange[0].hex();
 
       for(u32 bank = bankLo; bank <= bankHi; bank++) {
         for(u32 addr = addrLo; addr <= addrHi; addr++) {
@@ -77,17 +78,18 @@ auto Bus::map(
 }
 
 auto Bus::unmap(const string& addr) -> void {
-  auto p = addr.split(":", 1L);
-  auto banks = p(0).split(",");
-  auto addrs = p(1).split(",");
+  auto p = ::nall::split(addr, ":", 1L);
+  p.resize(2);
+  auto banks = ::nall::split(p[0], ",");
+  auto addrs = ::nall::split(p[1], ",");
   for(auto& bank : banks) {
     for(auto& addr : addrs) {
-      auto bankRange = bank.split("-", 1L);
-      auto addrRange = addr.split("-", 1L);
-      u32 bankLo = bankRange(0).hex();
-      u32 bankHi = bankRange(1, bankRange(0)).hex();
-      u32 addrLo = addrRange(0).hex();
-      u32 addrHi = addrRange(1, addrRange(1)).hex();
+      auto bankRange = ::nall::split(bank, "-", 1L);
+      auto addrRange = ::nall::split(addr, "-", 1L);
+      u32 bankLo = bankRange[0].hex();
+      u32 bankHi = bankRange.size() > 1 ? bankRange[1].hex() : bankRange[0].hex();
+      u32 addrLo = addrRange[0].hex();
+      u32 addrHi = addrRange.size() > 1 ? addrRange[1].hex() : addrRange[0].hex();
 
       for(u32 bank = bankLo; bank <= bankHi; bank++) {
         for(u32 addr = addrLo; addr <= addrHi; addr++) {

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -97,7 +97,7 @@ auto nall::main(Arguments arguments) -> void {
   if(arguments.find("--setting")) {
     string settingValue;
     while(arguments.take("--setting", settingValue)) {
-      auto kv = settingValue.split("=", 1L);
+      auto kv = nall::split(settingValue, "=", 1L);
       if(kv.size() == 2) {
         auto node = settings[kv[0]];
         if(node) {

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -149,9 +149,9 @@ auto nall::main(Arguments arguments) -> void {
     return;
   }
 
-  program.startGameLoad.reset();
+  program.startGameLoad.clear();
   for(auto argument : arguments) {
-    if(file::exists(argument) || directory::exists(argument)) program.startGameLoad.append(argument);
+    if(file::exists(argument) || directory::exists(argument)) program.startGameLoad.push_back(argument);
   }
 
   Instances::presentation.construct();

--- a/desktop-ui/emulator/arcade.cpp
+++ b/desktop-ui/emulator/arcade.cpp
@@ -45,7 +45,7 @@ Arcade::Arcade() {
     }
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/atari-2600.cpp
+++ b/desktop-ui/emulator/atari-2600.cpp
@@ -19,7 +19,7 @@ Atari2600::Atari2600() {
     device.digital("TV Type",          virtualPorts[0].pad.north);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 
   for(auto id : range(2)) {
@@ -34,7 +34,7 @@ Atari2600::Atari2600() {
 
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/colecovision.cpp
+++ b/desktop-ui/emulator/colecovision.cpp
@@ -9,7 +9,7 @@ ColecoVision::ColecoVision() {
   manufacturer = "Coleco";
   name = "ColecoVision";
 
-  firmware.append({"BIOS", "World", "990bf1956f10207d8781b619eb74f89b00d921c8d45c95c334c16c8cceca09ad"});
+  firmware.push_back({"BIOS", "World", "990bf1956f10207d8781b619eb74f89b00d921c8d45c95c334c16c8cceca09ad"});
 
   for(auto id : range(2)) {
     InputPort port{string{"Controller Port ", 1 + id}};
@@ -35,7 +35,7 @@ ColecoVision::ColecoVision() {
     device.digital("#",     virtualPorts[id].pad.start);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/emulator.cpp
+++ b/desktop-ui/emulator/emulator.cpp
@@ -38,10 +38,10 @@ auto Emulator::locate(const string& location, const string& suffix, const string
 
 //handles region selection when games support multiple regions
 auto Emulator::region() -> string {
-  auto preferredRegions = ::nall::split_and_strip(settings.boot.prefer, ",");
+  auto preferredRegions = nall::split_and_strip(settings.boot.prefer, ",");
   if(game && game->pak) {
     auto regionList = game->pak->attribute("region");
-    auto regions = ::nall::split_and_strip(regionList, ",");
+    auto regions = nall::split_and_strip(regionList, ",");
     if(!regions.empty()) {
       for(auto &prefer: preferredRegions) {
         if(std::ranges::find(regions, prefer) != regions.end()) return prefer; //NTSC-U, NTSC-J or PAL

--- a/desktop-ui/emulator/emulator.cpp
+++ b/desktop-ui/emulator/emulator.cpp
@@ -38,20 +38,22 @@ auto Emulator::locate(const string& location, const string& suffix, const string
 
 //handles region selection when games support multiple regions
 auto Emulator::region() -> string {
-  auto preferredRegions = settings.boot.prefer.split(",").strip();
+  auto preferredRegions = ::nall::split_and_strip(settings.boot.prefer, ",");
   if(game && game->pak) {
-    if(auto regions = game->pak->attribute("region").split(",").strip()) {
+    auto regionList = game->pak->attribute("region");
+    auto regions = ::nall::split_and_strip(regionList, ",");
+    if(!regions.empty()) {
       for(auto &prefer: preferredRegions) {
-        if(regions.find(prefer)) return prefer; //NTSC-U, NTSC-J or PAL
+        if(std::ranges::find(regions, prefer) != regions.end()) return prefer; //NTSC-U, NTSC-J or PAL
       }
 
       //Handle generic "NTSC" region.
       //NOTE: we don't need to check PAL because the above check covered it
-      if(regions.find("NTSC")) return "NTSC";
+      if(std::ranges::find(regions, string{"NTSC"}) != regions.end()) return "NTSC";
 
       //If no preferred region was found, return the first region in the list
       //NOTE: required for 'unsual' regions like NTSC-DEV for 64DD
-      return regions.first();
+      return regions.front();
     }
   }
 

--- a/desktop-ui/emulator/emulator.hpp
+++ b/desktop-ui/emulator/emulator.hpp
@@ -6,7 +6,7 @@ struct Emulator {
   virtual ~Emulator() = default;
 
   //emulator.cpp
-  static auto enumeratePorts(string name) -> vector<InputPort>&;
+  static auto enumeratePorts(string name) -> std::vector<InputPort>&;
   auto location() -> string;
   auto locate(const string& location, const string& suffix, const string& path = "", maybe<string> system = {}) -> string;
   auto region() -> string;
@@ -44,14 +44,14 @@ struct Emulator {
   string name;
   string medium;
   ares::Node::System root;
-  vector<Firmware> firmware;
+  std::vector<Firmware> firmware;
   shared_pointer<mia::Pak> system;
   shared_pointer<mia::Pak> game;
   shared_pointer<mia::Pak> gamepad;
   shared_pointer<mia::Pak> gb;
-  vector<InputPort> ports;
-  vector<string> inputBlacklist;
-  vector<string> portBlacklist;
+  std::vector<InputPort> ports;
+  std::vector<string> inputBlacklist;
+  std::vector<string> portBlacklist;
 
   struct Configuration {
     bool visible = true;  //whether or not to show this emulator in the load menu
@@ -66,8 +66,8 @@ struct Emulator {
   } latch;
 
   //queue of pre-specified game locations; used by Program::load()
-  vector<string> locationQueue;
+  std::vector<string> locationQueue;
 };
 
-extern vector<shared_pointer<Emulator>> emulators;
+extern std::vector<shared_pointer<Emulator>> emulators;
 extern shared_pointer<Emulator> emulator;

--- a/desktop-ui/emulator/emulators.cpp
+++ b/desktop-ui/emulator/emulators.cpp
@@ -161,99 +161,99 @@ namespace ares::ZXSpectrum {
 #include "arcade.cpp"
 
 auto Emulator::construct() -> void {
-  emulators.append(new Arcade);
+  emulators.push_back(new Arcade);
 
   #ifdef CORE_A26
-  emulators.append(new Atari2600);
+  emulators.push_back(new Atari2600);
   #endif
 
   #ifdef CORE_WS
-  emulators.append(new WonderSwan);
-  emulators.append(new WonderSwanColor);
-  emulators.append(new PocketChallengeV2);
+  emulators.push_back(new WonderSwan);
+  emulators.push_back(new WonderSwanColor);
+  emulators.push_back(new PocketChallengeV2);
   #endif
 
   #ifdef CORE_CV
-  emulators.append(new ColecoVision);
+  emulators.push_back(new ColecoVision);
   #endif
 
   #ifdef CORE_MYVISION
-  emulators.append(new MyVision);
+  emulators.push_back(new MyVision);
   #endif
 
   #ifdef CORE_MSX
-  emulators.append(new MSX);
-  emulators.append(new MSX2);
+  emulators.push_back(new MSX);
+  emulators.push_back(new MSX2);
   #endif
 
   #ifdef CORE_PCE
-  emulators.append(new PCEngine);
-  emulators.append(new PCEngineCD);
-  emulators.append(new SuperGrafx);
-  emulators.append(new SuperGrafxCD);
+  emulators.push_back(new PCEngine);
+  emulators.push_back(new PCEngineCD);
+  emulators.push_back(new SuperGrafx);
+  emulators.push_back(new SuperGrafxCD);
   #endif
 
   #ifdef CORE_FC
-  emulators.append(new Famicom);
-  emulators.append(new FamicomDiskSystem);
+  emulators.push_back(new Famicom);
+  emulators.push_back(new FamicomDiskSystem);
   #endif
 
   #ifdef CORE_SFC
-  emulators.append(new SuperFamicom);
+  emulators.push_back(new SuperFamicom);
   #endif
 
   #ifdef CORE_N64
-  emulators.append(new Nintendo64);
-  emulators.append(new Nintendo64DD);
+  emulators.push_back(new Nintendo64);
+  emulators.push_back(new Nintendo64DD);
   #endif
 
   #ifdef CORE_GB
-  emulators.append(new GameBoy);
-  emulators.append(new GameBoyColor);
+  emulators.push_back(new GameBoy);
+  emulators.push_back(new GameBoyColor);
   #endif
 
   #ifdef CORE_GBA
-  emulators.append(new GameBoyAdvance);
+  emulators.push_back(new GameBoyAdvance);
   #endif
 
   #ifdef CORE_SG
-  emulators.append(new SG1000);
-  emulators.append(new SC3000);
+  emulators.push_back(new SG1000);
+  emulators.push_back(new SC3000);
   #endif
 
   #ifdef CORE_MS
-  emulators.append(new MasterSystem);
-  emulators.append(new GameGear);
+  emulators.push_back(new MasterSystem);
+  emulators.push_back(new GameGear);
   #endif
 
   #ifdef CORE_MD
-  emulators.append(new MegaDrive);
-  emulators.append(new Mega32X);
-  emulators.append(new MegaCD);
-  emulators.append(new MegaCD32X);
-  emulators.append(new MegaLD);
+  emulators.push_back(new MegaDrive);
+  emulators.push_back(new Mega32X);
+  emulators.push_back(new MegaCD);
+  emulators.push_back(new MegaCD32X);
+  emulators.push_back(new MegaLD);
   #endif
 
   #ifdef CORE_SATURN
-  emulators.append(new Saturn);
+  emulators.push_back(new Saturn);
   #endif
 
   #ifdef CORE_NG
-  emulators.append(new NeoGeoAES);
-  emulators.append(new NeoGeoMVS);
+  emulators.push_back(new NeoGeoAES);
+  emulators.push_back(new NeoGeoMVS);
   #endif
 
   #ifdef CORE_NGP
-  emulators.append(new NeoGeoPocket);
-  emulators.append(new NeoGeoPocketColor);
+  emulators.push_back(new NeoGeoPocket);
+  emulators.push_back(new NeoGeoPocketColor);
   #endif
 
   #ifdef CORE_PS1
-  emulators.append(new PlayStation);
+  emulators.push_back(new PlayStation);
   #endif
 
   #ifdef CORE_SPEC
-  emulators.append(new ZXSpectrum);
-  emulators.append(new ZXSpectrum128);
+  emulators.push_back(new ZXSpectrum);
+  emulators.push_back(new ZXSpectrum128);
   #endif
 }

--- a/desktop-ui/emulator/famicom-disk-system.cpp
+++ b/desktop-ui/emulator/famicom-disk-system.cpp
@@ -16,7 +16,7 @@ FamicomDiskSystem::FamicomDiskSystem() {
   manufacturer = "Nintendo";
   name = "Famicom Disk System";
 
-  firmware.append({"BIOS", "Japan", "fdc1a76e654feea993fcb38366e05ee5f4eb641f86fe6bebaeefd412e112dd72"});
+  firmware.push_back({"BIOS", "Japan", "fdc1a76e654feea993fcb38366e05ee5f4eb641f86fe6bebaeefd412e112dd72"});
 
   for(auto id : range(2)) {
     InputPort port{string{"Controller Port ", 1 + id}};
@@ -33,7 +33,7 @@ FamicomDiskSystem::FamicomDiskSystem() {
     device.digital("Microphone", virtualPorts[id].pad.north);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/famicom.cpp
+++ b/desktop-ui/emulator/famicom.cpp
@@ -31,7 +31,7 @@ Famicom::Famicom() {
     port.append(device);
     }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/game-boy-advance.cpp
+++ b/desktop-ui/emulator/game-boy-advance.cpp
@@ -11,7 +11,7 @@ GameBoyAdvance::GameBoyAdvance() {
   manufacturer = "Nintendo";
   name = "Game Boy Advance";
 
-  firmware.append({"BIOS", "World", "fd2547724b505f487e6dcb29ec2ecff3af35a841a77ab2e85fd87350abd36570"});
+  firmware.push_back({"BIOS", "World", "fd2547724b505f487e6dcb29ec2ecff3af35a841a77ab2e85fd87350abd36570"});
 
   { InputPort port{string{"Game Boy Advance"}};
 
@@ -29,7 +29,7 @@ GameBoyAdvance::GameBoyAdvance() {
     device.rumble ("Rumble", virtualPorts[0].pad.rumble);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/game-boy-color.cpp
+++ b/desktop-ui/emulator/game-boy-color.cpp
@@ -23,7 +23,7 @@ GameBoyColor::GameBoyColor() {
     device.rumble ("Rumble",  virtualPorts[0].pad.rumble);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/game-boy.cpp
+++ b/desktop-ui/emulator/game-boy.cpp
@@ -24,7 +24,7 @@ GameBoy::GameBoy() {
     device.rumble ("Rumble",  virtualPorts[0].pad.rumble);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/game-gear.cpp
+++ b/desktop-ui/emulator/game-gear.cpp
@@ -9,7 +9,7 @@ GameGear::GameGear() {
   manufacturer = "Sega";
   name = "Game Gear";
 
-  firmware.append({"BIOS", "World", "8c8a21335038285cfa03dc076100c1f0bfadf3e4ff70796f11f3dfaaab60eee2"});
+  firmware.push_back({"BIOS", "World", "8c8a21335038285cfa03dc076100c1f0bfadf3e4ff70796f11f3dfaaab60eee2"});
 
   { InputPort port{"Game Gear"};
 
@@ -23,7 +23,7 @@ GameGear::GameGear() {
     device.digital("Start", virtualPorts[0].pad.start);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/master-system.cpp
+++ b/desktop-ui/emulator/master-system.cpp
@@ -11,9 +11,9 @@ MasterSystem::MasterSystem() {
   manufacturer = "Sega";
   name = "Master System";
 
-  firmware.append({"BIOS", "US", "477617917a12a30f9f43844909dc2de6e6a617430f5c9a36306c86414a670d50"});      //NTSC-U
-  firmware.append({"BIOS", "Japan", "67846e26764bd862f19179294347f7353a4166b62ac4198a5ec32933b7da486e"});   //NTSC-J
-  firmware.append({"BIOS", "Europe", "477617917a12a30f9f43844909dc2de6e6a617430f5c9a36306c86414a670d50"});  //PAL
+  firmware.push_back({"BIOS", "US", "477617917a12a30f9f43844909dc2de6e6a617430f5c9a36306c86414a670d50"});      //NTSC-U
+  firmware.push_back({"BIOS", "Japan", "67846e26764bd862f19179294347f7353a4166b62ac4198a5ec32933b7da486e"});   //NTSC-J
+  firmware.push_back({"BIOS", "Europe", "477617917a12a30f9f43844909dc2de6e6a617430f5c9a36306c86414a670d50"});  //PAL
 
   { InputPort port{"Master System"};
 
@@ -22,7 +22,7 @@ MasterSystem::MasterSystem() {
     //device.digital("Reset", virtualPorts[0].pad.rt);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 
   for(auto id : range(2)) {
@@ -86,7 +86,7 @@ MasterSystem::MasterSystem() {
     device.digital ("Start",  virtualPorts[id].mouse.extra);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/mega-32x.cpp
+++ b/desktop-ui/emulator/mega-32x.cpp
@@ -39,7 +39,7 @@ Mega32X::Mega32X() {
     device.digital ("Start",  virtualPorts[id].mouse.extra);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 
@@ -59,11 +59,11 @@ auto Mega32X::load() -> LoadResult {
   string name;
   if(game->pak->attribute("megacd").boolean()) {
     //use Mega CD firmware settings
-    vector<Firmware> firmware;
+    std::vector<Firmware> firmware;
     for(auto& emulator : emulators) {
       if(emulator->name == "Mega CD") firmware = emulator->firmware;
     }
-    if(!firmware) return otherError;  //should never occur
+    if(firmware.empty()) return otherError;  //should never occur
     name = "Mega CD 32X";
     system = mia::System::create("Mega CD 32X");
     result = system->load(firmware[regionID].location);

--- a/desktop-ui/emulator/mega-cd-32x.cpp
+++ b/desktop-ui/emulator/mega-cd-32x.cpp
@@ -41,7 +41,7 @@ MegaCD32X::MegaCD32X() {
     device.digital ("Start",  virtualPorts[id].mouse.extra);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 
@@ -59,11 +59,11 @@ auto MegaCD32X::load() -> LoadResult {
   if(region == "NTSC-U") regionID = 0;
 
   //use Mega CD firmware settings
-  vector<Firmware> firmware;
+  std::vector<Firmware> firmware;
   for(auto& emulator : emulators) {
     if(emulator->name == "Mega CD") firmware = emulator->firmware;
   }
-  if(!firmware) return otherError;  //should never occur
+  if(firmware.empty()) return otherError;  //should never occur
 
   system = mia::System::create("Mega CD 32X");
   result = system->load(firmware[regionID].location);

--- a/desktop-ui/emulator/mega-cd.cpp
+++ b/desktop-ui/emulator/mega-cd.cpp
@@ -14,9 +14,9 @@ MegaCD::MegaCD() {
   manufacturer = "Sega";
   name = "Mega CD";
 
-  firmware.append({"BIOS", "US", "fb477cdbf94c84424c2feca4fe40656d85393fe7b7b401911b45ad2eb991258c"});      //NTSC-U
-  firmware.append({"BIOS", "Japan", "7133fc2dd2fe5b7d0acd53a5f10f3d00b5d31270239ad20d74ef32393e24af88"});   //NTSC-J
-  firmware.append({"BIOS", "Europe", "fe608a2a07676a23ab5fd5eee2f53c9e2526d69a28aa16ccd85c0ec42e6933cb"});  //PAL
+  firmware.push_back({"BIOS", "US", "fb477cdbf94c84424c2feca4fe40656d85393fe7b7b401911b45ad2eb991258c"});      //NTSC-U
+  firmware.push_back({"BIOS", "Japan", "7133fc2dd2fe5b7d0acd53a5f10f3d00b5d31270239ad20d74ef32393e24af88"});   //NTSC-J
+  firmware.push_back({"BIOS", "Europe", "fe608a2a07676a23ab5fd5eee2f53c9e2526d69a28aa16ccd85c0ec42e6933cb"});  //PAL
 
   for(auto id : range(2)) {
     InputPort port{string{"Controller Port ", 1 + id}};
@@ -56,7 +56,7 @@ MegaCD::MegaCD() {
     device.digital ("Start",  virtualPorts[id].mouse.extra);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/mega-drive.cpp
+++ b/desktop-ui/emulator/mega-drive.cpp
@@ -50,7 +50,7 @@ MegaDrive::MegaDrive() {
     device.digital ("Start",  virtualPorts[id].mouse.extra);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 
@@ -70,11 +70,11 @@ auto MegaDrive::load() -> LoadResult {
   string name;
   if(game->pak->attribute("megacd").boolean()) {
     //use Mega CD firmware settings
-    vector<Firmware> firmware;
+    std::vector<Firmware> firmware;
     for(auto& emulator : emulators) {
       if(emulator->name == "Mega CD") firmware = emulator->firmware;
     }
-    if(!firmware) return otherError;  //should never occur
+    if(firmware.empty()) return otherError;  //should never occur
     name = "Mega CD";
     system = mia::System::create("Mega CD");
     result = system->load(firmware[regionID].location);

--- a/desktop-ui/emulator/mega-ld.cpp
+++ b/desktop-ui/emulator/mega-ld.cpp
@@ -15,8 +15,8 @@ MegaLD::MegaLD() {
   manufacturer = "Sega";
   name = "Mega LD";
 
-  firmware.append({"BIOS", "US"});      //NTSC-U
-  firmware.append({"BIOS", "Japan"});   //NTSC-J
+  firmware.push_back({"BIOS", "US"});      //NTSC-U
+  firmware.push_back({"BIOS", "Japan"});   //NTSC-J
 
   for(auto id : range(2)) {
     InputPort port{string{"Controller Port ", 1 + id}};
@@ -36,7 +36,7 @@ MegaLD::MegaLD() {
     device.digital("Start", virtualPorts[id].pad.start);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/mega-ld.cpp
+++ b/desktop-ui/emulator/mega-ld.cpp
@@ -89,7 +89,7 @@ auto MegaLD::load(Menu menu) -> void {
   changeSideMenu.setIcon(Icon::Device::Optical);
   changeSideMenu.setText("Change Side");
   auto medium = game->pak->attribute("medium");
-  auto sides = ::nall::split_and_strip(medium, ",");
+  auto sides = nall::split_and_strip(medium, ",");
 
   MenuRadioItem noDiscItem{&changeSideMenu};
   noDiscItem.setText("No Disc").onActivate([&] {

--- a/desktop-ui/emulator/mega-ld.cpp
+++ b/desktop-ui/emulator/mega-ld.cpp
@@ -88,7 +88,8 @@ auto MegaLD::load(Menu menu) -> void {
   Menu changeSideMenu{&menu};
   changeSideMenu.setIcon(Icon::Device::Optical);
   changeSideMenu.setText("Change Side");
-  auto sides = game->pak->attribute("medium").split(",").strip();
+  auto medium = game->pak->attribute("medium");
+  auto sides = ::nall::split_and_strip(medium, ",");
 
   MenuRadioItem noDiscItem{&changeSideMenu};
   noDiscItem.setText("No Disc").onActivate([&] {

--- a/desktop-ui/emulator/msx.cpp
+++ b/desktop-ui/emulator/msx.cpp
@@ -12,7 +12,7 @@ MSX::MSX() {
   name = "MSX";
 
   // TODO: Support other region bios versions
-  firmware.append({"BIOS", "Japan", "413a2b601a94b3792e054be2439cc77a1819cceadbfa9542f88d51c7480f2ef0"});
+  firmware.push_back({"BIOS", "Japan", "413a2b601a94b3792e054be2439cc77a1819cceadbfa9542f88d51c7480f2ef0"});
 
   for(auto id : range(2)) {
     InputPort port{string{"Controller Port ", 1 + id}};
@@ -33,7 +33,7 @@ MSX::MSX() {
     device.digital("Button",  virtualPorts[id].pad.south);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/msx2.cpp
+++ b/desktop-ui/emulator/msx2.cpp
@@ -12,8 +12,8 @@ MSX2::MSX2() {
 
   // TODO: Support other region bios versions
   firmware = {};
-  firmware.append({"MAIN", "Japan", "0c672d86ead61a97f49a583b88b7c1905da120645cd44f0c9f2baf4f4631e0b1"});
-  firmware.append({"SUB", "Japan", "6c6f421a10c428d960b7ecc990f99af1c638147f747bddca7b0bf0e2ab738300"});
+  firmware.push_back({"MAIN", "Japan", "0c672d86ead61a97f49a583b88b7c1905da120645cd44f0c9f2baf4f4631e0b1"});
+  firmware.push_back({"SUB", "Japan", "6c6f421a10c428d960b7ecc990f99af1c638147f747bddca7b0bf0e2ab738300"});
 
   for(auto id : range(2)) {
     InputPort port{string{"Controller Port ", 1 + id}};
@@ -27,7 +27,7 @@ MSX2::MSX2() {
     device.digital("B",     virtualPorts[id].pad.south);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/myvision.cpp
+++ b/desktop-ui/emulator/myvision.cpp
@@ -38,7 +38,7 @@ MyVision::MyVision() {
       port.append(device);
     }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/neo-geo-aes.cpp
+++ b/desktop-ui/emulator/neo-geo-aes.cpp
@@ -11,7 +11,7 @@ NeoGeoAES::NeoGeoAES() {
   name = "Neo Geo AES";
   medium = "Neo Geo";
 
-  firmware.append({"BIOS", "World"});
+  firmware.push_back({"BIOS", "World"});
 
   for(auto id : range(2)) {
     InputPort port{string{"Controller Port ", 1 + id}};
@@ -30,7 +30,7 @@ NeoGeoAES::NeoGeoAES() {
     device.digital("Start",  virtualPorts[id].pad.start);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/neo-geo-mvs.cpp
+++ b/desktop-ui/emulator/neo-geo-mvs.cpp
@@ -12,7 +12,7 @@ NeoGeoMVS::NeoGeoMVS() {
   name = "Neo Geo MVS";
   medium = "Neo Geo";
 
-  firmware.append({"BIOS", "World"});
+  firmware.push_back({"BIOS", "World"});
 
   for(auto id : range(2)) {
     InputPort port{string{"Controller Port ", 1 + id}};
@@ -31,7 +31,7 @@ NeoGeoMVS::NeoGeoMVS() {
     device.digital("Start",  virtualPorts[id].pad.start);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/neo-geo-pocket-color.cpp
+++ b/desktop-ui/emulator/neo-geo-pocket-color.cpp
@@ -9,7 +9,7 @@ NeoGeoPocketColor::NeoGeoPocketColor() {
   manufacturer = "SNK";
   name = "Neo Geo Pocket Color";
 
-  firmware.append({"BIOS", "World", "8fb845a2f71514cec20728e2f0fecfade69444f8d50898b92c2259f1ba63e10d"});
+  firmware.push_back({"BIOS", "World", "8fb845a2f71514cec20728e2f0fecfade69444f8d50898b92c2259f1ba63e10d"});
 
   { InputPort port{"Neo Geo Pocket Color"};
 
@@ -25,7 +25,7 @@ NeoGeoPocketColor::NeoGeoPocketColor() {
     device.digital("Debugger", virtualPorts[0].pad.r_bumper);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/neo-geo-pocket.cpp
+++ b/desktop-ui/emulator/neo-geo-pocket.cpp
@@ -9,7 +9,7 @@ NeoGeoPocket::NeoGeoPocket() {
   manufacturer = "SNK";
   name = "Neo Geo Pocket";
 
-  firmware.append({"BIOS", "World", "0293555b21c4fac516d25199df7809b26beeae150e1d4504a050db32264a6ad7"});
+  firmware.push_back({"BIOS", "World", "0293555b21c4fac516d25199df7809b26beeae150e1d4504a050db32264a6ad7"});
 
   { InputPort port{"Neo Geo Pocket"};
 
@@ -25,7 +25,7 @@ NeoGeoPocket::NeoGeoPocket() {
     device.digital("Debugger", virtualPorts[0].pad.r_bumper);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -50,7 +50,7 @@ Nintendo64::Nintendo64() {
     device.digital ("Right", virtualPorts[id].mouse.right);
     port.append(device); }
   
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 
@@ -66,11 +66,11 @@ auto Nintendo64::load() -> LoadResult {
   string name;
   if(game->pak->attribute("dd").boolean()) {
     //use 64DD firmware settings
-    vector<Firmware> firmware;
+    std::vector<Firmware> firmware;
     for(auto& emulator : emulators) {
       if(emulator->name == "Nintendo 64DD") firmware = emulator->firmware;
     }
-    if(!firmware) return otherError;  //should never occur
+    if(firmware.empty()) return otherError;  //should never occur
     name = "Nintendo 64DD";
 
     disk = mia::Medium::create("Nintendo 64DD");

--- a/desktop-ui/emulator/nintendo-64dd.cpp
+++ b/desktop-ui/emulator/nintendo-64dd.cpp
@@ -14,9 +14,9 @@ Nintendo64DD::Nintendo64DD() {
   manufacturer = "Nintendo";
   name = "Nintendo 64DD";
 
-  firmware.append({"BIOS", "Japan", "806400ec0df94b0755de6c5b8249d6b6a9866124c5ddbdac198bde22499bfb8b"});
-  firmware.append({"BIOS", "US", "e9fec87a45fba02399e88064b9e2f8cf0f2106e351c58279a87f05da5bc984ad"});
-  firmware.append({"BIOS", "DEV", "9c2962a8b994a29e4cd04b3a6e4ed730a751414655ab6a9799ebf5fc08b79d44"});
+  firmware.push_back({"BIOS", "Japan", "806400ec0df94b0755de6c5b8249d6b6a9866124c5ddbdac198bde22499bfb8b"});
+  firmware.push_back({"BIOS", "US", "e9fec87a45fba02399e88064b9e2f8cf0f2106e351c58279a87f05da5bc984ad"});
+  firmware.push_back({"BIOS", "DEV", "9c2962a8b994a29e4cd04b3a6e4ed730a751414655ab6a9799ebf5fc08b79d44"});
 
   for(auto id : range(4)) {
     InputPort port{string{"Controller Port ", 1 + id}};
@@ -52,7 +52,7 @@ Nintendo64DD::Nintendo64DD() {
     device.digital ("Right", virtualPorts[id].mouse.right);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/pc-engine-cd.cpp
+++ b/desktop-ui/emulator/pc-engine-cd.cpp
@@ -12,10 +12,10 @@ PCEngineCD::PCEngineCD() {
   manufacturer = "NEC";
   name = "PC Engine CD";
 
-  firmware.append({"System-Card 1.0", "Japan", "afe9f27f91ac918348555b86298b4f984643eafa2773196f2c5441ea84f0c3bb"});
-  firmware.append({"Arcade Card"    , "Japan", "e11527b3b96ce112a037138988ca72fd117a6b0779c2480d9e03eaebece3d9ce"});
-  firmware.append({"System Card 3.0", "US",    "cadac2725711b3c442bcf237b02f5a5210c96f17625c35fa58f009e0ed39e4db"});
-  firmware.append({"Games Express"  , "Japan", "4b86bb96a48a4ca8375fc0109631d0b1d64f255a03b01de70594d40788ba6c3d"});
+  firmware.push_back({"System-Card 1.0", "Japan", "afe9f27f91ac918348555b86298b4f984643eafa2773196f2c5441ea84f0c3bb"});
+  firmware.push_back({"Arcade Card"    , "Japan", "e11527b3b96ce112a037138988ca72fd117a6b0779c2480d9e03eaebece3d9ce"});
+  firmware.push_back({"System Card 3.0", "US",    "cadac2725711b3c442bcf237b02f5a5210c96f17625c35fa58f009e0ed39e4db"});
+  firmware.push_back({"Games Express"  , "Japan", "4b86bb96a48a4ca8375fc0109631d0b1d64f255a03b01de70594d40788ba6c3d"});
 
   allocatePorts();
 }

--- a/desktop-ui/emulator/pc-engine.cpp
+++ b/desktop-ui/emulator/pc-engine.cpp
@@ -15,7 +15,7 @@ PCEngine::PCEngine() {
 }
 
 auto PCEngine::allocatePorts() -> void {
-  ports.reset();
+  ports.clear();
 
   InputPort port{string{"Controller Port"}};
 
@@ -45,7 +45,7 @@ auto PCEngine::allocatePorts() -> void {
     device.digital("Run",   virtualPorts[0].pad.start);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
 
   for(auto id : range(5)) {
     InputPort port{string{"Controller Port ", 1 + id}};
@@ -76,7 +76,7 @@ auto PCEngine::allocatePorts() -> void {
     device.digital("Run",   virtualPorts[id].pad.start);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/playstation.cpp
+++ b/desktop-ui/emulator/playstation.cpp
@@ -15,9 +15,9 @@ PlayStation::PlayStation() {
   manufacturer = "Sony";
   name = "PlayStation";
 
-  firmware.append({"BIOS", "US", "11052b6499e466bbf0a709b1f9cb6834a9418e66680387912451e971cf8a1fef"});      //NTSC-U
-  firmware.append({"BIOS", "Japan", "9c0421858e217805f4abe18698afea8d5aa36ff0727eb8484944e00eb5e7eadb"});   //NTSC-J
-  firmware.append({"BIOS", "Europe", "1faaa18fa820a0225e488d9f086296b8e6c46df739666093987ff7d8fd352c09"});  //PAL
+  firmware.push_back({"BIOS", "US", "11052b6499e466bbf0a709b1f9cb6834a9418e66680387912451e971cf8a1fef"});      //NTSC-U
+  firmware.push_back({"BIOS", "Japan", "9c0421858e217805f4abe18698afea8d5aa36ff0727eb8484944e00eb5e7eadb"});   //NTSC-J
+  firmware.push_back({"BIOS", "Europe", "1faaa18fa820a0225e488d9f086296b8e6c46df739666093987ff7d8fd352c09"});  //PAL
 
   for(auto id : range(2)) {
     InputPort port{string{"Controller Port ", 1 + id}};
@@ -71,7 +71,7 @@ PlayStation::PlayStation() {
     device.rumble("Rumble",    virtualPorts[0].pad.rumble);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/pocket-challenge-v2.cpp
+++ b/desktop-ui/emulator/pocket-challenge-v2.cpp
@@ -24,7 +24,7 @@ PocketChallengeV2::PocketChallengeV2() {
     device.digital("Escape", virtualPorts[0].pad.select);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/saturn.cpp
+++ b/desktop-ui/emulator/saturn.cpp
@@ -11,9 +11,9 @@ Saturn::Saturn() {
   manufacturer = "Sega";
   name = "Saturn";
 
-  firmware.append({"BIOS", "US"});      //NTSC-U
-  firmware.append({"BIOS", "Japan"});   //NTSC-J
-  firmware.append({"BIOS", "Europe"});  //PAL
+  firmware.push_back({"BIOS", "US"});      //NTSC-U
+  firmware.push_back({"BIOS", "Japan"});   //NTSC-J
+  firmware.push_back({"BIOS", "Europe"});  //PAL
 }
 
 auto Saturn::load() -> LoadResult {

--- a/desktop-ui/emulator/sc-3000.cpp
+++ b/desktop-ui/emulator/sc-3000.cpp
@@ -22,7 +22,7 @@ SC3000::SC3000() {
     device.digital("2",     virtualPorts[id].pad.east);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/sg-1000.cpp
+++ b/desktop-ui/emulator/sg-1000.cpp
@@ -21,7 +21,7 @@ SG1000::SG1000() {
     device.digital("2",     virtualPorts[id].pad.east);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/super-famicom.cpp
+++ b/desktop-ui/emulator/super-famicom.cpp
@@ -103,7 +103,7 @@ SuperFamicom::SuperFamicom() {
     device.digital("2", virtualPorts[id].pad.east);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 
   inputBlacklist = {"Justifiers", "Super Multitap"};

--- a/desktop-ui/emulator/supergrafx-cd.cpp
+++ b/desktop-ui/emulator/supergrafx-cd.cpp
@@ -12,7 +12,7 @@ SuperGrafxCD::SuperGrafxCD() {
   manufacturer = "NEC";
   name = "SuperGrafx CD";
 
-  firmware.append({"Arcade Card", "Japan", "e11527b3b96ce112a037138988ca72fd117a6b0779c2480d9e03eaebece3d9ce"});
+  firmware.push_back({"Arcade Card", "Japan", "e11527b3b96ce112a037138988ca72fd117a6b0779c2480d9e03eaebece3d9ce"});
 
   allocatePorts();
 }

--- a/desktop-ui/emulator/wonderswan-color.cpp
+++ b/desktop-ui/emulator/wonderswan-color.cpp
@@ -26,7 +26,7 @@ WonderSwanColor::WonderSwanColor() {
     device.digital("Start", virtualPorts[0].pad.start);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/emulator/wonderswan.cpp
+++ b/desktop-ui/emulator/wonderswan.cpp
@@ -26,7 +26,7 @@ WonderSwan::WonderSwan() {
     device.digital("Start", virtualPorts[0].pad.start);
     port.append(device); }
 
-    ports.append(port);
+    ports.push_back(port);
   }
 }
 

--- a/desktop-ui/game-browser/game-browser.cpp
+++ b/desktop-ui/game-browser/game-browser.cpp
@@ -30,7 +30,7 @@ GameBrowserWindow::GameBrowserWindow() {
 auto GameBrowserWindow::show(shared_pointer<Emulator> emulator) -> void {
   this->emulator = emulator;
   searchInput.setText();
-  games.reset();
+  games.clear();
 
   auto tmp = (shared_pointer<mia::Medium>)mia::Medium::create(emulator->medium);
   if(!tmp) {
@@ -48,11 +48,11 @@ auto GameBrowserWindow::show(shared_pointer<Emulator> emulator) -> void {
     path = {path, "/", node["name"].string(), ".zip"};
 
     if(inode::exists(path)) {
-      games.append({node["title"].string(), node["name"].string(), node["board"].string(), path});
+      games.push_back({node["title"].string(), node["name"].string(), node["board"].string(), path});
     }
   }
 
-  games.sort([](auto x, auto y) {
+  std::ranges::sort(games, [](auto x, auto y) {
     return string::icompare(x.title, y.title) < 0;
   });
 

--- a/desktop-ui/game-browser/game-browser.hpp
+++ b/desktop-ui/game-browser/game-browser.hpp
@@ -16,7 +16,7 @@ struct GameBrowserWindow : Window {
     LineEdit searchInput{&searchLayout, Size{~0, 0}};
   TableView gameList{&layout, Size{~0, ~0}};
 
-  vector<GameBrowserEntry> games;
+  std::vector<GameBrowserEntry> games;
   shared_pointer<Emulator> emulator;
 };
 

--- a/desktop-ui/input/input.cpp
+++ b/desktop-ui/input/input.cpp
@@ -12,16 +12,16 @@ auto InputMapping::bind() -> void {
     auto& assignment = assignments[index];
     auto& binding = bindings[index];
 
-    auto token = assignment.split("/");
+    auto token = nall::split(assignment, "/");
     if(token.size() < 3) continue;  //ignore invalid mappings
 
     binding.deviceID = token[0].natural();
     binding.groupID = token[1].natural();
     binding.inputID = token[2].natural();
     binding.qualifier = Qualifier::None;
-    if(token(3) == "Lo") binding.qualifier = Qualifier::Lo;
-    if(token(3) == "Hi") binding.qualifier = Qualifier::Hi;
-    if(token(3) == "Rumble") binding.qualifier = Qualifier::Rumble;
+    if(token.size() > 3 && token[3] == "Lo") binding.qualifier = Qualifier::Lo;
+    if(token.size() > 3 && token[3] == "Hi") binding.qualifier = Qualifier::Hi;
+    if(token.size() > 3 && token[3] == "Rumble") binding.qualifier = Qualifier::Rumble;
 
     for(auto& device : inputManager.devices) {
       if(binding.deviceID == device->id()) {

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -351,14 +351,14 @@ auto Presentation::loadEmulators() -> void {
   loadMenu.reset();
 
   //clean up the recent games history first
-  vector<string> recentGames;
+  std::vector<string> recentGames;
   for(u32 index : range(9)) {
     auto entry = settings.recent.game[index];
     auto system = entry.split(";", 1L)(0);
     auto location = entry.split(";", 1L)(1);
     if(location.length()) {  //remove missing games
-      if(!recentGames.find(entry)) {  //remove duplicate entries
-        recentGames.append(entry);
+      if(std::ranges::find(recentGames, entry) == recentGames.end()) {  //remove duplicate entries
+        recentGames.push_back(entry);
       }
     }
     settings.recent.game[index] = {};
@@ -549,7 +549,7 @@ auto Presentation::refreshSystemMenu() -> void {
   for(auto port : ares::Node::enumerate<ares::Node::Port>(emulator->root)) {
     //do not add unsupported ports to the port menu
     auto portName = port->name();
-    if(emulator->portBlacklist.find(portName)) continue;
+    if(std::ranges::find(emulator->portBlacklist, portName) != emulator->portBlacklist.end()) continue;
 
     if(!port->hotSwappable()) continue;
     if(port->type() != "Controller" && port->type() != "Expansion") continue;
@@ -574,7 +574,7 @@ auto Presentation::refreshSystemMenu() -> void {
     }
     for(auto peripheral : port->supported()) {
       //do not add unsupported peripherals to the peripheral port menu
-      if(emulator->inputBlacklist.find(peripheral)) continue;
+      if(std::ranges::find(emulator->inputBlacklist, peripheral) != emulator->inputBlacklist.end()) continue;
 
       MenuRadioItem peripheralItem{&portMenu};
       peripheralItem.setAttribute<ares::Node::Port>("port", port);
@@ -661,12 +661,12 @@ auto Presentation::loadShaders() -> void {
     function<void(string)> findShaderDirectories = [&](string path) {
       for(auto &entry: directory::folders(path)) findShaderDirectories({path, entry});
       auto files = directory::files(path, "*.slangp");
-      if(files.size() > 0) shaderDirectories.append((string({path}).trimLeft(location, 1L)));
+      if(files.size() > 0) shaderDirectories.push_back((string({path}).trimLeft(location, 1L)));
     };
     findShaderDirectories(location);
 
     // Sort by name and depth such that child folders appear after their parents
-    shaderDirectories.sort([](const string &lhs, const string &rhs) {
+    std::ranges::sort(shaderDirectories, [](const string &lhs, const string &rhs) {
       auto lhsParts = lhs.split("/");
       auto rhsParts = rhs.split("/");
       for(u32 i : range(min(lhsParts.size(), rhsParts.size()))) {

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -354,8 +354,10 @@ auto Presentation::loadEmulators() -> void {
   std::vector<string> recentGames;
   for(u32 index : range(9)) {
     auto entry = settings.recent.game[index];
-    auto system = entry.split(";", 1L)(0);
-    auto location = entry.split(";", 1L)(1);
+    auto parts = nall::split(entry, ";", 1L);
+    parts.resize(2);
+    auto system = parts[0];
+    auto location = parts[1];
     if(location.length()) {  //remove missing games
       if(std::ranges::find(recentGames, entry) == recentGames.end()) {  //remove duplicate entries
         recentGames.push_back(entry);
@@ -375,8 +377,10 @@ auto Presentation::loadEmulators() -> void {
     for(u32 index : range(count)) {
       MenuItem item{&recentGames};
       auto entry = settings.recent.game[index];
-      auto system = entry.split(";", 1L)(0);
-      auto location = entry.split(";", 1L)(1);
+      auto parts = nall::split(entry, ";", 1L);
+      parts.resize(2);
+      auto system = parts[0];
+      auto location = parts[1];
       item.setIconForFile(location);
       item.setText({Location::base(location).trimRight("/"), " (", system, ")"});
       item.onActivate([=, this] {
@@ -667,8 +671,8 @@ auto Presentation::loadShaders() -> void {
 
     // Sort by name and depth such that child folders appear after their parents
     std::ranges::sort(shaderDirectories, [](const string &lhs, const string &rhs) {
-      auto lhsParts = lhs.split("/");
-      auto rhsParts = rhs.split("/");
+      auto lhsParts = nall::split(lhs, "/");
+      auto rhsParts = nall::split(rhs, "/");
       for(u32 i : range(min(lhsParts.size(), rhsParts.size()))) {
         if(lhsParts[i] != rhsParts[i]) return lhsParts[i] < rhsParts[i];
       }
@@ -678,7 +682,7 @@ auto Presentation::loadShaders() -> void {
 
   if(ruby::video.hasShader()) {
     for(auto &directory : shaderDirectories) {
-      auto parts = directory.split("/");
+      auto parts = nall::split(directory, "/");
       Menu parent = videoShaderMenu;
 
       if(directory != "") {

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -10,7 +10,7 @@ struct Presentation : Window {
   auto loadShaders() -> void;
   auto refreshSystemMenu() -> void;
 
-  vector<string> shaderDirectories;
+  std::vector<string> shaderDirectories;
 
   MenuBar menuBar{this};
     Menu loadMenu{&menuBar};

--- a/desktop-ui/program/program.cpp
+++ b/desktop-ui/program/program.cpp
@@ -21,9 +21,10 @@ auto Program::create() -> void {
   worker = thread::create({&Program::emulatorRunLoop, this});
   program.rewindReset();
 
-  if(startGameLoad) {
+  if(!startGameLoad.empty()) {
     Program::Guard guard;
-    auto gameToLoad = startGameLoad.takeFirst();
+    auto gameToLoad = startGameLoad.front();
+    startGameLoad.erase(startGameLoad.begin());
     if(startSystem) {
       for(auto &emulator: emulators) {
         if(emulator->name == startSystem) {

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -57,7 +57,7 @@ struct Program : ares::Platform {
   auto inputDriverUpdate() -> void;
 
   bool startFullScreen = false;
-  vector<string> startGameLoad;
+  std::vector<string> startGameLoad;
   bool noFilePrompt = false;
 
   string startSystem;
@@ -82,7 +82,7 @@ struct Program : ares::Platform {
   //rewind.cpp
   struct Rewind {
     enum class Mode : u32 { Playing, Rewinding } mode = Mode::Playing;
-    vector<serializer> history;
+    std::vector<serializer> history;
     u32 length = 0;
     u32 frequency = 0;
     u32 counter = 0;

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -1,4 +1,5 @@
 #include "../desktop-ui.hpp"
+#include <nall/vector-helpers.hpp>
 #include "video.cpp"
 #include "audio.cpp"
 #include "input.cpp"
@@ -143,14 +144,22 @@ auto Settings::process(bool load) -> void {
       if(load == 0) for(auto& assignment : input.mapping->assignments) value.append(assignment, ";");
       if(load == 0) value.trimRight(";", 1L);
       bind(string, name, value);
-      if(load == 1) for(u32 binding : range(BindingLimit)) input.mapping->assignments[binding] = value.split(";")(binding);
+      if(load == 1) {
+        auto parts = nall::split(value, ";");
+        parts.resize(BindingLimit);
+        for(u32 binding : range(BindingLimit)) input.mapping->assignments[binding] = parts[binding];
+      }
     }
     for(auto& input : port.mouse.inputs) {
       string name = {"VirtualMouse", 1 + index, "/", input.name}, value;
       if(load == 0) for(auto& assignment : input.mapping->assignments) value.append(assignment, ";");
       if(load == 0) value.trimRight(";", 1L);
       bind(string, name, value);
-      if(load == 1) for(u32 binding : range(BindingLimit)) input.mapping->assignments[binding] = value.split(";")(binding);
+      if(load == 1) {
+        auto parts = nall::split(value, ";");
+        parts.resize(BindingLimit);
+        for(u32 binding : range(BindingLimit)) input.mapping->assignments[binding] = parts[binding];
+      }
     }
   }
 
@@ -159,7 +168,11 @@ auto Settings::process(bool load) -> void {
     if(load == 0) for(auto& assignment : mapping.assignments) value.append(assignment, ";");
     if(load == 0) value.trimRight(";", 1L);
     bind(string, name, value);
-    if(load == 1) for(u32 binding : range(BindingLimit)) mapping.assignments[binding] = value.split(";")(binding);
+    if(load == 1) {
+      auto parts = nall::split(value, ";");
+      parts.resize(BindingLimit);
+      for(u32 binding : range(BindingLimit)) mapping.assignments[binding] = parts[binding];
+    }
   }
 
   for(auto& emulator : emulators) {

--- a/desktop-ui/tools/cheats.cpp
+++ b/desktop-ui/tools/cheats.cpp
@@ -6,9 +6,9 @@ auto CheatEditor::Cheat::update(string description, string code, bool enabled) -
   //TODO: support other code formats based on the game system (e.g. GameShark, Game-Genie, etc.)
 
   addressValuePairs.reset();
-  auto codes = code.split("+");
+  auto codes = nall::split(code, "+");
   for(auto& code : codes) {
-    auto parts = code.split(":");
+    auto parts = nall::split(code, ":");
     if(parts.size() != 2) continue;
     addressValuePairs.insert(string{"0x", parts[0]}.natural(), string{"0x",parts[1]}.natural());
   }

--- a/desktop-ui/tools/cheats.cpp
+++ b/desktop-ui/tools/cheats.cpp
@@ -6,7 +6,7 @@ auto CheatEditor::Cheat::update(string description, string code, bool enabled) -
   //TODO: support other code formats based on the game system (e.g. GameShark, Game-Genie, etc.)
 
   addressValuePairs.reset();
-  vector<string> codes = code.split("+");
+  auto codes = code.split("+");
   for(auto& code : codes) {
     auto parts = code.split(":");
     if(parts.size() != 2) continue;
@@ -27,10 +27,11 @@ auto CheatEditor::construct() -> void {
     Program::Guard guard;
     if(auto item = cheatList.selected()) {
       if(auto cheat = item.attribute<Cheat*>("cheat")) {
-        if(auto c = cheats.find([cheat](auto& c) { return &c == cheat; })) {
+        auto it = std::ranges::find_if(cheats, [cheat](auto& c) { return &c == cheat; });
+        if(it != cheats.end()) {
           descriptionEdit.setText("");
           codeEdit.setText("");
-          cheats.remove(*c);
+          cheats.erase(it);
           deleteButton.setEnabled(false);
           refresh();
         }
@@ -43,10 +44,11 @@ auto CheatEditor::construct() -> void {
     string description = descriptionEdit.text();
     string code = codeEdit.text();
 
-    if(auto c = cheats.find([description](auto& c) { return c.description == description; })) {
-      cheats[*c].update(description, code);
+    auto it = std::ranges::find_if(cheats, [description](auto& c) { return c.description == description; });
+    if(it != cheats.end()) {
+      it->update(description, code);
     } else {
-      cheats.append(Cheat().update(description, code));
+      cheats.push_back(Cheat().update(description, code));
     }
 
     refresh();
@@ -79,13 +81,13 @@ auto CheatEditor::construct() -> void {
 
 auto CheatEditor::reload() -> void {
   Program::Guard guard;
-  cheats.reset();
+  cheats.clear();
 
   location = emulator->locate(emulator->game->location, {".cheats.bml"});
   if(file::exists(location)) {
     auto document = BML::unserialize(string::read(location), " ");
     for(auto cheatNode : document.find("cheat")) {
-      cheats.append(Cheat().update(
+      cheats.push_back(Cheat().update(
         cheatNode["description"].text(),
         cheatNode["code"].text(),
         cheatNode["enabled"].boolean()

--- a/desktop-ui/tools/tools.hpp
+++ b/desktop-ui/tools/tools.hpp
@@ -43,7 +43,7 @@ struct CheatEditor : VerticalLayout {
   };
 
   string location;
-  vector<Cheat> cheats;
+  std::vector<Cheat> cheats;
 };
 
 struct MemoryEditor : VerticalLayout {

--- a/hiro/cocoa/browser-window.cpp
+++ b/hiro/cocoa/browser-window.cpp
@@ -30,10 +30,10 @@ auto pBrowserWindow::open(BrowserWindow::State& state) -> string {
   @autoreleasepool {
     NSMutableArray* filters = [[NSMutableArray alloc] init];
     for(auto& rule : state.filters) {
-      auto parts = ::nall::split(rule, "|", 1L);
+      auto parts = nall::split(rule, "|", 1L);
       string pattern = (parts.size() > 1 ? parts[1] : string{}).replace("*", "").replace(".", "");
       if (pattern) {
-        for(auto& extension : ::nall::split(pattern, ":")) {
+        for(auto& extension : nall::split(pattern, ":")) {
           [filters addObject:[NSString stringWithUTF8String:extension]];
         }
       }
@@ -63,10 +63,10 @@ auto pBrowserWindow::save(BrowserWindow::State& state) -> string {
   @autoreleasepool {
     NSMutableArray* filters = [[NSMutableArray alloc] init];
     for(auto& rule : state.filters) {
-      auto parts = ::nall::split(rule, "|", 1L);
+      auto parts = nall::split(rule, "|", 1L);
       string pattern = (parts.size() > 1 ? parts[1] : string{}).replace("*", "").replace(".", "");
       if (pattern) {
-        for(auto& extension : ::nall::split(pattern, ":")) {
+        for(auto& extension : nall::split(pattern, ":")) {
           [filters addObject:[NSString stringWithUTF8String:extension]];
         }
       }

--- a/hiro/cocoa/browser-window.cpp
+++ b/hiro/cocoa/browser-window.cpp
@@ -30,9 +30,10 @@ auto pBrowserWindow::open(BrowserWindow::State& state) -> string {
   @autoreleasepool {
     NSMutableArray* filters = [[NSMutableArray alloc] init];
     for(auto& rule : state.filters) {
-      string pattern = rule.split("|", 1L)(1).replace("*", "").replace(".", "");
+      auto parts = ::nall::split(rule, "|", 1L);
+      string pattern = (parts.size() > 1 ? parts[1] : string{}).replace("*", "").replace(".", "");
       if (pattern) {
-        for(auto& extension : pattern.split(":")) {
+        for(auto& extension : ::nall::split(pattern, ":")) {
           [filters addObject:[NSString stringWithUTF8String:extension]];
         }
       }
@@ -62,9 +63,10 @@ auto pBrowserWindow::save(BrowserWindow::State& state) -> string {
   @autoreleasepool {
     NSMutableArray* filters = [[NSMutableArray alloc] init];
     for(auto& rule : state.filters) {
-      string pattern = rule.split("|", 1L)(1).replace("*", "").replace(".", "");
+      auto parts = ::nall::split(rule, "|", 1L);
+      string pattern = (parts.size() > 1 ? parts[1] : string{}).replace("*", "").replace(".", "");
       if (pattern) {
-        for(auto& extension : pattern.split(":")) {
+        for(auto& extension : ::nall::split(pattern, ":")) {
           [filters addObject:[NSString stringWithUTF8String:extension]];
         }
       }

--- a/hiro/core/hotkey.cpp
+++ b/hiro/core/hotkey.cpp
@@ -51,8 +51,8 @@ auto Hotkey::setSequence(const string& sequence) -> type& {
   state->active = false;
   state->sequence = sequence;
   state->keys.clear();
-  for(auto& key : ::nall::split(sequence, "+")) {
-    if (auto idx = ::nall::index_of(Keyboard::keys, key)) state->keys.push_back((u32)*idx);
+  for(auto& key : nall::split(sequence, "+")) {
+    if (auto idx = nall::index_of(Keyboard::keys, key)) state->keys.push_back((u32)*idx);
   }
   return *this;
 }

--- a/hiro/core/hotkey.cpp
+++ b/hiro/core/hotkey.cpp
@@ -51,8 +51,8 @@ auto Hotkey::setSequence(const string& sequence) -> type& {
   state->active = false;
   state->sequence = sequence;
   state->keys.clear();
-  for(auto& key : sequence.split("+")) {
-    if (auto idx = nall::index_of(Keyboard::keys, key)) state->keys.push_back((u32)*idx);
+  for(auto& key : ::nall::split(sequence, "+")) {
+    if (auto idx = ::nall::index_of(Keyboard::keys, key)) state->keys.push_back((u32)*idx);
   }
   return *this;
 }

--- a/hiro/core/widget/tree-view-item.cpp
+++ b/hiro/core/widget/tree-view-item.cpp
@@ -74,11 +74,13 @@ auto mTreeViewItem::icon() const -> multiFactorImage {
 
 auto mTreeViewItem::item(const string& path) const -> TreeViewItem {
   if(!path) return {};
-  auto paths = path.split("/");
-  u32 position = paths.takeLeft().natural();
+  auto paths = ::nall::split(path, "/");
+  if(paths.empty()) return {};
+  u32 position = paths.front().natural();
+  paths.erase(paths.begin());
   if(position >= itemCount()) return {};
-  if(!paths) return state.items[position];
-  return state.items[position]->item(paths.merge("/"));
+  if(paths.empty()) return state.items[position];
+  return state.items[position]->item(::nall::merge(paths, "/"));
 }
 
 auto mTreeViewItem::itemCount() const -> u32 {

--- a/hiro/core/widget/tree-view-item.cpp
+++ b/hiro/core/widget/tree-view-item.cpp
@@ -74,13 +74,13 @@ auto mTreeViewItem::icon() const -> multiFactorImage {
 
 auto mTreeViewItem::item(const string& path) const -> TreeViewItem {
   if(!path) return {};
-  auto paths = ::nall::split(path, "/");
+  auto paths = nall::split(path, "/");
   if(paths.empty()) return {};
   u32 position = paths.front().natural();
   paths.erase(paths.begin());
   if(position >= itemCount()) return {};
   if(paths.empty()) return state.items[position];
-  return state.items[position]->item(::nall::merge(paths, "/"));
+  return state.items[position]->item(nall::merge(paths, "/"));
 }
 
 auto mTreeViewItem::itemCount() const -> u32 {

--- a/hiro/core/widget/tree-view.cpp
+++ b/hiro/core/widget/tree-view.cpp
@@ -58,11 +58,13 @@ auto mTreeView::foregroundColor() const -> Color {
 
 auto mTreeView::item(const string& path) const -> TreeViewItem {
   if(!path) return {};
-  auto paths = path.split("/");
-  u32 position = paths.takeLeft().natural();
+  auto paths = ::nall::split(path, "/");
+  if(paths.empty()) return {};
+  u32 position = paths.front().natural();
+  paths.erase(paths.begin());
   if(position >= itemCount()) return {};
-  if(!paths) return state.items[position];
-  return state.items[position]->item(paths.merge("/"));
+  if(paths.empty()) return state.items[position];
+  return state.items[position]->item(::nall::merge(paths, "/"));
 }
 
 auto mTreeView::itemCount() const -> u32 {

--- a/hiro/core/widget/tree-view.cpp
+++ b/hiro/core/widget/tree-view.cpp
@@ -58,13 +58,13 @@ auto mTreeView::foregroundColor() const -> Color {
 
 auto mTreeView::item(const string& path) const -> TreeViewItem {
   if(!path) return {};
-  auto paths = ::nall::split(path, "/");
+  auto paths = nall::split(path, "/");
   if(paths.empty()) return {};
   u32 position = paths.front().natural();
   paths.erase(paths.begin());
   if(position >= itemCount()) return {};
   if(paths.empty()) return state.items[position];
-  return state.items[position]->item(::nall::merge(paths, "/"));
+  return state.items[position]->item(nall::merge(paths, "/"));
 }
 
 auto mTreeView::itemCount() const -> u32 {

--- a/hiro/extension/browser-dialog.cpp
+++ b/hiro/extension/browser-dialog.cpp
@@ -215,8 +215,8 @@ auto BrowserDialogWindow::run() -> BrowserDialog::Response {
   view.onContext([&] { context(); });
   filterList.setCollapsible().setVisible(state.action != "selectFolder").onChange([&] { setPath(state.path); });
   for(auto& filter : state.filters) {
-    auto part = filter.split("|", 1L);
-    filterList.append(ComboButtonItem().setText(part.left()));
+    auto part = ::nall::split(filter, "|", 1L);
+    filterList.append(ComboButtonItem().setText(part.empty() ? string{} : part.front()));
   }
   optionList
   .setCollapsible()
@@ -257,8 +257,9 @@ auto BrowserDialogWindow::run() -> BrowserDialog::Response {
 
   if(state.filters.empty()) state.filters.push_back("All|*");
   for(auto& filter : state.filters) {
-    auto part = filter.split("|", 1L);
-    auto filterParts = part.right().split(":");
+    auto part = ::nall::split(filter, "|", 1L);
+    auto partBack = part.size() > 1 ? part.back() : string{};
+    auto filterParts = ::nall::split(partBack, ":");
     std::vector<string> v;
     for(auto& s : filterParts) v.push_back(s);
     filters.push_back(std::move(v));
@@ -308,7 +309,7 @@ auto BrowserDialogWindow::run() -> BrowserDialog::Response {
     if(batched.empty()) return;
     if(MessageDialog()
     .setTitle("Remove Selected")
-    .setText({"Are you sure you want to permanently delete the selected item", batched.size() == 1 ? "" : "s", "?"})
+    .setText({"Are you sure you want to permanently delete the selected item", batched.size() == 1 ? string{} : string{"s"}, "?"})
     .setAlignment(window)
     .question() == "No") return;
     for(auto& item : batched) {

--- a/hiro/extension/browser-dialog.cpp
+++ b/hiro/extension/browser-dialog.cpp
@@ -309,7 +309,7 @@ auto BrowserDialogWindow::run() -> BrowserDialog::Response {
     if(batched.empty()) return;
     if(MessageDialog()
     .setTitle("Remove Selected")
-    .setText({"Are you sure you want to permanently delete the selected item", batched.size() == 1 ? string{} : string{"s"}, "?"})
+    .setText({"Are you sure you want to permanently delete the selected item", batched.size() == 1 ? "" : "s", "?"})
     .setAlignment(window)
     .question() == "No") return;
     for(auto& item : batched) {

--- a/hiro/extension/browser-dialog.cpp
+++ b/hiro/extension/browser-dialog.cpp
@@ -215,7 +215,7 @@ auto BrowserDialogWindow::run() -> BrowserDialog::Response {
   view.onContext([&] { context(); });
   filterList.setCollapsible().setVisible(state.action != "selectFolder").onChange([&] { setPath(state.path); });
   for(auto& filter : state.filters) {
-    auto part = ::nall::split(filter, "|", 1L);
+    auto part = nall::split(filter, "|", 1L);
     filterList.append(ComboButtonItem().setText(part.empty() ? string{} : part.front()));
   }
   optionList
@@ -257,9 +257,9 @@ auto BrowserDialogWindow::run() -> BrowserDialog::Response {
 
   if(state.filters.empty()) state.filters.push_back("All|*");
   for(auto& filter : state.filters) {
-    auto part = ::nall::split(filter, "|", 1L);
+    auto part = nall::split(filter, "|", 1L);
     auto partBack = part.size() > 1 ? part.back() : string{};
-    auto filterParts = ::nall::split(partBack, ":");
+    auto filterParts = nall::split(partBack, ":");
     std::vector<string> v;
     for(auto& s : filterParts) v.push_back(s);
     filters.push_back(std::move(v));

--- a/hiro/gtk/browser-window-native.cpp
+++ b/hiro/gtk/browser-window-native.cpp
@@ -4,12 +4,12 @@ namespace hiro {
 
 static auto BrowserWindow_addFilters(GtkFileChooserNative* dialog, std::vector<string> filters) -> void {
   for(auto& filter : filters) {
-    auto part = filter.split("|", 1L);
+    auto part = ::nall::split(filter, "|", 1L);
     if(part.size() != 2) continue;
 
     GtkFileFilter* gtkFilter = gtk_file_filter_new();
     gtk_file_filter_set_name(gtkFilter, part[0]);
-    auto patterns = part[1].split(":");
+    auto patterns = ::nall::split(part[1], ":");
     for(auto& pattern : patterns) gtk_file_filter_add_pattern(gtkFilter, pattern);
     gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog), gtkFilter);
   }

--- a/hiro/gtk/browser-window-native.cpp
+++ b/hiro/gtk/browser-window-native.cpp
@@ -4,12 +4,12 @@ namespace hiro {
 
 static auto BrowserWindow_addFilters(GtkFileChooserNative* dialog, std::vector<string> filters) -> void {
   for(auto& filter : filters) {
-    auto part = ::nall::split(filter, "|", 1L);
+    auto part = nall::split(filter, "|", 1L);
     if(part.size() != 2) continue;
 
     GtkFileFilter* gtkFilter = gtk_file_filter_new();
     gtk_file_filter_set_name(gtkFilter, part[0]);
-    auto patterns = ::nall::split(part[1], ":");
+    auto patterns = nall::split(part[1], ":");
     for(auto& pattern : patterns) gtk_file_filter_add_pattern(gtkFilter, pattern);
     gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog), gtkFilter);
   }

--- a/hiro/gtk/widget/tree-view.cpp
+++ b/hiro/gtk/widget/tree-view.cpp
@@ -194,13 +194,15 @@ auto pTreeView::_buttonEvent(GdkEventButton* gdkEvent) -> s32 {
 
 auto pTreeView::_doDataFunc(GtkTreeViewColumn* column, GtkCellRenderer* renderer, GtkTreeIter* iter) -> void {
   auto path = gtk_tree_model_get_string_from_iter(gtkTreeModel, iter);
-  auto parts = string{path}.split(":");
+  auto parts = ::nall::split((const char*)path, ":");
   g_free(path);
 
-  auto item = self().item(parts.takeLeft().natural());
+  auto item = self().item(parts.empty() ? 0u : parts.front().natural());
+  if(!parts.empty()) parts.erase(parts.begin());
   if(!item) return;
-  while(parts) {
-    item = item.item(parts.takeLeft().natural());
+  while(!parts.empty()) {
+    item = item.item(parts.front().natural());
+    parts.erase(parts.begin());
     if(!item) return;
   }
 

--- a/hiro/gtk/widget/tree-view.cpp
+++ b/hiro/gtk/widget/tree-view.cpp
@@ -194,7 +194,7 @@ auto pTreeView::_buttonEvent(GdkEventButton* gdkEvent) -> s32 {
 
 auto pTreeView::_doDataFunc(GtkTreeViewColumn* column, GtkCellRenderer* renderer, GtkTreeIter* iter) -> void {
   auto path = gtk_tree_model_get_string_from_iter(gtkTreeModel, iter);
-  auto parts = ::nall::split((const char*)path, ":");
+  auto parts = nall::split((const char*)path, ":");
   g_free(path);
 
   auto item = self().item(parts.empty() ? 0u : parts.front().natural());

--- a/hiro/qt/browser-window.cpp
+++ b/hiro/qt/browser-window.cpp
@@ -16,7 +16,7 @@ auto pBrowserWindow::directory(BrowserWindow::State& state) -> string {
 auto pBrowserWindow::open(BrowserWindow::State& state) -> string {
   string filters;
   for(auto& filter : state.filters) {
-    auto part = ::nall::split(filter, "|", 1L);
+    auto part = nall::split(filter, "|", 1L);
     if(part.size() != 2) continue;
     filters.append(part[0], " (", part[1].transform(":", " "), ");;");
   }
@@ -33,7 +33,7 @@ auto pBrowserWindow::open(BrowserWindow::State& state) -> string {
 auto pBrowserWindow::save(BrowserWindow::State& state) -> string {
   string filters;
   for(auto& filter : state.filters) {
-    auto part = ::nall::split(filter, "|", 1L);
+    auto part = nall::split(filter, "|", 1L);
     if(part.size() != 2) continue;
     filters.append(part[0], " (", part[1].transform(":", " "), ");;");
   }

--- a/hiro/qt/browser-window.cpp
+++ b/hiro/qt/browser-window.cpp
@@ -16,7 +16,7 @@ auto pBrowserWindow::directory(BrowserWindow::State& state) -> string {
 auto pBrowserWindow::open(BrowserWindow::State& state) -> string {
   string filters;
   for(auto& filter : state.filters) {
-    auto part = filter.split("|", 1L);
+    auto part = ::nall::split(filter, "|", 1L);
     if(part.size() != 2) continue;
     filters.append(part[0], " (", part[1].transform(":", " "), ");;");
   }
@@ -33,7 +33,7 @@ auto pBrowserWindow::open(BrowserWindow::State& state) -> string {
 auto pBrowserWindow::save(BrowserWindow::State& state) -> string {
   string filters;
   for(auto& filter : state.filters) {
-    auto part = filter.split("|", 1L);
+    auto part = ::nall::split(filter, "|", 1L);
     if(part.size() != 2) continue;
     filters.append(part[0], " (", part[1].transform(":", " "), ");;");
   }

--- a/hiro/qt/font.cpp
+++ b/hiro/qt/font.cpp
@@ -9,7 +9,7 @@ auto pFont::size(const Font& font, const string& text) -> Size {
 auto pFont::size(const QFont& qtFont, const string& text) -> Size {
   QFontMetrics metrics(qtFont);
   s32 maxWidth = 0;
-  auto lines = ::nall::split(text, "\n");
+  auto lines = nall::split(text, "\n");
   for(auto& line : lines) {
     maxWidth = max(maxWidth, metrics.boundingRect(QString::fromUtf8(line)).width());
   }

--- a/hiro/qt/font.cpp
+++ b/hiro/qt/font.cpp
@@ -9,7 +9,7 @@ auto pFont::size(const Font& font, const string& text) -> Size {
 auto pFont::size(const QFont& qtFont, const string& text) -> Size {
   QFontMetrics metrics(qtFont);
   s32 maxWidth = 0;
-  auto lines = text.split("\n");
+  auto lines = ::nall::split(text, "\n");
   for(auto& line : lines) {
     maxWidth = max(maxWidth, metrics.boundingRect(QString::fromUtf8(line)).width());
   }

--- a/hiro/qt/keyboard.cpp
+++ b/hiro/qt/keyboard.cpp
@@ -48,7 +48,7 @@ auto pKeyboard::initialize() -> void {
     lo = lo ? (u8)XKeysymToKeycode(pApplication::state().display, lo) : 0;
     hi = hi ? (u8)XKeysymToKeycode(pApplication::state().display, hi) : 0;
     #endif
-    settings.keycodes.append(lo << 0 | hi << 8);
+    settings.keycodes.push_back(lo << 0 | hi << 8);
   };
 
   #define map(name, ...) if(key == name) { append(__VA_ARGS__); continue; }

--- a/hiro/qt/widget/canvas.cpp
+++ b/hiro/qt/widget/canvas.cpp
@@ -106,7 +106,8 @@ auto QtCanvas::dragEnterEvent(QDragEnterEvent* event) -> void {
 }
 
 auto QtCanvas::dropEvent(QDropEvent* event) -> void {
-  if(auto paths = DropPaths(event)) p.self().doDrop(paths);
+  auto paths = DropPaths(event);
+  if(!paths.empty()) p.self().doDrop(paths);
 }
 
 auto QtCanvas::leaveEvent(QEvent* event) -> void {

--- a/hiro/qt/widget/viewport.cpp
+++ b/hiro/qt/widget/viewport.cpp
@@ -40,7 +40,8 @@ auto QtViewport::dragEnterEvent(QDragEnterEvent* event) -> void {
 }
 
 auto QtViewport::dropEvent(QDropEvent* event) -> void {
-  if(auto paths = DropPaths(event)) p.self().doDrop(paths);
+  auto paths = DropPaths(event);
+  if(!paths.empty()) p.self().doDrop(paths);
 }
 
 auto QtViewport::leaveEvent(QEvent* event) -> void {

--- a/hiro/qt/window.cpp
+++ b/hiro/qt/window.cpp
@@ -326,7 +326,8 @@ auto QtWindow::dragEnterEvent(QDragEnterEvent* event) -> void {
 }
 
 auto QtWindow::dropEvent(QDropEvent* event) -> void {
-  if(auto paths = DropPaths(event)) p.self().doDrop(paths);
+  auto paths = DropPaths(event);
+  if(!paths.empty()) p.self().doDrop(paths);
 }
 
 auto QtWindow::keyPressEvent(QKeyEvent* event) -> void {

--- a/hiro/windows/application.hpp
+++ b/hiro/windows/application.hpp
@@ -15,9 +15,9 @@ struct pApplication {
 
   struct State {
     std::vector<pMenuBar*> menuBarsToRebuild;  //deferred menu bars to update
-    s32 modalCount = 0;                   //number of modal loops
-    Timer modalTimer;                     //to run Application during modal events
-    pToolTip* toolTip = nullptr;          //active toolTip
+    s32 modalCount = 0;                        //number of modal loops
+    Timer modalTimer;                          //to run Application during modal events
+    pToolTip* toolTip = nullptr;               //active toolTip
   };
   static auto state() -> State&;
 };

--- a/hiro/windows/browser-window.cpp
+++ b/hiro/windows/browser-window.cpp
@@ -19,7 +19,7 @@ static auto BrowserWindow_fileDialog(bool save, BrowserWindow::State& state) -> 
 
   string filters;
   for(auto& filter : state.filters) {
-    auto part = filter.split("|", 1L);
+    auto part = ::nall::split(filter, "|", 1L);
     if(part.size() != 2) continue;
     filters.append(part[0], "\t", part[1].transform(":", ";"), "\t");
   }

--- a/hiro/windows/browser-window.cpp
+++ b/hiro/windows/browser-window.cpp
@@ -19,7 +19,7 @@ static auto BrowserWindow_fileDialog(bool save, BrowserWindow::State& state) -> 
 
   string filters;
   for(auto& filter : state.filters) {
-    auto part = ::nall::split(filter, "|", 1L);
+    auto part = nall::split(filter, "|", 1L);
     if(part.size() != 2) continue;
     filters.append(part[0], "\t", part[1].transform(":", ";"), "\t");
   }

--- a/mia/medium/arcade.cpp
+++ b/mia/medium/arcade.cpp
@@ -1,6 +1,6 @@
 struct Arcade : Mame {
   auto name() -> string override { return "Arcade"; }
-  auto extensions() -> vector<string> override { return {}; }
+  auto extensions() -> std::vector<string> override { return {}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };

--- a/mia/medium/atari-2600.cpp
+++ b/mia/medium/atari-2600.cpp
@@ -1,6 +1,6 @@
 struct Atari2600 : Cartridge {
   auto name() -> string override { return "Atari 2600"; }
-  auto extensions() -> vector<string> override { return {"a26", "bin"}; }
+  auto extensions() -> std::vector<string> override { return {"a26", "bin"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;

--- a/mia/medium/bs-memory.cpp
+++ b/mia/medium/bs-memory.cpp
@@ -1,6 +1,6 @@
 struct BSMemory : Cartridge {
   auto name() -> string override { return "BS Memory"; }
-  auto extensions() -> vector<string> override { return {"bs"}; }
+  auto extensions() -> std::vector<string> override { return {"bs"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;

--- a/mia/medium/colecovision.cpp
+++ b/mia/medium/colecovision.cpp
@@ -1,6 +1,6 @@
 struct ColecoVision : Cartridge {
   auto name() -> string override { return "ColecoVision"; }
-  auto extensions() -> vector<string> override { return {"col"}; }
+  auto extensions() -> std::vector<string> override { return {"col"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;

--- a/mia/medium/famicom-disk-system.cpp
+++ b/mia/medium/famicom-disk-system.cpp
@@ -1,6 +1,6 @@
 struct FamicomDiskSystem : FloppyDisk {
   auto name() -> string override { return "Famicom Disk System"; }
-  auto extensions() -> vector<string> override { return {"fds"}; }
+  auto extensions() -> std::vector<string> override { return {"fds"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze() -> string;

--- a/mia/medium/famicom-disk-system.cpp
+++ b/mia/medium/famicom-disk-system.cpp
@@ -4,7 +4,7 @@ struct FamicomDiskSystem : FloppyDisk {
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze() -> string;
-  auto transform(array_view<u8> input) -> vector<u8>;
+  auto transform(array_view<u8> input) -> std::vector<u8>;
 };
 
 auto FamicomDiskSystem::load(string location) -> LoadResult {
@@ -33,7 +33,8 @@ auto FamicomDiskSystem::load(string location) -> LoadResult {
     array_view<u8> view{input};
     if(view.size() % 65500 == 16) view += 16;  //skip iNES / fwNES header
     u32 index = 0;
-    while(auto output = transform(view)) {
+    auto output = transform(view);
+    while(!output.empty()) {
       string name;
       name.append("disk", (char)('1' + index / 2), ".");
       name.append("side", (char)('A' + index % 2));
@@ -72,7 +73,7 @@ auto FamicomDiskSystem::analyze() -> string {
   return s;
 }
 
-auto FamicomDiskSystem::transform(array_view<u8> input) -> vector<u8> {
+auto FamicomDiskSystem::transform(array_view<u8> input) -> std::vector<u8> {
   if(input.size() < 65500) return {};
 
   array_view<u8> data{input.data(), 65500};
@@ -81,7 +82,7 @@ auto FamicomDiskSystem::transform(array_view<u8> input) -> vector<u8> {
   if(data[0x3a] != 0x03) return {};
   if(data[0x4a] != 0x04) return {};
 
-  vector<u8> output;
+  std::vector<u8> output;
   u16 crc16 = 0;
   auto hash = [&](u8 byte) {
     for(u32 bit : range(8)) {
@@ -92,13 +93,13 @@ auto FamicomDiskSystem::transform(array_view<u8> input) -> vector<u8> {
   };
   auto write = [&](u8 byte) {
     hash(byte);
-    output.append(byte);
+    output.push_back(byte);
   };
   auto flush = [&] {
     hash(0x00);
     hash(0x00);
-    output.append(crc16 >> 0);
-    output.append(crc16 >> 8);
+    output.push_back(crc16 >> 0);
+    output.push_back(crc16 >> 8);
     crc16 = 0;
   };
 
@@ -133,7 +134,7 @@ auto FamicomDiskSystem::transform(array_view<u8> input) -> vector<u8> {
   }
 
   //note: actual maximum capacity of a Famicom Disk is currently unknown
-  while(output.size() < 0x12000) output.append(0x00);  //expand if too small
+  while(output.size() < 0x12000) output.push_back(0x00);  //expand if too small
   output.resize(0x12000);  //shrink if too large
   return output;
 }

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -1,6 +1,6 @@
 struct Famicom : Cartridge {
   auto name() -> string override { return "Famicom"; }
-  auto extensions() -> vector<string> override { return {"fc", "nes", "unf", "unif", "unh"}; }
+  auto extensions() -> std::vector<string> override { return {"fc", "nes", "unf", "unif", "unh"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;

--- a/mia/medium/game-boy-advance.cpp
+++ b/mia/medium/game-boy-advance.cpp
@@ -1,7 +1,7 @@
 struct GameBoyAdvance : Cartridge {
   auto name() -> string override { return "Game Boy Advance"; }
   auto saveName() -> string override { return "Game Boy Advance"; }
-  auto extensions() -> vector<string> override { return {"gba"}; }
+  auto extensions() -> std::vector<string> override { return {"gba"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;
@@ -72,7 +72,7 @@ auto GameBoyAdvance::save(string location) -> bool {
 }
 
 auto GameBoyAdvance::analyze(std::vector<u8>& rom) -> string {
-  vector<string> mirrorCodes = {
+  std::vector<string> mirrorCodes = {
     "FBME",  //Classic NES Series - Bomberman (USA, Europe)
     "FADE",  //Classic NES Series - Castlevania (USA)
     "FDKE",  //Classic NES Series - Donkey Kong (USA, Europe)
@@ -123,7 +123,7 @@ auto GameBoyAdvance::analyze(std::vector<u8>& rom) -> string {
     }
   }
 
-  vector<string> identifiers = {
+  std::vector<string> identifiers = {
     "SRAM_V",
     "SRAM_F_V",
     "EEPROM_V",
@@ -132,17 +132,17 @@ auto GameBoyAdvance::analyze(std::vector<u8>& rom) -> string {
     "FLASH1M_V",
   };
 
-  vector<string> saveTypes;
-  if(gameCode == "A2YE") { saveTypes.append("NONE"      ); };  //Top Gun - Combat Zones (USA)
-  if(gameCode == "ALUE") { saveTypes.append("EEPROM_V"  ); };  //Super Monkey Ball Jr. (USA)
-  if(gameCode == "AR8E") { saveTypes.append("EEPROM_V"  ); };  //Rocky (USA)
-  if(gameCode == "AROP") { saveTypes.append("EEPROM_V"  ); };  //Rocky (Europe)
-  if(gameCode == "BR4J") { saveTypes.append("FLASH512_V"); };  //Rockman EXE 4.5 - Real Operation (Japan)
+  std::vector<string> saveTypes;
+  if(gameCode == "A2YE") { saveTypes.push_back("NONE"      ); };  //Top Gun - Combat Zones (USA)
+  if(gameCode == "ALUE") { saveTypes.push_back("EEPROM_V"  ); };  //Super Monkey Ball Jr. (USA)
+  if(gameCode == "AR8E") { saveTypes.push_back("EEPROM_V"  ); };  //Rocky (USA)
+  if(gameCode == "AROP") { saveTypes.push_back("EEPROM_V"  ); };  //Rocky (Europe)
+  if(gameCode == "BR4J") { saveTypes.push_back("FLASH512_V"); };  //Rockman EXE 4.5 - Real Operation (Japan)
 
   for(auto& identifier : identifiers) {
     for(s32 n : range(rom.size() - 16)) {
       if(!memory::compare(&rom[n], identifier.data(), identifier.size())) {
-        if(!saveTypes.find(identifier.data())) saveTypes.append(identifier.data());
+        if(std::ranges::find(saveTypes, string(identifier.data())) == saveTypes.end()) saveTypes.push_back(identifier.data());
       }
     }
   }
@@ -168,22 +168,22 @@ auto GameBoyAdvance::analyze(std::vector<u8>& rom) -> string {
   s += "      content: Program\n";
   s +={"      mirror: ", mirror, "\n"};
 
-  if(saveTypes) {
-    if(saveTypes.first().beginsWith("SRAM_V") || saveTypes.first().beginsWith("SRAM_F_V")) {
+  if(!saveTypes.empty()) {
+    if(saveTypes.front().beginsWith("SRAM_V") || saveTypes.front().beginsWith("SRAM_F_V")) {
       s += "    memory\n";
       s += "      type: RAM\n";
       s += "      size: 0x8000\n";
       s += "      content: Save\n";
     }
 
-    if(saveTypes.first().beginsWith("EEPROM_V")) {
+    if(saveTypes.front().beginsWith("EEPROM_V")) {
       s += "    memory\n";
       s += "      type: EEPROM\n";
       s += "      size: 0x0\n";  //auto-detected
       s += "      content: Save\n";
     }
 
-    if(saveTypes.first().beginsWith("FLASH_V") || saveTypes.first().beginsWith("FLASH512_V")) {
+    if(saveTypes.front().beginsWith("FLASH_V") || saveTypes.front().beginsWith("FLASH512_V")) {
       s += "    memory\n";
       s += "      type: Flash\n";
       s += "      size: 0x10000\n";
@@ -191,7 +191,7 @@ auto GameBoyAdvance::analyze(std::vector<u8>& rom) -> string {
       s += "      manufacturer: Macronix\n";
     }
 
-    if(saveTypes.first().beginsWith("FLASH1M_V")) {
+    if(saveTypes.front().beginsWith("FLASH1M_V")) {
       s += "    memory\n";
       s += "      type: Flash\n";
       s += "      size: 0x20000\n";

--- a/mia/medium/game-boy-color.cpp
+++ b/mia/medium/game-boy-color.cpp
@@ -1,5 +1,5 @@
 struct GameBoyColor : GameBoy {
   auto name() -> string override { return "Game Boy Color"; }
   auto saveName() -> string override { return "Game Boy"; }
-  auto extensions() -> vector<string> override { return {"gb", "gbc"}; }
+  auto extensions() -> std::vector<string> override { return {"gb", "gbc"}; }
 };

--- a/mia/medium/game-boy.cpp
+++ b/mia/medium/game-boy.cpp
@@ -1,6 +1,6 @@
 struct GameBoy : Cartridge {
   auto name() -> string override { return "Game Boy"; }
-  auto extensions() -> vector<string> override { return {"gb"}; }
+  auto extensions() -> std::vector<string> override { return {"gb"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;

--- a/mia/medium/game-gear.cpp
+++ b/mia/medium/game-gear.cpp
@@ -1,6 +1,6 @@
 struct GameGear : Cartridge {
   auto name() -> string override { return "Game Gear"; }
-  auto extensions() -> vector<string> override { return {"gg"}; }
+  auto extensions() -> std::vector<string> override { return {"gg"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;

--- a/mia/medium/master-system.cpp
+++ b/mia/medium/master-system.cpp
@@ -1,6 +1,6 @@
 struct MasterSystem : Cartridge {
   auto name() -> string override { return "Master System"; }
-  auto extensions() -> vector<string> override { return {"ms", "sms"}; }
+  auto extensions() -> std::vector<string> override { return {"ms", "sms"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;

--- a/mia/medium/medium.cpp
+++ b/mia/medium/medium.cpp
@@ -1,5 +1,5 @@
 namespace Media {
-  vector<Database> databases;
+  std::vector<Database> databases;
   #include "mame.cpp"
   #include "arcade.cpp"
   #include "atari-2600.cpp"
@@ -95,7 +95,7 @@ auto Medium::loadDatabase() -> bool {
   auto databaseFile = locate({"Database/", name(), ".bml"});
   if(inode::exists(databaseFile)) {
     database.list = BML::unserialize(file::read(databaseFile));
-    Media::databases.append(std::move(database));
+    Media::databases.push_back(std::move(database));
     return true;
   }
 
@@ -170,7 +170,7 @@ auto CompactDisc::isAudioCd(string pathname) -> bool {
   auto fp = file::open({pathname, "cd.rom"}, file::mode::read);
   if(!fp) return {};
 
-  vector<u8> toc;
+  std::vector<u8> toc;
   toc.resize(96 * 7500);
   for(u32 sector : range(7500)) {
     fp.read({toc.data() + 96 * sector, 96});
@@ -188,7 +188,7 @@ auto CompactDisc::isAudioCd(string pathname) -> bool {
   return true;
 }
 
-auto CompactDisc::readDataSector(string pathname, u32 sectorID) -> vector<u8> {
+auto CompactDisc::readDataSector(string pathname, u32 sectorID) -> std::vector<u8> {
   if(pathname.iendsWith(".bcd")) {
     return readDataSectorBCD(pathname, sectorID);
   }
@@ -203,11 +203,11 @@ auto CompactDisc::readDataSector(string pathname, u32 sectorID) -> vector<u8> {
   return {};
 }
 
-auto CompactDisc::readDataSectorBCD(string pathname, u32 sectorID) -> vector<u8> {
+auto CompactDisc::readDataSectorBCD(string pathname, u32 sectorID) -> std::vector<u8> {
   auto fp = file::open({pathname, "cd.rom"}, file::mode::read);
   if(!fp) return {};
 
-  vector<u8> toc;
+  std::vector<u8> toc;
   toc.resize(96 * 7500);
   for(u32 sector : range(7500)) {
     fp.read({toc.data() + 96 * sector, 96});
@@ -219,7 +219,7 @@ auto CompactDisc::readDataSectorBCD(string pathname, u32 sectorID) -> vector<u8>
     if(auto& track = session.tracks[trackID]) {
       if(!track.isData()) continue;
       if(auto index = track.index(1)) {
-        vector<u8> sector;
+        std::vector<u8> sector;
         sector.resize(2448);
         fp.seek(2448 * (abs(session.leadIn.lba) + index->lba + sectorID) + 16);
         fp.read({sector.data(), 2448});
@@ -231,7 +231,7 @@ auto CompactDisc::readDataSectorBCD(string pathname, u32 sectorID) -> vector<u8>
   return {};
 }
 
-auto CompactDisc::readDataSectorCUE(string filename, u32 sectorID) -> vector<u8> {
+auto CompactDisc::readDataSectorCUE(string filename, u32 sectorID) -> std::vector<u8> {
   Decode::CUE cuesheet;
   if(!cuesheet.load(filename, nullptr, nullptr)) return {};
 
@@ -250,7 +250,7 @@ auto CompactDisc::readDataSectorCUE(string filename, u32 sectorID) -> vector<u8>
           if(track.type == "mode2/2352") sectorSize = 2352;
           if(sectorSize && index.number == 1) {
             binary.seek(offset + (sectorSize * sectorID) + (sectorSize == 2352 ? 16 : 0));
-            vector<u8> sector;
+            std::vector<u8> sector;
             sector.resize(2048);
             binary.read({sector.data(), sector.size()});
             return sector;
@@ -277,7 +277,7 @@ auto CompactDisc::readDataSectorCUE(string filename, u32 sectorID) -> vector<u8>
 }
 
 #if defined(ARES_ENABLE_CHD)
-auto CompactDisc::readDataSectorCHD(string filename, u32 sectorID) -> vector<u8> {
+auto CompactDisc::readDataSectorCHD(string filename, u32 sectorID) -> std::vector<u8> {
   Decode::CHD chd;
   if(!chd.load(filename)) return {};
 
@@ -289,7 +289,7 @@ auto CompactDisc::readDataSectorCHD(string filename, u32 sectorID) -> vector<u8>
 
       // Read the sector from CHD and extract the user data portion (2048 bytes)
       auto sector = chd.read(index.lba + sectorID);
-      vector<u8> output;
+      std::vector<u8> output;
       output.resize(2048);
 
       if (sector.size() == 2048) {
@@ -306,7 +306,7 @@ auto CompactDisc::readDataSectorCHD(string filename, u32 sectorID) -> vector<u8>
 }
 #endif
 
-auto LaserDisc::readDataSector(string mmiPath, string cuePath, u32 sectorID) -> vector<u8> {
+auto LaserDisc::readDataSector(string mmiPath, string cuePath, u32 sectorID) -> std::vector<u8> {
   unique_pointer archive = new Decode::ZIP;
   if (!archive->open(mmiPath)) return {};
   Decode::CUE cuesheet;
@@ -320,7 +320,7 @@ auto LaserDisc::readDataSector(string mmiPath, string cuePath, u32 sectorID) -> 
       auto fileEntry = archive->findFile(filePathInArchive);
       if(!fileEntry) continue;
       array_view<u8> rawDataView;
-      vector<u8> rawDataBuffer;
+      std::vector<u8> rawDataBuffer;
       if (archive->isDataUncompressed(*fileEntry)) {
         rawDataView = archive->dataViewIfUncompressed(*fileEntry);
       } else {
@@ -337,7 +337,7 @@ auto LaserDisc::readDataSector(string mmiPath, string cuePath, u32 sectorID) -> 
           if(track.type == "mode2/2352") sectorSize = 2352;
           if(sectorSize && index.number == 1) {
             size_t readPos = offset + (sectorSize * sectorID) + (sectorSize == 2352 ? 16 : 0);
-            vector<u8> sector;
+            std::vector<u8> sector;
             sector.resize(2048);
             memcpy(sector.data(), rawDataView.data() + readPos, sector.size());
             return sector;

--- a/mia/medium/medium.hpp
+++ b/mia/medium/medium.hpp
@@ -19,7 +19,7 @@ struct Cartridge : Medium {
 
 struct CompactDisc : Medium {
   auto type() -> string override { return "Compact Disc"; }
-  auto extensions() -> vector<string> override {
+  auto extensions() -> std::vector<string> override {
 #if defined(ARES_ENABLE_CHD)
     return {"cue", "chd"};
 #else
@@ -43,7 +43,7 @@ struct FloppyDisk : Medium {
 
 struct LaserDisc : Medium {
   auto type() -> string override { return "LaserDisc"; }
-  auto extensions() -> vector<string> override { return {"mmi"}; }
+  auto extensions() -> std::vector<string> override { return {"mmi"}; }
   auto readDataSector(string mmiPath, string cuePath, u32 sectorID) -> vector<u8>;
 protected:
   Decode::MMI mmiArchive;

--- a/mia/medium/medium.hpp
+++ b/mia/medium/medium.hpp
@@ -28,12 +28,12 @@ struct CompactDisc : Medium {
   }
   auto isAudioCd(string location) -> bool;
   auto manifestAudio(string location) -> string;
-  auto readDataSector(string filename, u32 sectorID) -> vector<u8>;
+  auto readDataSector(string filename, u32 sectorID) -> std::vector<u8>;
 private:
-  auto readDataSectorBCD(string filename, u32 sectorID) -> vector<u8>;
-  auto readDataSectorCUE(string filename, u32 sectorID) -> vector<u8>;
+  auto readDataSectorBCD(string filename, u32 sectorID) -> std::vector<u8>;
+  auto readDataSectorCUE(string filename, u32 sectorID) -> std::vector<u8>;
 #if defined(ARES_ENABLE_CHD)
-  auto readDataSectorCHD(string filename, u32 sectorID) -> vector<u8>;
+  auto readDataSectorCHD(string filename, u32 sectorID) -> std::vector<u8>;
 #endif
 };
 
@@ -44,7 +44,7 @@ struct FloppyDisk : Medium {
 struct LaserDisc : Medium {
   auto type() -> string override { return "LaserDisc"; }
   auto extensions() -> std::vector<string> override { return {"mmi"}; }
-  auto readDataSector(string mmiPath, string cuePath, u32 sectorID) -> vector<u8>;
+  auto readDataSector(string mmiPath, string cuePath, u32 sectorID) -> std::vector<u8>;
 protected:
   Decode::MMI mmiArchive;
 };

--- a/mia/medium/mega-32x.cpp
+++ b/mia/medium/mega-32x.cpp
@@ -44,7 +44,9 @@ auto Mega32X::load(string location) -> LoadResult {
   pak->setAttribute("region",   document["game/region"].string());
   pak->setAttribute("bootable", true);
   pak->setAttribute("mega32x",  true);
-  pak->setAttribute("megacd",   (bool)document["game/device"].string().split(", ").find("Mega CD"));
+  auto deviceList = document["game/device"].string();
+  auto devices = ::nall::split(deviceList, ", ");
+  pak->setAttribute("megacd",   (bool)(std::ranges::find(devices, string{"Mega CD"}) != devices.end()));
   pak->append("manifest.bml", manifest);
   pak->append("program.rom",  rom);
 
@@ -175,9 +177,9 @@ auto Mega32X::analyze(std::vector<u8>& rom) -> string {
   s +={"  label:  ", domesticName, "\n"};
   s +={"  label:  ", internationalName, "\n"};
   s +={"  serial: ", serialNumber, "\n"};
-  s +={"  region: ", nall::merge(regions, ", "), "\n"};
+  s +={"  region: ", ::nall::merge(regions, ", "), "\n"};
   if(!devices.empty())
-  s +={"  device: ", nall::merge(devices, ", "), "\n"};
+  s +={"  device: ", ::nall::merge(devices, ", "), "\n"};
   s += "  board\n";
   s += "    memory\n";
   s += "      type: ROM\n";

--- a/mia/medium/mega-32x.cpp
+++ b/mia/medium/mega-32x.cpp
@@ -125,7 +125,7 @@ auto Mega32X::analyze(std::vector<u8>& rom) -> string {
   //uses an 'E' value for both PAL and NTSC-U region. (NTSC-J cartridge uses '1')  
   //https://segaretro.org/ROM_header#Regional_compatiblity
   if(region(0) == 'E' && hash == "2f9b6017258fbb1c37d81df07c68d5255495d3bf76d9c7b680ff66bccf665750") {
-    regions.push_back("NTSC-U"); regions.push_back("PAL");
+    regions.insert(regions.end(), {"NTSC-U", "PAL"});
   }
   if(regions.empty()) {
     if(region.find("J")) regions.push_back("NTSC-J");
@@ -143,7 +143,7 @@ auto Mega32X::analyze(std::vector<u8>& rom) -> string {
     if(bits && *bits & 8) regions.push_back("PAL");     //overseas 50hz
   }
   if(regions.empty()) {
-    regions.push_back("NTSC-J"); regions.push_back("NTSC-U"); regions.push_back("PAL");
+    regions.insert(regions.end(), {"NTSC-J", "NTSC-U", "PAL"});
   }
 
   string domesticName;

--- a/mia/medium/mega-32x.cpp
+++ b/mia/medium/mega-32x.cpp
@@ -45,7 +45,7 @@ auto Mega32X::load(string location) -> LoadResult {
   pak->setAttribute("bootable", true);
   pak->setAttribute("mega32x",  true);
   auto deviceList = document["game/device"].string();
-  auto devices = ::nall::split(deviceList, ", ");
+  auto devices = nall::split(deviceList, ", ");
   pak->setAttribute("megacd",   (bool)(std::ranges::find(devices, string{"Mega CD"}) != devices.end()));
   pak->append("manifest.bml", manifest);
   pak->append("program.rom",  rom);
@@ -177,9 +177,9 @@ auto Mega32X::analyze(std::vector<u8>& rom) -> string {
   s +={"  label:  ", domesticName, "\n"};
   s +={"  label:  ", internationalName, "\n"};
   s +={"  serial: ", serialNumber, "\n"};
-  s +={"  region: ", ::nall::merge(regions, ", "), "\n"};
+  s +={"  region: ", nall::merge(regions, ", "), "\n"};
   if(!devices.empty())
-  s +={"  device: ", ::nall::merge(devices, ", "), "\n"};
+  s +={"  device: ", nall::merge(devices, ", "), "\n"};
   s += "  board\n";
   s += "    memory\n";
   s += "      type: ROM\n";

--- a/mia/medium/mega-32x.cpp
+++ b/mia/medium/mega-32x.cpp
@@ -1,6 +1,6 @@
 struct Mega32X : Cartridge {
   auto name() -> string override { return "Mega 32X"; }
-  auto extensions() -> vector<string> override { return {"32x"}; }
+  auto extensions() -> std::vector<string> override { return {"32x"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;
@@ -96,7 +96,7 @@ auto Mega32X::analyze(std::vector<u8>& rom) -> string {
   auto hash = Hash::SHA256(rom).digest();
   analyzeStorage(rom, hash);
 
-  vector<string> devices;
+  std::vector<string> devices;
   string device = slice((const char*)&rom[0x190], 0, 16).trimRight(" ");
   for(auto& id : device) {
     if(id == '0');  //Master System controller
@@ -104,7 +104,7 @@ auto Mega32X::analyze(std::vector<u8>& rom) -> string {
     if(id == '6');  //6-button controller
     if(id == 'A');  //analog joystick
     if(id == 'B');  //trackball
-    if(id == 'C') devices.append("Mega CD");
+    if(id == 'C') devices.push_back("Mega CD");
     if(id == 'D');  //download?
     if(id == 'F');  //floppy drive
     if(id == 'G');  //light gun
@@ -118,32 +118,32 @@ auto Mega32X::analyze(std::vector<u8>& rom) -> string {
     if(id == 'V');  //paddle
   }
 
-  vector<string> regions;
+  std::vector<string> regions;
   string region = slice((const char*)&rom[0x01f0], 0, 16).trimRight(" ");
 
   //Stellar Assault (U,E) is the one game using the single-byte region coding which
   //uses an 'E' value for both PAL and NTSC-U region. (NTSC-J cartridge uses '1')  
   //https://segaretro.org/ROM_header#Regional_compatiblity
   if(region(0) == 'E' && hash == "2f9b6017258fbb1c37d81df07c68d5255495d3bf76d9c7b680ff66bccf665750") {
-    regions.append("NTSC-U", "PAL");
+    regions.push_back("NTSC-U"); regions.push_back("PAL");
   }
-  if(!regions) {
-    if(region.find("J")) regions.append("NTSC-J");
-    if(region.find("U")) regions.append("NTSC-U");
-    if(region.find("E")) regions.append("PAL");
+  if(regions.empty()) {
+    if(region.find("J")) regions.push_back("NTSC-J");
+    if(region.find("U")) regions.push_back("NTSC-U");
+    if(region.find("E")) regions.push_back("PAL");
   }
-  if(!regions && region.size() == 1) {
+  if(regions.empty() && region.size() == 1) {
     maybe<u8> bits;
     u8 field = region(0);
     if(field >= '0' && field <= '9') bits = field - '0';
     if(field >= 'A' && field <= 'F') bits = field - 'A' + 10;
-    if(bits && *bits & 1) regions.append("NTSC-J");  //domestic 60hz
+    if(bits && *bits & 1) regions.push_back("NTSC-J");  //domestic 60hz
     if(bits && *bits & 2);                           //domestic 50hz
-    if(bits && *bits & 4) regions.append("NTSC-U");  //overseas 60hz
-    if(bits && *bits & 8) regions.append("PAL");     //overseas 50hz
+    if(bits && *bits & 4) regions.push_back("NTSC-U");  //overseas 60hz
+    if(bits && *bits & 8) regions.push_back("PAL");     //overseas 50hz
   }
-  if(!regions) {
-    regions.append("NTSC-J", "NTSC-U", "PAL");
+  if(regions.empty()) {
+    regions.push_back("NTSC-J"); regions.push_back("NTSC-U"); regions.push_back("PAL");
   }
 
   string domesticName;
@@ -175,9 +175,9 @@ auto Mega32X::analyze(std::vector<u8>& rom) -> string {
   s +={"  label:  ", domesticName, "\n"};
   s +={"  label:  ", internationalName, "\n"};
   s +={"  serial: ", serialNumber, "\n"};
-  s +={"  region: ", regions.merge(", "), "\n"};
-  if(devices)
-  s +={"  device: ", devices.merge(", "), "\n"};
+  s +={"  region: ", nall::merge(regions, ", "), "\n"};
+  if(!devices.empty())
+  s +={"  device: ", nall::merge(devices, ", "), "\n"};
   s += "  board\n";
   s += "    memory\n";
   s += "      type: ROM\n";

--- a/mia/medium/mega-cd.cpp
+++ b/mia/medium/mega-cd.cpp
@@ -43,11 +43,11 @@ auto MegaCD::save(string location) -> bool {
 }
 
 auto MegaCD::analyze(string location) -> string {
-  vector<u8> sector;
+  std::vector<u8> sector;
 
   sector = readDataSector(location, 0);
 
-  if(!sector || memory::compare(sector.data(), "SEGA", 4))
+  if(sector.empty() || memory::compare(sector.data(), "SEGA", 4))
     return CompactDisc::manifestAudio(location);
 
   std::vector<string> regions;
@@ -60,7 +60,7 @@ auto MegaCD::analyze(string location) -> string {
     else if(Hash::CRC32({sector.data()+0x200, 1412}).value() == 0xf361ab57) // US boot
       regions.push_back("NTSC-U");
   }
-  if(regions.empty()) { regions.push_back("NTSC-J"); regions.push_back("NTSC-U"); regions.push_back("PAL"); } // unknown boot
+  if(regions.empty()) { regions.insert(regions.end(), {"NTSC-J", "NTSC-U", "PAL"}); } // unknown boot
 
   string serialNumber = slice((const char*)(sector.data() + 0x180), 0, 14).trimRight(" ");
 

--- a/mia/medium/mega-cd.cpp
+++ b/mia/medium/mega-cd.cpp
@@ -91,8 +91,8 @@ auto MegaCD::analyze(string location) -> string {
   s +={"  name:   ", Medium::name(location), "\n"};
   s +={"  title:  ", Medium::name(location), "\n"};
   s +={"  serial: ", serialNumber, "\n"};
-  s +={"  region: ", nall::merge(regions, ", "), "\n"};
+  s +={"  region: ", ::nall::merge(regions, ", "), "\n"};
   if(!devices.empty())
-  s +={"  device: ", nall::merge(devices, ", "), "\n"};
+  s +={"  device: ", ::nall::merge(devices, ", "), "\n"};
   return s;
 }

--- a/mia/medium/mega-cd.cpp
+++ b/mia/medium/mega-cd.cpp
@@ -91,8 +91,8 @@ auto MegaCD::analyze(string location) -> string {
   s +={"  name:   ", Medium::name(location), "\n"};
   s +={"  title:  ", Medium::name(location), "\n"};
   s +={"  serial: ", serialNumber, "\n"};
-  s +={"  region: ", ::nall::merge(regions, ", "), "\n"};
+  s +={"  region: ", nall::merge(regions, ", "), "\n"};
   if(!devices.empty())
-  s +={"  device: ", ::nall::merge(devices, ", "), "\n"};
+  s +={"  device: ", nall::merge(devices, ", "), "\n"};
   return s;
 }

--- a/mia/medium/mega-drive.cpp
+++ b/mia/medium/mega-drive.cpp
@@ -57,7 +57,7 @@ auto MegaDrive::load(string location) -> LoadResult {
   pak->setAttribute("board",    document["game/board"].string());
   pak->setAttribute("bootable", true);
   auto deviceList = document["game/device"].string();
-  auto devices = ::nall::split(deviceList, ", ");
+  auto devices = nall::split(deviceList, ", ");
   pak->setAttribute("megacd",   (bool)(std::ranges::find(devices, string{"Mega CD"}) != devices.end()));
   pak->append("manifest.bml", manifest);
 
@@ -191,9 +191,9 @@ auto MegaDrive::analyze(std::vector<u8>& rom) -> string {
   s +={"  label:  ", domesticName, "\n"};
   s +={"  label:  ", internationalName, "\n"};
   s +={"  serial: ", serialNumber, "\n"};
-  s +={"  region: ", ::nall::merge(regions, ", "), "\n"};
+  s +={"  region: ", nall::merge(regions, ", "), "\n"};
   if(!devices.empty())
-  s +={"  device: ", ::nall::merge(devices, ", "), "\n"};
+  s +={"  device: ", nall::merge(devices, ", "), "\n"};
   if(board)
   s +={"  board:  ", board, "\n"};
   s += "  board\n";

--- a/mia/medium/mega-drive.cpp
+++ b/mia/medium/mega-drive.cpp
@@ -56,7 +56,9 @@ auto MegaDrive::load(string location) -> LoadResult {
   pak->setAttribute("region",   document["game/region"].string());
   pak->setAttribute("board",    document["game/board"].string());
   pak->setAttribute("bootable", true);
-  pak->setAttribute("megacd",   (bool)document["game/device"].string().split(", ").find("Mega CD"));
+  auto deviceList = document["game/device"].string();
+  auto devices = ::nall::split(deviceList, ", ");
+  pak->setAttribute("megacd",   (bool)(std::ranges::find(devices, string{"Mega CD"}) != devices.end()));
   pak->append("manifest.bml", manifest);
 
   //add SVP ROM to image if it is missing
@@ -189,9 +191,9 @@ auto MegaDrive::analyze(std::vector<u8>& rom) -> string {
   s +={"  label:  ", domesticName, "\n"};
   s +={"  label:  ", internationalName, "\n"};
   s +={"  serial: ", serialNumber, "\n"};
-  s +={"  region: ", nall::merge(regions, ", "), "\n"};
+  s +={"  region: ", ::nall::merge(regions, ", "), "\n"};
   if(!devices.empty())
-  s +={"  device: ", nall::merge(devices, ", "), "\n"};
+  s +={"  device: ", ::nall::merge(devices, ", "), "\n"};
   if(board)
   s +={"  board:  ", board, "\n"};
   s += "  board\n";

--- a/mia/medium/mega-drive.cpp
+++ b/mia/medium/mega-drive.cpp
@@ -277,7 +277,7 @@ auto MegaDrive::analyzeRegion(std::vector<u8>& rom, string hash) -> void {
     if(bits && *bits & 8) regions.push_back("PAL");     //overseas 50hz
   }
   if(regions.empty()) {
-    regions.push_back("NTSC-J"); regions.push_back("NTSC-U"); regions.push_back("PAL");
+    regions.insert(regions.end(), {"NTSC-J", "NTSC-U", "PAL"});
   }
 
   // Many PAL games have incorrect headers, so force PAL based on name

--- a/mia/medium/msx.cpp
+++ b/mia/medium/msx.cpp
@@ -1,6 +1,6 @@
 struct MSX : Cartridge {
   auto name() -> string override { return "MSX"; }
-  auto extensions() -> vector<string> override { return {"msx", "rom", "wav"}; }
+  auto extensions() -> std::vector<string> override { return {"msx", "rom", "wav"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;
@@ -164,12 +164,12 @@ auto MSX::loadTape(string location) -> LoadResult {
     if(location.iendsWith(".wav")) {
         Decode::WAV wav;
         if (wav.open(location)) {
-          vector <u8> data;
+          std::vector<u8> data;
           for (int i = 0; i < wav.size(); i++) {
             u64 sample = wav.read();
 
             for (int byte = 0; byte < sizeof(u64); byte++) {
-              data.append((sample & (0xff << (byte * 8))) >> (byte * 8));
+              data.push_back((sample & (0xff << (byte * 8))) >> (byte * 8));
             }
           }
         pak->append("program.tape", data);

--- a/mia/medium/msx2.cpp
+++ b/mia/medium/msx2.cpp
@@ -1,4 +1,4 @@
 struct MSX2 : MSX {
   auto name() -> string override { return "MSX2"; }
-  auto extensions() -> vector<string> override { return {"msx2", "rom", "wav"}; }
+  auto extensions() -> std::vector<string> override { return {"msx2", "rom", "wav"}; }
 };

--- a/mia/medium/myvision.cpp
+++ b/mia/medium/myvision.cpp
@@ -3,7 +3,7 @@
 
 struct MyVision : Cartridge {
   auto name() -> string override { return "MyVision"; }
-  auto extensions() -> vector<string> override { return {"myv"}; }
+  auto extensions() -> std::vector<string> override { return {"myv"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;

--- a/mia/medium/neo-geo-pocket-color.cpp
+++ b/mia/medium/neo-geo-pocket-color.cpp
@@ -1,4 +1,4 @@
 struct NeoGeoPocketColor : NeoGeoPocket {
   auto name() -> string override { return "Neo Geo Pocket Color"; }
-  auto extensions() -> vector<string> override { return {"ngpc", "ngc"}; }
+  auto extensions() -> std::vector<string> override { return {"ngpc", "ngc"}; }
 };

--- a/mia/medium/neo-geo-pocket.cpp
+++ b/mia/medium/neo-geo-pocket.cpp
@@ -1,6 +1,6 @@
 struct NeoGeoPocket : Cartridge {
   auto name() -> string override { return "Neo Geo Pocket"; }
-  auto extensions() -> vector<string> override { return {"ngp"}; }
+  auto extensions() -> std::vector<string> override { return {"ngp"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;

--- a/mia/medium/neo-geo.cpp
+++ b/mia/medium/neo-geo.cpp
@@ -4,7 +4,7 @@
 
 struct NeoGeo : Mame {
   auto name() -> string override { return "Neo Geo"; }
-  auto extensions() -> vector<string> override { return {"ng"}; }
+  auto extensions() -> std::vector<string> override { return {"ng"}; }
   auto read(string location, string match) -> std::vector<u8>;
   auto load(string location) -> LoadResult override;
   auto board() -> string;

--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -1,6 +1,6 @@
 struct Nintendo64 : Cartridge {
   auto name() -> string override { return "Nintendo 64"; }
-  auto extensions() -> vector<string> override { return {"n64", "v64", "z64"}; }
+  auto extensions() -> std::vector<string> override { return {"n64", "v64", "z64"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;

--- a/mia/medium/nintendo-64dd.cpp
+++ b/mia/medium/nintendo-64dd.cpp
@@ -1,6 +1,6 @@
 struct Nintendo64DD : FloppyDisk {
   auto name() -> string override { return "Nintendo 64DD"; }
-  auto extensions() -> vector<string> override { return {"n64dd", "ndd", "d64"}; }
+  auto extensions() -> std::vector<string> override { return {"n64dd", "ndd", "d64"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom, std::vector<u8> errorTable) -> string;

--- a/mia/medium/nintendo-64dd.cpp
+++ b/mia/medium/nintendo-64dd.cpp
@@ -4,7 +4,7 @@ struct Nintendo64DD : FloppyDisk {
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom, std::vector<u8> errorTable) -> string;
-  auto transform(array_view<u8> input, std::vector<u8> errorTable) -> vector<u8>;
+  auto transform(array_view<u8> input, std::vector<u8> errorTable) -> std::vector<u8>;
   auto sizeCheck(array_view<u8> input) -> bool;
   auto repeatCheck(array_view<u8> input, u32 repeat, u32 size) -> bool;
   auto createErrorTable(array_view<u8> input) -> std::vector<u8>;
@@ -34,7 +34,8 @@ auto Nintendo64DD::load(string location) -> LoadResult {
   pak->append("manifest.bml", manifest);
   pak->append("program.disk.error", errorTable);
 
-  if(auto output = transform(view, errorTable)) {
+  auto output = transform(view, errorTable);
+  if(!output.empty()) {
     pak->append("program.disk", output);
   }
 
@@ -306,7 +307,7 @@ auto Nintendo64DD::createErrorTable(array_view<u8> input) -> std::vector<u8> {
   return output;
 }
 
-auto Nintendo64DD::transform(array_view<u8> input, std::vector<u8> errorTable) -> vector<u8> {
+auto Nintendo64DD::transform(array_view<u8> input, std::vector<u8> errorTable) -> std::vector<u8> {
   //basic disk format check (further d64 check will be done later)
   b1 ndd = (input.size() == 0x3DEC800);
   b1 mame = (input.size() == 0x435B0C0);
@@ -319,7 +320,7 @@ auto Nintendo64DD::transform(array_view<u8> input, std::vector<u8> errorTable) -
     //mame physical format (canon ares format)
     //just copy
     input.begin();
-    vector<u8> output;
+    std::vector<u8> output;
     output.resize(0x435B0C0, 0);
 
     for(u32 n : range(input.size()))
@@ -362,7 +363,7 @@ auto Nintendo64DD::transform(array_view<u8> input, std::vector<u8> errorTable) -
 
   //ndd conv
   input.begin();
-  vector<u8> output;
+  std::vector<u8> output;
   output.resize(0x435B0C0, 0);
 
   u32 lba = 0;

--- a/mia/medium/pc-engine-cd.cpp
+++ b/mia/medium/pc-engine-cd.cpp
@@ -43,15 +43,15 @@ auto PCEngineCD::save(string location) -> bool {
 }
 
 auto PCEngineCD::analyze(string location) -> string {
-  vector<u8> sectors[2];
+  std::vector<u8> sectors[2];
 
   sectors[0] = readDataSector(location, 0);
   sectors[1] = readDataSector(location, 16);
 
-  if(!sectors[0] && !sectors[1]) return CompactDisc::manifestAudio(location);
+  if(sectors[0].empty() && sectors[1].empty()) return CompactDisc::manifestAudio(location);
 
-  bool isNEC = sectors[0] && (memory::compare(sectors[0].data() + 0x264, "NEC Home Electoronics", 21) == 0);
-  bool isGamesExpress = sectors[1] &&(memory::compare(sectors[1].data() + 0x1, "CD001", 5) == 0);
+  bool isNEC = !sectors[0].empty() && (memory::compare(sectors[0].data() + 0x264, "NEC Home Electoronics", 21) == 0);
+  bool isGamesExpress = !sectors[1].empty() && (memory::compare(sectors[1].data() + 0x1, "CD001", 5) == 0);
 
   if(!isGamesExpress && !isNEC) return CompactDisc::manifestAudio(location);
 

--- a/mia/medium/pc-engine-cd.cpp
+++ b/mia/medium/pc-engine-cd.cpp
@@ -1,6 +1,6 @@
 struct PCEngineCD : CompactDisc {
   auto name() -> string override { return "PC Engine CD"; }
-  auto extensions() -> vector<string> override {
+  auto extensions() -> std::vector<string> override {
 #if defined(ARES_ENABLE_CHD)
     return {"cue", "chd"};
 #else

--- a/mia/medium/pc-engine.cpp
+++ b/mia/medium/pc-engine.cpp
@@ -1,6 +1,6 @@
 struct PCEngine : Cartridge {
   auto name() -> string override { return "PC Engine"; }
-  auto extensions() -> vector<string> override { return {"pce"}; }
+  auto extensions() -> std::vector<string> override { return {"pce"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;

--- a/mia/medium/playstation.cpp
+++ b/mia/medium/playstation.cpp
@@ -10,7 +10,7 @@ struct PlayStation : CompactDisc {
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(string location) -> string;
-  auto cdFromExecutable(string location) -> vector<u8>;
+  auto cdFromExecutable(string location) -> std::vector<u8>;
 };
 
 auto PlayStation::load(string location) -> LoadResult {
@@ -53,10 +53,10 @@ auto PlayStation::analyze(string location) -> string {
   if(location.iendsWith(".cue") || location.iendsWith(".chd")) {
     if(isAudioCd(location)) return CompactDisc::manifestAudio(location);
 
-    vector<u8> sector;
+    std::vector<u8> sector;
     sector = readDataSector(location, 4);
 
-    if(!sector) return CompactDisc::manifestAudio(location);
+    if(sector.empty()) return CompactDisc::manifestAudio(location);
 
     string text;
     text.resize(sector.size());
@@ -98,10 +98,10 @@ auto PlayStation::analyze(string location) -> string {
 }
 
 //todo: not implemented yet
-auto PlayStation::cdFromExecutable(string location) -> vector<u8> {
+auto PlayStation::cdFromExecutable(string location) -> std::vector<u8> {
   auto exe = file::read(location);
   if(exe.size() < 2048) return {};
   if(memory::compare(exe.data(), "PS-X EXE", 8)) return {};
-  vector<u8> cd;
+  std::vector<u8> cd;
   return cd;
 }

--- a/mia/medium/playstation.cpp
+++ b/mia/medium/playstation.cpp
@@ -1,6 +1,6 @@
 struct PlayStation : CompactDisc {
   auto name() -> string override { return "PlayStation"; }
-  auto extensions() -> vector<string> override {
+  auto extensions() -> std::vector<string> override {
 #if defined(ARES_ENABLE_CHD)
     return {"cue", "chd", "exe", "ps-exe"};
 #else

--- a/mia/medium/pocket-challenge-v2.cpp
+++ b/mia/medium/pocket-challenge-v2.cpp
@@ -1,6 +1,6 @@
 struct PocketChallengeV2 : WonderSwan {
   auto name() -> string override { return "Pocket Challenge V2"; }
-  auto extensions() -> vector<string> override { return {"pcv2", "pc2"}; }
+  auto extensions() -> std::vector<string> override { return {"pcv2", "pc2"}; }
   auto mapper(std::vector<u8>& rom) -> string override;
 };
 

--- a/mia/medium/saturn.cpp
+++ b/mia/medium/saturn.cpp
@@ -1,6 +1,6 @@
 struct Saturn : CompactDisc {
   auto name() -> string override { return "Saturn"; }
-  auto extensions() -> vector<string> override { return {"cue", "chd"}; }
+  auto extensions() -> std::vector<string> override { return {"cue", "chd"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(string location) -> string;

--- a/mia/medium/sc-3000.cpp
+++ b/mia/medium/sc-3000.cpp
@@ -1,4 +1,4 @@
 struct SC3000 : SG1000 {
   auto name() -> string override { return "SC-3000"; }
-  auto extensions() -> vector<string> override { return {"sg", "sc"}; }
+  auto extensions() -> std::vector<string> override { return {"sg", "sc"}; }
 };

--- a/mia/medium/sg-1000.cpp
+++ b/mia/medium/sg-1000.cpp
@@ -1,6 +1,6 @@
 struct SG1000 : Cartridge {
   auto name() -> string override { return "SG-1000"; }
-  auto extensions() -> vector<string> override { return {"sg1000", "sg"}; }
+  auto extensions() -> std::vector<string> override { return {"sg1000", "sg"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;

--- a/mia/medium/sufami-turbo.cpp
+++ b/mia/medium/sufami-turbo.cpp
@@ -1,6 +1,6 @@
 struct SufamiTurbo : Cartridge {
   auto name() -> string override { return "Sufami Turbo"; }
-  auto extensions() -> vector<string> override { return {"st"}; }
+  auto extensions() -> std::vector<string> override { return {"st"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& data) -> string;

--- a/mia/medium/super-famicom.cpp
+++ b/mia/medium/super-famicom.cpp
@@ -1,6 +1,6 @@
 struct SuperFamicom : Cartridge {
   auto name() -> string override { return "Super Famicom"; }
-  auto extensions() -> vector<string> override { return {"sfc", "smc", "swc", "fig"}; }
+  auto extensions() -> std::vector<string> override { return {"sfc", "smc", "swc", "fig"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;

--- a/mia/medium/super-famicom.cpp
+++ b/mia/medium/super-famicom.cpp
@@ -95,8 +95,9 @@ auto SuperFamicom::load(string location) -> LoadResult {
   this->manifest = Medium::manifestDatabase(sha256);
   
   if(!manifest) {
-    auto extension = string{ ".", location.split(".").last() };
-    auto local_manifest = location.replace(extension, ".bml");
+    auto tmp = nall::split(location, ".");
+    auto ext = string{".", tmp.back()};
+    auto local_manifest = location.replace(ext, ".bml");
     if (folder)
       local_manifest = directory.append("manifest.bml");
     if(file::exists(local_manifest)) {
@@ -158,7 +159,8 @@ auto SuperFamicom::load(string location) -> LoadResult {
 
     //add msu-1 audio tracks
     if(_file.imatch("*-*.pcm")) {
-      auto track = _file.split("-").last().replace(".pcm", "").integer();
+      auto tmp = nall::split(_file, "-");
+      auto track = tmp.back().replace(".pcm", "").integer();
       auto mem = file::read({directory, "/", _file});
       pak->append({"msu1.track-", track,".pcm"}, mem);
     }
@@ -252,10 +254,10 @@ auto SuperFamicom::analyze(std::vector<u8>& rom) -> string {
   s +={"  revision: ", revision(), "\n"};
   s +={"  board:    ", board(), "\n"};
 
-  auto board = this->board().trimRight("#A", 1L).split("-");
+  auto board = nall::split(this->board().trimRight("#A", 1L), "-");
 
   if(auto size = romSize()) {
-    if(board(0) == "SPC7110" && size > 0x100000) {
+    if(board[0] == "SPC7110" && size > 0x100000) {
       s += "    memory\n";
       s += "      type: ROM\n";
       s += "      size: 0x100000\n";
@@ -264,7 +266,7 @@ auto SuperFamicom::analyze(std::vector<u8>& rom) -> string {
       s += "      type: ROM\n";
       s +={"      size: 0x", hex(size - 0x100000), "\n"};
       s += "      content: Data\n";
-    } else if(board(0) == "EXSPC7110" && size == 0x700000) {
+    } else if(board[0] == "EXSPC7110" && size == 0x700000) {
       //Tengai Maykou Zero (fan translation)
       s += "    memory\n";
       s += "      type: ROM\n";
@@ -300,7 +302,7 @@ auto SuperFamicom::analyze(std::vector<u8>& rom) -> string {
     s += "      content: Save\n";
   }
 
-  if(board(0) == "ARM") {
+  if(board[0] == "ARM") {
     s += "    memory\n";
     s += "      type: ROM\n";
     s += "      size: 0x20000\n";
@@ -325,12 +327,12 @@ auto SuperFamicom::analyze(std::vector<u8>& rom) -> string {
     s += "      volatile\n";
     s += "    oscillator\n";
     s += "      frequency: 21440000\n";
-  } else if(board(0) == "BS" && board(1) == "MCC") {
+  } else if(board[0] == "BS" && board[1] == "MCC") {
     s += "    memory\n";
     s += "      type: RAM\n";
     s += "      size: 0x80000\n";
     s += "      content: Download\n";
-  } else if(board(0) == "EXNEC") {
+  } else if(board[0] == "EXNEC") {
     s += "    memory\n";
     s += "      type: ROM\n";
     s += "      size: 0xc000\n";
@@ -354,7 +356,7 @@ auto SuperFamicom::analyze(std::vector<u8>& rom) -> string {
     s +={"      identifier: ", firmwareEXNEC(), "\n"};
     s += "    oscillator\n";
     s +={"      frequency: ", firmwareEXNEC() == "ST010" ? 11000000 : 15000000, "\n"};
-  } else if(board(0) == "GB") {
+  } else if(board[0] == "GB") {
     s += "    memory\n";
     s += "      type: ROM\n";
     s += "      size: 0x100\n";
@@ -366,11 +368,11 @@ auto SuperFamicom::analyze(std::vector<u8>& rom) -> string {
       s += "    oscillator\n";
       s += "      frequency: 20971520\n";
     }
-  } else if(board(0) == "GSU") {
+  } else if(board[0] == "GSU") {
   //todo: MARIO CHIP 1 uses CPU oscillator
     s += "    oscillator\n";
     s += "      frequency: 21440000\n";
-  } else if(board(0) == "HITACHI") {
+  } else if(board[0] == "HITACHI") {
     s += "    memory\n";
     s += "      type: ROM\n";
     s += "      size: 0xc00\n";
@@ -388,7 +390,7 @@ auto SuperFamicom::analyze(std::vector<u8>& rom) -> string {
     s += "      volatile\n";
     s += "    oscillator\n";
     s += "      frequency: 20000000\n";
-  } else if(board(0) == "NEC") {
+  } else if(board[0] == "NEC") {
     s += "    memory\n";
     s += "      type: ROM\n";
     s += "      size: 0x1800\n";
@@ -413,7 +415,7 @@ auto SuperFamicom::analyze(std::vector<u8>& rom) -> string {
     s += "      volatile\n";
     s += "    oscillator\n";
     s += "      frequency: 7600000\n";
-  } else if(board(0) == "SA1" || board(1) == "SA1") {  //SA1-* or BS-SA1-*
+  } else if(board[0] == "SA1" || board[1] == "SA1") {  //SA1-* or BS-SA1-*
     s += "    memory\n";
     s += "      type: RAM\n";
     s += "      size: 0x800\n";
@@ -421,13 +423,13 @@ auto SuperFamicom::analyze(std::vector<u8>& rom) -> string {
     s += "      volatile\n";
   }
 
-  if(board.right() == "EPSONRTC") {
+  if(board.back() == "EPSONRTC") {
     s += "    memory\n";
     s += "      type: RTC\n";
     s += "      size: 0x10\n";
     s += "      content: Time\n";
     s += "      manufacturer: Epson\n";
-  } else if(board.right() == "SHARPRTC") {
+  } else if(board.back() == "SHARPRTC") {
     s += "    memory\n";
     s += "      type: RTC\n";
     s += "      size: 0x10\n";

--- a/mia/medium/supergrafx.cpp
+++ b/mia/medium/supergrafx.cpp
@@ -1,4 +1,4 @@
 struct SuperGrafx : PCEngine {
   auto name() -> string override { return "SuperGrafx"; }
-  auto extensions() -> vector<string> override { return {"sgx"}; }
+  auto extensions() -> std::vector<string> override { return {"sgx"}; }
 };

--- a/mia/medium/wonderswan-color.cpp
+++ b/mia/medium/wonderswan-color.cpp
@@ -1,4 +1,4 @@
 struct WonderSwanColor : WonderSwan {
   auto name() -> string override { return "WonderSwan Color"; }
-  auto extensions() -> vector<string> override { return {"wsc"}; }
+  auto extensions() -> std::vector<string> override { return {"wsc"}; }
 };

--- a/mia/medium/wonderswan.cpp
+++ b/mia/medium/wonderswan.cpp
@@ -1,6 +1,6 @@
 struct WonderSwan : Cartridge {
   auto name() -> string override { return "WonderSwan"; }
-  auto extensions() -> vector<string> override { return {"ws"}; }
+  auto extensions() -> std::vector<string> override { return {"ws"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(std::vector<u8>& rom) -> string;

--- a/mia/medium/zx-spectrum.cpp
+++ b/mia/medium/zx-spectrum.cpp
@@ -1,6 +1,6 @@
 struct ZXSpectrum : Medium {
   auto name() -> string override { return "ZX Spectrum"; }
-  auto extensions() -> vector<string> override { return {"wav", "tzx", "tap" }; }
+  auto extensions() -> std::vector<string> override { return {"wav", "tzx", "tap" }; }
   auto load(string location) -> LoadResult override;
   auto loadWav(string location) -> LoadResult;
   auto loadTzx(string location) -> LoadResult;
@@ -67,12 +67,12 @@ auto ZXSpectrum::loadWav(string location) -> LoadResult {
     if(location.iendsWith(".wav")) {
       Decode::WAV wav;
       if (wav.open(location)) {
-        vector <u8> data;
+        std::vector<u8> data;
         for (int i = 0; i < wav.size(); i++) {
           u64 sample = wav.read();
 
           for (int byte = 0; byte < sizeof(u64); byte++) {
-            data.append((sample & (0xff << (byte * 8))) >> (byte * 8));
+            data.push_back((sample & (0xff << (byte * 8))) >> (byte * 8));
           }
         }
         pak->append("program.tape", data);

--- a/mia/medium/zx-spectrum.cpp
+++ b/mia/medium/zx-spectrum.cpp
@@ -34,13 +34,13 @@ auto ZXSpectrum::loadTzx(string location) -> LoadResult {
   pak->setAttribute("length",    tzx.GetAudioBufferLengthInSamples());
   pak->append("manifest.bml",    manifest);
 
-  vector<u8> output;
+  std::vector<u8> output;
   auto decodedData = tzx.GetAudioBufferPtr();
   for(int i = 0; i < tzx.GetAudioBufferLength();) {
     u64 sample = (u64)((i32)decodedData[i++] + 128);
 
     for (int byte = 0; byte < sizeof(u64); byte++) {
-      output.append((sample & (0xff << (byte * 8))) >> (byte * 8));
+      output.push_back((sample & (0xff << (byte * 8))) >> (byte * 8));
     }
   }
   pak->append("program.tape", output);

--- a/mia/mia.cpp
+++ b/mia/mia.cpp
@@ -6,7 +6,7 @@ namespace mia {
 
 function<string ()> homeLocation = [] { return string{Path::user(), "Emulation/Systems/"}; };
 function<string ()> saveLocation = [] { return string{}; };
-vector<string> media;
+std::vector<string> media;
 
 auto locate(const string &name) -> string {
   // First check each path for the presence of the file we are looking for in the following order
@@ -86,41 +86,41 @@ auto construct() -> void {
   if(initialized) return;
   initialized = true;
 
-  media.append("Atari 2600");
-  media.append("BS Memory");
-  media.append("ColecoVision");
-  media.append("MyVision");
-  media.append("Famicom");
-  media.append("Famicom Disk System");
-  media.append("Game Boy");
-  media.append("Game Boy Color");
-  media.append("Game Boy Advance");
-  media.append("Game Gear");
-  media.append("Master System");
-  media.append("Mega Drive");
-  media.append("Mega 32X");
-  media.append("Mega CD");
-  media.append("Mega LD");  
-  media.append("MSX");
-  media.append("MSX2");
-  media.append("Neo Geo");
-  media.append("Neo Geo Pocket");
-  media.append("Neo Geo Pocket Color");
-  media.append("Nintendo 64");
-  media.append("Nintendo 64DD");
-  media.append("PC Engine");
-  media.append("PC Engine CD");
-  media.append("PlayStation");
-  media.append("Pocket Challenge V2");
-  media.append("Saturn");
-  media.append("SC-3000");
-  media.append("SG-1000");
-  media.append("Sufami Turbo");
-  media.append("Super Famicom");
-  media.append("SuperGrafx");
-  media.append("WonderSwan");
-  media.append("WonderSwan Color");
-  media.append("ZX Spectrum");
+  media.push_back("Atari 2600");
+  media.push_back("BS Memory");
+  media.push_back("ColecoVision");
+  media.push_back("MyVision");
+  media.push_back("Famicom");
+  media.push_back("Famicom Disk System");
+  media.push_back("Game Boy");
+  media.push_back("Game Boy Color");
+  media.push_back("Game Boy Advance");
+  media.push_back("Game Gear");
+  media.push_back("Master System");
+  media.push_back("Mega Drive");
+  media.push_back("Mega 32X");
+  media.push_back("Mega CD");
+  media.push_back("Mega LD");  
+  media.push_back("MSX");
+  media.push_back("MSX2");
+  media.push_back("Neo Geo");
+  media.push_back("Neo Geo Pocket");
+  media.push_back("Neo Geo Pocket Color");
+  media.push_back("Nintendo 64");
+  media.push_back("Nintendo 64DD");
+  media.push_back("PC Engine");
+  media.push_back("PC Engine CD");
+  media.push_back("PlayStation");
+  media.push_back("Pocket Challenge V2");
+  media.push_back("Saturn");
+  media.push_back("SC-3000");
+  media.push_back("SG-1000");
+  media.push_back("Sufami Turbo");
+  media.push_back("Super Famicom");
+  media.push_back("SuperGrafx");
+  media.push_back("WonderSwan");
+  media.push_back("WonderSwan Color");
+  media.push_back("ZX Spectrum");
 }
 
 auto identify(const string& filename) -> string {
@@ -134,7 +134,8 @@ auto identify(const string& filename) -> string {
         auto match = Location::suffix(file.name).trimLeft(".", 1L).downcase();
         for(auto& medium : media) {
           auto pak = mia::Medium::create(medium);
-          if(pak->extensions().find(match)) {
+          auto exts = pak->extensions();
+          if(std::ranges::find(exts, match) != exts.end()) {
             extension = match;
           }
         }
@@ -144,7 +145,8 @@ auto identify(const string& filename) -> string {
 
   for(auto& medium : media) {
     auto pak = mia::Medium::create(medium);
-    if(pak->extensions().find(extension)) {
+    auto exts = pak->extensions();
+    if(std::ranges::find(exts, extension) != exts.end()) {
       if(pak->load(filename) != successful) continue; // Skip medium that the system cannot load
       if(pak->pak->attribute("audio").boolean()) continue; // Skip audio-only media to give the next system a chance to match
       return pak->name();
@@ -156,7 +158,7 @@ auto identify(const string& filename) -> string {
 
 auto import(shared_pointer<Pak> pak, const string& filename) -> bool {
   if(pak->load(filename) == successful) {
-    string pathname = {Path::user(), "Emulation/", pak->name(), "/", Location::prefix(filename), ".", pak->extensions().first(), "/"};
+    string pathname = {Path::user(), "Emulation/", pak->name(), "/", Location::prefix(filename), ".", pak->extensions().front(), "/"};
     if(!directory::create(pathname)) return false;
     for(auto& node : *pak->pak) {
       if(auto input = node.cast<vfs::file>()) {

--- a/mia/pak/pak.cpp
+++ b/mia/pak/pak.cpp
@@ -22,7 +22,7 @@ auto Pak::read(string location) -> std::vector<u8> {
   return memory;
 }
 
-auto Pak::read(string location, vector<string> match) -> std::vector<u8> {
+auto Pak::read(string location, std::vector<string> match) -> std::vector<u8> {
   std::vector<u8> memory;
   std::vector<u8> ips_patch;
   std::vector<u8> bps_patch;

--- a/mia/pak/pak.hpp
+++ b/mia/pak/pak.hpp
@@ -5,14 +5,14 @@ struct Pak {
   virtual auto type() -> string { return pak->attribute("type"); }
   virtual auto name() -> string { return pak->attribute("name"); }
   virtual auto saveName() -> string { return name(); }
-  virtual auto extensions() -> vector<string> { return {}; }
+  virtual auto extensions() -> std::vector<string> { return {}; }
   virtual auto load(string location = {}) -> LoadResult { return successful; }
-  virtual auto loadMultiple(vector<string> location = {}) -> bool { return true; }
+  virtual auto loadMultiple(std::vector<string> location = {}) -> bool { return true; }
   virtual auto save(string location = {}) -> bool { return true; }
 
   auto name(string location) const -> string;
   auto read(string location) -> std::vector<u8>;
-  auto read(string location, vector<string> match) -> std::vector<u8>;
+  auto read(string location, std::vector<string> match) -> std::vector<u8>;
   auto append(vector<u8>& data, string location) -> bool;
   auto append(std::vector<u8>& data, string location) -> bool;
   auto load(string name, string extension, string location = {}) -> bool;

--- a/mia/program/game-importer.cpp
+++ b/mia/program/game-importer.cpp
@@ -5,7 +5,7 @@ GameImporter::GameImporter(View* parent) : Panel(parent, Size{~0, ~0}) {
   closeButton.setCollapsible().setText("Close").onActivate([&] { eventClose(); });
 }
 
-auto GameImporter::import(string system, const vector<string>& files) -> void {
+auto GameImporter::import(string system, const std::vector<string>& files) -> void {
   importList.reset();
   abortButton.setVisible(true);
   closeButton.setVisible(false);

--- a/mia/program/game-importer.hpp
+++ b/mia/program/game-importer.hpp
@@ -1,6 +1,6 @@
 struct GameImporter : Panel {
   GameImporter(View*);
-  auto import(string system, const vector<string>& files) -> void;
+  auto import(string system, const std::vector<string>& files) -> void;
   auto eventChange() -> void;
   auto eventClose() -> void;
 

--- a/mia/program/game-manager.cpp
+++ b/mia/program/game-manager.cpp
@@ -23,7 +23,7 @@ GameManager::GameManager(View* parent) : Panel(parent, Size{~0, ~0}) {
     auto files = BrowserDialog()
     .setTitle({"Import ", system, " Games"})
     .setPath(settings.recent)
-    .setFilters({{system, "|", extensions.merge(":"), ":*.zip:", extensions.merge(":").upcase(), ":*.ZIP"}, "All|*"})
+    .setFilters({{system, "|", nall::merge(extensions, ":"), ":*.zip:", nall::merge(extensions, ":").upcase(), ":*.ZIP"}, "All|*"})
     .setAlignment(programWindow)
     .openFiles();
     if(!files.empty()) {

--- a/mia/system/msx2.cpp
+++ b/mia/system/msx2.cpp
@@ -1,10 +1,10 @@
 struct MSX2 : System {
   auto name() -> string override { return "MSX2"; }
-  auto loadMultiple(vector<string> location) -> bool override;
+  auto loadMultiple(std::vector<string> location) -> bool override;
   auto save(string location) -> bool override;
 };
 
-auto MSX2::loadMultiple(vector<string> location) -> bool {
+auto MSX2::loadMultiple(std::vector<string> location) -> bool {
   if(location.size() != 2) return false;
 
   auto bios = Pak::read(location[0]);

--- a/mia/system/system.hpp
+++ b/mia/system/system.hpp
@@ -2,6 +2,6 @@ struct System : Pak {
   static auto create(string name) -> shared_pointer<Pak>;
 
   auto type() -> string override { return "System"; }
-  auto extensions() -> vector<string> override { return {"sys"}; }
+  auto extensions() -> std::vector<string> override { return {"sys"}; }
   auto locate() -> string;
 };

--- a/nall/nall/decode/cue.hpp
+++ b/nall/nall/decode/cue.hpp
@@ -115,8 +115,8 @@ inline auto CUE::loadFile(std::vector<string>& lines, u32& offset) -> File {
   File file;
 
   lines[offset].itrimLeft("FILE ", 1L).strip();
-  auto parts = nall::split(lines[offset], " ");
-  file.type = parts.empty() ? string{} : parts.back().strip().downcase();
+  auto parts = nall::split_and_strip(lines[offset], " ");
+  file.type = parts.empty() ? string{} : parts.back().downcase();
   lines[offset].itrimRight(file.type, 1L).strip();
   file.name = lines[offset].trim("\"", "\"", 1L);
   offset++;
@@ -140,8 +140,8 @@ inline auto CUE::loadTrack(std::vector<string>& lines, u32& offset) -> Track {
   Track track;
 
   lines[offset].itrimLeft("TRACK ", 1L).strip();
-  auto parts2 = nall::split(lines[offset], " ");
-  track.type = parts2.empty() ? string{} : parts2.back().strip().downcase();
+  auto parts = nall::split_and_strip(lines[offset], " ");
+  track.type = parts.empty() ? string{} : parts.back().downcase();
   lines[offset].itrimRight(track.type, 1L).strip();
   track.number = lines[offset].natural();
   offset++;
@@ -180,8 +180,8 @@ inline auto CUE::loadIndex(std::vector<string>& lines, u32& offset) -> Index {
   Index index;
 
   lines[offset].itrimLeft("INDEX ", 1L);
-  auto parts3 = nall::split(lines[offset], " ");
-  string sector = parts3.empty() ? string{} : parts3.back().strip();
+  auto parts = nall::split_and_strip(lines[offset], " ");
+  string sector = parts.empty() ? string{} : parts.back();
   lines[offset].itrimRight(sector, 1L).strip();
   index.number = lines[offset].natural();
   index.lba = toLBA(sector);

--- a/nall/nall/decode/cue.hpp
+++ b/nall/nall/decode/cue.hpp
@@ -65,12 +65,12 @@ inline auto CUE::load(const string& location, const Decode::ZIP* archive, const 
     // meaning we can't create a string_view from a fixed-length input. We use an array_view here as a
     // workaround.
     auto rawDataBufferAsArrayView = array_view<u8>(rawDataBuffer.data(), rawDataBuffer.size());
-    auto splitLines = ::nall::split(string(rawDataBufferAsArrayView).replace("\r", ""), "\n");
+    auto splitLines = nall::split(string(rawDataBufferAsArrayView).replace("\r", ""), "\n");
     lines.clear();
     lines.reserve(splitLines.size());
     for (u32 i = 0; i < splitLines.size(); i++) lines.push_back(splitLines[i]);
   } else {
-    auto splitLines = ::nall::split(string::read(location).replace("\r", ""), "\n");
+    auto splitLines = nall::split(string::read(location).replace("\r", ""), "\n");
     lines.clear();
     lines.reserve(splitLines.size());
     for (u32 i = 0; i < splitLines.size(); i++) lines.push_back(splitLines[i]);
@@ -115,7 +115,7 @@ inline auto CUE::loadFile(std::vector<string>& lines, u32& offset) -> File {
   File file;
 
   lines[offset].itrimLeft("FILE ", 1L).strip();
-  auto parts = ::nall::split(lines[offset], " ");
+  auto parts = nall::split(lines[offset], " ");
   file.type = parts.empty() ? string{} : parts.back().strip().downcase();
   lines[offset].itrimRight(file.type, 1L).strip();
   file.name = lines[offset].trim("\"", "\"", 1L);
@@ -140,7 +140,7 @@ inline auto CUE::loadTrack(std::vector<string>& lines, u32& offset) -> Track {
   Track track;
 
   lines[offset].itrimLeft("TRACK ", 1L).strip();
-  auto parts2 = ::nall::split(lines[offset], " ");
+  auto parts2 = nall::split(lines[offset], " ");
   track.type = parts2.empty() ? string{} : parts2.back().strip().downcase();
   lines[offset].itrimRight(track.type, 1L).strip();
   track.number = lines[offset].natural();
@@ -180,7 +180,7 @@ inline auto CUE::loadIndex(std::vector<string>& lines, u32& offset) -> Index {
   Index index;
 
   lines[offset].itrimLeft("INDEX ", 1L);
-  auto parts3 = ::nall::split(lines[offset], " ");
+  auto parts3 = nall::split(lines[offset], " ");
   string sector = parts3.empty() ? string{} : parts3.back().strip();
   lines[offset].itrimRight(sector, 1L).strip();
   index.number = lines[offset].natural();
@@ -192,7 +192,7 @@ inline auto CUE::loadIndex(std::vector<string>& lines, u32& offset) -> Index {
 }
 
 inline auto CUE::toLBA(const string& msf) -> u32 {
-  auto parts = ::nall::split(msf, ":");
+  auto parts = nall::split(msf, ":");
   u32 m = parts.size() > 0 ? parts[0].natural() : 0;
   u32 s = parts.size() > 1 ? parts[1].natural() : 0;
   u32 f = parts.size() > 2 ? parts[2].natural() : 0;

--- a/nall/nall/directory.cpp
+++ b/nall/nall/directory.cpp
@@ -23,7 +23,7 @@ NALL_HEADER_INLINE auto directory::ufolders(const string& pathname, const string
       if(!*p) *p = ';';
       p++;
     }
-    auto parts = ::nall::split((const char*)utf8_t(drives), ";");
+    auto parts = nall::split((const char*)utf8_t(drives), ";");
     std::vector<string> out;
     out.reserve(parts.size());
     for(auto& s : parts) out.push_back(s);

--- a/nall/nall/directory.cpp
+++ b/nall/nall/directory.cpp
@@ -23,7 +23,7 @@ NALL_HEADER_INLINE auto directory::ufolders(const string& pathname, const string
       if(!*p) *p = ';';
       p++;
     }
-    auto parts = string{(const char*)utf8_t(drives)}.replace("\\", "/").split(";");
+    auto parts = ::nall::split((const char*)utf8_t(drives), ";");
     std::vector<string> out;
     out.reserve(parts.size());
     for(auto& s : parts) out.push_back(s);

--- a/nall/nall/directory.hpp
+++ b/nall/nall/directory.hpp
@@ -183,7 +183,7 @@ inline auto directory::copy(const string& source, const string& target) -> bool 
 #if defined(PLATFORM_WINDOWS)
   inline auto directory::create(const string& pathname, u32 permissions) -> bool {
     string path;
-    auto list = string{pathname}.transform("\\", "/").trimRight("/").split("/");
+    auto list = ::nall::split(string{pathname}.transform("\\", "/").trimRight("/"), "/");
     bool result = true;
     for(auto& part : list) {
       path.append(part, "/");
@@ -217,7 +217,7 @@ inline auto directory::copy(const string& source, const string& target) -> bool 
 
   inline auto directory::create(const string& pathname, u32 permissions) -> bool {
     string path;
-    auto list = string{pathname}.trimRight("/").split("/");
+    auto list = ::nall::split(string{pathname}.trimRight("/"), "/");
     bool result = true;
     for(auto& part : list) {
       path.append(part, "/");

--- a/nall/nall/directory.hpp
+++ b/nall/nall/directory.hpp
@@ -183,7 +183,7 @@ inline auto directory::copy(const string& source, const string& target) -> bool 
 #if defined(PLATFORM_WINDOWS)
   inline auto directory::create(const string& pathname, u32 permissions) -> bool {
     string path;
-    auto list = ::nall::split(string{pathname}.transform("\\", "/").trimRight("/"), "/");
+    auto list = nall::split(string{pathname}.transform("\\", "/").trimRight("/"), "/");
     bool result = true;
     for(auto& part : list) {
       path.append(part, "/");
@@ -217,7 +217,7 @@ inline auto directory::copy(const string& source, const string& target) -> bool 
 
   inline auto directory::create(const string& pathname, u32 permissions) -> bool {
     string path;
-    auto list = ::nall::split(string{pathname}.trimRight("/"), "/");
+    auto list = nall::split(string{pathname}.trimRight("/"), "/");
     bool result = true;
     for(auto& part : list) {
       path.append(part, "/");

--- a/nall/nall/gdb/server.cpp
+++ b/nall/nall/gdb/server.cpp
@@ -2,8 +2,8 @@
 
 #include <inttypes.h>
 
-using string = ::nall::string;
-using string_view = ::nall::string_view;
+using string = nall::string;
+using string_view = nall::string_view;
 
 namespace {
   constexpr bool GDB_LOG_MESSAGES = false;
@@ -110,7 +110,7 @@ namespace nall::GDB {
    */
   auto Server::processCommand(const string& cmd, bool &shouldReply) -> string
   {
-    auto cmdParts = ::nall::split(cmd, ":");
+    auto cmdParts = nall::split(cmd, ":");
     auto cmdName = cmdParts[0];
     char cmdPrefix = cmdName.size() > 0 ? cmdName(0) : ' ';
 

--- a/nall/nall/gdb/server.cpp
+++ b/nall/nall/gdb/server.cpp
@@ -110,7 +110,7 @@ namespace nall::GDB {
    */
   auto Server::processCommand(const string& cmd, bool &shouldReply) -> string
   {
-    auto cmdParts = cmd.split(":");
+    auto cmdParts = ::nall::split(cmd, ":");
     auto cmdName = cmdParts[0];
     char cmdPrefix = cmdName.size() > 0 ? cmdName(0) : ' ';
 

--- a/nall/nall/inode.cpp
+++ b/nall/nall/inode.cpp
@@ -8,7 +8,7 @@ NALL_HEADER_INLINE auto inode::hidden(const string& name) -> bool {
   return attributes & FILE_ATTRIBUTE_HIDDEN;
   #else
   //todo: is this really the best way to do this? stat doesn't have S_ISHIDDEN ...
-  auto parts = ::nall::split(name, "/"); return !parts.empty() && parts.back().beginsWith(".");
+  auto parts = nall::split(name, "/"); return !parts.empty() && parts.back().beginsWith(".");
   #endif
 }
 

--- a/nall/nall/inode.cpp
+++ b/nall/nall/inode.cpp
@@ -8,7 +8,7 @@ NALL_HEADER_INLINE auto inode::hidden(const string& name) -> bool {
   return attributes & FILE_ATTRIBUTE_HIDDEN;
   #else
   //todo: is this really the best way to do this? stat doesn't have S_ISHIDDEN ...
-  return name.split("/").last().beginsWith(".");
+  auto parts = ::nall::split(name, "/"); return !parts.empty() && parts.back().beginsWith(".");
   #endif
 }
 

--- a/nall/nall/string.hpp
+++ b/nall/nall/string.hpp
@@ -265,12 +265,6 @@ public:
   auto qreplace(string_view from, string_view to, long limit = LONG_MAX) -> type&;
   auto iqreplace(string_view from, string_view to, long limit = LONG_MAX) -> type&;
 
-  //split.hpp
-  auto split(string_view key, long limit = LONG_MAX) const -> vector<string>;
-  auto isplit(string_view key, long limit = LONG_MAX) const -> vector<string>;
-  auto qsplit(string_view key, long limit = LONG_MAX) const -> vector<string>;
-  auto iqsplit(string_view key, long limit = LONG_MAX) const -> vector<string>;
-
   //trim.hpp
   auto trim(string_view lhs, string_view rhs, long limit = LONG_MAX) -> type&;
   auto trimLeft(string_view lhs, long limit = LONG_MAX) -> type&;

--- a/nall/nall/string.hpp
+++ b/nall/nall/string.hpp
@@ -138,7 +138,6 @@ protected:
 
 public:
   string();
-  string(string& source) : string() { operator=(source); }
   string(const string& source) : string() { operator=(source); }
   string(string&& source) : string() { operator=(std::move(source)); }
   template<typename T = char> auto get() -> T*;
@@ -302,7 +301,6 @@ template<> struct vector<string> : vector_base<string> {
   template<typename... P> explicit vector(P&&... p) { append(std::forward<P>(p)...); }
 
   auto operator=(const vector& source) -> type& { return vector_base::operator=(source), *this; }
-  auto operator=(vector& source) -> type& { return vector_base::operator=(source), *this; }
   auto operator=(vector&& source) -> type& { return vector_base::operator=(std::move(source)), *this; }
 
   //vector.hpp

--- a/nall/nall/string.hpp
+++ b/nall/nall/string.hpp
@@ -350,6 +350,7 @@ inline auto operator"" _s(const char* value, std::size_t) -> string { return {va
 #include <nall/string/format.hpp>
 #include <nall/string/match.hpp>
 #include <nall/string/replace.hpp>
+#include <nall/vector-helpers.hpp>
 #include <nall/string/split.hpp>
 #include <nall/string/trim.hpp>
 #include <nall/string/utf8.hpp>
@@ -368,5 +369,3 @@ inline auto operator"" _s(const char* value, std::size_t) -> string { return {va
 
 #include <nall/string/transform/cml.hpp>
 #include <nall/string/transform/dml.hpp>
-
-#include <nall/vector-helpers.hpp>

--- a/nall/nall/string.hpp
+++ b/nall/nall/string.hpp
@@ -305,7 +305,7 @@ template<> struct vector<string> : vector_base<string> {
   vector(const vector& source) { vector_base::operator=(source); }
   vector(vector& source) { vector_base::operator=(source); }
   vector(vector&& source) { vector_base::operator=(std::move(source)); }
-  template<typename... P> vector(P&&... p) { append(std::forward<P>(p)...); }
+  template<typename... P> explicit vector(P&&... p) { append(std::forward<P>(p)...); }
 
   auto operator=(const vector& source) -> type& { return vector_base::operator=(source), *this; }
   auto operator=(vector& source) -> type& { return vector_base::operator=(source), *this; }

--- a/nall/nall/string/markup/bml.hpp
+++ b/nall/nall/string/markup/bml.hpp
@@ -80,7 +80,7 @@ protected:
   }
 
   //read a node and all of its child nodes
-  auto parseNode(const vector<string>& text, u32& y, string_view spacing) -> void {
+  auto parseNode(const std::vector<string>& text, u32& y, string_view spacing) -> void {
     const char* p = text[y++];
     _metadata = parseDepth(p);
     parseName(p);
@@ -130,7 +130,7 @@ protected:
     document.resize(document.size() - (p - output)).trimRight("\n");
     if(document.size() == 0) return;  //empty document
 
-    auto text = document.split("\n");
+    auto text = ::nall::split(document, "\n");
     u32 y = 0;
     while(y < text.size()) {
       SharedNode node(new ManagedNode);
@@ -166,8 +166,8 @@ inline auto serialize(const Markup::Node& node, string_view spacing = {}, u32 de
   padding.resize(depth * 2);
   padding.fill(' ');
 
-  vector<string> lines;
-  if(auto value = node.value()) lines = value.split("\n");
+  std::vector<string> lines;
+  if(auto value = node.value()) lines = ::nall::split(value, "\n");
 
   string result;
   result.append(padding);

--- a/nall/nall/string/markup/bml.hpp
+++ b/nall/nall/string/markup/bml.hpp
@@ -130,7 +130,7 @@ protected:
     document.resize(document.size() - (p - output)).trimRight("\n");
     if(document.size() == 0) return;  //empty document
 
-    auto text = ::nall::split(document, "\n");
+    auto text = nall::split(document, "\n");
     u32 y = 0;
     while(y < text.size()) {
       SharedNode node(new ManagedNode);
@@ -167,7 +167,7 @@ inline auto serialize(const Markup::Node& node, string_view spacing = {}, u32 de
   padding.fill(' ');
 
   std::vector<string> lines;
-  if(auto value = node.value()) lines = ::nall::split(value, "\n");
+  if(auto value = node.value()) lines = nall::split(value, "\n");
 
   string result;
   result.append(padding);

--- a/nall/nall/string/markup/find.hpp
+++ b/nall/nall/string/markup/find.hpp
@@ -5,7 +5,7 @@ namespace nall::Markup {
 inline auto ManagedNode::_evaluate(string query) const -> bool {
   if(!query) return true;
 
-  for(auto& rule : query.split(",")) {
+  for(auto& rule : ::nall::split(query, ",")) {
     enum class Comparator : u32 { ID, EQ, NE, LT, LE, GT, GE, NF };
     auto comparator = Comparator::ID;
          if(rule.match("*!=*")) comparator = Comparator::NE;
@@ -27,30 +27,30 @@ inline auto ManagedNode::_evaluate(string query) const -> bool {
       continue;
     }
 
-    vector<string> side;
+    std::vector<string> side;
     switch(comparator) {
-    case Comparator::EQ: side = rule.split ("=", 1L); break;
-    case Comparator::NE: side = rule.split("!=", 1L); break;
-    case Comparator::LT: side = rule.split ("<", 1L); break;
-    case Comparator::LE: side = rule.split("<=", 1L); break;
-    case Comparator::GT: side = rule.split (">", 1L); break;
-    case Comparator::GE: side = rule.split(">=", 1L); break;
+    case Comparator::EQ: side = ::nall::split(rule, "=", 1L); break;
+    case Comparator::NE: side = ::nall::split(rule, "!=", 1L); break;
+    case Comparator::LT: side = ::nall::split(rule, "<", 1L); break;
+    case Comparator::LE: side = ::nall::split(rule, "<=", 1L); break;
+    case Comparator::GT: side = ::nall::split(rule, ">", 1L); break;
+    case Comparator::GE: side = ::nall::split(rule, ">=", 1L); break;
     }
 
     string data = string{_value}.strip();
-    if(side(0)) {
-      auto result = _find(side(0));
+    if(!side.empty() && side[0]) {
+      auto result = _find(side[0]);
       if(result.size() == 0) return false;
       data = result[0].text();  //strips whitespace so rules can match without requiring it
     }
 
     switch(comparator) {
-    case Comparator::EQ: if(data.match(side(1)) ==  true)      continue; break;
-    case Comparator::NE: if(data.match(side(1)) == false)      continue; break;
-    case Comparator::LT: if(data.natural()  < side(1).natural()) continue; break;
-    case Comparator::LE: if(data.natural() <= side(1).natural()) continue; break;
-    case Comparator::GT: if(data.natural()  > side(1).natural()) continue; break;
-    case Comparator::GE: if(data.natural() >= side(1).natural()) continue; break;
+    case Comparator::EQ: if(side.size() > 1 && data.match(side[1]) ==  true)      continue; break;
+    case Comparator::NE: if(side.size() > 1 && data.match(side[1]) == false)      continue; break;
+    case Comparator::LT: if(side.size() > 1 && data.natural()  < side[1].natural()) continue; break;
+    case Comparator::LE: if(side.size() > 1 && data.natural() <= side[1].natural()) continue; break;
+    case Comparator::GT: if(side.size() > 1 && data.natural()  > side[1].natural()) continue; break;
+    case Comparator::GE: if(side.size() > 1 && data.natural() >= side[1].natural()) continue; break;
     }
 
     return false;
@@ -62,26 +62,28 @@ inline auto ManagedNode::_evaluate(string query) const -> bool {
 inline auto ManagedNode::_find(const string& query) const -> vector<Node> {
   vector<Node> result;
 
-  auto path = query.split("/");
-  string name = path.take(0), rule;
+  auto path = ::nall::split(query, "/");
+  string name = path.empty() ? string{} : path.front();
+  if(!path.empty()) path.erase(path.begin());
+  string rule;
   u32 lo = 0u, hi = ~0u;
 
   if(name.match("*[*]")) {
-    auto p = name.trimRight("]", 1L).split("[", 1L);
-    name = p(0);
-    if(p(1).find("-")) {
-      p = p(1).split("-", 1L);
-      lo = !p(0) ?  0u : p(0).natural();
-      hi = !p(1) ? ~0u : p(1).natural();
-    } else {
-      lo = hi = p(1).natural();
+    auto p = ::nall::split(name.trimRight("]", 1L), "[", 1L);
+    name = p.empty() ? string{} : p[0];
+    if(p.size() > 1 && p[1].find("-")) {
+      auto p2 = ::nall::split(p[1], "-", 1L);
+      lo = p2.empty() || !p2[0] ?  0u : p2[0].natural();
+      hi = p2.size() <= 1 || !p2[1] ? ~0u : p2[1].natural();
+    } else if(p.size() > 1) {
+      lo = hi = p[1].natural();
     }
   }
 
   if(name.match("*(*)")) {
-    auto p = name.trimRight(")", 1L).split("(", 1L);
-    name = p(0);
-    rule = p(1);
+    auto p = ::nall::split(name.trimRight(")", 1L), "(", 1L);
+    name = p.empty() ? string{} : p[0];
+    rule = p.size() > 1 ? p[1] : string{};
   }
 
   u32 position = 0;
@@ -93,9 +95,9 @@ inline auto ManagedNode::_find(const string& query) const -> vector<Node> {
     position++;
     if(!inrange) continue;
 
-    if(path.size() == 0) {
+    if(path.empty()) {
       result.append(node);
-    } else for(auto& item : node->_find(path.merge("/"))) {
+    } else for(auto& item : node->_find(::nall::merge(path, "/"))) {
       result.append(item);
     }
   }

--- a/nall/nall/string/markup/find.hpp
+++ b/nall/nall/string/markup/find.hpp
@@ -5,7 +5,7 @@ namespace nall::Markup {
 inline auto ManagedNode::_evaluate(string query) const -> bool {
   if(!query) return true;
 
-  for(auto& rule : ::nall::split(query, ",")) {
+  for(auto& rule : nall::split(query, ",")) {
     enum class Comparator : u32 { ID, EQ, NE, LT, LE, GT, GE, NF };
     auto comparator = Comparator::ID;
          if(rule.match("*!=*")) comparator = Comparator::NE;
@@ -29,12 +29,12 @@ inline auto ManagedNode::_evaluate(string query) const -> bool {
 
     std::vector<string> side;
     switch(comparator) {
-    case Comparator::EQ: side = ::nall::split(rule, "=", 1L); break;
-    case Comparator::NE: side = ::nall::split(rule, "!=", 1L); break;
-    case Comparator::LT: side = ::nall::split(rule, "<", 1L); break;
-    case Comparator::LE: side = ::nall::split(rule, "<=", 1L); break;
-    case Comparator::GT: side = ::nall::split(rule, ">", 1L); break;
-    case Comparator::GE: side = ::nall::split(rule, ">=", 1L); break;
+    case Comparator::EQ: side = nall::split(rule, "=", 1L); break;
+    case Comparator::NE: side = nall::split(rule, "!=", 1L); break;
+    case Comparator::LT: side = nall::split(rule, "<", 1L); break;
+    case Comparator::LE: side = nall::split(rule, "<=", 1L); break;
+    case Comparator::GT: side = nall::split(rule, ">", 1L); break;
+    case Comparator::GE: side = nall::split(rule, ">=", 1L); break;
     }
 
     string data = string{_value}.strip();
@@ -62,17 +62,17 @@ inline auto ManagedNode::_evaluate(string query) const -> bool {
 inline auto ManagedNode::_find(const string& query) const -> vector<Node> {
   vector<Node> result;
 
-  auto path = ::nall::split(query, "/");
+  auto path = nall::split(query, "/");
   string name = path.empty() ? string{} : path.front();
   if(!path.empty()) path.erase(path.begin());
   string rule;
   u32 lo = 0u, hi = ~0u;
 
   if(name.match("*[*]")) {
-    auto p = ::nall::split(name.trimRight("]", 1L), "[", 1L);
+    auto p = nall::split(name.trimRight("]", 1L), "[", 1L);
     name = p.empty() ? string{} : p[0];
     if(p.size() > 1 && p[1].find("-")) {
-      auto p2 = ::nall::split(p[1], "-", 1L);
+      auto p2 = nall::split(p[1], "-", 1L);
       lo = p2.empty() || !p2[0] ?  0u : p2[0].natural();
       hi = p2.size() <= 1 || !p2[1] ? ~0u : p2[1].natural();
     } else if(p.size() > 1) {
@@ -81,7 +81,7 @@ inline auto ManagedNode::_find(const string& query) const -> vector<Node> {
   }
 
   if(name.match("*(*)")) {
-    auto p = ::nall::split(name.trimRight(")", 1L), "(", 1L);
+    auto p = nall::split(name.trimRight(")", 1L), "(", 1L);
     name = p.empty() ? string{} : p[0];
     rule = p.size() > 1 ? p[1] : string{};
   }
@@ -97,7 +97,7 @@ inline auto ManagedNode::_find(const string& query) const -> vector<Node> {
 
     if(path.empty()) {
       result.append(node);
-    } else for(auto& item : node->_find(::nall::merge(path, "/"))) {
+    } else for(auto& item : node->_find(nall::merge(path, "/"))) {
       result.append(item);
     }
   }

--- a/nall/nall/string/split.hpp
+++ b/nall/nall/string/split.hpp
@@ -38,9 +38,5 @@ inline auto vector<string>::_split(string_view source, string_view find, long li
   return *this;
 }
 
-inline auto string::split(string_view on, long limit) const -> vector<string> { return vector<string>()._split<0, 0>(*this, on, limit); }
-inline auto string::isplit(string_view on, long limit) const -> vector<string> { return vector<string>()._split<1, 0>(*this, on, limit); }
-inline auto string::qsplit(string_view on, long limit) const -> vector<string> { return vector<string>()._split<0, 1>(*this, on, limit); }
-inline auto string::iqsplit(string_view on, long limit) const -> vector<string> { return vector<string>()._split<1, 1>(*this, on, limit); }
 
 }

--- a/nall/nall/string/transform/cml.hpp
+++ b/nall/nall/string/transform/cml.hpp
@@ -29,7 +29,7 @@ private:
     string name;
     string value;
   };
-  vector<Variable> variables;
+  std::vector<Variable> variables;
   bool inMedia = false;
   bool inMediaNode = false;
 
@@ -57,9 +57,10 @@ inline auto CML::parseDocument(const string& filedata, const string& pathname, u
     state.output.append("  -webkit-", name, ": ", value, ";\n");
   };
 
-  for(auto& block : filedata.split("\n\n")) {
-    auto lines = block.stripRight().split("\n");
-    auto name = lines.takeFirst();
+  for(auto& block : ::nall::split(filedata, "\n\n")) {
+    auto lines = ::nall::split(block.stripRight(), "\n");
+    auto name = lines.empty() ? string{} : lines.front();
+    if(!lines.empty()) lines.erase(lines.begin());
 
     if(name.beginsWith("include ")) {
       name.trimLeft("include ", 1L);
@@ -71,8 +72,10 @@ inline auto CML::parseDocument(const string& filedata, const string& pathname, u
 
     if(name == "variables") {
       for(auto& line : lines) {
-        auto data = line.split(":", 1L).strip();
-        variables.append({data(0), data(1)});
+        auto dataParts = ::nall::split(line, ":", 1L);
+        std::vector<string> data;
+        for(auto& part : dataParts) data.push_back(part.strip());
+        variables.emplace_back(data.size() > 0 ? data[0] : string{}, data.size() > 1 ? data[1] : string{});
       }
       continue;
     }
@@ -88,8 +91,11 @@ inline auto CML::parseDocument(const string& filedata, const string& pathname, u
         continue;
       }
 
-      auto data = line.split(":", 1L).strip();
-      auto name = data(0), value = data(1);
+      auto dataParts2 = ::nall::split(line, ":", 1L);
+      std::vector<string> data2;
+      for(auto& part : dataParts2) data2.push_back(part.strip());
+      string name = data2.size() > 0 ? data2[0] : string{};
+      string value = data2.size() > 1 ? data2[1] : string{};
       while(auto offset = value.find("var(")) {
         bool found = false;
         if(auto length = value.findFrom(*offset, ")")) {

--- a/nall/nall/string/transform/cml.hpp
+++ b/nall/nall/string/transform/cml.hpp
@@ -57,8 +57,8 @@ inline auto CML::parseDocument(const string& filedata, const string& pathname, u
     state.output.append("  -webkit-", name, ": ", value, ";\n");
   };
 
-  for(auto& block : ::nall::split(filedata, "\n\n")) {
-    auto lines = ::nall::split(block.stripRight(), "\n");
+  for(auto& block : nall::split(filedata, "\n\n")) {
+    auto lines = nall::split(block.stripRight(), "\n");
     auto name = lines.empty() ? string{} : lines.front();
     if(!lines.empty()) lines.erase(lines.begin());
 
@@ -72,7 +72,7 @@ inline auto CML::parseDocument(const string& filedata, const string& pathname, u
 
     if(name == "variables") {
       for(auto& line : lines) {
-        auto dataParts = ::nall::split(line, ":", 1L);
+        auto dataParts = nall::split(line, ":", 1L);
         std::vector<string> data;
         for(auto& part : dataParts) data.push_back(part.strip());
         variables.emplace_back(data.size() > 0 ? data[0] : string{}, data.size() > 1 ? data[1] : string{});
@@ -91,7 +91,7 @@ inline auto CML::parseDocument(const string& filedata, const string& pathname, u
         continue;
       }
 
-      auto dataParts2 = ::nall::split(line, ":", 1L);
+      auto dataParts2 = nall::split(line, ":", 1L);
       std::vector<string> data2;
       for(auto& part : dataParts2) data2.push_back(part.strip());
       string name = data2.size() > 0 ? data2[0] : string{};

--- a/nall/nall/string/transform/cml.hpp
+++ b/nall/nall/string/transform/cml.hpp
@@ -72,9 +72,7 @@ inline auto CML::parseDocument(const string& filedata, const string& pathname, u
 
     if(name == "variables") {
       for(auto& line : lines) {
-        auto dataParts = nall::split(line, ":", 1L);
-        std::vector<string> data;
-        for(auto& part : dataParts) data.push_back(part.strip());
+        auto data = nall::split_and_strip(line, ":", 1L);
         variables.emplace_back(data.size() > 0 ? data[0] : string{}, data.size() > 1 ? data[1] : string{});
       }
       continue;
@@ -91,9 +89,7 @@ inline auto CML::parseDocument(const string& filedata, const string& pathname, u
         continue;
       }
 
-      auto dataParts2 = nall::split(line, ":", 1L);
-      std::vector<string> data2;
-      for(auto& part : dataParts2) data2.push_back(part.strip());
+      auto data2 = nall::split_and_strip(line, ":", 1L);
       string name = data2.size() > 0 ? data2[0] : string{};
       string value = data2.size() > 1 ? data2[1] : string{};
       while(auto offset = value.find("var(")) {

--- a/nall/nall/string/transform/dml.hpp
+++ b/nall/nall/string/transform/dml.hpp
@@ -94,10 +94,10 @@ inline auto DML::parseBlock(string& block, const string& pathname, u32 depth) ->
   else if(block.beginsWith("? ")) {
     for(auto n : range(lines.size())) {
       if(!lines[n].beginsWith("? ")) continue;
-      auto part = nall::split(lines[n].trimLeft("? ", 1L), ":", 1L);
+      auto part = nall::split_and_strip(lines[n].trimLeft("? ", 1L), ":", 1L);
       if(part.size() != 2) continue;
-      auto name = part[0].strip();
-      auto value = part[1].strip();
+      auto name = part[0];
+      auto value = part[1];
       attributes.append({name, value});
     }
   }

--- a/nall/nall/string/transform/dml.hpp
+++ b/nall/nall/string/transform/dml.hpp
@@ -74,14 +74,14 @@ inline auto DML::parse(const string& filename) -> string {
 inline auto DML::parseDocument(const string& filedata, const string& pathname, u32 depth) -> bool {
   if(depth >= 100) return false;  //attempt to prevent infinite recursion with reasonable limit
 
-  auto blocks = filedata.split("\n\n");
+  auto blocks = ::nall::split(filedata, "\n\n");
   for(auto& block : blocks) parseBlock(block, pathname, depth);
   return true;
 }
 
 inline auto DML::parseBlock(string& block, const string& pathname, u32 depth) -> bool {
   if(!block.stripRight()) return true;
-  auto lines = block.split("\n");
+  auto lines = ::nall::split(block, "\n");
 
   //include
   if(block.beginsWith("<include ") && block.endsWith(">")) {
@@ -94,7 +94,7 @@ inline auto DML::parseBlock(string& block, const string& pathname, u32 depth) ->
   else if(block.beginsWith("? ")) {
     for(auto n : range(lines.size())) {
       if(!lines[n].beginsWith("? ")) continue;
-      auto part = lines[n].trimLeft("? ", 1L).split(":", 1L);
+      auto part = ::nall::split(lines[n].trimLeft("? ", 1L), ":", 1L);
       if(part.size() != 2) continue;
       auto name = part[0].strip();
       auto value = part[1].strip();
@@ -112,8 +112,9 @@ inline auto DML::parseBlock(string& block, const string& pathname, u32 depth) ->
 
   //header
   else if(auto depth = count(block, '#')) {
-    auto nextLine = lines.takeLeft();
-    auto content = slice(nextLine, depth + 1);
+    auto front = lines.empty() ? string{} : lines.front();
+    auto content = slice(front, depth + 1);
+    if(!lines.empty()) lines.erase(lines.begin());
     auto data = markup(content);
     auto name = anchor(content);
     if(depth <= 5) {
@@ -284,9 +285,11 @@ inline auto DML::markup(const string& s) -> string {
     }
 
     if(link && !image && a == ']' && b == ']') {
-      auto list = slice(s, link(), n - link()).split("::", 1L);
-      string uri = address(list.last());
-      string name = list.size() == 2 ? list.first() : uri.split("//", 1L).last();
+      auto sliceStr = slice(s, link(), n - link());
+      auto   list     = ::nall::split(sliceStr, "::", 1L);
+      string uri      = address(list.empty() ? string{} : list.back());
+      auto   uriParts = ::nall::split(uri, "//", 1L);
+      string name     = list.size() == 2 ? list.front() : (uriParts.empty() ? string{} : uriParts.back());
 
       t.append("<a href=\"", escape(uri), "\">", escape(name), "</a>");
 
@@ -296,11 +299,15 @@ inline auto DML::markup(const string& s) -> string {
     }
 
     if(image && !link && a == '}' && b == '}') {
-      auto side = slice(s, image(), n - image()).split("}{", 1L);
-      auto list = side(0).split("::", 1L);
-      string uri = address(list.last());
-      string name = list.size() == 2 ? list.first() : uri.split("//", 1L).last();
-      list = side(1).split("; ");
+      auto   sliceStr  = slice(s, image(), n - image());
+      auto   side      = ::nall::split(sliceStr, "}{", 1L);
+      string side0     = side.empty() ? string{} : side[0];
+      auto   list      = ::nall::split(side0, "::", 1L);
+      string uri       = address(list.empty() ? string{} : list.back());
+      auto   uriParts2 = ::nall::split(uri, "//", 1L);
+      string name      = list.size() == 2 ? list.front() : (uriParts2.empty() ? string{} : uriParts2.back());
+      string side1     = side.size() > 1 ? side[1] : string{};
+      list = ::nall::split(side1, "; ");
       Boolean link, title, caption;
       string Class, width, height;
       for(auto p : list) {

--- a/nall/nall/string/transform/dml.hpp
+++ b/nall/nall/string/transform/dml.hpp
@@ -74,14 +74,14 @@ inline auto DML::parse(const string& filename) -> string {
 inline auto DML::parseDocument(const string& filedata, const string& pathname, u32 depth) -> bool {
   if(depth >= 100) return false;  //attempt to prevent infinite recursion with reasonable limit
 
-  auto blocks = ::nall::split(filedata, "\n\n");
+  auto blocks = nall::split(filedata, "\n\n");
   for(auto& block : blocks) parseBlock(block, pathname, depth);
   return true;
 }
 
 inline auto DML::parseBlock(string& block, const string& pathname, u32 depth) -> bool {
   if(!block.stripRight()) return true;
-  auto lines = ::nall::split(block, "\n");
+  auto lines = nall::split(block, "\n");
 
   //include
   if(block.beginsWith("<include ") && block.endsWith(">")) {
@@ -94,7 +94,7 @@ inline auto DML::parseBlock(string& block, const string& pathname, u32 depth) ->
   else if(block.beginsWith("? ")) {
     for(auto n : range(lines.size())) {
       if(!lines[n].beginsWith("? ")) continue;
-      auto part = ::nall::split(lines[n].trimLeft("? ", 1L), ":", 1L);
+      auto part = nall::split(lines[n].trimLeft("? ", 1L), ":", 1L);
       if(part.size() != 2) continue;
       auto name = part[0].strip();
       auto value = part[1].strip();
@@ -286,9 +286,9 @@ inline auto DML::markup(const string& s) -> string {
 
     if(link && !image && a == ']' && b == ']') {
       auto sliceStr = slice(s, link(), n - link());
-      auto   list     = ::nall::split(sliceStr, "::", 1L);
+      auto   list     = nall::split(sliceStr, "::", 1L);
       string uri      = address(list.empty() ? string{} : list.back());
-      auto   uriParts = ::nall::split(uri, "//", 1L);
+      auto   uriParts = nall::split(uri, "//", 1L);
       string name     = list.size() == 2 ? list.front() : (uriParts.empty() ? string{} : uriParts.back());
 
       t.append("<a href=\"", escape(uri), "\">", escape(name), "</a>");
@@ -300,14 +300,14 @@ inline auto DML::markup(const string& s) -> string {
 
     if(image && !link && a == '}' && b == '}') {
       auto   sliceStr  = slice(s, image(), n - image());
-      auto   side      = ::nall::split(sliceStr, "}{", 1L);
+      auto   side      = nall::split(sliceStr, "}{", 1L);
       string side0     = side.empty() ? string{} : side[0];
-      auto   list      = ::nall::split(side0, "::", 1L);
+      auto   list      = nall::split(side0, "::", 1L);
       string uri       = address(list.empty() ? string{} : list.back());
-      auto   uriParts2 = ::nall::split(uri, "//", 1L);
+      auto   uriParts2 = nall::split(uri, "//", 1L);
       string name      = list.size() == 2 ? list.front() : (uriParts2.empty() ? string{} : uriParts2.back());
       string side1     = side.size() > 1 ? side[1] : string{};
-      list = ::nall::split(side1, "; ");
+      list = nall::split(side1, "; ");
       Boolean link, title, caption;
       string Class, width, height;
       for(auto p : list) {

--- a/nall/nall/string/vector.hpp
+++ b/nall/nall/string/vector.hpp
@@ -33,13 +33,6 @@ inline auto vector<string>::ifind(string_view source) const -> maybe<u32> {
   return {};
 }
 
-inline auto vector<string>::match(string_view pattern) const -> vector<string> {
-  vector<string> result;
-  for(u32 n = 0; n < size(); n++) {
-    if(operator[](n).match(pattern)) result.append(operator[](n));
-  }
-  return result;
-}
 
 inline auto vector<string>::merge(string_view separator) const -> string {
   string output;

--- a/nall/nall/vector-helpers.hpp
+++ b/nall/nall/vector-helpers.hpp
@@ -47,6 +47,56 @@ inline auto split(string_view source, string_view on, long limit = LONG_MAX) -> 
   return out;
 }
 
+inline auto isplit(string_view source, string_view on, long limit = LONG_MAX) -> std::vector<string> {
+  auto tmp = vector<string>()._split<1, 0>(source, on, limit);
+  std::vector<string> out;
+  out.reserve(tmp.size());
+  for(u32 i = 0; i < tmp.size(); i++) out.push_back(tmp[i]);
+  return out;
+}
+
+inline auto qsplit(string_view source, string_view on, long limit = LONG_MAX) -> std::vector<string> {
+  auto tmp = vector<string>()._split<0, 1>(source, on, limit);
+  std::vector<string> out;
+  out.reserve(tmp.size());
+  for(u32 i = 0; i < tmp.size(); i++) out.push_back(tmp[i]);
+  return out;
+}
+
+inline auto iqsplit(string_view source, string_view on, long limit = LONG_MAX) -> std::vector<string> {
+  auto tmp = vector<string>()._split<1, 1>(source, on, limit);
+  std::vector<string> out;
+  out.reserve(tmp.size());
+  for(u32 i = 0; i < tmp.size(); i++) out.push_back(tmp[i]);
+  return out;
+}
+
+// Helper function to replace vector<string>::match
+inline auto match(const vector<string>& strings, string_view pattern) -> std::vector<string> {
+  std::vector<string> result;
+  for(u32 n = 0; n < strings.size(); n++) {
+    if(strings[n].match(pattern)) result.push_back(strings[n]);
+  }
+  return result;
+}
+
+// Helper function to strip a single string (for use with ranges)
+inline auto strip(const string& s) -> string {
+  auto copy = s;
+  return copy.strip();
+}
+
+// Helper function that combines split + strip for convenience
+inline auto split_and_strip(string_view source, string_view delimiter, long limit = LONG_MAX) -> std::vector<string> {
+  auto tmp = split(source, delimiter, limit);
+  std::vector<string> result;
+  result.reserve(tmp.size());
+  for(const auto& item : tmp | std::views::transform(strip)) {
+    result.push_back(item);
+  }
+  return result;
+}
+
 }
 
 

--- a/nall/nall/windows/registry.cpp
+++ b/nall/nall/windows/registry.cpp
@@ -29,10 +29,12 @@ NALL_HEADER_INLINE auto registry::root(const string& name) {
 }
 
 NALL_HEADER_INLINE auto registry::exists(const string& name) -> bool {
-  auto part = name.split("\\");
-  HKEY handle, rootKey = root(part.takeLeft());
-  string node = part.takeRight();
-  string path = part.merge("\\");
+  auto part = ::nall::split(name, "\\");
+  HKEY handle, rootKey = root(part.front());
+  part.erase(part.begin());
+  string node = part.empty() ? string("") : part.back();
+  if(!part.empty()) part.pop_back();
+  string path = nall::merge(part, "\\");
   if(RegOpenKeyExW(rootKey, utf16_t(path), 0, NWR_FLAGS | KEY_READ, &handle) == ERROR_SUCCESS) {
     wchar_t data[NWR_SIZE] = L"";
     DWORD size = NWR_SIZE * sizeof(wchar_t);
@@ -44,10 +46,12 @@ NALL_HEADER_INLINE auto registry::exists(const string& name) -> bool {
 }
 
 NALL_HEADER_INLINE auto registry::read(const string& name) -> string {
-  auto part = name.split("\\");
-  HKEY handle, rootKey = root(part.takeLeft());
-  string node = part.takeRight();
-  string path = part.merge("\\");
+  auto part = ::nall::split(name, "\\");
+  HKEY handle, rootKey = root(part.front());
+  part.erase(part.begin());
+  string node = part.empty() ? string("") : part.back();
+  if(!part.empty()) part.pop_back();
+  string path = nall::merge(part, "\\");
   if(RegOpenKeyExW(rootKey, utf16_t(path), 0, NWR_FLAGS | KEY_READ, &handle) == ERROR_SUCCESS) {
     wchar_t data[NWR_SIZE] = L"";
     DWORD size = NWR_SIZE * sizeof(wchar_t);
@@ -59,9 +63,11 @@ NALL_HEADER_INLINE auto registry::read(const string& name) -> string {
 }
 
 NALL_HEADER_INLINE auto registry::write(const string& name, const string& data) -> void {
-  auto part = name.split("\\");
-  HKEY handle, rootKey = root(part.takeLeft());
-  string node = part.takeRight(), path;
+  auto part = ::nall::split(name, "\\");
+  HKEY handle, rootKey = root(part.front());
+  part.erase(part.begin());
+  string node = part.empty() ? string("") : part.back(), path;
+  if(!part.empty()) part.pop_back();
   DWORD disposition;
   for(u32 n = 0; n < part.size(); n++) {
     path.append(part[n]);
@@ -76,20 +82,23 @@ NALL_HEADER_INLINE auto registry::write(const string& name, const string& data) 
 }
 
 NALL_HEADER_INLINE auto registry::remove(const string& name) -> bool {
-  auto part = name.split("\\");
-  HKEY rootKey = root(part.takeLeft());
-  string node = part.takeRight();
-  string path = part.merge("\\");
+  auto part = ::nall::split(name, "\\");
+  HKEY rootKey = root(part.front());
+  part.erase(part.begin());
+  string node = part.empty() ? string("") : part.back();
+  if(!part.empty()) part.pop_back();
+  string path = nall::merge(part, "\\");
   if(!node) return SHDeleteKeyW(rootKey, utf16_t(path)) == ERROR_SUCCESS;
   return SHDeleteValueW(rootKey, utf16_t(path), utf16_t(node)) == ERROR_SUCCESS;
 }
 
 NALL_HEADER_INLINE auto registry::contents(const string& name) -> std::vector<string> {
   std::vector<string> result;
-  auto part = name.split("\\");
-  HKEY handle, rootKey = root(part.takeLeft());
-  part.removeRight();
-  string path = part.merge("\\");
+  auto part = ::nall::split(name, "\\");
+  HKEY handle, rootKey = root(part.front());
+  part.erase(part.begin());
+  if(!part.empty()) part.pop_back();
+  string path = nall::merge(part, "\\");
   if(RegOpenKeyExW(rootKey, utf16_t(path), 0, NWR_FLAGS | KEY_READ, &handle) == ERROR_SUCCESS) {
     DWORD folders, nodes;
     RegQueryInfoKey(handle, nullptr, nullptr, nullptr, &folders, nullptr, nullptr, &nodes, nullptr, nullptr, nullptr, nullptr);

--- a/nall/nall/windows/registry.cpp
+++ b/nall/nall/windows/registry.cpp
@@ -29,7 +29,7 @@ NALL_HEADER_INLINE auto registry::root(const string& name) {
 }
 
 NALL_HEADER_INLINE auto registry::exists(const string& name) -> bool {
-  auto part = ::nall::split(name, "\\");
+  auto part = nall::split(name, "\\");
   HKEY handle, rootKey = root(part.front());
   part.erase(part.begin());
   string node = part.empty() ? string("") : part.back();
@@ -46,7 +46,7 @@ NALL_HEADER_INLINE auto registry::exists(const string& name) -> bool {
 }
 
 NALL_HEADER_INLINE auto registry::read(const string& name) -> string {
-  auto part = ::nall::split(name, "\\");
+  auto part = nall::split(name, "\\");
   HKEY handle, rootKey = root(part.front());
   part.erase(part.begin());
   string node = part.empty() ? string("") : part.back();
@@ -63,7 +63,7 @@ NALL_HEADER_INLINE auto registry::read(const string& name) -> string {
 }
 
 NALL_HEADER_INLINE auto registry::write(const string& name, const string& data) -> void {
-  auto part = ::nall::split(name, "\\");
+  auto part = nall::split(name, "\\");
   HKEY handle, rootKey = root(part.front());
   part.erase(part.begin());
   string node = part.empty() ? string("") : part.back(), path;
@@ -82,7 +82,7 @@ NALL_HEADER_INLINE auto registry::write(const string& name, const string& data) 
 }
 
 NALL_HEADER_INLINE auto registry::remove(const string& name) -> bool {
-  auto part = ::nall::split(name, "\\");
+  auto part = nall::split(name, "\\");
   HKEY rootKey = root(part.front());
   part.erase(part.begin());
   string node = part.empty() ? string("") : part.back();
@@ -94,7 +94,7 @@ NALL_HEADER_INLINE auto registry::remove(const string& name) -> bool {
 
 NALL_HEADER_INLINE auto registry::contents(const string& name) -> std::vector<string> {
   std::vector<string> result;
-  auto part = ::nall::split(name, "\\");
+  auto part = nall::split(name, "\\");
   HKEY handle, rootKey = root(part.front());
   part.erase(part.begin());
   if(!part.empty()) part.pop_back();

--- a/ruby/input/joypad/uhid.cpp
+++ b/ruby/input/joypad/uhid.cpp
@@ -32,7 +32,7 @@ struct InputJoypadUHID {
     if(thisTimestamp - lastTimestamp >= 2000) {
       lastTimestamp = thisTimestamp;
       auto devices = directory::files("/dev/", "uhid*");
-      if(enumeratedDevices != devices.merge(";")) initialize();
+      if(enumeratedDevices != nall::merge(devices, ";")) initialize();
     }
 
     for(auto& joypad : joypads) {
@@ -86,7 +86,7 @@ struct InputJoypadUHID {
         }
         hid_end_parse(parse);
       }
-      devices.append(joypad.hid);
+      devices.push_back(joypad.hid);
     }
   }
 
@@ -95,7 +95,7 @@ struct InputJoypadUHID {
 
     u32 pathID = 0;
     auto devices = directory::files("/dev/", "uhid*");
-    enumeratedDevices = devices.merge(";");
+    enumeratedDevices = nall::merge(devices, ";");
     for(auto device : devices) {
       Joypad joypad;
       string deviceName = {"/dev/", device};

--- a/tools/genius/genius.cpp
+++ b/tools/genius/genius.cpp
@@ -281,7 +281,7 @@ GameWindow::GameWindow() {
     if(auto item = componentTree.selected()) {
       setEnabled(false);
       auto itemPath = item.path();
-      auto path     = ::nall::split(itemPath, "/");
+      auto path     = nall::split(itemPath, "/");
       auto offset   = path.empty() ? 0u : path[0].natural();
       Component component = game.components[offset];
       if(component.type == Component::Type::Memory) {
@@ -426,7 +426,7 @@ auto GameWindow::modifyComponent(Component component) -> void {
   if(auto item = componentTree.selected()) {
     modified = true;
     auto itemPath = item.path();
-    auto path     = ::nall::split(itemPath, "/");
+    auto path     = nall::split(itemPath, "/");
     auto offset   = path.empty() ? 0u : path[0].natural();
     game.components[offset] = component;
     reloadList();
@@ -442,7 +442,7 @@ auto GameWindow::removeComponent() -> void {
     }).question() == "Yes") {
       modified = true;
       auto itemPath = item.path();
-      auto path     = ::nall::split(itemPath, "/");
+      auto path     = nall::split(itemPath, "/");
       auto offset   = path.empty() ? 0u : path[0].natural();
       game.components.erase(game.components.begin() + offset);
       reloadList();

--- a/tools/genius/genius.cpp
+++ b/tools/genius/genius.cpp
@@ -107,7 +107,7 @@ auto ListWindow::updateWindow() -> void {
 }
 
 auto ListWindow::newDatabase() -> void {
-  games.reset();
+  games.clear();
   modified = false;
   location = "";
   reloadList();
@@ -117,7 +117,7 @@ auto ListWindow::newDatabase() -> void {
 auto ListWindow::loadDatabase(string location) -> void {
   auto document = BML::unserialize(string::read(location));
 
-  games.reset();
+  games.clear();
   for(auto node : document.find("game")) {
     Game game;
     game.sha256 = node["sha256"].text();
@@ -142,10 +142,10 @@ auto ListWindow::loadDatabase(string location) -> void {
         component.type = Component::Type::Oscillator;
         component.oscillator.frequency = object["frequency"].text();
       }
-      game.components.append(component);
+      game.components.push_back(component);
     }
     game.note = node["note"].text();
-    games.append(game);
+    games.push_back(game);
   }
 
   modified = false;
@@ -162,7 +162,7 @@ auto ListWindow::saveDatabase(string location) -> void {
   }).error(), void();
 
   auto copy = games;
-  copy.sort([](auto x, auto y) {
+  std::sort(copy.begin(), copy.end(), [](const Game& x, const Game& y) {
     string a = { x.name, "\n", x.region, "\n", x.revision };
     string b = { y.name, "\n", y.region, "\n", y.revision };
     return string::icompare(a, b) < 0;
@@ -181,7 +181,7 @@ auto ListWindow::saveDatabase(string location) -> void {
     fp.print("  revision: ", game.revision, "\n");
   if(game.board)
     fp.print("  board:    ", game.board, "\n");
-  else if(game.components)
+  else if(!game.components.empty())
     fp.print("  board\n");
     for(auto& component : game.components) {
       if(component.type == Component::Type::Memory) {
@@ -217,7 +217,7 @@ auto ListWindow::saveDatabase(string location) -> void {
 auto ListWindow::appendGame(Game game) -> void {
   modified = true;
   auto offset = games.size();
-  games.append(game);
+  games.push_back(game);
   reloadList();
   gameList.item(offset).setSelected().setFocused();
   updateWindow();
@@ -241,7 +241,7 @@ auto ListWindow::removeGame() -> void {
       "Name: ", item.cell(0).text()
     }).question() == "Yes") {
       modified = true;
-      games.remove(item.offset());
+      games.erase(games.begin() + item.offset());
       reloadList();
       updateWindow();
     }
@@ -280,8 +280,9 @@ GameWindow::GameWindow() {
   modifyComponentButton.setText("Modify").onActivate([&] {
     if(auto item = componentTree.selected()) {
       setEnabled(false);
-      auto path = item.path().split("/");
-      auto offset = path(0).natural();
+      auto itemPath = item.path();
+      auto path     = ::nall::split(itemPath, "/");
+      auto offset   = path.empty() ? 0u : path[0].natural();
       Component component = game.components[offset];
       if(component.type == Component::Type::Memory) {
         memoryWindow.show(component.memory);
@@ -415,7 +416,7 @@ auto GameWindow::updateWindow() -> void {
 auto GameWindow::appendComponent(Component component) -> void {
   modified = true;
   auto offset = game.components.size();
-  game.components.append(component);
+  game.components.push_back(component);
   reloadList();
   componentTree.item(offset).setSelected().setFocused();
   updateWindow();
@@ -424,8 +425,9 @@ auto GameWindow::appendComponent(Component component) -> void {
 auto GameWindow::modifyComponent(Component component) -> void {
   if(auto item = componentTree.selected()) {
     modified = true;
-    auto path = item.path().split("/");
-    auto offset = path(0).natural();
+    auto itemPath = item.path();
+    auto path     = ::nall::split(itemPath, "/");
+    auto offset   = path.empty() ? 0u : path[0].natural();
     game.components[offset] = component;
     reloadList();
     componentTree.item(offset).setSelected().setFocused();
@@ -439,9 +441,10 @@ auto GameWindow::removeComponent() -> void {
       "Are you sure you want to permanently remove this component?"
     }).question() == "Yes") {
       modified = true;
-      auto path = item.path().split("/");
-      auto offset = path(0).natural();
-      game.components.remove(offset);
+      auto itemPath = item.path();
+      auto path     = ::nall::split(itemPath, "/");
+      auto offset   = path.empty() ? 0u : path[0].natural();
+      game.components.erase(game.components.begin() + offset);
       reloadList();
       updateWindow();
     }

--- a/tools/genius/genius.hpp
+++ b/tools/genius/genius.hpp
@@ -30,7 +30,7 @@ struct Game {
   string name;
   string label;
   string note;
-  vector<Component> components;
+  std::vector<Component> components;
 };
 
 struct ListWindow : Window {
@@ -47,7 +47,7 @@ struct ListWindow : Window {
 
 private:
   bool modified = false;
-  vector<Game> games;
+  std::vector<Game> games;
   string location;
 
   MenuBar menuBar{this};


### PR DESCRIPTION
This is next step in the series. The main news here is that we start adding some global functions to nall. In general, nall containers have many more methods than standard C++ and those methods implement useful helpers that need to stay around. Since we can't add methods to standard classes, we'll migrate those to global functions instead. We start with merge/split of strings as they use vectors of strings as well, which we want to migrate to std::vector anyway.

~~Some uses have now been decorated with `::nall::split` for namespace issues that I want to postpone for later. They're pretty easy to find with a grep and fix later anyway.~~