### PR TITLE
Build: fixups

### DIFF
--- a/cmake/common/compiler_common.cmake
+++ b/cmake/common/compiler_common.cmake
@@ -48,7 +48,6 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
 set(
   _ares_clang_common_options
   -fno-strict-aliasing
-  -fno-char8_t
   -Wblock-capture-autoreleasing
   # -Wswitch
   -Wdeprecated
@@ -96,6 +95,7 @@ set(_ares_clang_c_options ${_ares_clang_common_options})
 set(
   _ares_clang_cxx_options
   ${_ares_clang_common_options}
+  -fno-char8_t
   -Wvexing-parse
   -Wdelete-non-virtual-dtor
   -Wrange-loop-analysis
@@ -104,7 +104,9 @@ set(
   -Wno-delete-non-abstract-non-virtual-dtor
 )
 
-set(_ares_gcc_common_options -fwrapv -fno-strict-aliasing -Wno-unused-result -Wno-stringop-overflow -fno-char8_t)
+set(_ares_gcc_common_options -fwrapv -fno-strict-aliasing -Wno-unused-result -Wno-stringop-overflow)
+
+set(_ares_gcc_cxx_options -fno-char8_t)
 
 if(NOT DEFINED CMAKE_COMPILE_WARNING_AS_ERROR)
   set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)

--- a/cmake/linux/compilerconfig.cmake
+++ b/cmake/linux/compilerconfig.cmake
@@ -25,7 +25,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     -fwrapv
   )
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  add_compile_options(${_ares_gcc_common_options})
+  add_compile_options(
+    "${_ares_gcc_common_options}"
+    "$<$<COMPILE_LANGUAGE:CXX>:${_ares_gcc_cxx_options}>"
+  )
 endif()
 
 if(ARES_BUILD_LOCAL)

--- a/cmake/macos/helpers.cmake
+++ b/cmake/macos/helpers.cmake
@@ -174,10 +174,28 @@ function(_bundle_dependencies target)
       add_custom_command(
         TARGET ${target}
         POST_BUILD
-        COMMAND ditto ${library_paths} "$<TARGET_BUNDLE_CONTENT_DIR:${target}>/Frameworks/"
-        WORKING_DIRECTORY "$<TARGET_BUNDLE_CONTENT_DIR:${target}>"
-        COMMENT "Copying dynamic libraries into app bundle"
+        COMMAND "${CMAKE_COMMAND}" -E make_directory "$<TARGET_BUNDLE_CONTENT_DIR:${target}>/Frameworks/"
+        VERBATIM
       )
+      foreach(dep IN LISTS library_paths)
+        cmake_path(GET dep FILENAME filename)
+        add_custom_command(
+          TARGET ${target}
+          POST_BUILD
+          COMMAND ditto "${dep}" "$<TARGET_BUNDLE_CONTENT_DIR:${target}>/Frameworks/${filename}"
+          COMMENT "Copying ${dep} into app bundle"
+          VERBATIM
+        )
+        if(EXISTS "${dep}.dSYM" AND ARES_DEBUG_DEPENDENCIES)
+          add_custom_command(
+            TARGET ${target}
+            POST_BUILD
+            COMMAND ditto "${dep}.dSYM" "$<TARGET_BUNDLE_CONTENT_DIR:${target}>/Frameworks/${filename}.dSYM"
+            COMMENT "Copying ${dep}.dSYM into app bundle"
+            VERBATIM
+          )
+        endif()
+      endforeach()
       # Add an rpath for the bundled dynamic libraries
       add_custom_command(
         TARGET ${target}


### PR DESCRIPTION
* Don't use `-fno-char8_t` when compiling C code (the type only exists in C++, currently)
* Fix an issue preventing macOS framework bundle dependencies from being properly copied inside .app bundles on generators other than Xcode