### PR TITLE
desktop-ui: Properly initialize rewind state on startup

### DIFF
--- a/desktop-ui/program/program.cpp
+++ b/desktop-ui/program/program.cpp
@@ -19,6 +19,7 @@ auto Program::create() -> void {
 
   _isRunning = true;
   worker = thread::create({&Program::emulatorRunLoop, this});
+  program.rewindReset();
 
   if(startGameLoad) {
     Program::Guard guard;


### PR DESCRIPTION
#2129 revealed an issue where important state was being initialized via the UI in a somewhat tough to spot way; the call to `rewindReset()` when initializing the rewind checkbox. If this function is not called before a title is loaded with rewind enabled, the rewind routine will end up in a bad state that causes a crash.

Fixes #2193