### PR TITLE
n64: Use ISV read pointer as a start address

### DIFF
--- a/ares/n64/cartridge/isviewer.cpp
+++ b/ares/n64/cartridge/isviewer.cpp
@@ -24,12 +24,16 @@ auto Cartridge::ISViewer::writeHalf(u32 address, u16 data) -> void {
     // libdragon instead treats this as a "number of bytes" register, only
     // writing an "output byte count"
     // In order to satisfy both libraries, we assume it behaves as libdragon
-    // expects, and by forcing the write to never hit ram, libultra remains
-    // functional.
-    for(auto address : range(data)) {
+    // expects, and by forcing the write pointer to always be zero, libultra
+    // remains functional.
+    // Also reset the read pointer back to zero if it is used as a starting
+    // address, for compatibility with hardware even though neither library
+    // ever writes to it.
+    for(auto address : range(ram.read<Half>(0x4), data)) {
       char c = ram.read<Byte>(0x20 + address);
       messageChar(c);
     }
+    ram.write<Word>(0x4, 0);
     return;
   }
 


### PR DESCRIPTION
Allows the ISViewer buffer to be used for unaligned transfers using PI DMA. I have a POC implementation [here](https://github.com/LateGator/rust-n64-gcc-template/blob/327b4cce442fa41e8f3834821a4f45b391707aa2/src/isv.rs#L67-L98) that works on Summercart using this method. It is a lot faster than the manual poking at words aligning the ring buffer. This patch will allow it to work in ares too without affecting libultra/libdragon since those libraries never try to set the read pointer.