### PR TITLE
m68000: fix write ordering in MOVEM.L with indirect pre-decrement addressing

### DIFF
--- a/ares/component/processor/m68000/instructions.cpp
+++ b/ares/component/processor/m68000/instructions.cpp
@@ -752,7 +752,12 @@ template<u32 Size> auto M68000::instructionMOVEM_TO_MEM(EffectiveAddress to) -> 
 
     if(to.mode == AddressRegisterIndirectWithPreDecrement) addr -= bytes<Size>();
     auto data = index < 8 ? read<Size>(DataRegister{index}) : read<Size>(AddressRegister{index});
-    write<Size>(addr, data);
+    if(to.mode == AddressRegisterIndirectWithPreDecrement) {
+        //pre-decrement mode writes longwords in reverse-word order (low word before high)
+        write<Size, Reverse>(addr, data);
+    } else {
+        write<Size>(addr, data);
+    }
     if(to.mode != AddressRegisterIndirectWithPreDecrement) addr += bytes<Size>();
   }
 


### PR DESCRIPTION
MOVEM.L in pre-decrement mode performs each longword write in reverse-word order (low word before high word) in addition to writing the registers in reverse order.

This fixes #2171.