### PR TITLE
GCC11 - Fix ambiguous overload on mouseCursor types. Always compare with matc…

### DIFF
--- a/hiro/gtk/widget/widget.cpp
+++ b/hiro/gtk/widget/widget.cpp
@@ -139,9 +139,9 @@ auto pWidget::setMouseCursor(const MouseCursor& mouseCursor) -> void {
 
   if(mouseCursor) {
     string name;
-    if(mouseCursor == MouseCursor::Hand) name = "hand1";
-    if(mouseCursor == MouseCursor::HorizontalResize) name = "sb_h_double_arrow";
-    if(mouseCursor == MouseCursor::VerticalResize) name = "sb_v_double_arrow";
+    if(mouseCursor.name() == MouseCursor::Hand) name = "hand1";
+    if(mouseCursor.name() == MouseCursor::HorizontalResize) name = "sb_h_double_arrow";
+    if(mouseCursor.name() == MouseCursor::VerticalResize) name = "sb_v_double_arrow";
     if(name) {
       gdkMouseCursor = gdk_cursor_new_from_name(gdk_display_get_default(), name);
     }


### PR DESCRIPTION
…hing string types.

Fixes:
```
widget.cpp:142:20: error: ambiguous overload for ‘operator==’ (operand types are ‘const hiro::MouseCursor’ and ‘const nall::string’)
 142 | if(mouseCursor == MouseCursor::Hand) name = "hand1";
  | ~~~~~~~~~~~ ^~ ~~~~~~~~~~~~~~~~~
  | |           |
  | const hiro::MouseCursor const nall::string
```

As `mouse-cursor.hpp` defines `name` as `MouseCursor(const string& name = "");` seems like direct comparison via type should be made on these 3 checks.