### PR TITLE
fc: values in CGRAM are six bits in size

### DIFF
--- a/ares/fc/ppu/debugger.cpp
+++ b/ares/fc/ppu/debugger.cpp
@@ -10,10 +10,10 @@ auto PPU::Debugger::load(Node::Object parent) -> void {
 
   memory.cgram = parent->append<Node::Debugger::Memory>("PPU CGRAM");
   memory.cgram->setSize(ppu.cgram.size());
-  memory.cgram->setRead([&](u32 address) -> u8 {
+  memory.cgram->setRead([&](u32 address) -> u6 {
     return ppu.cgram[address];
   });
-  memory.cgram->setWrite([&](u32 address, u8 data) -> void {
+  memory.cgram->setWrite([&](u32 address, u6 data) -> void {
     ppu.cgram[address] = data;
   });
 

--- a/ares/fc/ppu/memory.cpp
+++ b/ares/fc/ppu/memory.cpp
@@ -6,14 +6,14 @@ auto PPU::writeCIRAM(n11 address, n8 data) -> void {
   ciram[address] = data;
 }
 
-auto PPU::readCGRAM(n5 address) -> n8 {
+auto PPU::readCGRAM(n5 address) -> n6 {
   if((address & 0x3) == 0x0) address &= ~0x10;
   n8 data = cgram[address];
   if(io.grayscale) data &= 0x30;
   return data;
 }
 
-auto PPU::writeCGRAM(n5 address, n8 data) -> void {
+auto PPU::writeCGRAM(n5 address, n6 data) -> void {
   cgram[address] = data;
 
   if((address & 0x3) == 0x0)

--- a/ares/fc/ppu/ppu.hpp
+++ b/ares/fc/ppu/ppu.hpp
@@ -2,7 +2,7 @@ struct PPU : Thread {
   Node::Object node;
   Node::Video::Screen screen;
   Memory::Writable<n8> ciram;
-  Memory::Writable<n8> cgram;
+  Memory::Writable<n6> cgram;
   Memory::Writable<n8> oam;
   Memory::Writable<n8> soam;
 
@@ -39,8 +39,8 @@ struct PPU : Thread {
   auto readCIRAM(n11 address) -> n8;
   auto writeCIRAM(n11 address, n8 data) -> void;
 
-  auto readCGRAM(n5 address) -> n8;
-  auto writeCGRAM(n5 address, n8 data) -> void;
+  auto readCGRAM(n5 address) -> n6;
+  auto writeCGRAM(n5 address, n6 data) -> void;
 
   auto readIO(n16 address) -> n8;
   auto writeIO(n16 address, n8 data) -> void;


### PR DESCRIPTION
Fixes some graphical glitches that could occur after writing values over 0x3f to CGRAM, and fixes reading said values from CGRAM.