### PR TITLE
n64: in emux, implement xioctl fast/slow

### DIFF
--- a/ares/ares/platform.hpp
+++ b/ares/ares/platform.hpp
@@ -8,6 +8,8 @@ enum class Event : u32 {
   Frame,
   Power,
   Synchronize,
+  FastForwardOn,
+  FastForwardOff,
   Shutdown
 };
 

--- a/ares/n64/cpu/emux.cpp
+++ b/ares/n64/cpu/emux.cpp
@@ -20,6 +20,8 @@ auto CPU::XDETECT(r64& rd, u64 code) -> void {
   detect.bit(0x2a) = 1;  // XEXCEPTION
   detect.bit(0x2c) = 1;  // XIOCTL
   ioctl.bit(0x01) = 1;   // XIOCTL exit
+  ioctl.bit(0x02) = 1;   // XIOCTL fast
+  ioctl.bit(0x03) = 1;   // XIOCTL slow
   switch(code) {
   case 0x00: rd.s64 = (s32)detect.bit(0x00, 0x1F); break;
   case 0x01: rd.s64 = (s32)detect.bit(0x20, 0x3F); break;
@@ -186,6 +188,12 @@ auto CPU::XIOCTL(u64 code) -> void {
     case 0x1: //exit
       printf("[emux] Ares exit requested by application\n");
       platform->event(ares::Event::Shutdown);
+      break;
+    case 0x2: //fast
+      platform->event(ares::Event::FastForwardOn);
+      break;
+    case 0x3: //slow
+      platform->event(ares::Event::FastForwardOff);
       break;
   }
 }

--- a/ares/n64/rsp/emux.cpp
+++ b/ares/n64/rsp/emux.cpp
@@ -28,6 +28,8 @@ auto RSP::XDETECT(r32& rd, u32 code) -> void {
   detect.bit(0x2a) = 1;  // XEXCEPTION
   detect.bit(0x2c) = 1;  // XIOCTL
   ioctl.bit(0x01) = 1;   // XIOCTL exit
+  ioctl.bit(0x02) = 1;   // XIOCTL fast
+  ioctl.bit(0x03) = 1;   // XIOCTL slow
   switch(code) {
   case 0x00: rd.u32 = detect.bit(0x00, 0x1f); break;
   case 0x01: rd.u32 = detect.bit(0x20, 0x3f); break;

--- a/desktop-ui/program/platform.cpp
+++ b/desktop-ui/program/platform.cpp
@@ -27,6 +27,22 @@ auto Program::pak(ares::Node::Object node) -> std::shared_ptr<vfs::directory> {
 }
 
 auto Program::event(ares::Event event) -> void {
+  if(event == ares::Event::FastForwardOn) {
+    fastForwarding = true;
+    ruby::video.setBlocking(false);
+    ruby::audio.setBlocking(false);
+    ruby::audio.setDynamic(false);
+    return;
+  }
+
+  if(event == ares::Event::FastForwardOff) {
+    fastForwarding = false;
+    ruby::video.setBlocking(true);
+    ruby::audio.setBlocking(true);
+    ruby::audio.setDynamic(true);
+    return;
+  }
+
   if(event == ares::Event::Shutdown) {
     quit();
   }


### PR DESCRIPTION
These can be used by testroms to automatically turn on fast forward mode